### PR TITLE
Add config option for pool timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #690, Add `?columns` query parameter for faster bulk inserts, also ignores unspecified json keys in a payload - @steve-chavez
 - #1239, Add support for resource embedding on materialized views - @vitorbaptista
 - #1264, Add support for bulk RPC call - @steve-chavez
+- #1278, Add db-pool-timeout config option - @qu4tro
 
 ### Fixed
 
@@ -19,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #1238, Fix PostgreSQL to OpenAPI type mappings for numeric and character types - @fpusch
 - #1265, Fix query generated on bulk upsert with an empty array - @qu4tro
 - #1273, Fix RPC ignoring unknown arguments by default - @steve-chavez
+- #1257, Fix incorrect status when a PATCH request doesn't find rows to change - @qu4tro
 
 ## [5.2.0] - 2018-12-12
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -164,7 +164,7 @@ main = do
   --
   -- create connection pool with the provided settings, returns either
   -- a 'Connection' or a 'ConnectionError'. Does not throw.
-  pool <- P.acquire (configPool conf, 10, pgSettings)
+  pool <- P.acquire (configPool conf, toEnum $ configPoolTimeout conf, pgSettings)
   --
   -- To be filled in by connectionWorker
   refDbStructure <- newIORef Nothing

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -164,7 +164,7 @@ main = do
   --
   -- create connection pool with the provided settings, returns either
   -- a 'Connection' or a 'ConnectionError'. Does not throw.
-  pool <- P.acquire (configPool conf, toEnum $ configPoolTimeout conf, pgSettings)
+  pool <- P.acquire (configPool conf, (fromRational . toRational . configPoolTimeout) conf, pgSettings)
   --
   -- To be filled in by connectionWorker
   refDbStructure <- newIORef Nothing

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -4,7 +4,7 @@ module Main where
 
 
 import           PostgREST.App              (postgrest)
