### PR TITLE
Breaking changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,15 +91,6 @@ jobs:
       - run:
           name: run linter
           command: git ls-files | grep '\.l\?hs$' | xargs stack exec -- hlint -X QuasiQuotes -X NoPatternSynonyms "$@"
-      - run:
-          name: extra checks
-          command: |
-            stack exec -- cabal update
-            stack exec --no-ghc-package-path -- cabal install --only-d --dry-run
-            stack exec -- packdeps *.cabal || true
-            stack exec -- cabal check
-            stack haddock --no-haddock-deps
-            stack sdist
       - save_cache:
           paths:
             - "~/.stack"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #1273, Fix RPC ignoring unknown arguments by default - @steve-chavez
 - #1257, Fix incorrect status when a PATCH request doesn't find rows to change - @qu4tro
 
+### Changed
+
+- #1288, Change server-host default of 127.0.0.1 to !4
+
 ### Removed
 
 - #1288, Removed support for schema reloading with SIGHUP, SIGUSR1 should be used instead - @steve-chavez

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - #1288, Change server-host default of 127.0.0.1 to !4
 
+### Deprecated
+
+- #1288, Deprecate `.` symbol for disambiguating resource embedding(added in #918). '+' should be used instead. Though '+' is url safe, certain clients might need to encode it to '%2B'.
+
 ### Removed
 
 - #1288, Removed support for schema reloading with SIGHUP, SIGUSR1 should be used instead - @steve-chavez

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #1273, Fix RPC ignoring unknown arguments by default - @steve-chavez
 - #1257, Fix incorrect status when a PATCH request doesn't find rows to change - @qu4tro
 
+### Removed
+
+- #1288, Removed support for schema reloading with SIGHUP, SIGUSR1 should be used instead - @steve-chavez
+
 ## [5.2.0] - 2018-12-12
 
 ### Added

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -198,15 +198,14 @@ main = do
         throwTo mainTid UserInterrupt
       ) Nothing
 
-  forM_ [sigHUP, sigUSR1] $ \sig ->
-    void $ installHandler sig (
-      Catch $ connectionWorker
-                mainTid
-                pool
-                (configSchema conf)
-                refDbStructure
-                refIsWorkerOn
-      ) Nothing
+  void $ installHandler sigUSR1 (
+    Catch $ connectionWorker
+              mainTid
+              pool
+              (configSchema conf)
+              refDbStructure
+              refIsWorkerOn
+    ) Nothing
 #endif
 
 

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -137,7 +137,7 @@ readOptions = do
           <*> C.key "db-anon-role"
           <*> (mfilter (/= "") <$> C.key "server-proxy-uri")
           <*> C.key "db-schema"
-          <*> (fromMaybe "127.0.0.1" . mfilter (/= "") <$> C.key "server-host")
+          <*> (fromMaybe "!4" . mfilter (/= "") <$> C.key "server-host")
           <*> (fromMaybe 3000 . join . fmap coerceInt <$> C.key "server-port")
           <*> (fmap encodeUtf8 . mfilter (/= "") <$> C.key "jwt-secret")
           <*> (fromMaybe False . join . fmap coerceBool <$> C.key "secret-is-base64")
@@ -218,7 +218,7 @@ readOptions = do
           |db-pool = 10
           |db-pool-timeout = 10
           |
-          |server-host = "127.0.0.1"
+          |server-host = "!4"
           |server-port = 3000
           |
           |## base url for swagger output

--- a/src/PostgREST/Parsers.hs
+++ b/src/PostgREST/Parsers.hs
@@ -124,7 +124,10 @@ pRelationSelect :: Parser SelectItem
 pRelationSelect = lexeme $ try ( do
     alias <- optionMaybe ( try(pFieldName <* aliasSeparator) )
     fld <- pField
-    relationDetail <- optionMaybe ( try( char '.' *> pFieldName ) )
+    relationDetail <- optionMaybe (
+        try ( char '+' *> pFieldName ) <|>
+        try ( char '.' *> pFieldName ) -- TODO deprecated, remove in next major version
+      )
 
     return (fld, Nothing, alias, relationDetail)
   )

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,7 +12,12 @@ extra-deps:
   - text-builder-0.5.1.1
   - jose-0.7.0.0
   - postgresql-libpq-0.9.4.1
