### PR TITLE
Fix #905, intermittent empty replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #1129, Fix view embedding when table is capitalized - @steve-chavez
 - #1149, OpenAPI: Change `GET` response type to array - @laughedelic
 - #1152, Fix RPC failing when having arguments with reserved or uppercase keywords - @mdr1384
+- #905, Fix intermittent empty replies - @steve-chavez
 
 ### Changed
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -33,8 +33,7 @@ import qualified Hasql.Pool               as P
 import qualified Hasql.Session            as H
 import           Network.Wai.Handler.Warp (defaultSettings,
                                            runSettings, setHost,
-                                           setPort, setServerName,
-                                           setTimeout)
+                                           setPort, setServerName)
 import           System.IO                (BufferMode (..),
                                            hSetBuffering)
 
@@ -152,8 +151,7 @@ main = do
       appSettings =
         setHost ((fromString . toS) host) -- Warp settings
         . setPort port
-        . setServerName (toS $ "postgrest/" <> prettyVersion)
-        . setTimeout 3600 $
+        . setServerName (toS $ "postgrest/" <> prettyVersion) $
         defaultSettings
 
   -- Checks that the provided proxy uri is formated correctly


### PR DESCRIPTION
Fixes #905. Basically revert https://github.com/PostgREST/postgrest/pull/834, main problem that PR intended to solve was to remove a warning in the logs. Don't see a strong reason(like perf tests) to not restore the timeout default of 30 seconds.

I don't have the means to reproduce this bug now so don't know exactly why the empty replies happen on certain systems(like raspbian on rpi), but I'm suspicious of kernel [tcp variables](https://www.frozentux.net/ipsysctl-tutorial/chunkyhtml/tcpvariables.html)(can be queried with `sysctl -a | grep tcp`), these are usually [tuned](http://www.linux-admins.net/2010/09/linux-tcp-tuning.html) on low-memory setups.