-import           PostgREST.Config           (AppConfig (..),
+import           PostgREST.Config           (AppConfig (..), configPoolTimeout',
                                              prettyVersion, readOptions)
 import           PostgREST.DbStructure      (getDbStructure, getPgVersion)
 import           PostgREST.Error            (encodeError)
@@ -164,7 +164,7 @@ main = do
   --
   -- create connection pool with the provided settings, returns either
   -- a 'Connection' or a 'ConnectionError'. Does not throw.
-  pool <- P.acquire (configPool conf, (fromRational . toRational . configPoolTimeout) conf, pgSettings)
+  pool <- P.acquire (configPool conf, configPoolTimeout' conf, pgSettings)
   --
   -- To be filled in by connectionWorker
   refDbStructure <- newIORef Nothing

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -74,7 +74,7 @@ data AppConfig = AppConfig {
   , configJwtAudience       :: Maybe StringOrURI
 
   , configPool              :: Int
-  , configPoolTimeout       :: Float
+  , configPoolTimeout       :: Int
   , configMaxRows           :: Maybe Integer
   , configReqCheck          :: Maybe Text
   , configQuiet             :: Bool
@@ -143,7 +143,7 @@ readOptions = do
           <*> (fromMaybe False . join . fmap coerceBool <$> C.key "secret-is-base64")
           <*> parseJwtAudience "jwt-aud"
           <*> (fromMaybe 10 . join . fmap coerceInt <$> C.key "db-pool")
-          <*> (fromMaybe 10.0 . join . fmap coerceFloat <$> C.key "db-pool-timeout")
+          <*> (fromMaybe 10 . join . fmap coerceInt <$> C.key "db-pool-timeout")
           <*> (join . fmap coerceInt <$> C.key "max-rows")
           <*> (mfilter (/= "") <$> C.key "pre-request")
           <*> pure False
@@ -172,16 +172,10 @@ readOptions = do
     coerceText (String s) = s
     coerceText v = show v
 
-    coerceNum :: (Read i, Num i) => Value -> Maybe i
-    coerceNum (Number x) = fromIntegral <$> (rightToMaybe . floatingOrInteger $ x)
-    coerceNum (String x) = readMaybe $ toS x
-    coerceNum _          = Nothing
-
     coerceInt :: (Read i, Integral i) => Value -> Maybe i
-    coerceInt = coerceNum
-
-    coerceFloat :: (Read i, RealFloat i) => Value -> Maybe i
-    coerceFloat = coerceNum
+    coerceInt (Number x) = rightToMaybe $ floatingOrInteger x
+    coerceInt (String x) = readMaybe $ toS x
+    coerceInt _          = Nothing
 
     coerceBool :: Value -> Maybe Bool
     coerceBool (Bool b)   = Just b

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -19,6 +19,7 @@ module PostgREST.Config ( prettyVersion
                         , readOptions
                         , corsPolicy
                         , AppConfig (..)
+                        , configPoolTimeout'
                         )
        where
 
@@ -35,7 +36,6 @@ import qualified Data.Configurator.Parser     as C
 import           Data.Configurator.Types      as C
 import           Data.List                    (lookup)
 import           Data.Monoid
--- import           Data.Time.Clock.UTC          (NominalDiffTime)
 import           Data.Scientific              (floatingOrInteger)
 import           Data.String                  (String)
 import           Data.Text                    (dropWhileEnd, dropEnd,
@@ -82,6 +82,11 @@ data AppConfig = AppConfig {
   , configRoleClaimKey      :: Either ApiRequestError JSPath
   , configExtraSearchPath   :: [Text]
   }
+
+configPoolTimeout' :: (Fractional a) => AppConfig -> a
+configPoolTimeout' =
+  fromRational . toRational . configPoolTimeout
+
 
 defaultCorsPolicy :: CorsResourcePolicy
 defaultCorsPolicy =  CorsResourcePolicy Nothing

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -73,6 +73,7 @@ data AppConfig = AppConfig {
   , configJwtAudience       :: Maybe StringOrURI
 
   , configPool              :: Int
+  , configPoolTimeout       :: Int
   , configMaxRows           :: Maybe Integer
   , configReqCheck          :: Maybe Text
   , configQuiet             :: Bool
@@ -136,6 +137,7 @@ readOptions = do
           <*> (fromMaybe False . join . fmap coerceBool <$> C.key "secret-is-base64")
           <*> parseJwtAudience "jwt-aud"
           <*> (fromMaybe 10 . join . fmap coerceInt <$> C.key "db-pool")
+          <*> (fromMaybe 10 . join . fmap coerceInt <$> C.key "db-pool-timeout")
           <*> (join . fmap coerceInt <$> C.key "max-rows")
           <*> (mfilter (/= "") <$> C.key "pre-request")
           <*> pure False
@@ -208,6 +210,7 @@ readOptions = do
           |db-schema = "public" # this schema gets added to the search_path of every request
           |db-anon-role = "postgres"
           |db-pool = 10
+          |db-pool-timeout = 10
           |
           |server-host = "127.0.0.1"
           |server-port = 3000

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -172,15 +172,16 @@ readOptions = do
     coerceText (String s) = s
     coerceText v = show v
 
+    coerceNum :: (Read i, Num i) => Value -> Maybe i
+    coerceNum (Number x) = fromIntegral <$> (rightToMaybe . floatingOrInteger $ x)
+    coerceNum (String x) = readMaybe $ toS x
+    coerceNum _          = Nothing
+
     coerceInt :: (Read i, Integral i) => Value -> Maybe i
-    coerceInt (Number x) = rightToMaybe $ floatingOrInteger x
-    coerceInt (String x) = readMaybe $ toS x
-    coerceInt _          = Nothing
+    coerceInt = coerceNum
 
     coerceFloat :: (Read i, RealFloat i) => Value -> Maybe i
-    coerceFloat (Number x) = fromIntegral <$> (rightToMaybe . floatingOrInteger $ x)
-    coerceFloat (String x) = readMaybe $ toS x
-    coerceFloat _          = Nothing
+    coerceFloat = coerceNum
 
     coerceBool :: Value -> Maybe Bool
     coerceBool (Bool b)   = Just b

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -178,7 +178,7 @@ readOptions = do
     coerceInt _          = Nothing
 
     coerceFloat :: (Read i, RealFloat i) => Value -> Maybe i
-    coerceFloat (Number x) = leftToMaybe $ floatingOrInteger x
+    coerceFloat (Number x) = rightToMaybe $ floatingOrInteger x
     coerceFloat (String x) = readMaybe $ toS x
     coerceFloat _          = Nothing
 

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -178,7 +178,7 @@ readOptions = do
     coerceInt _          = Nothing
 
     coerceFloat :: (Read i, RealFloat i) => Value -> Maybe i
-    coerceFloat (Number x) = rightToMaybe $ floatingOrInteger x
+    coerceFloat (Number x) = fromIntegral <$> (rightToMaybe . floatingOrInteger $ x)
     coerceFloat (String x) = readMaybe $ toS x
     coerceFloat _          = Nothing
 

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -70,7 +70,7 @@ _baseCfg =  -- Connection Settings
             -- Jwt settings
             (Just $ encodeUtf8 "reallyreallyreallyreallyverysafe") False Nothing
             -- Connection Modifiers
-            10 Nothing (Just "test.switch_role")
+            10 10 Nothing (Just "test.switch_role")
             -- Debug Settings
             True
             [ ("app.settings.app_host", "localhost")


### PR DESCRIPTION
Resolves #1278 

Added to config, key `db-pool-timeout` that accepts float/int.