### PR TITLE
[WIP] Correct status code on upserts

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -167,7 +167,7 @@ app dbStructure proc cols conf apiRequest =
 
                 (CTSingularJSON, _, Full) ->
                   do HT.condemn
-                     return $ singularityError (toInteger queryTotal)
+                     return . errorResponseFor . singularityError $ toInteger queryTotal
 
                 (_, 0, _) ->
                   successResponse

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -155,23 +155,25 @@ app dbStructure proc cols conf apiRequest =
                         else (\x -> ("Preference-Applied", show x)) <$> iPreferResolution apiRequest
                     ]
 
-              let successBody = if iPreferRepresentation apiRequest == Full then toS body else ""
+                  successBody = if iPreferRepresentation apiRequest == Full then toS body else ""
+                  status | queryTotal == 0 = status200
+                         | otherwise       = status201
 
-              let successResponse status = return (responseLBS status headers successBody)
+                  successResponse = return (responseLBS status headers successBody)
 
               case (contentType, queryTotal, iPreferRepresentation apiRequest) of
                 (CTSingularJSON, 1, Full) ->
-                  successResponse status201
+                  successResponse
 
                 (CTSingularJSON, _, Full) ->
                   do HT.condemn
                      return $ singularityError (toInteger queryTotal)
 
                 (_, 0, _) ->
-                  successResponse status200
+                  successResponse
 
                 (_, _, _) ->
-                  successResponse status201
+                  successResponse
 
         (ActionUpdate, TargetIdent (QualifiedIdentifier tSchema tName), Just pJson) ->
           case mutateSqlParts tSchema tName of

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -146,7 +146,7 @@ spec actualPgVersion = do
                        [json| [] |]
           liftIO $ do
             simpleBody p `shouldBe` [json| [] |]
-            simpleStatus p `shouldBe` created201
+            simpleStatus p `shouldBe` ok200
 
         it "can insert in tables with no select privileges" $ do
           p <- request methodPost "/insertonly"
@@ -154,7 +154,7 @@ spec actualPgVersion = do
                        [json| { "v":"some value" } |]
           liftIO $ do
             simpleBody p `shouldBe` ""
-            simpleStatus p `shouldBe` created201
+            simpleStatus p `shouldBe` ok200
 
 
         it "can post nulls" $ do

--- a/test/Feature/SingularSpec.hs
+++ b/test/Feature/SingularSpec.hs
@@ -87,7 +87,7 @@ spec =
           [("Prefer", "return=minimal"), singular]
           [json| [ { id: 101, address: "xxx" } ] |]
           `shouldRespondWith` ""
-          { matchStatus  = 201
+          { matchStatus  = 200
           , matchHeaders = ["Content-Range" <:> "*/*"]
           }
         -- and the element should exist
@@ -112,7 +112,7 @@ spec =
           [("Prefer", "return=minimal"), singular]
           [json| [ { id: 200, address: "xxx" }, { id: 201, address: "yyy" } ] |]
           `shouldRespondWith` ""
-          { matchStatus  = 201
+          { matchStatus  = 200
           , matchHeaders = ["Content-Range" <:> "*/*"]
           }
 

--- a/test/Feature/UpsertSpec.hs
+++ b/test/Feature/UpsertSpec.hs
@@ -101,10 +101,10 @@ spec =
       it "succeeds if not a single resource is created" $ do
         request methodPost "/tiobe_pls" [("Prefer", "return=representation"), ("Prefer", "resolution=ignore-duplicates")]
           [json|[ { "name": "Java", "rank": 1 } ]|] `shouldRespondWith`
-          [json|[]|] { matchStatus = 201 , matchHeaders = [matchContentTypeJson] }
+          [json|[]|] { matchStatus = 200 , matchHeaders = [matchContentTypeJson] }
         request methodPost "/tiobe_pls" [("Prefer", "return=representation"), ("Prefer", "resolution=ignore-duplicates")]
           [json|[ { "name": "Java", "rank": 1 }, { "name": "C", "rank": 2 } ]|] `shouldRespondWith`
-          [json|[]|] { matchStatus = 201 , matchHeaders = [matchContentTypeJson] }
+          [json|[]|] { matchStatus = 200 , matchHeaders = [matchContentTypeJson] }
 
     context "with PUT" $ do
       context "Restrictions" $ do
@@ -271,7 +271,7 @@ spec =
             { "idUnitTest": 1, "nameUnitTest": "name of unittest 1" },
             { "idUnitTest": 2, "nameUnitTest": "name of unittest 2" }
           ]|] `shouldRespondWith` [json|[]|]
-          { matchStatus = 201
+          { matchStatus = 200
           , matchHeaders = ["Preference-Applied" <:> "resolution=ignore-duplicates", matchContentTypeJson]
           }
 


### PR DESCRIPTION
As discussed in #1270 . Quoting my description of the changes made:

> Changed return code to 200 and both tests to expect 200 as discussed. A few others tests started to fail as a result, which I changed them as well. These fall under two fields: 
> `return=minimal` - When using return=minimal, the query  that it is built is hardcoded with a zero. I'm guessing that's for  performance reasons and I don't think that's bad, since it's explicit. 
`resolution=ignore-duplicates` when no row is actually inserted.

@steve-chavez , also quoting your description of an additional step that will also fix #1070 :
> I think `return=minimal` responding with 200 is not accurate when a resource is created, it should be `201`. We could make it work by having the same query for this [two](https://github.com/PostgREST/postgrest/blob/master/src/PostgREST/QueryBuilder.hs#L111-L117) and returning [xmax](https://www.postgresql.org/docs/11/ddl-system-columns.html) in this [line](https://github.com/PostgREST/postgrest/blob/master/src/PostgREST/DbRequestBuilder.hs#L342).

