### PR TITLE
Faster bulk insert with ?columns query arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- #690, Add `?columns` query parameter for faster bulk inserts, also ignores unspecified json keys in a payload - @steve-chavez
+
 ### Fixed
 
 - #1223, Fix incorrect OpenAPI externalDocs url - @steve-chavez

--- a/src/PostgREST/DbRequestBuilder.hs
+++ b/src/PostgREST/DbRequestBuilder.hs
@@ -321,8 +321,8 @@ addProperty f (targetNodeName:remainingPath, a) (Node rn forest) =
 mutateRequest :: ApiRequest -> TableName -> [Text] -> [FieldName] -> Either Response MutateRequest
 mutateRequest apiRequest tName pkCols fldNames = mapLeft apiRequestError $
   case action of
-    ActionCreate -> Right $ Insert tName payload ((,) <$> iPreferResolution apiRequest <*> Just pkCols) [] returnings
-    ActionUpdate -> Update tName payload <$> combinedLogic <*> pure returnings
+    ActionCreate -> Right $ Insert tName (pjKeys payload) ((,) <$> iPreferResolution apiRequest <*> Just pkCols) [] returnings
+    ActionUpdate -> Update tName (pjKeys payload) <$> combinedLogic <*> pure returnings
     ActionSingleUpsert ->
       (\flts ->
         if null (iLogic apiRequest) &&
@@ -331,7 +331,7 @@ mutateRequest apiRequest tName pkCols fldNames = mapLeft apiRequestError $
            all (\case
               Filter _ (OpExpr False (Op "eq" _)) -> True
               _ -> False) flts
-          then Insert tName payload (Just (MergeDuplicates, pkCols)) <$> combinedLogic <*> pure returnings
+          then Insert tName (pjKeys payload) (Just (MergeDuplicates, pkCols)) <$> combinedLogic <*> pure returnings
         else
           Left InvalidFilters) =<< filters
     ActionDelete -> Delete tName <$> combinedLogic <*> pure returnings

--- a/src/PostgREST/Parsers.hs
+++ b/src/PostgREST/Parsers.hs
@@ -13,6 +13,7 @@ import           Data.Functor                  (($>))
 import qualified Data.HashMap.Strict           as M
 import           Data.Text                     (intercalate, replace, strip)
 import           Data.List                     (init, last)
+import qualified Data.Set                      as S
 import           Data.Tree
 import           Data.Either.Combinators       (mapLeft)
 import           PostgREST.RangeQuery          (NonnegRange)
@@ -216,6 +217,13 @@ pLogicPath = do
   let op = last path
       notOp = "not." <> op
   return (filter (/= "not") (init path), if "not" `elem` path then notOp else op)
