### PR TITLE
Update stylish haskell config; apply all; add CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
             sudo apt-get install -y postgresql-client
             stack setup
             rm -rf $(stack path --dist-dir) $(stack path --local-install-root)
-            stack install hlint packdeps cabal-install
+            stack install hlint packdeps cabal-install stylish-haskell
       - run:
           name: build src and tests
           command: |
@@ -91,6 +91,9 @@ jobs:
       - run:
           name: run linter
           command: git ls-files | grep '\.l\?hs$' | xargs stack exec -- hlint -X QuasiQuotes -X NoPatternSynonyms "$@"
+      - run:
+          name: run styler
+          command: git ls-files | grep '\.l\?hs$' | xargs stack exec -- stylish-haskell -i && git diff-index --quiet HEAD --
       - save_cache:
           paths:
             - "~/.stack"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
           command: git ls-files | grep '\.l\?hs$' | xargs stack exec -- hlint -X QuasiQuotes -X NoPatternSynonyms "$@"
       - run:
           name: run styler
-          command: git ls-files | grep '\.l\?hs$' | xargs stack exec -- stylish-haskell -i && git diff-index --quiet HEAD --
+          command: git ls-files | grep '\.l\?hs$' | xargs stack exec -- stylish-haskell -i && git diff-index --exit-code HEAD --
       - save_cache:
           paths:
             - "~/.stack"

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -41,7 +41,7 @@ steps:
       # Default: global.
       align: global
 
-      # Folowing options affect only import list alignment.
+      # The following options affect only import list alignment.
       #
       # List align has following options:
       #
@@ -64,6 +64,25 @@ steps:
       # Default: after_alias
       list_align: after_alias
 
+      # Right-pad the module names to align imports in a group:
+      #
+      # - true: a little more readable
+      #
+      #   > import qualified Data.List       as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # - false: diff-safe
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, init,
+      #   >                                     last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # Default: true
+      pad_module_names: true
+
       # Long list align style takes effect when import is too long. This is
       # determined by 'columns' setting.
       #
@@ -75,7 +94,7 @@ steps:
       #   short enough to fit to single line. Otherwise it'll be multiline.
       #
       # - multiline: One line per import list entry.
-      #   Type with contructor list acts like single import.
+      #   Type with constructor list acts like single import.
       #
       #   > import qualified Data.Map as M
       #   >     ( empty
@@ -109,7 +128,7 @@ steps:
       #   Useful for 'file' and 'group' align settings.
       list_padding: 4
 
-      # Separate lists option affects formating of import list for type
+      # Separate lists option affects formatting of import list for type
       # or class. The only difference is single space between type and list
       # of constructors, selectors and class functions.
       #
@@ -125,6 +144,22 @@ steps:
       #
       # Default: true
       separate_lists: true
+
+      # Space surround option affects formatting of import lists on a single
+      # line. The only difference is single space after the initial
+      # parenthesis and a single space before the terminal parenthesis.
+      #
+      # - true: There is single space associated with the enclosing
+      #   parenthesis.
+      #
+      #   > import Data.Foo ( foo )
+      #
+      # - false: There is no space associated with the enclosing parenthesis
+      #
+      #   > import Data.Foo (foo)
+      #
+      # Default: false
+      space_surround: false
 
   # Language pragmas
   - language_pragmas:
@@ -142,7 +177,7 @@ steps:
 
       # Align affects alignment of closing pragma brackets.
       #
-      # - true: Brackets are aligned in same collumn.
+      # - true: Brackets are aligned in same column.
       #
       # - false: Brackets are not aligned together. There is only one space
       #   between actual import and closing bracket.
@@ -162,6 +197,11 @@ steps:
 
   # Remove trailing whitespace
   - trailing_whitespace: {}
+
+  # Squash multiple spaces between the left and right hand sides of some
+  # elements into single spaces. Basically, this undoes the effect of
+  # simple_align but is a bit less conservative.
+  # - squash: {}
 
 # A common setting is the number of columns (parts of) code will be wrapped
 # to. Different steps take this into account. Default: 80.

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -198,11 +198,6 @@ steps:
   # Remove trailing whitespace
   - trailing_whitespace: {}
 
-  # Squash multiple spaces between the left and right hand sides of some
-  # elements into single spaces. Basically, this undoes the effect of
-  # simple_align but is a bit less conservative.
-  # - squash: {}
-
 # A common setting is the number of columns (parts of) code will be wrapped
 # to. Different steps take this into account. Default: 80.
 columns: 70

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,2 @@
-import Distribution.Simple
+import           Distribution.Simple
 main = defaultMain

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -4,26 +4,38 @@ module Main where
 
 
 import           PostgREST.App              (postgrest)
-import           PostgREST.Config           (AppConfig (..), configPoolTimeout',
-                                             prettyVersion, readOptions)
-import           PostgREST.DbStructure      (getDbStructure, getPgVersion)
-import           PostgREST.Error            (errorPayload, checkIsFatal, PgError(PgError))
+import           PostgREST.Config           (AppConfig (..),
+                                             configPoolTimeout',
+                                             prettyVersion,
+                                             readOptions)
+import           PostgREST.DbStructure      (getDbStructure,
+                                             getPgVersion)
+import           PostgREST.Error            (PgError (PgError),
+                                             checkIsFatal,
+                                             errorPayload)
 import           PostgREST.OpenAPI          (isMalformedProxyUri)
-import           PostgREST.Types            (DbStructure, Schema, PgVersion(..), minimumPgVersion, ConnectionStatus(..))
-import           Protolude                  hiding (hPutStrLn, replace)
+import           PostgREST.Types            (ConnectionStatus (..),
+                                             DbStructure,
+                                             PgVersion (..), Schema,
+                                             minimumPgVersion)
+import           Protolude                  hiding (hPutStrLn,
+                                             replace)
 
 
 import           Control.AutoUpdate         (defaultUpdateSettings,
-                                             mkAutoUpdate, updateAction)
+                                             mkAutoUpdate,
+                                             updateAction)
 import           Control.Retry              (RetryStatus, capDelay,
                                              exponentialBackoff,
-                                             retrying, rsPreviousDelay)
+                                             retrying,
+                                             rsPreviousDelay)
 import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Base64     as B64
 import           Data.IORef                 (IORef, atomicWriteIORef,
                                              newIORef, readIORef)
 import           Data.String                (IsString (..))
-import           Data.Text                  (pack, replace, stripPrefix, strip)
+import           Data.Text                  (pack, replace, strip,
+                                             stripPrefix)
 import           Data.Text.Encoding         (decodeUtf8, encodeUtf8)
 import           Data.Text.IO               (hPutStrLn, readFile)
 import           Data.Time.Clock            (getCurrentTime)
@@ -75,7 +87,7 @@ connectionWorker mainTid pool schema refDbStructure refIsWorkerOn = do
       putStrLn ("Attempting to connect to the database..." :: Text)
       connected <- connectionStatus pool
       case connected of
-        FatalConnectionError reason -> hPutStrLn stderr reason 
+        FatalConnectionError reason -> hPutStrLn stderr reason
                                       >> killThread mainTid    -- Fatal error when connecting
         NotConnected                -> return ()               -- Unreachable
         Connected actualPgVersion   -> do                      -- Procede with initialization
@@ -87,7 +99,7 @@ connectionWorker mainTid pool schema refDbStructure refIsWorkerOn = do
               putStrLn ("Failed to query the database. Retrying." :: Text)
               hPutStrLn stderr . toS . errorPayload $ PgError False e
               work
-              
+
             Right _ -> do
               atomicWriteIORef refIsWorkerOn False
               putStrLn ("Connection successful" :: Text)
@@ -298,6 +310,6 @@ loadDbUriFile conf = extractDbUri mDbUri
     extractDbUri dbUri =
       fmap setDbUri $
       case stripPrefix "@" dbUri of
