### PR TITLE
Add numeric and character types to OpenAPI spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #1223, Fix incorrect OpenAPI externalDocs url - @steve-chavez
 - #1221, Fix embedding other resources when having a self join - @steve-chavez
 - #1242, Fix embedding a view having a select in a where - @steve-chavez
+- #1238, Fix PostgreSQL to OpenAPI type mappings for numeric and character types - @fpusch
 
 ## [5.2.0] - 2018-12-12
 

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -41,7 +41,6 @@ toSwaggerType "boolean"           = SwaggerBoolean
 toSwaggerType "smallint"          = SwaggerInteger
 toSwaggerType "integer"           = SwaggerInteger
 toSwaggerType "bigint"            = SwaggerInteger
-toSwaggerType "decimal"           = SwaggerNumber
 toSwaggerType "numeric"           = SwaggerNumber
 toSwaggerType "real"              = SwaggerNumber
 toSwaggerType "double precision"  = SwaggerNumber

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -34,11 +34,18 @@ makeMimeList :: [ContentType] -> MimeList
 makeMimeList cs = MimeList $ map (fromString . toS . toMime) cs
 
 toSwaggerType :: Text -> SwaggerType t
-toSwaggerType "text"      = SwaggerString
-toSwaggerType "integer"   = SwaggerInteger
-toSwaggerType "boolean"   = SwaggerBoolean
-toSwaggerType "numeric"   = SwaggerNumber
-toSwaggerType _           = SwaggerString
+toSwaggerType "character varying" = SwaggerString
+toSwaggerType "character"         = SwaggerString
+toSwaggerType "text"              = SwaggerString
+toSwaggerType "boolean"           = SwaggerBoolean
+toSwaggerType "smallint"          = SwaggerInteger
+toSwaggerType "integer"           = SwaggerInteger
+toSwaggerType "bigint"            = SwaggerInteger
+toSwaggerType "decimal"           = SwaggerNumber
+toSwaggerType "numeric"           = SwaggerNumber
+toSwaggerType "real"              = SwaggerNumber
+toSwaggerType "double precision"  = SwaggerNumber
+toSwaggerType _                   = SwaggerString
 
 makeTableDef :: [PrimaryKey] -> (Table, [Column], [Text]) -> (Text, Schema)
 makeTableDef pks (t, cs, _) =

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -219,6 +219,158 @@ spec = do
               ]
             |]
 
