### PR TITLE
Fix tests expected responses due to changes in pg11

### DIFF
--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -374,6 +374,9 @@ pgVersion96 = PgVersion 90600 "9.6"
 pgVersion100 :: PgVersion
 pgVersion100 = PgVersion 100000 "10"
 
+pgVersion112 :: PgVersion
+pgVersion112 = PgVersion 110002 "11.2"
+
 sourceCTEName :: SqlFragment
 sourceCTEName = "pg_source"
 

--- a/test/Feature/JsonOperatorSpec.hs
+++ b/test/Feature/JsonOperatorSpec.hs
@@ -1,12 +1,12 @@
 module Feature.JsonOperatorSpec where
 
-import Network.HTTP.Types
 import Test.Hspec
 import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
+import Network.HTTP.Types
 
-import Network.Wai         (Application)
 import SpecHelper
+import Network.Wai         (Application)
 
 import Protolude           hiding (get)
 

--- a/test/Feature/JsonOperatorSpec.hs
+++ b/test/Feature/JsonOperatorSpec.hs
@@ -1,16 +1,16 @@
 module Feature.JsonOperatorSpec where
 
-import           Network.HTTP.Types
-import           Test.Hspec
-import           Test.Hspec.Wai
-import           Test.Hspec.Wai.JSON
+import Network.HTTP.Types
+import Test.Hspec
+import Test.Hspec.Wai
+import Test.Hspec.Wai.JSON
 
-import           Network.Wai         (Application)
-import           SpecHelper
+import Network.Wai         (Application)
+import SpecHelper
 
-import           Protolude           hiding (get)
+import Protolude           hiding (get)
 
-import           PostgREST.Types     (PgVersion, pgVersion112)
+import PostgREST.Types     (PgVersion, pgVersion112)
 
 spec :: PgVersion -> SpecWith Application
 spec actualPgVersion = describe "json and jsonb operators" $ do

--- a/test/Feature/JsonOperatorSpec.hs
+++ b/test/Feature/JsonOperatorSpec.hs
@@ -6,11 +6,11 @@ import Test.Hspec.Wai.JSON
 import Network.HTTP.Types
 
 import SpecHelper
-import Network.Wai         (Application)
+import Network.Wai (Application)
 
-import Protolude           hiding (get)
+import Protolude hiding (get)
 
-import PostgREST.Types     (PgVersion, pgVersion112)
+import PostgREST.Types (PgVersion, pgVersion112)
 
 spec :: PgVersion -> SpecWith Application
 spec actualPgVersion = describe "json and jsonb operators" $ do

--- a/test/Feature/JsonOperatorSpec.hs
+++ b/test/Feature/JsonOperatorSpec.hs
@@ -1,17 +1,19 @@
 module Feature.JsonOperatorSpec where
 
-import Test.Hspec
-import Test.Hspec.Wai
-import Test.Hspec.Wai.JSON
-import Network.HTTP.Types
+import           Network.HTTP.Types
+import           Test.Hspec
+import           Test.Hspec.Wai
+import           Test.Hspec.Wai.JSON
 
-import SpecHelper
-import Network.Wai (Application)
+import           Network.Wai         (Application)
+import           SpecHelper
 
-import Protolude hiding (get)
+import           Protolude           hiding (get)
 
-spec :: SpecWith Application
-spec = describe "json and jsonb operators" $ do
+import           PostgREST.Types     (PgVersion, pgVersion112)
+
+spec :: PgVersion -> SpecWith Application
+spec actualPgVersion = describe "json and jsonb operators" $ do
   context "Shaping response with select parameter" $ do
     it "obtains a json subfield one level with casting" $
       get "/complex_items?id=eq.1&select=settings->>foo::json" `shouldRespondWith`
@@ -52,14 +54,28 @@ spec = describe "json and jsonb operators" $ do
     -- this works fine for /rpc/unexistent requests, but for this case a 500 seems more appropriate
     it "fails when a double arrow ->> is followed with a single arrow ->" $ do
       get "/json_arr?select=data->>c->1"
-        `shouldRespondWith` [json|
+        `shouldRespondWith` (
+        if actualPgVersion >= pgVersion112 then
+        [json|
+          {"hint":"No operator matches the given name and argument types. You might need to add explicit type casts.",
+           "details":null,"code":"42883","message":"operator does not exist: text -> integer"} |]
+           else
+        [json|
           {"hint":"No operator matches the given name and argument type(s). You might need to add explicit type casts.",
            "details":null,"code":"42883","message":"operator does not exist: text -> integer"} |]
+                            )
         { matchStatus  = 404 , matchHeaders = [] }
       get "/json_arr?select=data->>c->b"
-        `shouldRespondWith` [json|
+        `shouldRespondWith` (
+        if actualPgVersion >= pgVersion112 then
+        [json|
+          {"hint":"No operator matches the given name and argument types. You might need to add explicit type casts.",
+           "details":null,"code":"42883","message":"operator does not exist: text -> unknown"} |]
+           else
+        [json|
           {"hint":"No operator matches the given name and argument type(s). You might need to add explicit type casts.",
            "details":null,"code":"42883","message":"operator does not exist: text -> unknown"} |]
+                            )
         { matchStatus  = 404 , matchHeaders = [] }
 
     context "with array index" $ do

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -80,12 +80,12 @@ main = do
         [("Feature.PgVersion96Spec", Feature.PgVersion96Spec.spec) | actualPgVersion >= pgVersion96]
 
       specs = uncurry describe <$> [
-          ("Feature.AuthSpec"               , Feature.AuthSpec.spec)
+          ("Feature.AuthSpec"               , Feature.AuthSpec.spec actualPgVersion)
         , ("Feature.ConcurrentSpec"         , Feature.ConcurrentSpec.spec)
         , ("Feature.CorsSpec"               , Feature.CorsSpec.spec)
         , ("Feature.DeleteSpec"             , Feature.DeleteSpec.spec)
-        , ("Feature.InsertSpec"             , Feature.InsertSpec.spec)
-        , ("Feature.JsonOperatorSpec"       , Feature.JsonOperatorSpec.spec)
+        , ("Feature.InsertSpec"             , Feature.InsertSpec.spec actualPgVersion)
+        , ("Feature.JsonOperatorSpec"       , Feature.JsonOperatorSpec.spec actualPgVersion)
         , ("Feature.QuerySpec"              , Feature.QuerySpec.spec)
         , ("Feature.RpcSpec"                , Feature.RpcSpec.spec)
         , ("Feature.RangeSpec"              , Feature.RangeSpec.spec)


### PR DESCRIPTION
Hey there.

While running PostgREST test suit, I found 5 tests that failed. Investigating it further, it seems there was a change in postgres error messages, making the expected outputs in a way, obsolete.

Reproducing this issue by running the tests as described in the [documentation](http://postgrest.org/en/v5.1/install.html?highlight=test#testing-with-docker):
```
$ docker run --name db-scripting-test -e POSTGRES_PASSWORD=pwd -p 5434:5432 -d postgres:latest
$ POSTGREST_TEST_CONNECTION=$(test/create_test_db "postgres://postgres:pwd@localhost:5434" test_db) stack test
```
Notice the flag as latest. Omitting it or using the tag `:11` or even `:11.2` would fetch the same postgres image. To get the tests running we can simply pick the tag `:10` or anything under (and above PostgREST minimum postgres version).
I specifically picked 11.2 (which is currently latest), because both `:11.0` and `11.1`, tests fail with another issue.

This PR simply adds the `pgVersion112` value and if expressions on the affects tests to get the correct expected value.

Let me know if there's anything you would like me to improve on this PR.

Cheers