### PR TITLE
fix parser to show errors when ordering modificators are misspelled

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,10 +10,10 @@ stgrest:
     PGRST_DB_ANON_ROLE: app_user
 
 postgres:
-  image: postgres
+  image: postgres:9
   ports:
     - "5432:5432"
   environment:
-    POSTGRES_DB: app_db
-    POSTGRES_USER: app_user
+    POSTGRES_DB: postgrest_test
+    POSTGRES_USER: postgrest_test
     POSTGRES_PASSWORD: password

--- a/src/PostgREST/Parsers.hs
+++ b/src/PostgREST/Parsers.hs
@@ -172,11 +172,11 @@ pOrderTerm =
   try ( do
     c <- pField
     let pDirectionNulls =
-               try(string "asc"        $> OrderTerm mempty (Just OrderAsc) Nothing)
-           <|> try(string "desc"       $> OrderTerm mempty (Just OrderDesc) Nothing)
-           <|> try(string "nullslast"  $> OrderTerm mempty Nothing (Just OrderNullsLast))
-           <|> try(string "nullsfirst" $> OrderTerm mempty Nothing (Just OrderNullsFirst))
-    ords <-  pDelimiter *> pDirectionNulls `sepBy1` char '.' <|> pure []
+               try(string "asc"        <* notFollowedBy (noneOf ".") $> OrderTerm mempty (Just OrderAsc) Nothing)
+           <|> try(string "desc"       <* notFollowedBy (noneOf ".") $> OrderTerm mempty (Just OrderDesc) Nothing)
+           <|> try(string "nullslast"  <* notFollowedBy (noneOf ".") $> OrderTerm mempty Nothing (Just OrderNullsLast))
+           <|> try(string "nullsfirst" <* notFollowedBy (noneOf ".") $> OrderTerm mempty Nothing (Just OrderNullsFirst))
+    ords <-  try $ pDelimiter *> pDirectionNulls `sepBy1` char '.' <|> pure []
     return $ foldr mappend (OrderTerm c Nothing Nothing) ords
   )
 

--- a/src/PostgREST/Parsers.hs
+++ b/src/PostgREST/Parsers.hs
@@ -172,12 +172,12 @@ pOrderTerm =
   try ( do
     c <- pField
     let pDirectionNulls =
-               try(string "asc"        $> OrderTerm c (Just OrderAsc) Nothing)
-           <|> try(string "desc"       $> OrderTerm c (Just OrderDesc) Nothing)
-           <|> try(string "nullslast"  $> OrderTerm c Nothing (Just OrderNullsLast))
-           <|> try(string "nullsfirst" $> OrderTerm c Nothing (Just OrderNullsFirst))
-    ords <-  pDelimiter *> pDirectionNulls `sepBy1` char '.'
-    return $ foldl1 mappend ords
+               try(string "asc"        $> OrderTerm mempty (Just OrderAsc) Nothing)
+           <|> try(string "desc"       $> OrderTerm mempty (Just OrderDesc) Nothing)
+           <|> try(string "nullslast"  $> OrderTerm mempty Nothing (Just OrderNullsLast))
+           <|> try(string "nullsfirst" $> OrderTerm mempty Nothing (Just OrderNullsFirst))
+    ords <-  pDelimiter *> pDirectionNulls `sepBy1` char '.' <|> pure []
+    return $ foldr mappend (OrderTerm c Nothing Nothing) ords
   )
 
 pLogicTree :: Parser LogicTree

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -115,6 +115,10 @@ data OrderTerm = OrderTerm {
 , otDirection :: Maybe OrderDirection
 , otNullOrder :: Maybe OrderNulls
 } deriving (Show, Eq)
