### PR TITLE
Make full text search be explicit with config.

### DIFF
--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -434,7 +434,9 @@ pgFmtFilter table (Filter fld (OpExpr hasNot oper)) = notOp <> " " <> case oper 
       Nothing    -> emptyValForIn
 
    Fts op lang val ->
-     pgFmtFieldOp op
+       maybe (\x -> x) (\l fmtfld -> "to_tsvector(" <> pgFmtLit l <> ", " <> fmtfld <> ")") lang (pgFmtField table fld)
+       <> " "
+       <> sqlOperator op
        <> "("
        <> maybe "" ((<> ", ") . pgFmtLit) lang
        <> unknownLiteral val


### PR DESCRIPTION
`to_tsvector(<lang>,<lhs>)` is now called explicitly before being passed to `@@` if a language configuration has been supplied in the query.

This way the `tsquery` and the `tsvector` match. Not doing this causes weird results to be returned.

If people are happy with this, I can add tests.