### PR TITLE
Fix invalid SQL generated for bulk upsert with empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #1221, Fix embedding other resources when having a self join - @steve-chavez
 - #1242, Fix embedding a view having a select in a where - @steve-chavez
 - #1238, Fix PostgreSQL to OpenAPI type mappings for numeric and character types - @fpusch
+- #1265, Fix query generated on bulk upsert with an empty array - @qu4tro
 
 ## [5.2.0] - 2018-12-12
 

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -295,8 +295,10 @@ requestToQuery schema _ (DbMutate (Insert mainTbl iCols onConflct putConditions 
       IgnoreDuplicates ->
         "DO NOTHING"
       MergeDuplicates  ->
-        "DO UPDATE SET " <> intercalate ", " (pgFmtIdent <> const " = EXCLUDED." <> pgFmtIdent <$> S.toList iCols)
-    ) `emptyOnFalse` null oncCols) onConflct,
+        if S.null iCols
+           then "DO NOTHING"
+           else "DO UPDATE SET " <> intercalate ", " (pgFmtIdent <> const " = EXCLUDED." <> pgFmtIdent <$> S.toList iCols)
+                                   ) `emptyOnFalse` null oncCols) onConflct,
     ("RETURNING " <> intercalate ", " (map (pgFmtColumn qi) returnings)) `emptyOnFalse` null returnings]
   where
     qi = QualifiedIdentifier schema mainTbl

--- a/test/Feature/UpsertSpec.hs
+++ b/test/Feature/UpsertSpec.hs
@@ -44,7 +44,7 @@ spec =
             , matchHeaders = ["Preference-Applied" <:> "resolution=merge-duplicates", matchContentTypeJson]
             }
 
-        it "succeeds when the payload has no elements" $ do
+        it "succeeds when the payload has no elements" $
           request methodPost "/articles" [("Prefer", "return=representation"), ("Prefer", "resolution=merge-duplicates")]
             [json|[]|] `shouldRespondWith`
             [json|[]|] { matchStatus = 201 , matchHeaders = [matchContentTypeJson] }

--- a/test/Feature/UpsertSpec.hs
+++ b/test/Feature/UpsertSpec.hs
@@ -44,6 +44,12 @@ spec =
             , matchHeaders = ["Preference-Applied" <:> "resolution=merge-duplicates", matchContentTypeJson]
             }
 
+        it "succeeds when the payload has no elements" $ do
+          request methodPost "/articles" [("Prefer", "return=representation"), ("Prefer", "resolution=merge-duplicates")]
+            [json|[]|] `shouldRespondWith`
+            [json|[]|] { matchStatus = 201 , matchHeaders = [matchContentTypeJson] }
+
+
       context "when Prefer: resolution=ignore-duplicates is specified" $ do
         it "INSERTs and ignores rows on pk conflict" $
           request methodPost "/tiobe_pls" [("Prefer", "return=representation"), ("Prefer", "resolution=ignore-duplicates")]


### PR DESCRIPTION
Simple fix and respective test that resolves #1265.

I've added a simple check to check what columns are selected. If none are (the reason behind the syntax error), then it creates a `DO NOTHING` as suggested in the issue.