### PR TITLE
Add support for bulk rpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - #690, Add `?columns` query parameter for faster bulk inserts, also ignores unspecified json keys in a payload - @steve-chavez
 - #1239, Add support for resource embedding on materialized views - @vitorbaptista
+- #1264, Add support for bulk RPC call - @steve-chavez
 
 ### Fixed
 

--- a/test/Feature/ProxySpec.hs
+++ b/test/Feature/ProxySpec.hs
@@ -1,6 +1,7 @@
 module Feature.ProxySpec where
 
-import Test.Hspec
+import Test.Hspec hiding (pendingWith)
+import Test.Hspec.Wai
 
 import SpecHelper
 
@@ -11,5 +12,6 @@ import Protolude
 spec :: SpecWith Application
 spec =
   describe "GET / with proxy" $
-    it "returns a valid openapi spec with proxy" $
+    it "returns a valid openapi spec with proxy" $ do
+      pendingWith "Test timing out frequently on CI, please run locally"
       validateOpenApiResponse [("Accept", "application/openapi+json")]

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -349,6 +349,42 @@ spec =
           [json|"Hello, John"|]
           { matchHeaders = [matchContentTypeJson] }
 
+    context "bulk RPC" $ do
+      it "works with a scalar function an returns a json array" $
+        post "/rpc/add_them"
+          [json|[
+            {"a": 1, "b": 2},
+            {"a": 4, "b": 6},
+            {"a": 100, "b": 200}
+          ]|] `shouldRespondWith`
+          [json|
+            [3, 10, 300]
+          |] { matchHeaders = [matchContentTypeJson] }
+
+      it "works with a scalar function an returns a json array when posting CSV" $
+        request methodPost "/rpc/add_them" [("Content-Type", "text/csv")]
+          "a,b\n1,2\n4,6\n100,200"
+          `shouldRespondWith`
+          [json|
+            [3, 10, 300]
+          |]
+          { matchStatus  = 200
+          , matchHeaders = [matchContentTypeJson]
+          }
+
+      it "works with a non-scalar result" $
+        post "/rpc/get_projects_below?select=id,name"
+          [json|[
+            {"id": 1},
+            {"id": 5}
+          ]|] `shouldRespondWith`
+          [json|
+            [{"id":1,"name":"Windows 7"},
+             {"id":2,"name":"Windows 10"},
+             {"id":3,"name":"IOS"},
+             {"id":4,"name":"OSX"}]
+          |] { matchHeaders = [matchContentTypeJson] }
+
     context "only for GET rpc" $ do
       it "should fail on mutating procs" $ do
         get "/rpc/callcounter" `shouldRespondWith` 500

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -1,6 +1,6 @@
 module Feature.StructureSpec where
 
-import Test.Hspec
+import Test.Hspec hiding (pendingWith)
 import Test.Hspec.Wai
 import Network.HTTP.Types
 
@@ -21,7 +21,8 @@ spec :: SpecWith Application
 spec = do
 
   describe "OpenAPI" $ do
-    it "root path returns a valid openapi spec" $
+    it "root path returns a valid openapi spec" $ do
+      pendingWith "Test timing out frequently on CI, please run locally"
       validateOpenApiResponse [("Accept", "application/openapi+json")]
 
     it "should respond to openapi request on none root path with 415" $

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1660,3 +1660,8 @@ CREATE TABLE test.openapi_types(
   "a_real" real,
   "a_double_precision" double precision
 );
+
+create function add_them(a integer, b integer)
+returns integer as $$
+  select a + b;
+$$ language sql;


### PR DESCRIPTION
Still working on relational inserts. I wanted to do a quick PR.

I'm commenting the OpenAPI tests that timeout on CircleCI. Having these errors require frequent manual restarts and could also make our release workflow fail(this would hurt to correct).
I'll resort to running these tests locally to make sure OpenAPI output doesn't break.

A better solution would be https://github.com/PostgREST/postgrest/issues/934#issuecomment-478696637, but for now I'll do this. 

Also added support for #1264.