### PR TITLE
[WIP] Allow specifying root function

### DIFF
--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -319,8 +319,8 @@ instance JSON.FromJSON GucHeader where
     _ -> mzero
   parseJSON _          = mzero
 
-toHeaders :: [GucHeader] -> [Header]
-toHeaders = map $ \(GucHeader (k, v)) -> (CI.mk $ toS k, toS v)
+gucHToHeader :: GucHeader -> Header
+gucHToHeader (GucHeader (k, v)) = (CI.mk $ toS k, toS v)
 
 {-|
   This type will hold information about which particular 'Relation' between two tables to choose when there are multiple ones.

--- a/test/Feature/PgVersion96Spec.hs
+++ b/test/Feature/PgVersion96Spec.hs
@@ -1,10 +1,12 @@
 module Feature.PgVersion96Spec where
 
-import Network.Wai (Application)
+import Network.HTTP.Types
+import Network.Wai        (Application)
 
 import Test.Hspec
 import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
+import Text.Heredoc
 
 import Protolude  hiding (get)
 import SpecHelper
@@ -66,6 +68,21 @@ spec =
               matchContentTypeJson,
               "Set-Cookie" <:> "sessionid=38afes7a8; HttpOnly; Path=/",
               "Set-Cookie" <:> "id=a3fWa; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Secure; HttpOnly"]}
+
+      it "can override the Content-Type" $
+        request methodGet "/rpc/html" [("Accept", "application/octet-stream, */*")] ""
+          `shouldRespondWith`
+          [str|
+              |<html>
+              |  <head>
+              |    <title>PostgREST</title>
+              |  </head>
+              |  <body>
+              |    <h1>REST API</h1>
+              |  </body>
+              |</html>
+              |]
+          { matchHeaders = ["Content-Type" <:> "text/html; charset=utf-8"] }
 
     context "Use of the phraseto_tsquery function" $ do
       it "finds matches" $

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1670,3 +1670,19 @@ create function add_them(a integer, b integer)
 returns integer as $$
   select a + b;
 $$ language sql;
+
+create or replace function html() returns text as $_$
+begin
+set local "response.headers" = '[{"Content-Type": "text/html; charset=utf-8"}]';
+return $$
+<html>
+  <head>
+    <title>PostgREST</title>
+  </head>
+  <body>
+    <h1>REST API</h1>
+  </body>
+</html>
+$$::text;
+end
+$_$ language plpgsql;


### PR DESCRIPTION
As discussed in https://github.com/PostgREST/postgrest/issues/790#issuecomment-495330657. With this function we could solve all the [current OpenAPI issues](https://github.com/PostgREST/postgrest/issues?q=is%3Aopen+is%3Aissue+label%3AOpenAPI).

This is a work in progress.

To do this first we need to be able to override the `Content-Type`(in case user wants to specify `application/openapiv3+json` or other spec). Previously we discussed this in https://github.com/PostgREST/postgrest/pull/986#discussion_r143622820.

For now content negotiation is kind of broken on RPC, since client can specify `Accept: x` and server can respond with `Content-Type: y`. Not sure if we should enforce a way to make this consistent or leave the responsibility to the user. 