+  - http-types-0.12.3
+  - wai-middleware-static-0.8.2
 ghc-options:
   postgrest: -O2 -Werror -Wall -fwarn-identities -fno-warn-redundant-constraints
 nix:
   packages: [postgresql, zlib]
+# only added because of hjsonschema conflict with http-types
+# once hjsonschema upper bounding on http-types is solved it can be removed
+allow-newer: true

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -443,12 +443,12 @@ spec = do
 
     describe "path fixed" $ do
       it "works when requesting children 2 levels" $
-        get "/clients?id=eq.1&select=id,projects:projects.client_id(id,tasks(id))" `shouldRespondWith`
+        get "/clients?id=eq.1&select=id,projects:projects%2Bclient_id(id,tasks(id))" `shouldRespondWith`
           [json|[{"id":1,"projects":[{"id":1,"tasks":[{"id":1},{"id":2}]},{"id":2,"tasks":[{"id":3},{"id":4}]}]}]|]
           { matchHeaders = [matchContentTypeJson] }
 
       it "works with parent relation" $
-        get "/message?select=id,body,sender:person.sender(name),recipient:person.recipient(name)&id=lt.4" `shouldRespondWith`
+        get "/message?select=id,body,sender:person%2Bsender(name),recipient:person%2Brecipient(name)&id=lt.4" `shouldRespondWith`
           [json|
             [{"id":1,"body":"Hello Jane","sender":{"name":"John"},"recipient":{"name":"Jane"}},
              {"id":2,"body":"Hi John","sender":{"name":"Jane"},"recipient":{"name":"John"}},
@@ -456,7 +456,7 @@ spec = do
           { matchHeaders = [matchContentTypeJson] }
 
       it "works with a parent view relation" $
-        get "/message?select=id,body,sender:person_detail.sender(name,sent),recipient:person_detail.recipient(name,received)&id=lt.4" `shouldRespondWith`
+        get "/message?select=id,body,sender:person_detail%2Bsender(name,sent),recipient:person_detail%2Brecipient(name,received)&id=lt.4" `shouldRespondWith`
           [json|
             [{"id":1,"body":"Hello Jane","sender":{"name":"John","sent":2},"recipient":{"name":"Jane","received":2}},
              {"id":2,"body":"Hi John","sender":{"name":"Jane","sent":1},"recipient":{"name":"John","received":1}},
@@ -464,9 +464,18 @@ spec = do
           { matchHeaders = [matchContentTypeJson] }
 
       it "works with many<->many relation" $
-        get "/tasks?select=id,users:users.users_tasks(id)" `shouldRespondWith`
+        get "/tasks?select=id,users:users%2Busers_tasks(id)" `shouldRespondWith`
           [json|[{"id":1,"users":[{"id":1},{"id":3}]},{"id":2,"users":[{"id":1}]},{"id":3,"users":[{"id":1}]},{"id":4,"users":[{"id":1}]},{"id":5,"users":[{"id":2},{"id":3}]},{"id":6,"users":[{"id":2}]},{"id":7,"users":[{"id":2}]},{"id":8,"users":[]}]|]
           { matchHeaders = [matchContentTypeJson] }
+
+      describe "old dot '.' symbol, deprecated" $
+        it "still works" $ do
+          get "/clients?id=eq.1&select=id,projects:projects.client_id(id,tasks(id))" `shouldRespondWith`
+            [json|[{"id":1,"projects":[{"id":1,"tasks":[{"id":1},{"id":2}]},{"id":2,"tasks":[{"id":3},{"id":4}]}]}]|]
+            { matchHeaders = [matchContentTypeJson] }
+          get "/tasks?select=id,users:users.users_tasks(id)" `shouldRespondWith`
+            [json|[{"id":1,"users":[{"id":1},{"id":3}]},{"id":2,"users":[{"id":1}]},{"id":3,"users":[{"id":1}]},{"id":4,"users":[{"id":1}]},{"id":5,"users":[{"id":2},{"id":3}]},{"id":6,"users":[{"id":2}]},{"id":7,"users":[{"id":2}]},{"id":8,"users":[]}]|]
+            { matchHeaders = [matchContentTypeJson] }
 
     describe "aliased embeds" $ do
       it "works with child relation" $
@@ -536,7 +545,7 @@ spec = do
             { matchHeaders = [matchContentTypeJson] }
 
         it "embeds childs recursively" $
-          get "/family_tree?id=eq.1&select=id,name, childs:family_tree.parent(id,name,childs:family_tree.parent(id,name))" `shouldRespondWith`
+          get "/family_tree?id=eq.1&select=id,name, childs:family_tree%2Bparent(id,name,childs:family_tree%2Bparent(id,name))" `shouldRespondWith`
             [json|[{
               "id": "1", "name": "Parental Unit", "childs": [
                 { "id": "2", "name": "Kid One", "childs": [ { "id": "4", "name": "Grandkid One" } ] },
@@ -545,7 +554,7 @@ spec = do
             }]|] { matchHeaders = [matchContentTypeJson] }
 
         it "embeds parent and then embeds childs" $
-          get "/family_tree?id=eq.2&select=id,name,parent(id,name,childs:family_tree.parent(id,name))" `shouldRespondWith`
+          get "/family_tree?id=eq.2&select=id,name,parent(id,name,childs:family_tree%2Bparent(id,name))" `shouldRespondWith`
             [json|[{
               "id": "2", "name": "Kid One", "parent": {
                 "id": "1", "name": "Parental Unit", "childs": [ { "id": "2", "name": "Kid One" }, { "id": "3", "name": "Kid Two"} ]
@@ -568,7 +577,7 @@ spec = do
             }]|] { matchHeaders = [matchContentTypeJson] }
 
         it "embeds childs" $ do
-          get "/organizations?select=id,name,refereeds:organizations.referee(id,name)&id=eq.1" `shouldRespondWith`
+          get "/organizations?select=id,name,refereeds:organizations%2Breferee(id,name)&id=eq.1" `shouldRespondWith`
             [json|[{
               "id": 1, "name": "Referee Org",
               "refereeds": [
@@ -582,7 +591,7 @@ spec = do
                 }
               ]
             }]|] { matchHeaders = [matchContentTypeJson] }
-          get "/organizations?select=id,name,auditees:organizations.auditor(id,name)&id=eq.2" `shouldRespondWith`
+          get "/organizations?select=id,name,auditees:organizations%2Bauditor(id,name)&id=eq.2" `shouldRespondWith`
             [json|[{
               "id": 2, "name": "Auditor Org",
               "auditees": [
@@ -616,7 +625,7 @@ spec = do
                   "manager":{"name":"Referee Manager"}}}
             }]|] { matchHeaders = [matchContentTypeJson] }
 
-          get "/organizations?select=name,manager(name),auditees:organizations.auditor(name,manager(name),refereeds:organizations.referee(name,manager(name)))&id=eq.2" `shouldRespondWith`
+          get "/organizations?select=name,manager(name),auditees:organizations%2Bauditor(name,manager(name),refereeds:organizations%2Breferee(name,manager(name)))&id=eq.2" `shouldRespondWith`
             [json|[{
               "name":"Auditor Org",
               "manager":{"name":"Auditor Manager"},


### PR DESCRIPTION
Breaking changes for the upcoming version. 

- Remove SIGHUP
- Change server-host default of 127.0.0.1 to !4
- Change symbol for disambiguating resource embedding(undocumented featured added in #918) from dot '.' to plus '+'. Used to be `/clients?select=id,projects:projects.client_id(id,tasks(id))`, now is `/clients?select=id,projects:project+client_id(id,tasks(id))`.
  + Dot is not clear since we already use the dot '.' for representing embedded filters.
  + Dot in pg implies dot notation(e.g. `table.col`) which is not the case when we use the dot for disambiguating many to many relationships. 