+
+pRequestColumns :: Text -> Either ParseError (S.Set FieldName)
+pRequestColumns colStr =
+  S.fromList <$> parse pColumns ("failed to parse columns parameter (" <> toS colStr <> ")") (toS colStr)
+
+pColumns :: Parser [FieldName]
+pColumns = pFieldName `sepBy1` lexeme (char ',')
 
 mapError :: Either ParseError a -> Either ApiRequestError a
 mapError = mapLeft translateError

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -187,16 +187,21 @@ data Relation = Relation {
 isSelfJoin :: Relation -> Bool
 isSelfJoin r = relType r /= Root && relTable r == relFTable r
 
--- | Cached attributes of a JSON payload
-data PayloadJSON = PayloadJSON {
--- | This is the raw ByteString that comes from the request body.
--- We cache this instead of an Aeson Value because it was detected that for large payloads the encoding
--- had high memory usage, see #1005 for more details
-  pjRaw     :: BL.ByteString
-, pjType    :: PJType
--- | Keys of the object or if it's an array these keys are guaranteed to be the same across all its objects
-, pjKeys    :: S.Set Text
-} deriving (Show, Eq)
+data PayloadJSON =
+  -- | Cached attributes of a JSON payload
+  ProcessedJSON {
+    -- | This is the raw ByteString that comes from the request body.
+    -- We cache this instead of an Aeson Value because it was detected that for large payloads the encoding
+    -- had high memory usage, see #1005 for more details
+    pjRaw  :: BL.ByteString
+  , pjType :: PJType
+    -- | Keys of the object or if it's an array these keys are guaranteed to be the same across all its objects
+  , pjKeys :: S.Set Text
+  }|
+  RawJSON {
+    pjRaw  :: BL.ByteString
+  , pjKeys :: S.Set Text
+  } deriving (Show, Eq)
 
 data PJType = PJArray { pjaLength :: Int } | PJObject deriving (Show, Eq)
 

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -115,7 +115,7 @@ newtype ForeignKey = ForeignKey { fkCol :: Column } deriving (Show, Eq, Ord)
 data Column =
     Column {
       colTable       :: Table
-    , colName        :: ColumnName
+    , colName        :: FieldName
     , colDescription :: Maybe Text
     , colPosition    :: Int32
     , colNullable    :: Bool
@@ -134,7 +134,6 @@ instance Eq Column where
 -- | A view column that refers to a table column
 type Synonym = (Column, ViewColumn)
 type ViewColumn = Column
-type ColumnName = Text
 
 data PrimaryKey = PrimaryKey {
     pkTable :: Table
@@ -200,11 +199,6 @@ data PayloadJSON = PayloadJSON {
 } deriving (Show, Eq)
 
 data PJType = PJArray { pjaLength :: Int } | PJObject deriving (Show, Eq)
-
--- | e.g. whether it is []/{} or not
-pjIsEmpty :: PayloadJSON -> Bool
-pjIsEmpty (PayloadJSON _ PJObject keys) = S.size keys == 0
-pjIsEmpty (PayloadJSON _ (PJArray l) _) = l == 0
 
 data Proxy = Proxy {
   proxyScheme     :: Text
@@ -330,14 +324,14 @@ data ReadQuery = Select {
 data MutateQuery =
   Insert {
     in_        :: TableName
-  , qPayload   :: PayloadJSON
-  , onConflict :: Maybe (PreferResolution, [ColumnName])
+  , insCols    :: S.Set FieldName
+  , onConflict :: Maybe (PreferResolution, [FieldName])
   , where_     :: [LogicTree]
   , returning  :: [FieldName]
   }|
   Update {
     in_        :: TableName
-  , qPayload   :: PayloadJSON
+  , updCols    :: S.Set FieldName
   , where_     :: [LogicTree]
   , returning  :: [FieldName]
   }|

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -115,7 +115,7 @@ newtype ForeignKey = ForeignKey { fkCol :: Column } deriving (Show, Eq, Ord)
 data Column =
     Column {
       colTable       :: Table
-    , colName        :: Text
+    , colName        :: ColumnName
     , colDescription :: Maybe Text
     , colPosition    :: Int32
     , colNullable    :: Bool
@@ -134,6 +134,7 @@ instance Eq Column where
 -- | A view column that refers to a table column
 type Synonym = (Column, ViewColumn)
 type ViewColumn = Column
+type ColumnName = Text
 
 data PrimaryKey = PrimaryKey {
     pkTable :: Table
@@ -329,9 +330,8 @@ data ReadQuery = Select {
 data MutateQuery =
   Insert {
     in_        :: TableName
-  , insPkCols  :: [Text]
   , qPayload   :: PayloadJSON
-  , onConflict :: Maybe PreferResolution
+  , onConflict :: Maybe (PreferResolution, [ColumnName])
   , where_     :: [LogicTree]
   , returning  :: [FieldName]
   }|

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -222,12 +222,23 @@ spec = do
           , matchHeaders = ["Location" <:> location]
           }
 
-    context "empty object" $
-      it "successfully populates table with all-default columns" $
+    context "empty objects" $ do
+      it "successfully inserts a row with all-default columns" $ do
         post "/items" "{}" `shouldRespondWith` ""
           { matchStatus  = 201
           , matchHeaders = []
           }
+        post "/items" "[{}]" `shouldRespondWith` ""
+          { matchStatus  = 201
+          , matchHeaders = []
+          }
+
+      it "successfully inserts two rows with all-default columns" $
+        post "/items" "[{}, {}]" `shouldRespondWith` ""
+          { matchStatus  = 201
+          , matchHeaders = []
+          }
+
     context "table with limited privileges" $ do
       it "succeeds if correct select is applied" $
         request methodPost "/limited_article_stars?select=article_id,user_id" [("Prefer", "return=representation")]
@@ -427,20 +438,20 @@ spec = do
             matchHeaders = ["Content-Range" <:> "*/*"]
           }
 
-        get "/items" `shouldRespondWith`
-          [json|[{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9},{"id":10},{"id":11},{"id":12},{"id":13},{"id":14},{"id":15},{id:16},{"id":2},{"id":1}]|]
-          { matchHeaders = [matchContentTypeJson] }
+        request methodPatch "/items" [] [json| [{}] |]
+          `shouldRespondWith` ""
+          {
+            matchStatus  = 204,
+            matchHeaders = ["Content-Range" <:> "*/*"]
+          }
 
-      it "makes no updates and and returns 200, when patching with an empty json object and return=rep" $ do
+      it "makes no updates and and returns 200, when patching with an empty json object and return=rep" $
         request methodPatch "/items" [("Prefer", "return=representation")] [json| {} |]
           `shouldRespondWith` "[]"
           {
             matchStatus  = 200,
             matchHeaders = ["Content-Range" <:> "*/*"]
           }
-        get "/items" `shouldRespondWith`
-          [json| [{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9},{"id":10},{"id":11},{"id":12},{"id":13},{"id":14},{"id":15},{id:16},{"id":2},{"id":1}] |]
-          { matchHeaders = [matchContentTypeJson] }
   
     context "with unicode values" $
       it "succeeds and returns values intact" $ do

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -339,9 +339,15 @@ spec =
       get "/rpc/overloaded?a=1&b=2" `shouldRespondWith` [str|3|]
       get "/rpc/overloaded?a=1&b=2&c=3" `shouldRespondWith` [str|"123"|]
 
-    context "only for POST rpc" $
+    context "only for POST rpc" $ do
       it "gives a parse filter error if GET style proc args are specified" $
         post "/rpc/sayhello?name=John" [json|{}|] `shouldRespondWith` 400
+
+      it "ignores json keys not included in ?columns" $
+        post "/rpc/sayhello?columns=name"
+          [json|{"name": "John", "smth": "here", "other": "stuff", "fake_id": 13}|] `shouldRespondWith`
+          [json|"Hello, John"|]
+          { matchHeaders = [matchContentTypeJson] }
 
     context "only for GET rpc" $ do
       it "should fail on mutating procs" $ do

--- a/test/memory-tests.sh
+++ b/test/memory-tests.sh
@@ -96,21 +96,21 @@ setUp
 
 echo "Running memory usage tests.."
 
-jsonKeyTest "1M" "POST" "/rpc/leak" "20M"
-jsonKeyTest "1M" "POST" "/leak" "20M"
-jsonKeyTest "1M" "PATCH" "/leak?id=eq.1" "20M"
+jsonKeyTest "1M" "POST" "/rpc/leak?columns=blob" "12M"
+jsonKeyTest "1M" "POST" "/leak?columns=blob" "12M"
+jsonKeyTest "1M" "PATCH" "/leak?id=eq.1&columns=blob" "12M"
 
-jsonKeyTest "10M" "POST" "/rpc/leak" "105M"
-jsonKeyTest "10M" "POST" "/leak" "105M"
-jsonKeyTest "10M" "PATCH" "/leak?id=eq.1" "105M"
+jsonKeyTest "10M" "POST" "/rpc/leak?columns=blob" "40M"
+jsonKeyTest "10M" "POST" "/leak?columns=blob" "40M"
+jsonKeyTest "10M" "PATCH" "/leak?id=eq.1&columns=blob" "40M"
 
-jsonKeyTest "50M" "POST" "/rpc/leak" "500M"
-jsonKeyTest "50M" "POST" "/leak" "500M"
-jsonKeyTest "50M" "PATCH" "/leak?id=eq.1" "500M"
+jsonKeyTest "50M" "POST" "/rpc/leak?columns=blob" "170M"
+jsonKeyTest "50M" "POST" "/leak?columns=blob" "170M"
+jsonKeyTest "50M" "PATCH" "/leak?id=eq.1&columns=blob" "170M"
 
-postJsonArrayTest "1000" "/perf_articles" "20M"
-postJsonArrayTest "10000" "/perf_articles" "150M"
-postJsonArrayTest "100000" "/perf_articles" "1.15G"
+postJsonArrayTest "1000" "/perf_articles?columns=id,body" "9M"
+postJsonArrayTest "10000" "/perf_articles?columns=id,body" "10M"
+postJsonArrayTest "100000" "/perf_articles?columns=id,body" "20M"
 
 cleanUp
 


### PR DESCRIPTION
Fixes #690. Also fixes #1234.

As proposed in https://github.com/PostgREST/postgrest/issues/690#issuecomment-378363946, now a `columns` query parameter can be specified to delegate all the json processing to PostgreSQL when doing POSTs(also RPC and PATCH). This is analogous to how we've been doing GET until now.

This new mechanism makes our perf test of bulk inserting 100000 json array values improve on memory consumption, from 1.15G to 20M, around 1% of what it used to be.