+    describe "PostgreSQL to Swagger Type Mapping" $ do
+
+      it "character varying to string" $ do
+        r <- simpleBody <$> get "/"
+
+        let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_character_varying"
+
+        liftIO $ do
+
+          types `shouldBe` Just
+            [aesonQQ|
+              {
+                "format": "character varying",
+                "type": "string"
+              }
+            |]
+      it "character(1) to string" $ do
+        r <- simpleBody <$> get "/"
+
+        let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_character"
+
+        liftIO $ do
+
+          types `shouldBe` Just
+            [aesonQQ|
+              {
+                "maxLength": 1,
+                "format": "character",
+                "type": "string"
+              }
+            |]
+            
+      it "text to string" $ do
+        r <- simpleBody <$> get "/"
+
+        let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_text"
+
+        liftIO $ do
+
+          types `shouldBe` Just
+            [aesonQQ|
+              {
+                "format": "text",
+                "type": "string"
+              }
+            |]
+
+      it "boolean to boolean" $ do
+        r <- simpleBody <$> get "/"
+
+        let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_boolean"
+
+        liftIO $ do
+
+          types `shouldBe` Just
+            [aesonQQ|
+              {
+                "format": "boolean",
+                "type": "boolean"
+              }
+            |]
+      
+      it "smallint to integer" $ do
+        r <- simpleBody <$> get "/"
+
+        let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_smallint"
+
+        liftIO $ do
+
+          types `shouldBe` Just
+            [aesonQQ|
+              {
+                "format": "smallint",
+                "type": "integer"
+              }
+            |]
+      
+      it "integer to integer" $ do
+        r <- simpleBody <$> get "/"
+
+        let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_integer"
+
+        liftIO $ do
+
+          types `shouldBe` Just
+            [aesonQQ|
+              {
+                "format": "integer",
+                "type": "integer"
+              }
+            |]
+
+      it "bigint to integer" $ do
+        r <- simpleBody <$> get "/"
+
+        let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_bigint"
+
+        liftIO $ do
+
+          types `shouldBe` Just
+            [aesonQQ|
+              {
+                "format": "bigint",
+                "type": "integer"
+              }
+            |]
+
+      it "numeric to number" $ do
+        r <- simpleBody <$> get "/"
+
+        let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_numeric"
+
+        liftIO $ do
+
+          types `shouldBe` Just
+            [aesonQQ|
+              {
+                "format": "numeric",
+                "type": "number"
+              }
+            |]
+
+      it "real to number" $ do
+        r <- simpleBody <$> get "/"
+
+        let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_real"
+
+        liftIO $ do
+
+          types `shouldBe` Just
+            [aesonQQ|
+              {
+                "format": "real",
+                "type": "number"
+              }
+            |]
+      
+      it "double_precision to number" $ do
+        r <- simpleBody <$> get "/"
+
+        let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_double_precision"
+
+        liftIO $ do
+
+          types `shouldBe` Just
+            [aesonQQ|
+              {
+                "format": "double precision",
+                "type": "number"
+              }
+            |]
+
     describe "RPC" $ do
 
       it "includes function summary/description and body schema for arguments" $ do

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -249,7 +249,7 @@ spec = do
                 "properties": {
                   "double": {
                     "format": "double precision",
-                    "type": "string"
+                    "type": "number"
                   },
                   "varchar": {
                     "format": "character varying",

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -226,7 +226,7 @@ spec = do
 
         let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_character_varying"
 
-        liftIO $ do
+        liftIO $
 
           types `shouldBe` Just
             [aesonQQ|
@@ -240,7 +240,7 @@ spec = do
 
         let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_character"
 
-        liftIO $ do
+        liftIO $
 
           types `shouldBe` Just
             [aesonQQ|
@@ -256,7 +256,7 @@ spec = do
 
         let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_text"
 
-        liftIO $ do
+        liftIO $
 
           types `shouldBe` Just
             [aesonQQ|
@@ -271,7 +271,7 @@ spec = do
 
         let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_boolean"
 
-        liftIO $ do
+        liftIO $
 
           types `shouldBe` Just
             [aesonQQ|
@@ -286,7 +286,7 @@ spec = do
 
         let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_smallint"
 
-        liftIO $ do
+        liftIO $
 
           types `shouldBe` Just
             [aesonQQ|
@@ -301,7 +301,7 @@ spec = do
 
         let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_integer"
 
-        liftIO $ do
+        liftIO $
 
           types `shouldBe` Just
             [aesonQQ|
@@ -316,7 +316,7 @@ spec = do
 
         let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_bigint"
 
-        liftIO $ do
+        liftIO $
 
           types `shouldBe` Just
             [aesonQQ|
@@ -331,7 +331,7 @@ spec = do
 
         let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_numeric"
 
-        liftIO $ do
+        liftIO $
 
           types `shouldBe` Just
             [aesonQQ|
@@ -346,7 +346,7 @@ spec = do
 
         let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_real"
 
-        liftIO $ do
+        liftIO $
 
           types `shouldBe` Just
             [aesonQQ|
@@ -361,7 +361,7 @@ spec = do
 
         let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_double_precision"
 
-        liftIO $ do
+        liftIO $
 
           types `shouldBe` Just
             [aesonQQ|

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -100,6 +100,7 @@ GRANT ALL ON TABLE
     , "Server Today"
     , pgrst_reserved_chars
     , authors_w_entities
+    , openapi_types
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1647,3 +1647,16 @@ create table test.pgrst_reserved_chars (
   "a.dotted.column" text,
   "  col  w  space  " text
 );
+
+CREATE TABLE test.openapi_types(
+  "a_character_varying" character varying,
+  "a_character" character(1),
+  "a_text" text,
+  "a_boolean" boolean,
+  "a_smallint" smallint,
+  "a_integer" integer,
+  "a_bigint" bigint,
+  "a_numeric" numeric,
+  "a_real" real,
+  "a_double_precision" double precision
+);


### PR DESCRIPTION
At the moment smallint and other numeric types get `string` types in the OpenAPI spec. This attempts to fix this by adding some missing types to `toSwaggerType`. Types are based on https://www.postgresql.org/docs/current/datatype.html and https://swagger.io/docs/specification/data-models/data-types/ .

This should fix #1238 .

Note: I'm not at all familiar with Haskell, so point me in the right direction if a test or something else is missing or necessary to implement this.

Edit: I've missed the RPC test in `StructureSpec.hs`. Test should pass now.
