### PR TITLE
The process should not run as root within docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,6 +39,12 @@ ENV PGRST_DB_URI= \
     PGRST_PRE_REQUEST= \
     PGRST_ROLE_CLAIM_KEY=".role"
 
+RUN groupadd -g 1000 postgrest && \
+    useradd -r -u 1000 -g postgrest postgrest && \
+    chown postgrest:postgrest /etc/postgrest.conf
+
+USER 1000
+
 # PostgREST reads /etc/postgrest.conf so map the configuration
 # file in when you run this container
 CMD exec postgrest /etc/postgrest.conf


### PR DESCRIPTION
The docker image should not run as root by default.
I think it is best practice to create a separate user to run the process. Therefore I added a user and modified the docker image to use this user.