-        Nothing -> return dbUri
+        Nothing       -> return dbUri
         Just filename -> strip <$> readFile (toS filename)
     setDbUri dbUri = conf {configDatabase = dbUri}

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -4,7 +4,7 @@ Description : PostgREST functions to translate HTTP request to a domain type cal
 -}
 {-# LANGUAGE LambdaCase #-}
 
-module PostgREST.ApiRequest ( 
+module PostgREST.ApiRequest (
   ApiRequest(..)
 , ContentType(..)
 , Action(..)
@@ -14,32 +14,38 @@ module PostgREST.ApiRequest (
 , userApiRequest
 ) where
 
-import           Protolude
+import           Control.Arrow             ((***))
 import qualified Data.Aeson                as JSON
-import           Data.Aeson.Types          (emptyObject, emptyArray)
+import           Data.Aeson.Types          (emptyArray, emptyObject)
 import qualified Data.ByteString           as BS
 import qualified Data.ByteString.Internal  as BS (c2w)
 import qualified Data.ByteString.Lazy      as BL
+import qualified Data.CaseInsensitive      as CI
 import qualified Data.Csv                  as CSV
-import qualified Data.List                 as L
-import           Data.List                 (lookup, last, partition)
 import qualified Data.HashMap.Strict       as M
-import qualified Data.Set                  as S
+import           Data.List                 (last, lookup, partition)
+import qualified Data.List                 as L
 import           Data.Maybe                (fromJust)
-import           Control.Arrow             ((***))
+import           Data.Ranged.Boundaries
+import           Data.Ranged.Ranges        (Range (..), emptyRange,
+                                            rangeIntersection)
+import qualified Data.Set                  as S
 import qualified Data.Text                 as T
 import qualified Data.Vector               as V
 import           Network.HTTP.Base         (urlEncodeVars)
 import           Network.HTTP.Types.Header (hAuthorization, hCookie)
-import           Network.HTTP.Types.URI    (parseSimpleQuery, parseQueryReplacePlus)
+import           Network.HTTP.Types.URI    (parseQueryReplacePlus,
+                                            parseSimpleQuery)
 import           Network.Wai               (Request (..))
 import           Network.Wai.Parse         (parseHttpAccept)
-import           PostgREST.RangeQuery      (NonnegRange, rangeRequested, restrictRange, rangeGeq, allRange, rangeLimit, rangeOffset)
-import           Data.Ranged.Boundaries
+import           PostgREST.Error           (ApiRequestError (..))
+import           PostgREST.RangeQuery      (NonnegRange, allRange,
+                                            rangeGeq, rangeLimit,
+                                            rangeOffset,
+                                            rangeRequested,
+                                            restrictRange)
 import           PostgREST.Types
-import           PostgREST.Error           (ApiRequestError(..))
-import           Data.Ranged.Ranges        (Range(..), rangeIntersection, emptyRange)
-import qualified Data.CaseInsensitive      as CI
+import           Protolude
 import           Web.Cookie                (parseCookiesText)
 
 type RequestBody = BL.ByteString
@@ -68,41 +74,41 @@ data PreferRepresentation = Full | HeadersOnly | None deriving Eq
 -}
 data ApiRequest = ApiRequest {
   -- | Similar but not identical to HTTP verb, e.g. Create/Invoke both POST
-    iAction :: Action
+    iAction                      :: Action
   -- | Requested range of rows within response
-  , iRange  :: M.HashMap ByteString NonnegRange
+  , iRange                       :: M.HashMap ByteString NonnegRange
   -- | The target, be it calling a proc or accessing a table
-  , iTarget :: Target
+  , iTarget                      :: Target
   -- | Content types the client will accept, [CTAny] if no Accept header
-  , iAccepts :: [ContentType]
+  , iAccepts                     :: [ContentType]
   -- | Data sent by client and used for mutation actions
-  , iPayload :: Maybe PayloadJSON
+  , iPayload                     :: Maybe PayloadJSON
   -- | If client wants created items echoed back
-  , iPreferRepresentation :: PreferRepresentation
+  , iPreferRepresentation        :: PreferRepresentation
   -- | Pass all parameters as a single json object to a stored procedure
   , iPreferSingleObjectParameter :: Bool
   -- | Whether the client wants a result count (slower)
-  , iPreferCount :: Bool
+  , iPreferCount                 :: Bool
   -- | Whether the client wants to UPSERT or ignore records on PK conflict
-  , iPreferResolution :: Maybe PreferResolution
+  , iPreferResolution            :: Maybe PreferResolution
   -- | Filters on the result ("id", "eq.10")
-  , iFilters :: [(Text, Text)]
+  , iFilters                     :: [(Text, Text)]
   -- | &and and &or parameters used for complex boolean logic
-  , iLogic :: [(Text, Text)]
+  , iLogic                       :: [(Text, Text)]
   -- | &select parameter used to shape the response
-  , iSelect :: Text
+  , iSelect                      :: Text
   -- | &columns parameter used to shape the payload
-  , iColumns :: Maybe Text
+  , iColumns                     :: Maybe Text
   -- | &order parameters for each level
-  , iOrder :: [(Text, Text)]
+  , iOrder                       :: [(Text, Text)]
   -- | Alphabetized (canonical) request query string for response URLs
-  , iCanonicalQS :: ByteString
+  , iCanonicalQS                 :: ByteString
   -- | JSON Web Token
-  , iJWT :: Text
+  , iJWT                         :: Text
   -- | HTTP request headers
-  , iHeaders :: [(Text, Text)]
+  , iHeaders                     :: [(Text, Text)]
   -- | Request Cookies
-  , iCookies :: [(Text, Text)]
+  , iCookies                     :: [(Text, Text)]
   }
 
 -- | Examines HTTP request and translates it into user intent.

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -30,7 +30,6 @@ import Control.Arrow             ((***))
 import Data.Aeson.Types          (emptyArray, emptyObject)
 import Data.List                 (last, lookup, partition)
 import Data.Maybe                (fromJust)
-import Data.Ranged.Boundaries
 import Data.Ranged.Ranges        (Range (..), emptyRange,
                                   rangeIntersection)
 import Network.HTTP.Base         (urlEncodeVars)
@@ -40,6 +39,9 @@ import Network.HTTP.Types.URI    (parseQueryReplacePlus,
 import Network.Wai               (Request (..))
 import Network.Wai.Parse         (parseHttpAccept)
 import Web.Cookie                (parseCookiesText)
+
+
+import Data.Ranged.Boundaries
 
 import PostgREST.Error      (ApiRequestError (..))
 import PostgREST.RangeQuery (NonnegRange, allRange, rangeGeq,

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -14,17 +14,18 @@ import qualified Hasql.Transaction          as H
 import qualified Hasql.Transaction          as HT
 import qualified Hasql.Transaction.Sessions as HT
 
-import Control.Applicative
 import Data.Aeson                           as JSON
 import Data.Function                        (id)
 import Data.IORef                           (IORef, readIORef)
-import Data.Maybe
 import Data.Time.Clock                      (UTCTime)
+import Network.HTTP.Types.URI               (renderSimpleQuery)
+import Network.Wai.Middleware.RequestLogger (logStdout)
+
+import Control.Applicative
+import Data.Maybe
 import Network.HTTP.Types.Header
 import Network.HTTP.Types.Status
-import Network.HTTP.Types.URI               (renderSimpleQuery)
 import Network.Wai
-import Network.Wai.Middleware.RequestLogger (logStdout)
 
 import PostgREST.ApiRequest       (Action (..), ApiRequest (..),
                                    ContentType (..),

--- a/src/PostgREST/Auth.hs
+++ b/src/PostgREST/Auth.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LambdaCase       #-}
 {-|
 Module      : PostgREST.Auth
 Description : PostgREST authorization functions.
@@ -19,8 +19,8 @@ module PostgREST.Auth (
   , parseSecret
   ) where
 
-import           Control.Lens.Operators
 import           Control.Lens           (set)
+import           Control.Lens.Operators
 import qualified Data.Aeson             as JSON
 import qualified Data.HashMap.Strict    as M
 import           Data.Time.Clock        (UTCTime)

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -12,7 +12,8 @@ turned in configurable behaviour if needed.
 
 Other hardcoded options such as the minimum version number also belong here.
 -}
-{-# LANGUAGE LambdaCase, TemplateHaskell #-}
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
 module PostgREST.Config ( prettyVersion
@@ -25,8 +26,8 @@ module PostgREST.Config ( prettyVersion
        where
 
 import           Control.Applicative
-import           Control.Monad                (fail)
 import           Control.Lens                 (preview)
+import           Control.Monad                (fail)
 import           Crypto.JWT                   (StringOrURI,
                                                stringOrUri)
 import qualified Data.ByteString              as B
@@ -39,9 +40,9 @@ import           Data.List                    (lookup)
 import           Data.Monoid
 import           Data.Scientific              (floatingOrInteger)
 import           Data.String                  (String)
-import           Data.Text                    (dropWhileEnd, dropEnd,
+import           Data.Text                    (dropEnd, dropWhileEnd,
                                                intercalate, lines,
-                                               strip, take, splitOn)
+                                               splitOn, strip, take)
 import           Data.Text.Encoding           (encodeUtf8)
 import           Data.Text.IO                 (hPutStrLn)
 import           Data.Version                 (versionBranch)
@@ -50,11 +51,12 @@ import           Network.Wai
 import           Network.Wai.Middleware.Cors  (CorsResourcePolicy (..))
 import           Options.Applicative          hiding (str)
 import           Paths_postgrest              (version)
+import           PostgREST.Error              (ApiRequestError (..))
 import           PostgREST.Parsers            (pRoleClaimKey)
-import           PostgREST.Types              (JSPath, JSPathExp(..))
-import           PostgREST.Error              (ApiRequestError(..))
-import           Protolude                    hiding (hPutStrLn, take,
-                                               intercalate, (<>))
+import           PostgREST.Types              (JSPath, JSPathExp (..))
+import           Protolude                    hiding (hPutStrLn,
+                                               intercalate, take,
+                                               (<>))
 import           System.IO                    (hPrint)
 import           System.IO.Error              (IOError)
 import           Text.Heredoc
@@ -171,7 +173,7 @@ readOptions = do
 
     coerceText :: Value -> Text
     coerceText (String s) = s
-    coerceText v = show v
+    coerceText v          = show v
 
     coerceInt :: (Read i, Integral i) => Value -> Maybe i
     coerceInt (Number x) = rightToMaybe $ floatingOrInteger x
@@ -185,11 +187,11 @@ readOptions = do
 
     parseRoleClaimKey :: Value -> Either ApiRequestError JSPath
     parseRoleClaimKey (String s) = pRoleClaimKey s
-    parseRoleClaimKey v = pRoleClaimKey $ show v
+    parseRoleClaimKey v          = pRoleClaimKey $ show v
 
     splitExtraSearchPath :: Value -> [Text]
     splitExtraSearchPath (String s) = strip <$> splitOn "," s
-    splitExtraSearchPath _ = []
+    splitExtraSearchPath _          = []
 
     opts = info (helper <*> pathParser) $
              fullDesc

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -31,10 +31,8 @@ import qualified Data.CaseInsensitive         as CI
 import qualified Data.Configurator            as C
 import qualified Data.Configurator.Parser     as C
 import           Data.Configurator.Types      as C
-import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>), (<>))
 import qualified Text.PrettyPrint.ANSI.Leijen as L
 
-import Control.Applicative
 import Control.Lens                (preview)
 import Control.Monad               (fail)
 import Crypto.JWT                  (StringOrURI, stringOrUri)
@@ -53,10 +51,12 @@ import Paths_postgrest             (version)
 import System.IO                   (hPrint)
 import System.IO.Error             (IOError)
 
+import Control.Applicative
 import Data.Monoid
 import Network.Wai
-import Options.Applicative hiding (str)
+import Options.Applicative          hiding (str)
 import Text.Heredoc
+import Text.PrettyPrint.ANSI.Leijen hiding ((<$>), (<>))
 
 import PostgREST.Error   (ApiRequestError (..))
 import PostgREST.Parsers (pRoleClaimKey)

--- a/src/PostgREST/DbRequestBuilder.hs
+++ b/src/PostgREST/DbRequestBuilder.hs
@@ -6,11 +6,11 @@ This module is in charge of building an intermediate representation(ReadRequest,
 
 A query tree is built in case of resource embedding. By inferring the relationship between tables, join conditions are added for every embedded resource.
 -}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE DuplicateRecordFields#-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MultiWayIf #-}
-{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiWayIf            #-}
+{-# LANGUAGE NamedFieldPuns        #-}
 
 module PostgREST.DbRequestBuilder (
   readRequest
@@ -19,35 +19,37 @@ module PostgREST.DbRequestBuilder (
 ) where
 
 import           Control.Applicative
-import           Control.Arrow             ((***))
-import           Control.Lens.Getter       (view)
-import           Control.Lens.Tuple        (_1)
-import qualified Data.ByteString.Char8     as BS
-import           Data.List                 (delete)
-import           Data.Maybe                (fromJust)
-import qualified Data.Set                  as S
-import           Data.Text                 (isInfixOf)
+import           Control.Arrow           ((***))
+import           Control.Lens.Getter     (view)
+import           Control.Lens.Tuple      (_1)
+import qualified Data.ByteString.Char8   as BS
+import           Data.Either.Combinators (mapLeft)
+import           Data.List               (delete)
+import           Data.Maybe              (fromJust)
+import qualified Data.Set                as S
+import           Data.Text               (isInfixOf)
 import           Data.Tree
-import           Data.Either.Combinators   (mapLeft)
 
 import           Network.Wai
 
-import           Data.Foldable             (foldr1)
-import qualified Data.HashMap.Strict       as M
+import           Data.Foldable           (foldr1)
+import qualified Data.HashMap.Strict     as M
 
-import           PostgREST.ApiRequest      ( ApiRequest(..)
-                                           , PreferRepresentation(..)
-                                           , Action(..), Target(..)
-                                           , PreferRepresentation (..)
-                                           )
-import           PostgREST.Error           (ApiRequestError(..), errorResponseFor)
+import           PostgREST.ApiRequest    (Action (..),
+                                          ApiRequest (..),
+                                          PreferRepresentation (..),
+                                          PreferRepresentation (..),
+                                          Target (..))
+import           PostgREST.Error         (ApiRequestError (..),
+                                          errorResponseFor)
 import           PostgREST.Parsers
-import           PostgREST.RangeQuery      (NonnegRange, restrictRange, allRange)
+import           PostgREST.RangeQuery    (NonnegRange, allRange,
+                                          restrictRange)
 import           PostgREST.Types
 
-import           Protolude                 hiding (from)
-import           Text.Regex.TDFA           ((=~))
-import           Unsafe                    (unsafeHead)
+import           Protolude               hiding (from)
+import           Text.Regex.TDFA         ((=~))
+import           Unsafe                  (unsafeHead)
 
 readRequest :: Maybe Integer -> [Relation] -> Maybe ProcDescription -> ApiRequest -> Either Response ReadRequest
 readRequest maxRows allRels proc apiRequest  =
@@ -65,9 +67,9 @@ readRequest maxRows allRels proc apiRequest  =
         (TargetProc  (QualifiedIdentifier s pName) ) -> Just (s, tName)
           where
             tName = case pdReturnType <$> proc of
-              Just (SetOf (Composite qi)) -> qiName qi
+              Just (SetOf (Composite qi))  -> qiName qi
               Just (Single (Composite qi)) -> qiName qi
-              _ -> pName
+              _                            -> pName
 
         _ -> Nothing
 
@@ -93,7 +95,7 @@ readRequest maxRows allRels proc apiRequest  =
       ActionUpdate   -> fakeSourceRelations ++ allRels
       ActionDelete   -> fakeSourceRelations ++ allRels
       ActionInvoke _ -> fakeSourceRelations ++ allRels
-      _       -> allRels
+      _              -> allRels
       where fakeSourceRelations = mapMaybe (toSourceRelation rootTableName) allRels
 
 -- in a relation where one of the tables matches "TableName"

--- a/src/PostgREST/DbRequestBuilder.hs
+++ b/src/PostgREST/DbRequestBuilder.hs
@@ -22,7 +22,6 @@ import qualified Data.ByteString.Char8 as BS
 import qualified Data.HashMap.Strict   as M
 import qualified Data.Set              as S
 
-import Control.Applicative
 import Control.Arrow           ((***))
 import Control.Lens.Getter     (view)
 import Control.Lens.Tuple      (_1)
@@ -34,6 +33,7 @@ import Data.Text               (isInfixOf)
 import Text.Regex.TDFA         ((=~))
 import Unsafe                  (unsafeHead)
 
+import Control.Applicative
 import Data.Tree
 import Network.Wai
 

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -10,10 +10,10 @@ These queries are executed once at startup or when PostgREST is reloaded.
 -}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE QuasiQuotes           #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeSynonymInstances  #-}
-{-# LANGUAGE NamedFieldPuns  #-}
 module PostgREST.DbStructure (
   getDbStructure
 , accessibleTables
@@ -30,9 +30,8 @@ import           Control.Applicative
 import qualified Data.HashMap.Strict           as M
 import qualified Data.List                     as L
 import           Data.Set                      as S (fromList)
-import           Data.Text                     (split, strip,
-                                                breakOn, dropAround,
-                                                splitOn)
+import           Data.Text                     (breakOn, dropAround,
+                                                split, splitOn, strip)
 import qualified Data.Text                     as T
 import qualified Hasql.Session                 as H
 import qualified Hasql.Transaction             as HT
@@ -41,7 +40,7 @@ import           Text.InterpolatedString.Perl6 (q, qc)
 
 import           GHC.Exts                      (groupWith)
 import           Protolude
-import           Unsafe (unsafeHead)
+import           Unsafe                        (unsafeHead)
 
 getDbStructure :: Schema -> PgVersion -> HT.Transaction DbStructure
 getDbStructure schema pgVer = do

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -24,7 +24,6 @@ module PostgREST.DbStructure (
 
 import qualified Data.HashMap.Strict as M
 import qualified Data.List           as L
-import           Data.Set            as S (fromList)
 import qualified Data.Text           as T
 import qualified Hasql.Decoders      as HD
 import qualified Hasql.Encoders      as HE
@@ -32,6 +31,7 @@ import qualified Hasql.Session       as H
 import qualified Hasql.Statement     as H
 import qualified Hasql.Transaction   as HT
 
+import Data.Set                      as S (fromList)
 import Data.Text                     (breakOn, dropAround, split,
                                       splitOn, strip)
 import GHC.Exts                      (groupWith)

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -15,7 +15,6 @@ module PostgREST.Error (
 , checkIsFatal
 ) where
 
-import           Protolude
 import           Data.Aeson                ((.=))
 import qualified Data.Aeson                as JSON
 import           Data.Text                 (unwords)
@@ -25,6 +24,7 @@ import           Network.HTTP.Types.Header
 import qualified Network.HTTP.Types.Status as HT
 import           Network.Wai               (Response, responseLBS)
 import           PostgREST.Types
+import           Protolude
 import           Text.Read                 (readMaybe)
 
 

--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -12,7 +12,6 @@ import qualified Data.Aeson          as JSON
 import qualified Data.HashMap.Strict as M
 import qualified Hasql.Transaction   as H
 
--- import Network.HTTP.Types.Status     (status500, unauthorized401)
 import Network.Wai                   (Application, Response)
 import Network.Wai.Middleware.Cors   (cors)
 import Network.Wai.Middleware.Gzip   (def, gzip)

--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -3,8 +3,8 @@ Module      : PostgREST.Middleware
 Description : Sets the PostgreSQL GUCs, role, search_path and pre-request function. Validates JWT.
 -}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE FlexibleContexts #-}
 
 module PostgREST.Middleware where
 
@@ -18,11 +18,14 @@ import           Network.Wai.Middleware.Cors   (cors)
 import           Network.Wai.Middleware.Gzip   (def, gzip)
 import           Network.Wai.Middleware.Static (only, staticPolicy)
 
-import           PostgREST.ApiRequest          (ApiRequest(..))
-import           PostgREST.Auth                (JWTAttempt(..))
-import           PostgREST.Config              (AppConfig (..), corsPolicy)
-import           PostgREST.Error               (errorResponseFor, SimpleError(JwtTokenMissing, JwtTokenInvalid))
-import           PostgREST.QueryBuilder        (unquoted, pgFmtSetLocal, pgFmtSetLocalSearchPath)
+import           PostgREST.ApiRequest          (ApiRequest (..))
+import           PostgREST.Auth                (JWTAttempt (..))
+import           PostgREST.Config              (AppConfig (..),
+                                                corsPolicy)
+import           PostgREST.Error               (SimpleError (JwtTokenInvalid, JwtTokenMissing),
+                                                errorResponseFor)
+import           PostgREST.QueryBuilder        (pgFmtSetLocal, pgFmtSetLocalSearchPath,
+                                                unquoted)
 
 import           Protolude
 

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -10,25 +10,35 @@ module PostgREST.OpenAPI (
 , pickProxy
 ) where
 
-import           Control.Arrow               ((&&&))
+import           Control.Arrow              ((&&&))
 import           Control.Lens
-import           Data.Aeson                  (decode, encode)
-import           Data.HashMap.Strict.InsOrd  (InsOrdHashMap, fromList)
-import           Data.Maybe                  (fromJust)
-import qualified Data.Set                    as Set
-import           Data.String                 (IsString (..))
-import           Data.Text                   (unpack, pack, init, tail, toLower, intercalate, append, dropWhile, breakOn)
-import           Network.URI                 (parseURI, isAbsoluteURI,
-                                              URI (..), URIAuth (..))
+import           Data.Aeson                 (decode, encode)
+import           Data.HashMap.Strict.InsOrd (InsOrdHashMap, fromList)
+import           Data.Maybe                 (fromJust)
+import qualified Data.Set                   as Set
+import           Data.String                (IsString (..))
+import           Data.Text                  (append, breakOn,
+                                             dropWhile, init,
+                                             intercalate, pack, tail,
+                                             toLower, unpack)
+import           Network.URI                (URI (..), URIAuth (..),
+                                             isAbsoluteURI, parseURI)
 
-import           Protolude hiding              ((&), Proxy, get, intercalate, dropWhile)
+import           Protolude                  hiding (Proxy, dropWhile,
+                                             get, intercalate, (&))
 
 import           Data.Swagger
 
-import           PostgREST.ApiRequest        (ContentType(..))
-import           PostgREST.Config            (prettyVersion, docsVersion)
-import           PostgREST.Types             (Table(..), Column(..), PgArg(..), ForeignKey(..),
-                                              PrimaryKey(..), Proxy(..), ProcDescription(..), toMime)
+import           PostgREST.ApiRequest       (ContentType (..))
+import           PostgREST.Config           (docsVersion,
+                                             prettyVersion)
+import           PostgREST.Types            (Column (..),
+                                             ForeignKey (..),
+                                             PgArg (..),
+                                             PrimaryKey (..),
+                                             ProcDescription (..),
+                                             Proxy (..), Table (..),
+                                             toMime)
 
 makeMimeList :: [ContentType] -> MimeList
 makeMimeList cs = MimeList $ map (fromString . toS . toMime) cs
@@ -329,7 +339,7 @@ pickProxy proxy
    uri = toURI $ fromJust proxy
    scheme = init $ toLower $ pack $ uriScheme uri
    path URI {uriPath = ""} =  "/"
-   path URI {uriPath = p} = p
+   path URI {uriPath = p}  = p
    path' = pack $ path uri
    authority = fromJust $ uriAuthority uri
    host' = pack $ uriRegName authority
@@ -337,9 +347,9 @@ pickProxy proxy
    readPort = fromMaybe 80 . readMaybe
    port'' :: Integer
    port'' = case (port', scheme) of
-             ("", "http") -> 80
+             ("", "http")  -> 80
              ("", "https") -> 443
-             _ -> readPort $ unpack $ tail $ pack port'
+             _             -> readPort $ unpack $ tail $ pack port'
 
 isUriValid:: URI -> Bool
 isUriValid = fAnd [isSchemeValid, isQueryValid, isAuthorityValid]
@@ -355,7 +365,7 @@ isSchemeValid URI {uriScheme = s}
 
 isQueryValid :: URI -> Bool
 isQueryValid URI {uriQuery = ""} = True
-isQueryValid _ = False
+isQueryValid _                   = False
 
 isAuthorityValid :: URI -> Bool
 isAuthorityValid URI {uriAuthority = a}
@@ -364,16 +374,16 @@ isAuthorityValid URI {uriAuthority = a}
 
 isUserInfoValid :: URIAuth -> Bool
 isUserInfoValid URIAuth {uriUserInfo = ""} = True
-isUserInfoValid _ = False
+isUserInfoValid _                          = False
 
 isHostValid :: URIAuth -> Bool
 isHostValid URIAuth {uriRegName = ""} = False
-isHostValid _ = True
+isHostValid _                         = True
 
 isPortValid :: URIAuth -> Bool
 isPortValid URIAuth {uriPort = ""} = True
 isPortValid URIAuth {uriPort = (':':p)} =
   case readMaybe p of
-    Just i -> i > (0 :: Integer) && i < 65536
+    Just i  -> i > (0 :: Integer) && i < 65536
     Nothing -> False
 isPortValid _ = False

--- a/src/PostgREST/Parsers.hs
+++ b/src/PostgREST/Parsers.hs
@@ -9,16 +9,17 @@ module PostgREST.Parsers where
 import qualified Data.HashMap.Strict as M
 import qualified Data.Set            as S
 
-import Control.Monad                 ((>>))
-import Data.Either.Combinators       (mapLeft)
-import Data.Foldable                 (foldl1)
-import Data.Functor                  (($>))
-import Data.List                     (init, last)
-import Data.Text                     (intercalate, replace, strip)
+import Control.Monad           ((>>))
+import Data.Either.Combinators (mapLeft)
+import Data.Foldable           (foldl1)
+import Data.Functor            (($>))
+import Data.List               (init, last)
+import Data.Text               (intercalate, replace, strip)
+import Text.Read               (read)
+
 import Data.Tree
 import Text.Parsec.Error
 import Text.ParserCombinators.Parsec hiding (many, (<|>))
-import Text.Read                     (read)
 
 import PostgREST.Error      (ApiRequestError (ParseRequestError))
 import PostgREST.RangeQuery (NonnegRange)

--- a/src/PostgREST/Parsers.hs
+++ b/src/PostgREST/Parsers.hs
@@ -6,21 +6,23 @@ This module is in charge of parsing all the querystring values in an url, e.g. t
 -}
 module PostgREST.Parsers where
 
-import           Protolude                     hiding (try, intercalate, replace, option)
 import           Control.Monad                 ((>>))
+import           Data.Either.Combinators       (mapLeft)
 import           Data.Foldable                 (foldl1)
 import           Data.Functor                  (($>))
 import qualified Data.HashMap.Strict           as M
-import           Data.Text                     (intercalate, replace, strip)
 import           Data.List                     (init, last)
 import qualified Data.Set                      as S
+import           Data.Text                     (intercalate, replace,
+                                                strip)
 import           Data.Tree
-import           Data.Either.Combinators       (mapLeft)
+import           PostgREST.Error               (ApiRequestError (ParseRequestError))
 import           PostgREST.RangeQuery          (NonnegRange)
-import           PostgREST.Error               (ApiRequestError(ParseRequestError))
 import           PostgREST.Types
-import           Text.ParserCombinators.Parsec hiding (many, (<|>))
+import           Protolude                     hiding (intercalate,
+                                                option, replace, try)
 import           Text.Parsec.Error
+import           Text.ParserCombinators.Parsec hiding (many, (<|>))
 import           Text.Read                     (read)
 
 pRequestSelect :: Text -> Either ApiRequestError [Tree SelectItem]

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -37,13 +37,14 @@ import qualified Hasql.Decoders        as HD
 import qualified Hasql.Encoders        as HE
 import qualified Hasql.Statement       as H
 
-import Data.Maybe
 import Data.Scientific               (FPFormat (..), formatScientific,
                                       isInteger)
 import Data.Text                     (intercalate, isInfixOf, replace,
                                       toLower, unwords)
 import Data.Tree                     (Tree (..))
 import Text.InterpolatedString.Perl6 (qc)
+
+import Data.Maybe
 
 import PostgREST.ApiRequest (PreferRepresentation (..))
 import PostgREST.RangeQuery (allRange, rangeLimit, rangeOffset)

--- a/src/PostgREST/RangeQuery.hs
+++ b/src/PostgREST/RangeQuery.hs
@@ -14,8 +14,9 @@ module PostgREST.RangeQuery (
 ) where
 
 import qualified Data.ByteString.Char8 as BS
-import           Data.List             (lookup)
-import           Text.Regex.TDFA       ((=~))
+
+import Data.List       (lookup)
+import Text.Regex.TDFA ((=~))
 
 import Control.Applicative
 import Data.Ranged.Boundaries

--- a/src/PostgREST/RangeQuery.hs
+++ b/src/PostgREST/RangeQuery.hs
@@ -23,7 +23,7 @@ import           Data.Ranged.Ranges
 
 import           Text.Regex.TDFA           ((=~))
 
-import Data.List (lookup)
+import           Data.List                 (lookup)
 
 import           Protolude
 
@@ -60,7 +60,7 @@ rangeOffset :: NonnegRange -> Integer
 rangeOffset range =
   case rangeLower range of
     BoundaryBelow lower -> lower
-    _ -> panic "range without lower bound" -- should never happen
+    _                   -> panic "range without lower bound" -- should never happen
 
 rangeGeq :: Integer -> NonnegRange
 rangeGeq n =

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -2,20 +2,20 @@
 Module      : PostgREST.Types
 Description : PostgREST common types and functions used by the rest of the modules
 -}
-{-# LANGUAGE DuplicateRecordFields    #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 
 module PostgREST.Types where
 
-import           Protolude
-import qualified GHC.Show
-import qualified Data.Aeson           as JSON
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.CaseInsensitive as CI
-import qualified Data.HashMap.Strict  as M
+import qualified Data.Aeson                as JSON
+import qualified Data.ByteString.Lazy      as BL
+import qualified Data.CaseInsensitive      as CI
+import qualified Data.HashMap.Strict       as M
 import qualified Data.Set                  as S
 import           Data.Tree
-import           PostgREST.RangeQuery (NonnegRange)
-import           Network.HTTP.Types.Header (hContentType, Header)
+import qualified GHC.Show
+import           Network.HTTP.Types.Header (Header, hContentType)
+import           PostgREST.RangeQuery      (NonnegRange)
+import           Protolude
 
 -- | Enumeration of currently supported response content types
 data ContentType = CTApplicationJSON | CTTextCSV | CTOpenAPI
@@ -224,10 +224,10 @@ data PayloadJSON =
 data PJType = PJArray { pjaLength :: Int } | PJObject deriving (Show, Eq)
 
 data Proxy = Proxy {
-  proxyScheme     :: Text
-, proxyHost       :: Text
-, proxyPort       :: Integer
-, proxyPath       :: Text
+  proxyScheme :: Text
+, proxyHost   :: Text
+, proxyPort   :: Integer
+, proxyPath   :: Text
 } deriving (Show, Eq)
 
 type Operator = Text
@@ -272,8 +272,8 @@ type ListVal = [Text]
 
 data LogicOperator = And | Or deriving Eq
 instance Show LogicOperator where
-  show And  = "AND"
-  show Or = "OR"
+  show And = "AND"
+  show Or  = "OR"
 {-|
   Boolean logic expression tree e.g. "and(name.eq.N,or(id.eq.1,id.eq.2))" is:
 
@@ -353,15 +353,15 @@ data MutateQuery =
   , returning  :: [FieldName]
   }|
   Update {
-    in_        :: TableName
-  , updCols    :: S.Set FieldName
-  , where_     :: [LogicTree]
-  , returning  :: [FieldName]
+    in_       :: TableName
+  , updCols   :: S.Set FieldName
+  , where_    :: [LogicTree]
+  , returning :: [FieldName]
   }|
   Delete {
-    in_        :: TableName
-  , where_     :: [LogicTree]
-  , returning  :: [FieldName]
+    in_       :: TableName
+  , where_    :: [LogicTree]
+  , returning :: [FieldName]
   } deriving (Show, Eq)
 
 data DbRequest = DbRead ReadRequest | DbMutate MutateRequest
@@ -409,7 +409,7 @@ data JSPathExp = JSPKey Text | JSPIdx Int deriving (Eq, Show)
 
 
 -- | Current database connection status data ConnectionStatus
-data ConnectionStatus 
+data ConnectionStatus
   = NotConnected
   | Connected PgVersion
   | FatalConnectionError Text

--- a/test/Feature/AndOrParamsSpec.hs
+++ b/test/Feature/AndOrParamsSpec.hs
@@ -1,13 +1,13 @@
 module Feature.AndOrParamsSpec where
-import Test.Hspec
-import Test.Hspec.Wai
-import Test.Hspec.Wai.JSON
-import Network.HTTP.Types
+import           Network.HTTP.Types
+import           Test.Hspec
+import           Test.Hspec.Wai
+import           Test.Hspec.Wai.JSON
 
-import Network.Wai (Application)
+import           Network.Wai         (Application)
 
-import SpecHelper
-import Protolude hiding (get)
+import           Protolude           hiding (get)
+import           SpecHelper
 
 
 spec :: SpecWith Application

--- a/test/Feature/AsymmetricJwtSpec.hs
+++ b/test/Feature/AsymmetricJwtSpec.hs
@@ -1,14 +1,14 @@
 module Feature.AsymmetricJwtSpec where
 
 -- {{{ Imports
-import Test.Hspec
-import Test.Hspec.Wai
-import Network.HTTP.Types
+import           Network.HTTP.Types
+import           Test.Hspec
+import           Test.Hspec.Wai
 
-import SpecHelper
-import Network.Wai (Application)
+import           Network.Wai        (Application)
+import           SpecHelper
 
-import Protolude
+import           Protolude
 -- }}}
 
 spec :: SpecWith Application

--- a/test/Feature/AudienceJwtSecretSpec.hs
+++ b/test/Feature/AudienceJwtSecretSpec.hs
@@ -1,14 +1,14 @@
 module Feature.AudienceJwtSecretSpec where
 
 -- {{{ Imports
-import Test.Hspec
-import Test.Hspec.Wai
-import Network.HTTP.Types
+import           Network.HTTP.Types
+import           Test.Hspec
+import           Test.Hspec.Wai
 
-import SpecHelper
-import Network.Wai (Application)
+import           Network.Wai        (Application)
+import           SpecHelper
 
-import Protolude hiding (get)
+import           Protolude          hiding (get)
 -- }}}
 
 spec :: SpecWith Application
@@ -44,4 +44,4 @@ spec = describe "test handling of aud claims in JWT" $ do
       `shouldRespondWith` 200
 
   it "requests without JWT token should work" $
-    get "/has_count_column" `shouldRespondWith` 200 
+    get "/has_count_column" `shouldRespondWith` 200

--- a/test/Feature/AuthSpec.hs
+++ b/test/Feature/AuthSpec.hs
@@ -1,17 +1,17 @@
 module Feature.AuthSpec where
 
-import Text.Heredoc
-import Test.Hspec
-import Test.Hspec.Wai
-import Test.Hspec.Wai.JSON
-import Network.HTTP.Types
+import           Network.HTTP.Types
+import           Test.Hspec
+import           Test.Hspec.Wai
+import           Test.Hspec.Wai.JSON
+import           Text.Heredoc
 
-import SpecHelper
-import Network.Wai (Application)
+import           Network.Wai         (Application)
+import           SpecHelper
 
-import Protolude hiding (get)
+import           Protolude           hiding (get)
 
-import PostgREST.Types (PgVersion, pgVersion112)
+import           PostgREST.Types     (PgVersion, pgVersion112)
 
 spec :: PgVersion -> SpecWith Application
 spec actualPgVersion = describe "authorization" $ do

--- a/test/Feature/BinaryJwtSecretSpec.hs
+++ b/test/Feature/BinaryJwtSecretSpec.hs
@@ -1,14 +1,14 @@
 module Feature.BinaryJwtSecretSpec where
 
 -- {{{ Imports
-import Test.Hspec
-import Test.Hspec.Wai
-import Network.HTTP.Types
+import           Network.HTTP.Types
+import           Test.Hspec
+import           Test.Hspec.Wai
 
-import SpecHelper
-import Network.Wai (Application)
+import           Network.Wai        (Application)
+import           SpecHelper
 
-import Protolude
+import           Protolude
 -- }}}
 
 spec :: SpecWith Application

--- a/test/Feature/ConcurrentSpec.hs
+++ b/test/Feature/ConcurrentSpec.hs
@@ -1,22 +1,24 @@
-{-# LANGUAGE MultiParamTypeClasses, TypeFamilies, UndecidableInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Feature.ConcurrentSpec where
 
-import Control.Monad (void)
-import Control.Monad.Base
+import           Control.Monad               (void)
+import           Control.Monad.Base
 
-import Control.Monad.Trans.Control
-import Control.Concurrent.Async (mapConcurrently)
+import           Control.Concurrent.Async    (mapConcurrently)
+import           Control.Monad.Trans.Control
 
-import Test.Hspec
-import Test.Hspec.Wai.Internal
-import Test.Hspec.Wai
-import Test.Hspec.Wai.JSON
-import Network.Wai.Test (Session)
+import           Network.Wai.Test            (Session)
+import           Test.Hspec
+import           Test.Hspec.Wai
+import           Test.Hspec.Wai.Internal
+import           Test.Hspec.Wai.JSON
 
-import Network.Wai (Application)
+import           Network.Wai                 (Application)
 
-import Protolude hiding (get)
+import           Protolude                   hiding (get)
 
 spec :: SpecWith Application
 spec =

--- a/test/Feature/CorsSpec.hs
+++ b/test/Feature/CorsSpec.hs
@@ -1,17 +1,17 @@
 module Feature.CorsSpec where
 
 -- {{{ Imports
-import Test.Hspec
-import Test.Hspec.Wai
-import Network.Wai.Test (SResponse(simpleHeaders, simpleBody))
 import qualified Data.ByteString.Lazy as BL
+import           Network.Wai.Test     (SResponse (simpleBody, simpleHeaders))
+import           Test.Hspec
+import           Test.Hspec.Wai
 
-import SpecHelper
+import           SpecHelper
 
-import Network.HTTP.Types
-import Network.Wai (Application)
+import           Network.HTTP.Types
+import           Network.Wai          (Application)
 
-import Protolude
+import           Protolude
 -- }}}
 
 spec :: SpecWith Application

--- a/test/Feature/DeleteSpec.hs
+++ b/test/Feature/DeleteSpec.hs
@@ -1,13 +1,13 @@
 module Feature.DeleteSpec where
 
-import Test.Hspec
-import Test.Hspec.Wai
-import Text.Heredoc
+import           Test.Hspec
+import           Test.Hspec.Wai
+import           Text.Heredoc
 
-import Network.HTTP.Types
-import Network.Wai (Application)
+import           Network.HTTP.Types
+import           Network.Wai        (Application)
 
-import Protolude hiding (get)
+import           Protolude          hiding (get)
 
 spec :: SpecWith Application
 spec =

--- a/test/Feature/ExtraSearchPathSpec.hs
+++ b/test/Feature/ExtraSearchPathSpec.hs
@@ -1,14 +1,14 @@
 module Feature.ExtraSearchPathSpec where
 
-import Test.Hspec
-import Test.Hspec.Wai
-import Test.Hspec.Wai.JSON
-import Network.HTTP.Types
+import           Network.HTTP.Types
+import           Test.Hspec
+import           Test.Hspec.Wai
+import           Test.Hspec.Wai.JSON
 
-import SpecHelper
-import Network.Wai (Application)
+import           Network.Wai         (Application)
+import           SpecHelper
 
-import Protolude
+import           Protolude
 
 spec :: SpecWith Application
 spec = describe "extra search path" $ do

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -1,27 +1,28 @@
 module Feature.InsertSpec where
 
-import Test.Hspec hiding (pendingWith)
-import Test.Hspec.Wai
-import Test.Hspec.Wai.JSON
-import Test.Hspec.Wai.Matcher (bodyEquals)
-import Network.Wai.Test (SResponse(simpleBody,simpleHeaders,simpleStatus))
+import           Network.Wai.Test          (SResponse (simpleBody, simpleHeaders, simpleStatus))
+import           Test.Hspec                hiding (pendingWith)
+import           Test.Hspec.Wai
+import           Test.Hspec.Wai.JSON
+import           Test.Hspec.Wai.Matcher    (bodyEquals)
 
-import SpecHelper
+import           SpecHelper
 
-import qualified Data.Aeson as JSON
-import Data.List (lookup)
-import Data.Maybe (fromJust)
-import Text.Heredoc
-import Network.HTTP.Types.Header
-import Network.HTTP.Types
-import Control.Monad (replicateM_, void)
+import           Control.Monad             (replicateM_, void)
+import qualified Data.Aeson                as JSON
+import           Data.List                 (lookup)
+import           Data.Maybe                (fromJust)
+import           Network.HTTP.Types
+import           Network.HTTP.Types.Header
+import           Text.Heredoc
 
-import TestTypes(IncPK(..), CompoundPK(..))
-import Network.Wai (Application)
+import           Network.Wai               (Application)
+import           TestTypes                 (CompoundPK (..),
+                                            IncPK (..))
 
-import Protolude hiding (get)
+import           Protolude                 hiding (get)
 
-import PostgREST.Types (PgVersion, pgVersion112)
+import           PostgREST.Types           (PgVersion, pgVersion112)
 
 spec :: PgVersion -> SpecWith Application
 spec actualPgVersion = do

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -1,28 +1,26 @@
 module Feature.InsertSpec where
 
-import           Network.Wai.Test          (SResponse (simpleBody, simpleHeaders, simpleStatus))
-import           Test.Hspec                hiding (pendingWith)
+import           Network.Wai.Test       (SResponse (simpleBody, simpleHeaders, simpleStatus))
+import           Test.Hspec             hiding (pendingWith)
 import           Test.Hspec.Wai
 import           Test.Hspec.Wai.JSON
-import           Test.Hspec.Wai.Matcher    (bodyEquals)
+import           Test.Hspec.Wai.Matcher (bodyEquals)
 
 import           SpecHelper
 
-import           Control.Monad             (replicateM_, void)
-import qualified Data.Aeson                as JSON
-import           Data.List                 (lookup)
-import           Data.Maybe                (fromJust)
+import           Control.Monad          (replicateM_, void)
+import qualified Data.Aeson             as JSON
+import           Data.List              (lookup)
+import           Data.Maybe             (fromJust)
 import           Network.HTTP.Types
-import           Network.HTTP.Types.Header
 import           Text.Heredoc
 
-import           Network.Wai               (Application)
-import           TestTypes                 (CompoundPK (..),
-                                            IncPK (..))
+import           Network.Wai            (Application)
+import           TestTypes              (CompoundPK (..), IncPK (..))
 
-import           Protolude                 hiding (get)
+import           Protolude              hiding (get)
 
-import           PostgREST.Types           (PgVersion, pgVersion112)
+import           PostgREST.Types        (PgVersion, pgVersion112)
 
 spec :: PgVersion -> SpecWith Application
 spec actualPgVersion = do

--- a/test/Feature/JsonOperatorSpec.hs
+++ b/test/Feature/JsonOperatorSpec.hs
@@ -1,16 +1,16 @@
 module Feature.JsonOperatorSpec where
 
-import Test.Hspec
-import Test.Hspec.Wai
-import Test.Hspec.Wai.JSON
-import Network.HTTP.Types
+import           Network.HTTP.Types
+import           Test.Hspec
+import           Test.Hspec.Wai
+import           Test.Hspec.Wai.JSON
 
-import SpecHelper
-import Network.Wai (Application)
+import           Network.Wai         (Application)
+import           SpecHelper
 
-import Protolude hiding (get)
+import           Protolude           hiding (get)
 
-import PostgREST.Types (PgVersion, pgVersion112)
+import           PostgREST.Types     (PgVersion, pgVersion112)
 
 spec :: PgVersion -> SpecWith Application
 spec actualPgVersion = describe "json and jsonb operators" $ do

--- a/test/Feature/NoJwtSpec.hs
+++ b/test/Feature/NoJwtSpec.hs
@@ -1,15 +1,15 @@
 module Feature.NoJwtSpec where
 
 -- {{{ Imports
-import Test.Hspec
-import Test.Hspec.Wai
-import Test.Hspec.Wai.JSON
-import Network.HTTP.Types
+import           Network.HTTP.Types
+import           Test.Hspec
+import           Test.Hspec.Wai
+import           Test.Hspec.Wai.JSON
 
-import SpecHelper
-import Network.Wai (Application)
+import           Network.Wai         (Application)
+import           SpecHelper
 
-import Protolude
+import           Protolude
 -- }}}
 
 spec :: SpecWith Application

--- a/test/Feature/NonexistentSchemaSpec.hs
+++ b/test/Feature/NonexistentSchemaSpec.hs
@@ -1,9 +1,9 @@
 module Feature.NonexistentSchemaSpec where
 
-import Network.Wai (Application)
-import Protolude hiding (get)
-import Test.Hspec
-import Test.Hspec.Wai
+import           Network.Wai    (Application)
+import           Protolude      hiding (get)
+import           Test.Hspec
+import           Test.Hspec.Wai
 
 spec :: SpecWith Application
 spec =

--- a/test/Feature/NonexistentSchemaSpec.hs
+++ b/test/Feature/NonexistentSchemaSpec.hs
@@ -1,11 +1,11 @@
 module Feature.NonexistentSchemaSpec where
 
-import Network.Wai    (Application)
+import Network.Wai (Application)
 
 import Test.Hspec
 import Test.Hspec.Wai
 
-import Protolude      hiding (get)
+import Protolude hiding (get)
 
 spec :: SpecWith Application
 spec =

--- a/test/Feature/PgVersion95Spec.hs
+++ b/test/Feature/PgVersion95Spec.hs
@@ -6,8 +6,8 @@ import Test.Hspec
 import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 
+import Protolude  hiding (get)
 import SpecHelper
-import Protolude hiding (get)
 
 spec :: SpecWith Application
 spec = describe "features supported on PostgreSQL 9.5" $

--- a/test/Feature/PgVersion95Spec.hs
+++ b/test/Feature/PgVersion95Spec.hs
@@ -1,13 +1,13 @@
 module Feature.PgVersion95Spec where
 
-import Test.Hspec
-import Test.Hspec.Wai
-import Test.Hspec.Wai.JSON
+import           Test.Hspec
+import           Test.Hspec.Wai
+import           Test.Hspec.Wai.JSON
 
-import SpecHelper
-import Network.Wai (Application)
+import           Network.Wai         (Application)
+import           SpecHelper
 
-import Protolude hiding (get)
+import           Protolude           hiding (get)
 
 spec :: SpecWith Application
 spec = describe "features supported on PostgreSQL 9.5" $

--- a/test/Feature/PgVersion96Spec.hs
+++ b/test/Feature/PgVersion96Spec.hs
@@ -1,13 +1,13 @@
 module Feature.PgVersion96Spec where
 
-import Test.Hspec
-import Test.Hspec.Wai
-import Test.Hspec.Wai.JSON
+import           Test.Hspec
+import           Test.Hspec.Wai
+import           Test.Hspec.Wai.JSON
 
-import SpecHelper
-import Network.Wai (Application)
+import           Network.Wai         (Application)
+import           SpecHelper
 
-import Protolude hiding (get)
+import           Protolude           hiding (get)
 
 spec :: SpecWith Application
 spec =

--- a/test/Feature/PgVersion96Spec.hs
+++ b/test/Feature/PgVersion96Spec.hs
@@ -6,8 +6,8 @@ import Test.Hspec
 import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 
+import Protolude  hiding (get)
 import SpecHelper
-import Protolude hiding (get)
 
 spec :: SpecWith Application
 spec =

--- a/test/Feature/ProxySpec.hs
+++ b/test/Feature/ProxySpec.hs
@@ -1,13 +1,13 @@
 module Feature.ProxySpec where
 
-import Test.Hspec hiding (pendingWith)
-import Test.Hspec.Wai
+import           Test.Hspec     hiding (pendingWith)
+import           Test.Hspec.Wai
 
-import SpecHelper
+import           SpecHelper
 
-import Network.Wai (Application)
+import           Network.Wai    (Application)
 
-import Protolude
+import           Protolude
 
 spec :: SpecWith Application
 spec =

--- a/test/Feature/QueryLimitedSpec.hs
+++ b/test/Feature/QueryLimitedSpec.hs
@@ -1,14 +1,14 @@
 module Feature.QueryLimitedSpec where
 
-import Test.Hspec
-import Test.Hspec.Wai
-import Test.Hspec.Wai.JSON
-import Network.HTTP.Types
-import Network.Wai.Test (SResponse(simpleHeaders, simpleStatus))
-import SpecHelper
-import Network.Wai (Application)
+import           Network.HTTP.Types
+import           Network.Wai         (Application)
+import           Network.Wai.Test    (SResponse (simpleHeaders, simpleStatus))
+import           SpecHelper
+import           Test.Hspec
+import           Test.Hspec.Wai
+import           Test.Hspec.Wai.JSON
 
-import Protolude hiding (get)
+import           Protolude           hiding (get)
 
 spec :: SpecWith Application
 spec =

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -1,16 +1,16 @@
 module Feature.QuerySpec where
 
-import Test.Hspec
-import Test.Hspec.Wai
-import Test.Hspec.Wai.JSON
-import Network.HTTP.Types
-import Network.Wai.Test (SResponse(simpleHeaders))
+import           Network.HTTP.Types
+import           Network.Wai.Test    (SResponse (simpleHeaders))
+import           Test.Hspec
+import           Test.Hspec.Wai
+import           Test.Hspec.Wai.JSON
 
-import SpecHelper
-import Text.Heredoc
-import Network.Wai (Application)
+import           Network.Wai         (Application)
+import           SpecHelper
+import           Text.Heredoc
 
-import Protolude hiding (get)
+import           Protolude           hiding (get)
 
 spec :: SpecWith Application
 spec = do

--- a/test/Feature/RangeSpec.hs
+++ b/test/Feature/RangeSpec.hs
@@ -1,17 +1,17 @@
 module Feature.RangeSpec where
 
-import Test.Hspec
-import Test.Hspec.Wai
-import Test.Hspec.Wai.JSON
-import Network.HTTP.Types
-import Network.Wai.Test (SResponse(simpleHeaders,simpleStatus))
+import           Network.HTTP.Types
+import           Network.Wai.Test     (SResponse (simpleHeaders, simpleStatus))
+import           Test.Hspec
+import           Test.Hspec.Wai
+import           Test.Hspec.Wai.JSON
 
-import qualified Data.ByteString.Lazy         as BL
+import qualified Data.ByteString.Lazy as BL
 
-import SpecHelper
-import Network.Wai (Application)
+import           Network.Wai          (Application)
+import           SpecHelper
 
-import Protolude hiding (get)
+import           Protolude            hiding (get)
 
 defaultRange :: BL.ByteString
 defaultRange = [json| { "min": 0, "max": 15 } |]

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -1,19 +1,19 @@
 module Feature.RpcSpec where
 
-import Test.Hspec
-import Test.Hspec.Wai
-import Test.Hspec.Wai.JSON
-import Network.HTTP.Types
-import Network.Wai.Test (SResponse(simpleStatus, simpleBody))
 import qualified Data.ByteString.Lazy as BL (empty)
+import           Network.HTTP.Types
+import           Network.Wai.Test     (SResponse (simpleBody, simpleStatus))
+import           Test.Hspec
+import           Test.Hspec.Wai
+import           Test.Hspec.Wai.JSON
 
-import SpecHelper
-import Text.Heredoc
-import Network.Wai (Application)
+import           Network.Wai          (Application)
+import           SpecHelper
+import           Text.Heredoc
 
-import Protolude hiding (get)
+import           Protolude            hiding (get)
 
-import PostgREST.Types (PgVersion, pgVersion95)
+import           PostgREST.Types      (PgVersion, pgVersion95)
 
 spec :: PgVersion -> SpecWith Application
 spec actualPgVersion =

--- a/test/Feature/SingularSpec.hs
+++ b/test/Feature/SingularSpec.hs
@@ -1,16 +1,16 @@
 module Feature.SingularSpec where
 
-import Text.Heredoc
-import Test.Hspec
-import Test.Hspec.Wai
-import Test.Hspec.Wai.JSON
-import Network.HTTP.Types
-import Network.Wai.Test (SResponse(..))
+import           Network.HTTP.Types
+import           Network.Wai.Test    (SResponse (..))
+import           Test.Hspec
+import           Test.Hspec.Wai
+import           Test.Hspec.Wai.JSON
+import           Text.Heredoc
 
-import Network.Wai (Application)
+import           Network.Wai         (Application)
 
-import SpecHelper
-import Protolude hiding (get)
+import           Protolude           hiding (get)
+import           SpecHelper
 
 
 spec :: SpecWith Application

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -1,21 +1,21 @@
 module Feature.StructureSpec where
 
-import Test.Hspec hiding (pendingWith)
-import Test.Hspec.Wai
-import Network.HTTP.Types
+import           Network.HTTP.Types
+import           Test.Hspec         hiding (pendingWith)
+import           Test.Hspec.Wai
 
-import PostgREST.Config (docsVersion)
-import Control.Lens ((^?))
-import Data.Aeson.Types (Value (..))
-import Data.Aeson.Lens
-import Data.Aeson.QQ
+import           Control.Lens       ((^?))
+import           Data.Aeson.Lens
+import           Data.Aeson.QQ
+import           Data.Aeson.Types   (Value (..))
+import           PostgREST.Config   (docsVersion)
 
-import SpecHelper
+import           SpecHelper
 
-import Network.Wai (Application)
-import Network.Wai.Test (SResponse(..))
+import           Network.Wai        (Application)
+import           Network.Wai.Test   (SResponse (..))
 
-import Protolude hiding (get)
+import           Protolude          hiding (get)
 
 spec :: SpecWith Application
 spec = do
@@ -251,7 +251,7 @@ spec = do
                 "type": "string"
               }
             |]
-            
+
       it "text to string" $ do
         r <- simpleBody <$> get "/"
 
@@ -281,7 +281,7 @@ spec = do
                 "type": "boolean"
               }
             |]
-      
+
       it "smallint to integer" $ do
         r <- simpleBody <$> get "/"
 
@@ -296,7 +296,7 @@ spec = do
                 "type": "integer"
               }
             |]
-      
+
       it "integer to integer" $ do
         r <- simpleBody <$> get "/"
 
@@ -356,7 +356,7 @@ spec = do
                 "type": "number"
               }
             |]
-      
+
       it "double_precision to number" $ do
         r <- simpleBody <$> get "/"
 

--- a/test/Feature/UnicodeSpec.hs
+++ b/test/Feature/UnicodeSpec.hs
@@ -1,14 +1,14 @@
 module Feature.UnicodeSpec where
 
-import Test.Hspec
-import Test.Hspec.Wai
-import Test.Hspec.Wai.JSON
-import Network.Wai (Application)
-import Control.Monad (void)
+import           Control.Monad       (void)
+import           Network.Wai         (Application)
+import           Test.Hspec
+import           Test.Hspec.Wai
+import           Test.Hspec.Wai.JSON
 
-import SpecHelper
+import           SpecHelper
 
-import Protolude hiding (get)
+import           Protolude           hiding (get)
 
 spec :: SpecWith Application
 spec =

--- a/test/Feature/UpsertSpec.hs
+++ b/test/Feature/UpsertSpec.hs
@@ -1,15 +1,15 @@
 module Feature.UpsertSpec where
 
-import Test.Hspec
-import Test.Hspec.Wai
-import Test.Hspec.Wai.JSON
-import Network.HTTP.Types
+import           Network.HTTP.Types
+import           Test.Hspec
+import           Test.Hspec.Wai
+import           Test.Hspec.Wai.JSON
 
-import SpecHelper
-import Network.Wai (Application)
+import           Network.Wai         (Application)
+import           SpecHelper
 
-import Protolude hiding (get, put)
-import Text.Heredoc
+import           Protolude           hiding (get, put)
+import           Text.Heredoc
 
 spec :: SpecWith Application
 spec =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,23 +1,29 @@
 module Main where
 
-import Test.Hspec
-import SpecHelper
+import           SpecHelper
+import           Test.Hspec
 
-import qualified Hasql.Pool as P
-import qualified Hasql.Transaction.Sessions as HT
+import qualified Hasql.Pool                    as P
+import qualified Hasql.Transaction.Sessions    as HT
 
-import PostgREST.App (postgrest)
-import PostgREST.DbStructure (getDbStructure, getPgVersion)
-import PostgREST.Types (DbStructure(..), pgVersion95, pgVersion96)
-import Control.AutoUpdate (defaultUpdateSettings, mkAutoUpdate, updateAction)
-import Data.Function (id)
-import Data.IORef
-import Data.Time.Clock (getCurrentTime)
+import           Control.AutoUpdate            (defaultUpdateSettings,
+                                                mkAutoUpdate,
+                                                updateAction)
+import           Data.Function                 (id)
+import           Data.IORef
+import           Data.Time.Clock               (getCurrentTime)
+import           PostgREST.App                 (postgrest)
+import           PostgREST.DbStructure         (getDbStructure,
+                                                getPgVersion)
+import           PostgREST.Types               (DbStructure (..),
+                                                pgVersion95,
+                                                pgVersion96)
 
-import qualified Feature.AuthSpec
+import qualified Feature.AndOrParamsSpec
 import qualified Feature.AsymmetricJwtSpec
-import qualified Feature.BinaryJwtSecretSpec
 import qualified Feature.AudienceJwtSecretSpec
+import qualified Feature.AuthSpec
+import qualified Feature.BinaryJwtSecretSpec
 import qualified Feature.ConcurrentSpec
 import qualified Feature.CorsSpec
 import qualified Feature.DeleteSpec
@@ -25,21 +31,20 @@ import qualified Feature.ExtraSearchPathSpec
 import qualified Feature.InsertSpec
 import qualified Feature.JsonOperatorSpec
 import qualified Feature.NoJwtSpec
-import qualified Feature.QueryLimitedSpec
-import qualified Feature.QuerySpec
-import qualified Feature.RangeSpec
-import qualified Feature.StructureSpec
-import qualified Feature.SingularSpec
-import qualified Feature.UnicodeSpec
-import qualified Feature.ProxySpec
-import qualified Feature.AndOrParamsSpec
-import qualified Feature.RpcSpec
 import qualified Feature.NonexistentSchemaSpec
 import qualified Feature.PgVersion95Spec
 import qualified Feature.PgVersion96Spec
+import qualified Feature.ProxySpec
+import qualified Feature.QueryLimitedSpec
+import qualified Feature.QuerySpec
+import qualified Feature.RangeSpec
+import qualified Feature.RpcSpec
+import qualified Feature.SingularSpec
+import qualified Feature.StructureSpec
+import qualified Feature.UnicodeSpec
 import qualified Feature.UpsertSpec
 
-import Protolude
+import           Protolude
 
 main :: IO ()
 main = do

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -1,35 +1,35 @@
 module SpecHelper where
 
-import Control.Monad (void)
+import           Control.Monad          (void)
 
-import qualified System.IO.Error as E
-import System.Environment (getEnv)
+import           System.Environment     (getEnv)
+import qualified System.IO.Error        as E
 
-import qualified Data.ByteString.Base64 as B64 (encode, decodeLenient)
-import Data.CaseInsensitive (CI(..))
-import qualified Data.Set as S
-import qualified Data.Map.Strict as M
-import Data.List (lookup)
-import Text.Regex.TDFA ((=~))
-import qualified Data.ByteString.Char8 as BS
-import qualified Data.ByteString.Lazy as BL
-import           System.Process (readProcess)
+import qualified Data.ByteString.Base64 as B64 (decodeLenient, encode)
+import qualified Data.ByteString.Char8  as BS
+import qualified Data.ByteString.Lazy   as BL
+import           Data.CaseInsensitive   (CI (..))
+import           Data.List              (lookup)
+import qualified Data.Map.Strict        as M
+import qualified Data.Set               as S
+import           System.Process         (readProcess)
 import           Text.Heredoc
+import           Text.Regex.TDFA        ((=~))
 
-import PostgREST.Config (AppConfig(..))
-import PostgREST.Types  (JSPathExp(..))
+import           PostgREST.Config       (AppConfig (..))
+import           PostgREST.Types        (JSPathExp (..))
 
-import Test.Hspec
-import Test.Hspec.Wai
+import           Test.Hspec
+import           Test.Hspec.Wai
 
-import Network.HTTP.Types
-import Network.Wai.Test (SResponse(simpleStatus, simpleHeaders, simpleBody))
+import           Network.HTTP.Types
+import           Network.Wai.Test       (SResponse (simpleBody, simpleHeaders, simpleStatus))
 
-import Data.Maybe (fromJust)
-import Data.Aeson (decode, Value(..))
-import qualified JSONSchema.Draft4 as D4
+import           Data.Aeson             (Value (..), decode)
+import           Data.Maybe             (fromJust)
+import qualified JSONSchema.Draft4      as D4
 
-import Protolude
+import           Protolude
 
 matchContentTypeJson :: MatchHeader
 matchContentTypeJson = "Content-Type" <:> "application/json; charset=utf-8"

--- a/test/TestTypes.hs
+++ b/test/TestTypes.hs
@@ -3,16 +3,16 @@ module TestTypes (
 , CompoundPK(..)
 ) where
 
+import           Data.Aeson ((.:))
 import qualified Data.Aeson as JSON
-import Data.Aeson ((.:))
 
-import Protolude
+import           Protolude
 
 data IncPK = IncPK {
-  incId :: Int
+  incId          :: Int
 , incNullableStr :: Maybe Text
-, incStr :: Text
-, incInsert :: Text
+, incStr         :: Text
+, incInsert      :: Text
 } deriving (Eq, Show)
 
 instance JSON.FromJSON IncPK where
@@ -24,8 +24,8 @@ instance JSON.FromJSON IncPK where
   parseJSON _ = mzero
 
 data CompoundPK = CompoundPK {
-  compoundK1 :: Int
-, compoundK2 :: Text
+  compoundK1    :: Int
+, compoundK2    :: Text
 , compoundExtra :: Maybe Int
 } deriving (Eq, Show)
 


### PR DESCRIPTION
Added a few things in support of using stylish-haskell and keeping using it.

Commits:
 - Apply stylish-haskell to all files.
 - Update config default with `stylish-haskell --defaults > .stylish-haskell.yaml`. Kept non-defaults: `columns: 70` and `language_extensions` .
- Remove redundant import. Re-ordering the imports revealed this. What is used from `Network.HTTP.Types.Headers` are also exported by `Network.HTTP.Types`.
- Add CircleCI config. Since `stylish-haskell` doesn't have an option to check format correctness (https://github.com/jaspervdj/stylish-haskell/issues/107), I use a small hack: Run with `-i` to format all source files inplace and then check if the git repo has any changes (the formatted files).

Edit:
 - Last commit was to match stylish-haskell version with our setup. Instead of the original command, used: `stack exec -- stylish-haskell --defaults > .stylish-haskell.yaml`. Kept non-defaults.