### PR TITLE
Relax some version bounds

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -32,12 +32,12 @@ executable postgrest
     "-with-rtsopts=-N -I2"
   default-language:    Haskell2010
   build-depends:       auto-update
-                     , base >= 4.8 && < 4.10
+                     , base >= 4.8 && < 4.13
                      , hasql >= 1.3 && < 1.4
                      , hasql-pool >= 0.5 && < 0.6
                      , hasql-transaction >= 0.7 && < 0.8
                      , postgrest
-                     , protolude == 0.2.2
+                     , protolude >= 0.2.2 && < 0.3
                      , text
                      , time
                      , warp
@@ -54,7 +54,7 @@ library
   default-extensions:  OverloadedStrings, QuasiQuotes, NoImplicitPrelude
   build-depends:       aeson
                      , ansi-wl-pprint
-                     , base >= 4.8 && < 4.10
+                     , base >= 4.8 && < 4.13
                      , base64-bytestring
                      , bytestring
                      , case-insensitive
@@ -79,7 +79,7 @@ library
                      , network-uri
                      , optparse-applicative >= 0.13 && < 0.15
                      , parsec
-                     , protolude == 0.2.2
+                     , protolude >= 0.2.2 && < 0.3
                      , Ranged-sets == 0.3.0
                      , regex-tdfa
                      , scientific
@@ -147,7 +147,7 @@ Test-Suite spec
                      , aeson-qq
                      , async
                      , auto-update
-                     , base >= 4.8 && < 4.10
+                     , base >= 4.8 && < 4.13
                      , bytestring
                      , base64-bytestring
                      , case-insensitive
@@ -158,7 +158,7 @@ Test-Suite spec
                      , hasql-pool >= 0.5 && < 0.6
                      , hasql-transaction >= 0.7 && < 0.8
                      , heredoc
-                     , hjsonschema == 1.5.0.1
+                     , hjsonschema >= 1.5.0.1 && < 2
                      , hspec
                      , hspec-wai >= 0.7.0
                      , hspec-wai-json
@@ -168,7 +168,7 @@ Test-Suite spec
                      , monad-control
                      , postgrest
                      , process
-                     , protolude == 0.2.2
+                     , protolude >= 0.2.2 && < 0.3
                      , regex-tdfa
                      , time
                      , transformers-base


### PR DESCRIPTION
The build and tests went smoothly here with the updated dependencies (base-4.12.0.0, protolude-0.2.3, hjsonschema-1.9.0).