### PR TITLE
Add shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,19 @@
+with import (builtins.fetchGit {
+  url = https://github.com/NixOS/nixpkgs-channels;
+  ref = "nixos-17.09";
+  rev = "14f9ee66e63077539252f8b4550049381a082518";
+}) {};
+# alternatively you can add 17.09 to your channels with:
+#
+# nix-channel --add https://nixos.org/channels/nixos-17.09 nixos-17.09
+# nix-channel --update
+#
+# and then remove the above and uncomment this line.
+#with (import <nixos-17.09> {});
+
+haskell.lib.buildStackProject {
+  name = "postgrest";
+  # nixos-17.09 has ghc 8.0.2 by default
+  # this is the one used by stack lts-9.6
+  buildInputs = [ ghc postgresql zlib pcre ];
+}

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@ extra-deps:
 ghc-options:
   postgrest: -O2 -Werror -Wall -fwarn-identities -fno-warn-redundant-constraints
 nix:
-  packages: [postgresql, zlib]
+  shell-file: shell.nix
 # only added because of hjsonschema conflict with http-types
 # once hjsonschema upper bounding on http-types is solved it can be removed
 allow-newer: true


### PR DESCRIPTION
For NixOS users. Couldn't  `stack build` with latest NixOS(19.03) otherwise.