### PR TITLE
Re-read configuration and schema on SIGUSR2

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -23,7 +23,8 @@ import Network.Wai.Handler.Warp (defaultSettings, runSettings,
                                  setGracefulShutdownTimeout, setHost,
                                  setInstallShutdownHandler, setPort,
                                  setServerName)
-import System.IO                (BufferMode (..), hSetBuffering)
+
+import System.IO (BufferMode (..), hSetBuffering)
 
 import PostgREST.App         (postgrest)
 import PostgREST.Config      (AppConfig (..), configPoolTimeout',


### PR DESCRIPTION
This adds a signal handler that allows re-reading configuration and schema, by closing all open connections and restarting.

One thing I noticed, is that if the server is inside `connectionWorker` trying to connect, there still won't be a connection to close and it will keep its attempts.

Resolves #1119 