### PR TITLE
Fix segmentation fault/access violation on windows 10

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -10,6 +10,7 @@ extra-deps:
   - hasql-pool-0.4.3
   - hasql-transaction-0.5.2
   - jose-0.7.0.0
+  - postgresql-libpq-0.9.4.1
 ghc-options:
   postgrest: -O2 -Werror -Wall -fwarn-identities -fno-warn-redundant-constraints
 nix:


### PR DESCRIPTION
This was reported in https://gitter.im/begriffs/postgrest?at=5b7431eb5b07ae730ac083af
and according to https://ghc.haskell.org/trac/ghc/ticket/13112#comment:25
this is an issue with linking in postgresql-libpq. The 0.9.4.1 version
contains a patch(https://github.com/lpsmith/postgresql-libpq/pull/45) that fixes the issue.