### PR TITLE
include error message with custom raised errors

### DIFF
--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -129,6 +129,7 @@ instance JSON.ToJSON H.CommandError where
   toJSON (H.ResultError (H.ServerError c m d h)) = case toS c of
     'P':'T':_ ->
       JSON.object [
+        "message" .= (toS m::Text),
         "details" .= (fmap toS d::Maybe Text),
         "hint" .= (fmap toS h::Maybe Text)]
     _ ->

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -296,7 +296,7 @@ spec =
 
     it "can map a RAISE error code and message to a http status" $
       get "/rpc/raise_pt402"
-        `shouldRespondWith` [json|{ "hint": "Upgrade your plan", "details": "Quota exceeded" }|]
+        `shouldRespondWith` [json|{ "error": "Payment Required", "hint": "Upgrade your plan", "details": "Quota exceeded" }|]
         { matchStatus  = 402
         , matchHeaders = [matchContentTypeJson]
         }


### PR DESCRIPTION
currently only details/hint shows up, error (the main message) is skipped

there is a test to fix, trying to do it directly from GH interface, don't have local clone configured, if it does not work we'll delete it later