+instance Monoid OrderTerm where
+  mempty = OrderTerm (mempty, mempty) Nothing Nothing
+  OrderTerm nt (Just nd) Nothing `mappend` OrderTerm mt Nothing (Just mn) = OrderTerm (nt `mappend` mt) (Just nd) (Just mn)
+  OrderTerm nt Nothing (Just nn) `mappend` OrderTerm mt (Just md) Nothing = OrderTerm (nt `mappend` mt) (Just md) (Just nn)
 
 data QualifiedIdentifier = QualifiedIdentifier {
   qiSchema :: Schema

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -117,6 +117,9 @@ data OrderTerm = OrderTerm {
 } deriving (Show, Eq)
 instance Monoid OrderTerm where
   mempty = OrderTerm (mempty, mempty) Nothing Nothing
+  OrderTerm ("",Nothing) Nothing nn  `mappend` OrderTerm tm Nothing Nothing = OrderTerm tm Nothing nn
+  OrderTerm nt Nothing Nothing `mappend` OrderTerm mt Nothing (Just mn) = OrderTerm (nt `mappend` mt) Nothing (Just mn)
+  OrderTerm nt (Just nd) Nothing `mappend` OrderTerm mt Nothing Nothing = OrderTerm (nt `mappend` mt) (Just nd) Nothing
   OrderTerm nt (Just nd) Nothing `mappend` OrderTerm mt Nothing (Just mn) = OrderTerm (nt `mappend` mt) (Just nd) (Just mn)
   OrderTerm nt Nothing (Just nn) `mappend` OrderTerm mt (Just md) Nothing = OrderTerm (nt `mappend` mt) (Just md) (Just nn)
   OrderTerm{} `mappend` OrderTerm{} = mempty

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -119,6 +119,7 @@ instance Monoid OrderTerm where
   mempty = OrderTerm (mempty, mempty) Nothing Nothing
   OrderTerm nt (Just nd) Nothing `mappend` OrderTerm mt Nothing (Just mn) = OrderTerm (nt `mappend` mt) (Just nd) (Just mn)
   OrderTerm nt Nothing (Just nn) `mappend` OrderTerm mt (Just md) Nothing = OrderTerm (nt `mappend` mt) (Just md) (Just nn)
+  OrderTerm{} `mappend` OrderTerm{} = mempty
 
 data QualifiedIdentifier = QualifiedIdentifier {
   qiSchema :: Schema

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -518,6 +518,9 @@ spec = do
     it "with error when ordering direction is misspelled" $
       get "/items?order=id.wrong" `shouldRespondWith` 400
 
+    it "with error when ordering direction is not exact" $
+      get "/items?order=id.desc2" `shouldRespondWith` 400
+
     it "with error when ordering nulls is misspelled" $
       get "/items?order=id.desc.wrong" `shouldRespondWith` 400
 

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -413,7 +413,7 @@ spec = do
       get "/projects?id=in.1,3&select=id,name,client_id{id,name}" `shouldRespondWith`
         [json|[{"id":1,"name":"Windows 7","client_id":{"id":1,"name":"Microsoft"}},{"id":3,"name":"IOS","client_id":{"id":2,"name":"Apple"}}]|]
         { matchHeaders = [matchContentTypeJson] }
-    
+
     it "can embed by FK column name and select the FK value at the same time, if aliased" $
       get "/projects?id=in.1,3&select=id,name,client_id,client:client_id{id,name}" `shouldRespondWith`
         [json|[{"id":1,"name":"Windows 7","client_id":1,"client":{"id":1,"name":"Microsoft"}},{"id":3,"name":"IOS","client_id":2,"client":{"id":2,"name":"Apple"}}]|]
@@ -515,6 +515,14 @@ spec = do
       get "/projects?id=eq.1&select=id, name, client{id, name}&client.order=name.asc" `shouldRespondWith`
         [str|[{"id":1,"name":"Windows 7","client":{"id":1,"name":"Microsoft"}}]|]
 
+    it "with error when ordering direction is misspelled" $
+      get "/items?order=id.wrong" `shouldRespondWith` 400
+
+    it "with error when ordering nulls is misspelled" $
+      get "/items?order=id.desc.wrong" `shouldRespondWith` 400
+
+    it "with error when ordering nulls correct but ordering direction is misspelled" $
+      get "/items?order=id.nullslast.wrong" `shouldRespondWith` 400
 
 
   describe "Accept headers" $ do


### PR DESCRIPTION
Fix for issue #781
The solution:
1. Parse OrderDirection OrderNulls together (not one after the other) so we could tell between misspelling and change of type.
2. use setBy1 so errors are not swallowed

That was a tricky one, thanks for the challenge.