### PR TITLE
OpenAPI: add required section for the non-nullable columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #1099, Add support for getting json/jsonb by array index - @steve-chavez
 - #1145, Add materialized view columns to OpenAPI output - @steve-chavez
 - #709, Allow embedding on views with subselects/CTE - @steve-chavez
+- #1148, OpenAPI: add `required` section for the non-nullable columns - @laughedelic
 
 ### Fixed
 

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -42,7 +42,8 @@ makeTableDef pks (t, cs, _) =
       (tn, (mempty :: Schema)
         & description .~ tableDescription t
         & type_ .~ SwaggerObject
-        & properties .~ fromList (map (makeProperty pks) cs))
+        & properties .~ fromList (map (makeProperty pks) cs)
+        & required .~ map colName (filter (not . colNullable) cs))
 
 makeProperty :: [PrimaryKey] -> Column -> (Text, Referenced Schema)
 makeProperty pks c = (colName c, Inline s)

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -113,7 +113,10 @@ spec = do
                     "format": "integer",
                     "type": "integer"
                   }
-                }
+                },
+                "required": [
+                  "id"
+                ]
               }
             |]
 


### PR DESCRIPTION
This PR adds the `definitions.{definition}.required` list with the names of the columns that have `colNullable` set to `False`.

For example, if I have a table

```sql
create table organisms (
  name   text primary key,
  tax_id text not null
);
```

Then the corresponding definition in the generated OpenAPI specification will be

```json
  "definitions": {
    "organisms": {
      "required": [
        "name",
        "tax_id"
      ],
      "properties": {
        "name": {
          "format": "text",
          "type": "string",
          "description": "Note:\nThis is a Primary Key.<pk/>"
        },
        "tax_id": {
          "format": "text",
          "type": "string"
        }
      },
      "type": "object"
    }
  }
```

Notice the `required` list: `name` column is the primary key, so it's not null and `tax_id` has an explicit `not null` annotation.

Motivation: I'm using the Swagger/OpenAPI specification provided by PostgREST and [swagger-codegen](https://github.com/swagger-api/swagger-codegen#prerequisites) to generate client-side code (Elm), so if the `required` list is omitted, all fields are marked as optional (`Maybe ...`) which is very inconvenient, taking into account that the DB (and PostgREST) knows which columns are non-optional.