### PR TITLE
Update Dockerfile base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM ubuntu:18.04
 
 ARG POSTGREST_VERSION
 


### PR DESCRIPTION
Debian Jessie is quite old now and causes some issues with the `sources.list` when extending the image. `debian-stretch` also works in case there is a preference for that.