### PR TITLE
Vendor orphaned configuration dependencies critbit and configurator-ng

### DIFF
--- a/deps/Data/Configurator.hs
+++ b/deps/Data/Configurator.hs
@@ -1,0 +1,527 @@
+{-# LANGUAGE CPP, BangPatterns, OverloadedStrings, RecordWildCards,
+    ScopedTypeVariables, TupleSections #-}
+
+-- |
+-- Module:      Data.Configurator
+-- Copyright:   (c) 2011 MailRank, Inc.
+--              (c) 2015-2016 Leon P Smith
+-- License:     BSD3
+-- Maintainer:  Leon P Smith <leon@melding-monads.com>
+-- Stability:   experimental
+-- Portability: portable
+--
+-- A simple (yet powerful) library for working with configuration
+-- files.
+--
+-- Note that while the "Data.Configurator.Parser" and
+-- "Data.Configurator.FromValue" should be quite stable at this point,
+-- this module is likely to be subjected to significant breaking changes in
+-- subsequent versions of configurator-ng.   So please do file an issue
+-- if you have any opinions or especially needs with regards to
+-- configuration (re)loading,  change notifications,  etc.
+
+module Data.Configurator
+    (
+    -- * Configuration file format
+    -- $format
+
+    -- ** Binding a name to a value
+    -- $binding
+
+    -- *** Value types
+    -- $types
+
+    -- *** String interpolation
+    -- $interp
+
+    -- ** Grouping directives
+    -- $group
+
+    -- ** Importing files
+    -- $import
+
+    -- * Types
+      Worth(..)
+    -- * Loading configuration data
+    , autoReload
+    , autoReloadGroups
+    , autoConfig
+{--
+    -- * Lookup functions
+
+    , lookup
+    , lookupDefault
+    , require
+--}
+    -- * Notification of configuration changes
+    -- $notify
+    , prefix
+    , exact
+    , subscribe
+    -- * Low-level loading functions
+    , load
+    , loadGroups
+    , reload
+    , addToConfig
+    , addGroupsToConfig
+    -- * Helper functions
+    , display
+    , readConfig
+    ) where
+
+#if !(MIN_VERSION_base(4,8,0))
+import Control.Applicative ((<$>))
+#endif
+import Control.Concurrent (ThreadId, forkIO, threadDelay)
+import Control.Exception (SomeException, evaluate, handle, throwIO, try)
+import Control.Monad (foldM, forM, forM_, when, msum)
+import Data.Configurator.Syntax (interp, topLevel)
+import Data.Configurator.Types.Internal
+import Data.Configurator.Config.Internal(ConfigPlan(ConfigPlan), Config(Config))
+import Data.Int (Int64)
+import Data.IORef (atomicModifyIORef, newIORef, readIORef)
+import Data.List (tails)
+import Data.Maybe (isJust)
+#if !(MIN_VERSION_base(4,8,0))
+import Data.Monoid (mconcat)
+#endif
+import Data.Scientific ( toBoundedInteger, toRealFloat )
+import Data.Text.Lazy.Builder (fromString, fromText, toLazyText)
+import Data.Text.Lazy.Builder.Int (decimal)
+import Data.Text.Lazy.Builder.RealFloat (realFloat)
+import Prelude hiding (lookup)
+import System.Environment (getEnv)
+import System.IO (hPutStrLn, stderr)
+import System.Posix.Types (EpochTime, FileOffset)
+import System.PosixCompat.Files (fileSize, getFileStatus, modificationTime)
+import qualified Control.Exception as E
+import qualified Data.Attoparsec.Text as T
+import qualified Data.Attoparsec.Text.Lazy as L
+import qualified Data.HashMap.Lazy as H
+import qualified Data.CritBit.Map.Lazy as CB
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as L
+import qualified Data.Text.Lazy.IO as L
+
+loadFiles :: [Worth Path] -> IO (H.HashMap (Worth Path) [Directive])
+loadFiles = foldM go H.empty
+ where
+   go seen path = do
+     let rewrap n = const n <$> path
+         wpath = worth path
+     path' <- rewrap <$> interpolate "" wpath CB.empty
+     ds    <- loadOne (T.unpack <$> path')
+     let !seen'    = H.insert path ds seen
+         notSeen n = not . isJust . H.lookup n $ seen
+     foldM go seen' . filter notSeen . importsOf wpath $ ds
+
+-- | Create a 'ConfigCache' from the contents of the named files. Throws an
+-- exception on error, such as if files do not exist or contain errors.
+--
+-- File names have any environment variables expanded prior to the
+-- first time they are opened, so you can specify a file name such as
+-- @\"$(HOME)/myapp.cfg\"@.
+load :: [Worth FilePath] -> IO ConfigCache
+load files = load' Nothing (map (\f -> ("", f)) files)
+
+-- | Create a 'ConfigCache' from the contents of the named files, placing them
+-- into named prefixes.  If a prefix is non-empty, it should end in a
+-- dot.
+loadGroups :: [(Name, Worth FilePath)] -> IO ConfigCache
+loadGroups files = load' Nothing files
+
+load' :: Maybe AutoConfig -> [(Name, Worth FilePath)] -> IO ConfigCache
+load' auto paths0 = do
+  let second f (x,y) = (x, f y)
+      paths          = map (second (fmap T.pack)) paths0
+  ds <- loadFiles (map snd paths)
+  p <- newIORef paths
+  m <- newIORef =<< flatten paths ds
+  s <- newIORef H.empty
+  return ConfigCache {
+                cfgAuto = auto
+              , cfgPaths = p
+              , cfgMap = m
+              , cfgSubs = s
+              }
+
+-- | Forcibly reload a 'ConfigCache'. Throws an exception on error, such as
+-- if files no longer exist or contain errors.
+reload :: ConfigCache -> IO ()
+reload cfg@ConfigCache{..} = do
+  paths <- readIORef cfgPaths
+  m' <- flatten paths =<< loadFiles (map snd paths)
+  m <- atomicModifyIORef cfgMap $ \m -> (m', m)
+  notifySubscribers cfg m m' =<< readIORef cfgSubs
+
+-- | Add additional files to a 'ConfigCache', causing it to be reloaded to add
+-- their contents.
+addToConfig :: [Worth FilePath] -> ConfigCache -> IO ()
+addToConfig paths0 cfg = addGroupsToConfig (map (\x -> ("",x)) paths0) cfg
+
+-- | Add additional files to named groups in a 'ConfigCache', causing it to be
+-- reloaded to add their contents.  If the prefixes are non-empty, they should
+-- end in dots.
+addGroupsToConfig :: [(Name, Worth FilePath)] -> ConfigCache -> IO ()
+addGroupsToConfig paths0 cfg@ConfigCache{..} = do
+  let fix (x,y) = (x, fmap T.pack y)
+      paths     = map fix paths0
+  atomicModifyIORef cfgPaths $ \prev -> (prev ++ paths, ())
+  reload cfg
+
+-- | Defaults for automatic 'Config' reloading when using
+-- 'autoReload'.  The 'interval' is one second, while the 'onError'
+-- action ignores its argument and does nothing.
+autoConfig :: AutoConfig
+autoConfig = AutoConfig {
+               interval = 1
+             , onError = const $ return ()
+             }
+
+-- | Load a 'ConfigCache' from the given 'FilePath's, and start a reload
+-- thread.
+--
+-- At intervals, a thread checks for modifications to both the
+-- original files and any files they refer to in @import@ directives,
+-- and reloads the 'ConfigCache' if any files have been modified.
+--
+-- If the initial attempt to load the configuration files fails, an
+-- exception is thrown.  If the initial load succeeds, but a
+-- subsequent attempt fails, the 'onError' handler is invoked.
+--
+-- File names have any environment variables expanded prior to the
+-- first time they are opened, so you can specify a file name such as
+-- @\"$(HOME)/myapp.cfg\"@.
+autoReload :: AutoConfig
+           -- ^ Directions for when to reload and how to handle
+           -- errors.
+           -> [Worth FilePath]
+           -- ^ Configuration files to load.
+           -> IO (ConfigCache, ThreadId)
+autoReload auto paths = autoReloadGroups auto (map (\x -> ("", x)) paths)
+
+autoReloadGroups :: AutoConfig
+                 -> [(Name, Worth FilePath)]
+                 -> IO (ConfigCache, ThreadId)
+autoReloadGroups AutoConfig{..} _
+    | interval < 1    = error "autoReload: negative interval"
+autoReloadGroups _ [] = error "autoReload: no paths to load"
+autoReloadGroups auto@AutoConfig{..} paths = do
+  cfg <- load' (Just auto) paths
+  let files = map snd paths
+      loop meta = do
+        threadDelay (max interval 1 * 1000000)
+        meta' <- getMeta files
+        if meta' == meta
+          then loop meta
+          else (reload cfg `E.catch` onError) >> loop meta'
+  tid <- forkIO $ loop =<< getMeta files
+  return (cfg, tid)
+
+-- | Save both a file's size and its last modification date, so we
+-- have a better chance of detecting a modification on a crappy
+-- filesystem with timestamp resolution of 1 second or worse.
+type Meta = (FileOffset, EpochTime)
+
+getMeta :: [Worth FilePath] -> IO [Maybe Meta]
+getMeta paths = forM paths $ \path ->
+   handle (\(_::SomeException) -> return Nothing) . fmap Just $ do
+     st <- getFileStatus (worth path)
+     return (fileSize st, modificationTime st)
+
+{--
+-- | Look up a name in the given 'ConfigCache'.  If a binding exists, and
+-- the value can be 'convert'ed to the desired type, return the
+-- converted value, otherwise 'Nothing'.
+lookup :: Configured a => ConfigCache -> Name -> IO (Maybe a)
+lookup ConfigCache{..} name =
+    (convert . CB.lookup name) <$> readIORef cfgMap
+--}
+
+{--
+-- | Look up a name in the given 'ConfigCache'.  If a binding exists, and
+-- the value can be 'convert'ed to the desired type, return the
+-- converted value, otherwise throw a 'KeyError'.
+require :: Configured a => ConfigCache -> Name -> IO a
+require cfg name = do
+  val <- lookup cfg name
+  case val of
+    Just v -> return v
+    _      -> throwIO . KeyError $ name
+--}
+
+{--
+-- | Look up a name in the given 'ConfigCache'.  If a binding exists, and
+-- the value can be converted to the desired type, return it,
+-- otherwise return the default value.
+lookupDefault :: Configured a =>
+                 a
+              -- ^ Default value to return if 'lookup' or 'convert'
+              -- fails.
+              -> ConfigCache -> Name -> IO a
+lookupDefault def cfg name = fromMaybe def <$> lookup cfg name
+--}
+
+-- | Perform a simple dump of a 'ConfigCache' to @stdout@.
+display :: ConfigCache -> IO ()
+display ConfigCache{..} = print =<< readIORef cfgMap
+
+-- | Read the current configuration stored in the cache.
+readConfig :: ConfigCache -> IO Config
+readConfig = (Config . ConfigPlan <$>) . readIORef . cfgMap
+
+flatten :: [(Name, Worth Path)]
+        -> H.HashMap (Worth Path) [Directive]
+        -> IO (CB.CritBit Name Value)
+flatten roots files = foldM doPath CB.empty roots
+ where
+  doPath m (pfx, f) = case H.lookup f files of
+        Nothing -> return m
+        Just ds -> foldM (directive pfx (worth f)) m ds
+
+  directive pfx _ m (Bind name (String value)) = do
+      v <- interpolate pfx value m
+      return $! CB.insert (T.append pfx name) (String v) m
+  directive pfx _ m (Bind name value) =
+      return $! CB.insert (T.append pfx name) value m
+  directive pfx f m (Group name xs) = foldM (directive pfx' f) m xs
+      where pfx' = T.concat [pfx, name, "."]
+  directive pfx f m (Import path) =
+      let f' = relativize f path
+      in  case H.lookup (Required (relativize f path)) files of
+            Just ds -> foldM (directive pfx f') m ds
+            _       -> return m
+  directive _ _ m (DirectiveComment _) = return m
+
+interpolate :: T.Text -> T.Text -> CB.CritBit Name Value -> IO T.Text
+interpolate pfx s env
+    | "$" `T.isInfixOf` s =
+      case T.parseOnly interp s of
+        Left err   -> throwIO $ ParseError "" err
+        Right xs -> (L.toStrict . toLazyText . mconcat) <$> mapM interpret xs
+    | otherwise = return s
+ where
+  lookupEnv name = msum $ map (flip CB.lookup env) fullnames
+    where fullnames = map (T.intercalate ".")     -- ["a.b.c.x","a.b.x","a.x","x"]
+                    . map (reverse . (name:)) -- [["a","b","c","x"],["a","b","x"],["a","x"],["x"]]
+                    . tails                   -- [["c","b","a"],["b","a"],["a"],[]]
+                    . reverse                 -- ["c","b","a"]
+                    . filter (not . T.null)   -- ["a","b","c"]
+                    . T.split (=='.')         -- ["a","b","c",""]
+                    $ pfx                     -- "a.b.c."
+
+  interpret (Literal x)   = return (fromText x)
+  interpret (Interpolate name) =
+      case lookupEnv name of
+        Just (String x) -> return (fromText x)
+        Just (Number r) ->
+            case toBoundedInteger r :: Maybe Int64 of
+              Just n  -> return (decimal n)
+              Nothing -> return (realFloat (toRealFloat r :: Double))
+        Just _          -> error "type error"
+        _ -> do
+          e <- try . getEnv . T.unpack $ name
+          case e of
+            Left (_::SomeException) ->
+                throwIO . ParseError "" $ "no such variable " ++ show name
+            Right x -> return (fromString x)
+
+importsOf :: Path -> [Directive] -> [Worth Path]
+importsOf path (Import ref : xs) = Required (relativize path ref)
+                                 : importsOf path xs
+importsOf path (Group _ ys : xs) = importsOf path ys ++ importsOf path xs
+importsOf path (_ : xs)          = importsOf path xs
+importsOf _    _                 = []
+
+relativize :: Path -> Path -> Path
+relativize parent child
+  | T.head child == '/' = child
+  | otherwise           = fst (T.breakOnEnd "/" parent) `T.append` child
+
+loadOne :: Worth FilePath -> IO [Directive]
+loadOne path = do
+  es <- try . L.readFile . worth $ path
+  case es of
+    Left (err::SomeException) -> case path of
+                                   Required _ -> throwIO err
+                                   _          -> return []
+    Right s -> do
+            p <- evaluate (L.eitherResult $ L.parse topLevel s)
+                 `E.catch` \(e::ParseError) ->
+                 throwIO $ case e of
+                             ParseError _ err -> ParseError (worth path) err
+            case p of
+              Left err -> throwIO (ParseError (worth path) err)
+              Right ds -> return ds
+
+-- | Subscribe for notifications.  The given action will be invoked
+-- when any change occurs to a configuration property matching the
+-- supplied pattern.
+subscribe :: ConfigCache -> Pattern -> ChangeHandler -> IO ()
+subscribe ConfigCache{..} pat act = do
+  m' <- atomicModifyIORef cfgSubs $ \m ->
+        let m' = H.insertWith (++) pat [act] m in (m', m')
+  evaluate m' >> return ()
+
+notifySubscribers :: ConfigCache -> CB.CritBit Name Value -> CB.CritBit Name Value
+                  -> H.HashMap Pattern [ChangeHandler] -> IO ()
+notifySubscribers ConfigCache{..} m m' subs = H.foldrWithKey go (return ()) subs
+ where
+  changedOrGone = CB.foldrWithKey check [] m
+      where check n v nvs = case CB.lookup n m' of
+                              Just v' | v /= v'   -> (n,Just v'):nvs
+                                      | otherwise -> nvs
+                              _                   -> (n,Nothing):nvs
+  new = CB.foldrWithKey check [] m'
+      where check n v nvs = case CB.lookup n m of
+                              Nothing -> (n,v):nvs
+                              _       -> nvs
+  notify p n v a = a n v `E.catch` maybe report onError cfgAuto
+    where report e = hPutStrLn stderr $
+                     "*** a ChangeHandler threw an exception for " ++
+                     show (p,n) ++ ": " ++ show e
+  go p@(Exact n) acts next = (const next =<<) $ do
+    let v' = CB.lookup n m'
+    when (CB.lookup n m /= v') . mapM_ (notify p n v') $ acts
+  go p@(Prefix n) acts next = (const next =<<) $ do
+    let matching = filter (T.isPrefixOf n . fst)
+    forM_ (matching new) $ \(n',v) -> mapM_ (notify p n' (Just v)) acts
+    forM_ (matching changedOrGone) $ \(n',v) -> mapM_ (notify p n' v) acts
+
+-- $format
+--
+-- A configuration file consists of a series of directives and
+-- comments, encoded in UTF-8.  A comment begins with a \"@#@\"
+-- character, and continues to the end of a line.
+--
+-- Files and directives are processed from first to last, top to
+-- bottom.
+
+-- $binding
+--
+-- A binding associates a name with a value.
+--
+-- > my_string = "hi mom! \u2603"
+-- > your-int-33 = 33
+-- > his_bool = on
+-- > HerList = [1, "foo", off]
+--
+-- A name must begin with a Unicode letter, which is followed by zero
+-- or more of a Unicode alphanumeric code point, hyphen \"@-@\", or
+-- underscore \"@_@\".
+--
+-- Bindings are created or overwritten in the order in which they are
+-- encountered.  It is legitimate for a name to be bound multiple
+-- times, in which case the last value wins.
+--
+-- > a = 1
+-- > a = true
+-- > # value of a is now true, not 1
+
+-- $types
+--
+-- The configuration file format supports the following data types:
+--
+-- * Booleans, represented as @on@ or @off@, @true@ or @false@.  These
+--   are case sensitive, so do not try to use @True@ instead of
+--   @true@!
+--
+-- * Decimal fractions,  expressed in scientific notation.
+--
+-- * Unicode strings, represented as text (possibly containing escape
+--   sequences) surrounded by double quotes.
+--
+-- * Heterogeneous lists of values, represented as an opening square
+--   bracket \"@[@\", followed by a series of comma-separated values,
+--   ending with a closing square bracket \"@]@\".
+--
+-- The following escape sequences are recognised in a text string:
+--
+-- * @\\n@ - newline
+--
+-- * @\\r@ - carriage return
+--
+-- * @\\t@ - horizontal tab
+--
+-- * @\\\\@ - backslash
+--
+-- * @\\\"@ - double quote
+--
+-- * @\\u@/xxxx/ - Unicode character from the basic multilingual
+--   plane, encoded as four hexadecimal digits
+--
+-- * @\\u@/xxxx/@\\u@/xxxx/ - Unicode character from an astral plane,
+--   as two hexadecimal-encoded UTF-16 surrogates
+
+-- $interp
+--
+-- Strings support interpolation, so that you can dynamically
+-- construct a string based on data in your configuration or the OS
+-- environment.
+--
+-- If a string value contains the special sequence \"@$(foo)@\" (for
+-- any name @foo@), then the name @foo@ will be looked up in the
+-- configuration data and its value substituted.  If that name cannot
+-- be found, it will be looked up in the OS environment.
+--
+-- For security reasons, it is an error for a string interpolation
+-- fragment to contain a name that cannot be found in either the
+-- current configuration or the environment.
+--
+-- To represent a single literal \"@$@\" character in a string, double
+-- it: \"@$$@\".
+
+-- $group
+--
+-- It is possible to group a number of directives together under a
+-- single prefix:
+--
+-- > my-group
+-- > {
+-- >   a = 1
+-- >
+-- >   # groups support nesting
+-- >   nested {
+-- >     b = "yay!"
+-- >   }
+-- > }
+--
+-- The name of a group is used as a prefix for the items in the
+-- group. For instance, the value of \"@a@\" above can be retrieved
+-- using 'lookup' by supplying the name \"@my-group.a@\", and \"@b@\"
+-- will be named \"@my-group.nested.b@\".
+
+-- $import
+--
+-- To import the contents of another configuration file, use the
+-- @import@ directive.
+--
+-- > import "$(HOME)/etc/myapp.cfg"
+--
+-- Absolute paths are imported as is.  Relative paths are resolved with
+-- respect to the file they are imported from.  It is an error for an
+-- @import@ directive to name a file that does not exist, cannot be read,
+-- or contains errors.
+--
+-- If an @import@ appears inside a group, the group's naming prefix
+-- will be applied to all of the names imported from the given
+-- configuration file.
+--
+-- Supposing we have a file named \"@foo.cfg@\":
+--
+-- > bar = 1
+--
+-- And another file that imports it into a group:
+--
+-- > hi {
+-- >   import "foo.cfg"
+-- > }
+--
+-- This will result in a value named \"@hi.bar@\".
+
+-- $notify
+--
+-- To more efficiently support an application's need to dynamically
+-- reconfigure, a subsystem may ask to be notified when a
+-- configuration property is changed as a result of a reload, using
+-- the 'subscribe' action.

--- a/deps/Data/Configurator/Config.hs
+++ b/deps/Data/Configurator/Config.hs
@@ -1,0 +1,61 @@
+-- |
+-- Module:      Data.Configurator.Config
+-- Copyright:   (c) 2016 Leon P Smith
+-- License:     BSD3
+-- Maintainer:  Leon P Smith <leon@melding-monads.com>
+--
+-- This module provides the abstract data structure that backs @ConfigCache@
+-- and that @ConfigParser@s operate on.
+--
+-- It shouldn't be necessary to use this module much, if at all, in client
+-- code.  It might be considered semi-internal.  Please file a issue if you
+-- find a need to use it.
+
+module Data.Configurator.Config
+     ( Config
+     , empty
+     , null
+     , lookup
+     , lookupWithName
+     , subgroups
+     , subassocs
+     , subassocs'
+     , union
+     , subconfig
+     , superconfig
+     ) where
+
+import Prelude hiding (lookup,null)
+import Data.Configurator.Types(Name,Value)
+import Data.Configurator.Config.Implementation(Config(..),ConfigPlan(Empty))
+import qualified Data.Configurator.Config.Implementation as C
+
+lookup :: Name -> Config -> Maybe Value
+lookup k (Config c) = C.lookup k c
+
+lookupWithName :: Name -> Config -> Maybe (Name, Value)
+lookupWithName k (Config c) = C.lookupWithName k c
+
+subgroups :: Name -> Config -> [Name]
+subgroups k (Config c) = C.subgroups k c
+
+subassocs :: Name -> Config -> [(Name,Value)]
+subassocs k (Config c) = C.subassocs k c
+
+subassocs' :: Name -> Config -> [(Name,Value)]
+subassocs' k (Config c) = C.subassocs' k c
+
+empty :: Config
+empty =  Config Empty
+
+null :: Config -> Bool
+null (Config c) = C.null c
+
+union :: Config -> Config -> Config
+union (Config a) (Config b) = Config (C.union a b)
+
+subconfig :: Name -> Config -> Config
+subconfig key (Config c) = Config (C.subconfig key c)
+
+superconfig :: Name -> Config -> Config
+superconfig key (Config c) = Config (C.superconfig key c)

--- a/deps/Data/Configurator/Config/Implementation.hs
+++ b/deps/Data/Configurator/Config/Implementation.hs
@@ -1,0 +1,230 @@
+{-# LANGUAGE OverloadedStrings, ScopedTypeVariables    #-}
+{-# LANGUAGE BangPatterns, ViewPatterns, TupleSections #-}
+{-# LANGUAGE DeriveFunctor, DeriveDataTypeable         #-}
+
+-- |
+-- Module:      Data.Configurator.Config.Implementation
+-- Copyright:   (c) 2015-2016 Leon P Smith
+-- License:     BSD3
+-- Maintainer:  Leon P Smith <leon@melding-monads.com>
+
+module Data.Configurator.Config.Implementation where
+
+import           Prelude hiding ((++),null)
+import           Control.Applicative
+-- import           Control.Arrow(first)
+import           Data.Maybe(mapMaybe)
+--import           Data.Ratio
+--import           Data.ByteString (ByteString)
+import           Data.Configurator.Types.Internal hiding (Group)
+import           Data.Typeable
+import           Data.CritBit.Map.Lazy (CritBit)
+import qualified Data.CritBit.Map.Lazy as CB
+import qualified Data.List.Ordered as OL
+import           Data.Monoid
+import           Data.Function (on)
+import           Data.Text(Text)
+import qualified Data.Text as T
+--import qualified Data.Text.Encoding as T
+--import qualified Data.Text.Lazy as TL
+--import qualified Data.Text.Lazy.Builder as TB
+--import qualified Data.Text.Lazy.Builder.Int as TB
+--import qualified Data.Text.Lazy.Builder.RealFloat as TB
+
+data ConfigPlan a
+    = Subconfig   Text (ConfigPlan a)
+    | Superconfig Text (ConfigPlan a)
+    | Union       (ConfigPlan a) (ConfigPlan a)
+    | ConfigPlan  a
+    | Empty
+      deriving (Show, Typeable, Functor)
+
+addPrefix :: Name -> Name -> Name
+addPrefix pre key
+    | T.null pre = key
+    | T.null key = pre
+    | otherwise  = T.concat [pre, ".", key]
+
+stripPrefix :: Name -> Name -> Maybe Name
+stripPrefix pre key =
+    if   T.null pre
+    then Just key
+    else case T.stripPrefix pre key of
+           Nothing -> Nothing
+           Just key' -> if   T.null key'
+                        then Just T.empty
+                        else T.stripPrefix "." key'
+
+foldPlan :: b -> (b -> b -> b) -> (Text -> a -> b) -> Text -> ConfigPlan a -> b
+foldPlan empty union lookup = loop
+  where
+    loop key  (Subconfig   pre pl ) = loop (addPrefix pre key) pl
+    loop key  (Superconfig pre pl ) = case stripPrefix pre key of
+                                        Nothing   -> empty
+                                        Just key' -> loop key' pl
+    loop key  (Union       pl1 pl2) = loop key pl1 `union` loop key pl2
+    loop key  (ConfigPlan  a      ) = lookup key a
+    loop _key  Empty                = empty
+{-# INLINE foldPlan #-}
+
+
+type ConfigMap a = ConfigPlan (CB.CritBit Text a)
+
+-- | A 'Config' is a finite map from 'Text' to 'Value'.
+newtype Config = Config (ConfigMap Value)
+
+-- | FIXME: improve this implementation.
+subassocs :: Text -> ConfigMap a -> [(Text,a)]
+subassocs key c = filter pred (subassocs' key c)
+  where
+    pred (name,_) = case stripPrefix key name of
+                      Nothing -> False -- shouldn't happen
+                      Just name' -> T.find ('.'==) name' == Nothing
+
+subassocs' :: Text -> ConfigMap a -> [(Text,a)]
+subassocs' key c = subassocs_ subassocsMap key c
+
+lookup :: Text -> ConfigMap a -> Maybe a
+lookup = foldPlan Nothing (<|>) CB.lookup
+
+lookupWithName :: Name -> ConfigMap a -> Maybe (Name,a)
+lookupWithName = foldPlan Nothing (<|>) (\k m -> (k,) <$> CB.lookup k m)
+
+subassocs_ :: (Text -> a -> [(Text,b)])
+           -> Text -> ConfigPlan a -> [(Text,b)]
+subassocs_ subassocs = loop
+  where
+    addPrefixes pre
+        | T.null pre = id
+        | otherwise  = map (\(k,v) -> (addPrefix pre k,v))
+
+    stripPrefixes pre
+        | T.null pre = id
+        | otherwise  = mapMaybe $ \(k,v) -> case stripPrefix pre k of
+                                              Nothing -> Nothing
+                                              Just k' -> Just (k',v)
+
+    loop !_key Empty = []
+    loop !key (Subconfig   pre pl) =
+        stripPrefixes pre (loop (addPrefix pre key) pl)
+    loop !key (Superconfig pre pl) =
+        if T.length key <= T.length pre
+        then case stripPrefix key pre of
+               Nothing    -> []
+               Just _pre' -> addPrefixes pre (loop T.empty pl)
+        else case stripPrefix pre key of
+               Nothing    -> []
+               Just key'  -> addPrefixes pre (loop key' pl)
+    loop !key (Union pl1 pl2) =
+        OL.unionBy (compare `on` fst) (loop key pl1) (loop key pl2)
+    loop !key (ConfigPlan map) = subassocs key map
+
+submap :: Text -> CritBit Text a -> CritBit Text a
+submap key map
+    | T.null key = map
+    | otherwise  = let (_ , gt) = CB.split (key <> ".")  map
+                       (lt, _ ) = CB.split (key <> ".~") gt
+                    in lt
+
+subassocsMap :: Text -> CritBit Text a -> [(Text, a)]
+subassocsMap key map = CB.assocs (submap key map)
+
+null :: ConfigPlan (CritBit Text a) -> Bool
+null = foldPlan True (&&) nullSubmap T.empty
+
+nullSubmap :: Text -> CritBit Text a -> Bool
+-- nullSubmap key map = CB.null (submap key map)
+nullSubmap key map =
+    if T.null key
+    then CB.null map
+    else case CB.lookupGT key map of
+           Nothing -> True
+           Just (key', _) ->
+               case stripPrefix key key' of
+                 Nothing -> False
+                 Just _  -> True
+
+subgroups :: Text -> ConfigMap a -> [Text]
+subgroups = loop
+  where
+    stripPrefixes pre
+        | T.null pre = id
+        | otherwise  = mapMaybe (stripPrefix pre)
+
+    addPrefixes pre
+        | T.null pre = id
+        | otherwise  = map (addPrefix pre)
+
+    loop !_key Empty = []
+    loop !key (Subconfig   pre pl) =
+        stripPrefixes pre (loop (addPrefix pre key) pl)
+    loop !key (Superconfig pre pl) =
+        if T.length pre <= T.length key
+        then case stripPrefix pre key of
+               Nothing    -> []
+               Just key'  -> addPrefixes pre (loop key' pl)
+        else case stripPrefix key pre of
+               Nothing    -> []
+               Just pre'  -> if null pl
+                             then []
+                             else [addPrefix key (T.takeWhile ('.' /=) pre')]
+    loop !key (Union  pl1 pl2) =
+        OL.unionBy compare (loop key pl1) (loop key pl2)
+    loop !key (ConfigPlan map) = subgroupsMap key map
+
+subgroupsMap :: Text -> CritBit Text a -> [Text]
+subgroupsMap pre_ map = loop (CB.lookupGT pre map)
+  where
+    pre | T.null pre_ = T.empty
+        | otherwise   = pre_ <> "."
+    loop Nothing = []
+    loop (Just (key,_)) =
+        case T.stripPrefix pre key of
+          Nothing -> []
+          Just sfx -> let (sfxa, sfxz) = T.break ('.' ==) sfx
+                       in if T.null sfxz
+                          then loop (CB.lookupGT key map)
+                          else let key' = pre <> sfxa
+                                in key' : loop (CB.lookupGT (key' <> "/") map)
+
+union :: ConfigMap a -> ConfigMap a -> ConfigMap a
+union x y
+    | null x    = y
+    | null y    = x
+    | otherwise = Union x y
+
+subconfig :: Text -> ConfigMap a -> ConfigMap a
+subconfig = \k c -> if T.null k then c else loop k c
+  where
+    loop k c =
+        case c of
+          Empty -> Empty
+          Union a b -> union (loop k a) (loop k b)
+          Superconfig kk cc ->
+            if T.length k <= T.length kk
+            then case stripPrefix k kk of
+                   Nothing  -> Empty
+                   Just kk' -> if T.null kk'
+                               then cc
+                               else Superconfig kk' cc
+            else case stripPrefix kk k of
+                   Nothing  -> Empty
+                   Just k'  -> loop k' cc
+          ConfigPlan map ->
+            let map' = submap k map
+             in if CB.null map'
+                then Empty
+                else Subconfig k (ConfigPlan map')
+          (Subconfig _ _) ->
+            let c' = Subconfig k c
+             in if null c'
+                then Empty
+                else c'
+
+superconfig :: Text -> ConfigMap a -> ConfigMap a
+superconfig k c =
+    if T.null k
+    then c
+    else if null c
+         then Empty
+         else Superconfig k c

--- a/deps/Data/Configurator/Config/Internal.hs
+++ b/deps/Data/Configurator/Config/Internal.hs
@@ -1,0 +1,31 @@
+-- |
+-- Module:      Data.Configurator.Config.Internal
+-- Copyright:   (c) 2015-2016 Leon P Smith
+-- License:     BSD3
+-- Maintainer:  Leon P Smith <leon@melding-monads.com>
+
+module Data.Configurator.Config.Internal
+     ( Config(..)
+     , ConfigMap
+     , ConfigPlan(..)
+
+     , lookup
+     , lookupWithName
+     , subgroups
+     , subassocs
+
+     , null
+     , subconfig
+     , superconfig
+     , union
+
+     , subassocs_
+     , foldPlan
+     , submap
+     , subgroupsMap
+     , addPrefix
+     , stripPrefix
+     ) where
+
+import Prelude hiding (lookup, null)
+import Data.Configurator.Config.Implementation

--- a/deps/Data/Configurator/FromValue.hs
+++ b/deps/Data/Configurator/FromValue.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Module:      Data.Configurator.FromValue
+-- Copyright:   (c) 2016 Leon P Smith
+-- License:     BSD3
+-- Maintainer:  Leon P Smith <leon@melding-monads.com>
+
+module Data.Configurator.FromValue
+     ( MaybeParser
+     , runMaybeParser
+     , FromMaybeValue(..)
+     , optionalValue
+     , requiredValue
+     , ValueParser
+     , runValueParser
+     , FromValue(..)
+     , ListParser
+     , FromListValue(..)
+     , listValue
+     , listValue'
+     , listElem
+     , ConversionError(..)
+     , ConversionErrorWhy(..)
+     , defaultConversionError
+     -- * Assorted primitive value parsers
+     , boolValue
+     , boundedIntegerValue
+     , integralValue
+     , fractionalValue
+     , realFloatValue
+     , fixedValue
+     , scientificValue
+     , textValue
+     , charValue
+     , typeError
+     , valueError
+     , extraValuesError
+     , missingValueError
+     ) where
+
+import Data.Configurator.FromValue.Implementation
+import Data.Configurator.Types

--- a/deps/Data/Configurator/FromValue/Implementation.hs
+++ b/deps/Data/Configurator/FromValue/Implementation.hs
@@ -11,6 +11,7 @@
 
 module Data.Configurator.FromValue.Implementation where
 
+import           Prelude
 import           Control.Applicative
 import           Control.Arrow (first, second)
 import           Control.Monad (ap)

--- a/deps/Data/Configurator/FromValue/Implementation.hs
+++ b/deps/Data/Configurator/FromValue/Implementation.hs
@@ -1,0 +1,684 @@
+{-# LANGUAGE CPP, DeriveDataTypeable, DeriveFunctor #-}
+{-# LANGUAGE FlexibleInstances, DefaultSignatures #-}
+{-# LANGUAGE ScopedTypeVariables, BangPatterns, ViewPatterns #-}
+{-# LANGUAGE OverloadedStrings, OverlappingInstances #-}
+
+-- |
+-- Module:      Data.Configurator.FromValue.Implementation
+-- Copyright:   (c) 2016 Leon P Smith
+-- License:     BSD3
+-- Maintainer:  Leon P Smith <leon@melding-monads.com>
+
+module Data.Configurator.FromValue.Implementation where
+
+import           Control.Applicative
+import           Control.Arrow (first, second)
+import           Control.Monad (ap)
+import qualified Control.Monad.Fail as Fail
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as LB
+import           Data.Complex (Complex((:+)))
+import           Data.Configurator.Types
+                   ( Value(..)
+                   , ConversionError(..)
+                   , ConversionErrorWhy(..)
+                   , defaultConversionError
+                   )
+import           Data.Configurator.Types.Internal
+                   ( MultiErrors
+                   , singleError
+                   , toErrors
+                   )
+import           Data.Fixed (Fixed, HasResolution)
+import           Data.Int(Int8, Int16, Int32, Int64)
+import           Data.Monoid
+import           Data.Ratio ( Ratio, (%) )
+import           Data.Scientific
+                   ( Scientific,  coefficient, base10Exponent, normalize
+                   , floatingOrInteger, toRealFloat, toBoundedInteger )
+import           Data.Text(Text)
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as L
+import           Data.Text.Encoding(encodeUtf8)
+import           Data.Typeable(Typeable, TypeRep, typeOf)
+#if !(MIN_VERSION_base(4,8,0))
+import           Data.Word(Word)
+#endif
+import           Data.Word(Word8, Word16, Word32, Word64)
+import           Foreign.C.Types(CFloat, CDouble)
+
+type ConversionErrors = MultiErrors ConversionError
+
+-- | An action to turn a 'Maybe' 'Value' into zero or one values of type @a@,
+--   and possibly report errors/warnings.
+newtype MaybeParser a = MaybeParser {
+      unMaybeParser :: Maybe Value -> (Maybe a, ConversionErrors)
+    } deriving (Functor, Typeable)
+
+-- | An action to turn a 'Value' into zero or one values of type @a@,
+--   and possibly report errors/warnings.
+newtype ValueParser a = ValueParser {
+      unValueParser :: Value -> (Maybe a, ConversionErrors)
+    } deriving (Functor, Typeable)
+
+data ListParserResult a =
+     NonListError
+   | ListError
+   | ListOk a [Value]
+     deriving (Functor, Typeable)
+
+-- | An action to turn a @['Value']@ into zero or one values of type @a@,
+--   and possibly report errors/warnings.
+newtype ListParser a = ListParser {
+      unListParser :: [Value] -> (ListParserResult a, ConversionErrors)
+    } deriving (Functor, Typeable)
+
+instance Applicative MaybeParser where
+    pure a = MaybeParser $ \_v -> (Just a, mempty)
+    (<*>) ff fa =
+        MaybeParser $ \v ->
+            case unMaybeParser ff v of
+              (Nothing, w) -> (Nothing, w)
+              (Just f , w) ->
+                  case unMaybeParser fa v of
+                    (Nothing, w') -> (Nothing   , w <> w')
+                    (Just a , w') -> (Just (f a), w <> w')
+
+instance Applicative ValueParser where
+    pure a = ValueParser $ \_v -> (Just a, mempty)
+    (<*>) ff fa =
+        ValueParser $ \v ->
+            case unValueParser ff v of
+              (Nothing, w) -> (Nothing, w)
+              (Just f , w) ->
+                  case unValueParser fa v of
+                    (Nothing, w') -> (Nothing   , w <> w')
+                    (Just a , w') -> (Just (f a), w <> w')
+
+instance Alternative ValueParser where
+    empty   = ValueParser $ \_v -> (Nothing, mempty)
+    f <|> g = ValueParser $ \v ->
+                 case unValueParser f v of
+                   (Nothing, Nothing) -> unValueParser g v
+                   (Nothing, w) ->
+                       case unValueParser g v of
+                         (Nothing, w') -> (Nothing, w <> w')
+                         res -> res
+                   res -> res
+
+    some v = repeat <$> v
+    many v = some v <|> pure []
+
+instance Alternative MaybeParser where
+    empty   = MaybeParser $ \_v -> (Nothing, mempty)
+    f <|> g = MaybeParser $ \v ->
+                 case unMaybeParser f v of
+                   (Nothing, Nothing) -> unMaybeParser g v
+                   (Nothing, w) ->
+                       case unMaybeParser g v of
+                         (Nothing, w') -> (Nothing, w <> w')
+                         res -> res
+                   res -> res
+
+    some v = repeat <$> v
+    many v = some v <|> pure []
+
+instance Monad MaybeParser where
+#if !(MIN_VERSION_base(4,8,0))
+    return = pure
+#endif
+    m >>= k  = MaybeParser $ \v ->
+                   case unMaybeParser m v of
+                     (Just a, w) ->
+                         case w of
+                           Nothing -> unMaybeParser (k a) v
+                           Just _  -> let (mb, w') = unMaybeParser (k a) v
+                                       in (mb, w <> w')
+                     (Nothing, w) -> (Nothing, w)
+
+    fail = Fail.fail
+
+instance Monad ValueParser where
+#if !(MIN_VERSION_base(4,8,0))
+    return = pure
+#endif
+    m >>= k  = ValueParser $ \v ->
+                   case unValueParser m v of
+                     (Just a, w) ->
+                         case w of
+                           Nothing -> unValueParser (k a) v
+                           Just _  -> let (mb, w') = unValueParser (k a) v
+                                       in (mb, w <> w')
+                     (Nothing, w) -> (Nothing, w)
+
+    fail = Fail.fail
+
+instance Fail.MonadFail MaybeParser where
+    fail msg = MaybeParser $ \_v -> (Nothing, singleError (failError msg))
+
+instance Fail.MonadFail ValueParser where
+    fail msg = ValueParser $ \_v -> (Nothing, singleError (failError msg))
+
+failError :: String -> ConversionError
+failError msg = defaultConversionError {
+                  conversionErrorLoc = "fail",
+                  conversionErrorWhy = MonadFail,
+                  conversionErrorMsg = Just (T.pack msg)
+                }
+
+runMaybeParser :: MaybeParser a -> Maybe Value -> (Maybe a, [ConversionError])
+runMaybeParser p = second toErrors . unMaybeParser p
+
+runValueParser :: ValueParser a -> Value -> (Maybe a, [ConversionError])
+runValueParser p = second toErrors . unValueParser p
+
+instance Applicative ListParser where
+    pure a = ListParser $ \vs -> (ListOk a vs, mempty)
+    (<*>) = ap
+
+instance Alternative ListParser where
+    empty   = ListParser $ \_v -> (ListError, mempty)
+    f <|> g = ListParser $ \v ->
+                 case unListParser f v of
+                   (ListError, Nothing)  -> unListParser g v
+                   (ListError, w) ->
+                       case unListParser g v of
+                         (ListError, w') -> (ListError, w <> w')
+                         res -> res
+                   res -> res
+
+instance Monad ListParser where
+#if !(MIN_VERSION_base(4,8,0))
+    return = pure
+#endif
+    m >>= k  = ListParser $ \v ->
+                   case unListParser m v of
+                     (ListOk a v', w) ->
+                         case w of
+                           Nothing -> unListParser (k a) v'
+                           Just _  -> let (mb, w') = unListParser (k a) v'
+                                       in (mb, w <> w')
+                     (ListError, w) ->
+                         (ListError, w)
+                     (NonListError, w) ->
+                         (NonListError, w)
+
+    fail = Fail.fail
+
+instance Fail.MonadFail ListParser where
+    fail msg = ListParser $ \_v -> (NonListError, singleError (failError msg))
+
+-- | Turns a 'ValueParser' into a 'MaybeParser'.  If the 'Maybe' 'Value' the
+--   parser is passed is 'Nothing' (which normally means a key was not found),
+--   then this returns the @Nothing@ value with no errors or warnings.
+--   Otherwise, it passes the 'Value' to the subparser.  If the
+--   subparser returns a result value, then this returns 'Just' the value.
+--   Otherwise, if the subparser does not return a value,  then this does
+--   not return a value.
+--
+--   Any errors/warnings returned by the subparser are returned exactly as-is.
+
+optionalValue :: ValueParser a -> MaybeParser (Maybe a)
+optionalValue p =
+    MaybeParser $ \mv ->
+       case mv of
+         Nothing -> (Just Nothing, mempty)
+         Just v  -> first (Just <$>) (unValueParser p v)
+
+-- | Turns a 'ValueParser' into a 'MaybeParser'.  If the 'Maybe' 'Value' the
+--   parser is passed is 'Nothing' (which normally means a key was not found),
+--   then this does not return a value and also returns a 'missingValueError'.
+--   Otherwise,  the 'Value' is passed to the subparser,  and the result
+--   and any errors/warnings are returned as-is.
+
+requiredValue :: forall a. Typeable a => ValueParser a -> MaybeParser a
+requiredValue p =
+    MaybeParser $ \mv ->
+        case mv of
+          Nothing -> (Nothing, err)
+          Just v  -> unValueParser p v
+  where
+    funcName = "requiredValue"
+    err = singleError $ missingValueError funcName (typeOf (undefined :: a))
+
+missingValueError :: Text -> TypeRep -> ConversionError
+missingValueError funcName typ = defaultConversionError {
+      conversionErrorLoc  = funcName,
+      conversionErrorWhy  = MissingValue,
+      conversionErrorType = Just typ
+   }
+
+-- | Turns a 'ListParser' into a 'ValueParser'.  It first checks that the
+--   'Value' the 'ValueParser' is passed is a 'List' Value.  If it's not,
+--   this returns no result as well as a 'typeError'.  Otherwise, it passes
+--   the list of results to the 'ListParser' subparser.
+--
+--   If the subparser consumes all of the list elements,  this returns the
+--   value and errors as-is.   If there are leftover list elements,  this
+--   returns the value, and adds a message warning of the extra elements
+--   to the list of errors.
+--
+--   The difference from 'listValue\'' is that this returns values with
+--   unconsumed list elements (discarding the list elements).
+
+listValue :: forall a. Typeable a => ListParser a -> ValueParser a
+listValue p =
+    ValueParser $ \v ->
+        case v of
+          List vs ->
+              case unListParser p vs of
+                (ListOk a vs', errs) ->
+                   case vs' of
+                     []    -> (Just a, errs)
+                     (_:_) -> (,) (Just a) $! errs <> extraErr vs
+                (_, errs)  -> (Nothing, errs)
+          _ -> (Nothing, typeErr v)
+  where
+    fn = "listValue"
+    extraErr vs = singleError $ extraValuesError fn vs (typeOf (undefined :: a))
+    typeErr  v  = singleError $ typeError        fn v  (typeOf (undefined :: a))
+
+-- | Turns a 'ListParser' into a 'ValueParser'.  It first checks that the
+--   'Value' the 'ValueParser' is passed is a 'List' Value.  If it's not,
+--   this returns no result as well as a 'typeError'.  Otherwise, it passes
+--   the list of results to the 'ListParser' subparser.
+--
+--   If the subparser consumes all of the list elements,  this returns the
+--   value and errors as-is.   If there are leftover list elements,  this
+--   returns no value, and adds a message warning of the extra elements
+--   to the list of errors.
+--
+--   The difference from 'listValue' is that this never returns a value if
+--   there are unconsumed list elements. (discarding both the value returned
+--   and the list element.)
+
+listValue' :: forall a. Typeable a => ListParser a -> ValueParser a
+listValue' p =
+    ValueParser $ \v ->
+        case v of
+          List vs ->
+              case unListParser p vs of
+                (ListOk a vs', errs) ->
+                   case vs' of
+                     []    -> (Just a, errs)
+                     (_:_) -> (,) Nothing $! errs <> extraErr vs
+                (_, errs)  -> (Nothing, errs)
+          _ -> (Nothing, typeErr v)
+  where
+    fn = "listValue'"
+    extraErr vs = singleError $ extraValuesError fn vs (typeOf (undefined :: a))
+    typeErr  v  = singleError $ typeError        fn v  (typeOf (undefined :: a))
+
+-- | Turns a 'ValueParser' into a 'ListParser' that consumes a single element.
+--
+--   If there are no list elements left, this returns list error value and an
+--   'ExhaustedValues' error.
+--
+--   If there is an element left,  it is passed to the value parser.  If the
+--   value parser returns a value,  it is returned along with the errors as-is.
+--   If the value parser returns no value,  then this returns a non-list error
+--   value and the list of errors returned by the value parser.
+--
+--   The difference between a "list error value" and a "non-list error value",
+--   is that the 'Alternative' instance for 'ListParser' recovers from "list
+--   error" values but does not recover from "non-list error" values.   This
+--   behavior was chosen so that the 'optional', 'some', and 'many' combinators
+--   work on 'ListParser's in a way that is hopefully least surprising.
+
+listElem :: forall a. (Typeable a) => ValueParser a -> ListParser a
+listElem p =
+    ListParser $ \vs ->
+        case vs of
+          [] -> (ListError, exhaustedError)
+          (v:vs') -> case unValueParser p v of
+                       (Nothing, errs) -> (NonListError, errs)
+                       (Just a,  errs) -> (ListOk a vs', errs)
+  where
+    exhaustedError = singleError defaultConversionError {
+                       conversionErrorLoc  = "listElem",
+                       conversionErrorWhy  = ExhaustedValues,
+                       conversionErrorType = Just (typeOf (undefined :: a))
+                     }
+
+extraValuesError :: Text -> [Value] -> TypeRep -> ConversionError
+extraValuesError funcName vals typ
+    = defaultConversionError {
+        conversionErrorLoc  = funcName,
+        conversionErrorWhy  = ExtraValues,
+        conversionErrorVal  = Just (List vals),
+        conversionErrorType = Just typ
+      }
+
+typeError :: Text -> Value -> TypeRep -> ConversionError
+typeError funcName val typ
+    = defaultConversionError {
+        conversionErrorLoc  = funcName,
+        conversionErrorWhy  = TypeError,
+        conversionErrorVal  = Just val,
+        conversionErrorType = Just typ
+      }
+
+boundedIntegerValue :: forall a. (Typeable a, Integral a, Bounded a)
+                    => ValueParser a
+boundedIntegerValue =
+    ValueParser $ \v ->
+        case v of
+          (Number r) ->
+              case toBoundedInteger r of
+                ja@(Just _) -> (ja     , mempty)
+                Nothing     -> (Nothing, overflowErr r)
+          _ -> (Nothing, typeErr v)
+  where
+    fn = "boundedIntegerValue"
+    overflowErr v = singleError (overflowError fn v (typeOf (undefined :: a)))
+    typeErr     v = singleError (typeError     fn v (typeOf (undefined :: a)))
+
+overflowError :: Text -> Scientific -> TypeRep -> ConversionError
+overflowError fn val typ = valueError fn (Number val) typ "overflow"
+
+valueError :: Text -> Value -> TypeRep -> Text -> ConversionError
+valueError funcName val typ msg
+    = defaultConversionError {
+        conversionErrorLoc  = funcName,
+        conversionErrorWhy  = ValueError,
+        conversionErrorVal  = Just val,
+        conversionErrorType = Just typ,
+        conversionErrorMsg  = Just msg
+      }
+
+integralValue :: forall a. (Typeable a, Integral a) => ValueParser a
+integralValue =
+    ValueParser $ \v ->
+        case v of
+          Number r ->
+              if base10Exponent r >= 0
+              then toIntegral r
+              else let r' = normalize r
+                   in if base10Exponent r' >= 0
+                      then toIntegral r'
+                      else (Nothing, intErr r)
+          _  -> (Nothing, typeErr v)
+  where
+    fn = "integralValue"
+    intErr  r = singleError (notAnIntegerError fn r (typeOf (undefined :: a)))
+    typeErr v = singleError (typeError         fn v (typeOf (undefined :: a)))
+
+    toIntegral r =
+        case floatingOrInteger r of
+          Right a -> (Just a, mempty)
+          -- This case should be impossible:
+          Left  (_::Float) -> (Nothing, intErr r)
+
+notAnIntegerError :: Text -> Scientific -> TypeRep -> ConversionError
+notAnIntegerError fn val typ = valueError fn (Number val) typ "not an integer"
+
+fractionalValue :: forall a. (Typeable a, Fractional a) => ValueParser a
+fractionalValue =
+    ValueParser $ \v ->
+        case v of
+          Number r ->
+              let !c   = coefficient    r
+                  !e   = base10Exponent r
+                  !r'  = fromRational $! if e >= 0
+                                         then (c * 10^e) % 1
+                                         else c % (10^(- e))
+               in (Just r', mempty)
+          _ -> (Nothing, typeErr v)
+  where
+    fn = "fractionalValue"
+    typeErr v = singleError (typeError fn v (typeOf (undefined :: a)))
+
+realFloatValue :: forall a. (Typeable a, RealFloat a) => ValueParser a
+realFloatValue = realFloatValue_ (typeOf (undefined :: a))
+
+realFloatValue_ :: (RealFloat a) => TypeRep -> ValueParser a
+realFloatValue_ typ =
+    ValueParser $ \v ->
+        case v of
+          Number (toRealFloat -> !r) -> (Just r, mempty)
+          _ -> (Nothing, typeErr v)
+  where
+    fn = "realFloatValue"
+    typeErr v = singleError (typeError fn v typ)
+
+fixedValue :: forall a. (Typeable a, HasResolution a) => ValueParser (Fixed a)
+fixedValue = fractionalValue
+  -- FIXME: optimize fixedValue and/or Data.Fixed
+
+class FromMaybeValue a where
+    fromMaybeValue :: MaybeParser a
+    default fromMaybeValue :: (Typeable a, FromValue a) => MaybeParser a
+    fromMaybeValue = requiredValue fromValue
+
+class FromValue a where
+    fromValue :: ValueParser a
+
+class FromListValue a where
+    fromListValue :: ListParser a
+
+instance FromValue a => FromMaybeValue (Maybe a) where
+    fromMaybeValue = optionalValue fromValue
+
+instance FromMaybeValue Bool
+instance FromValue Bool where
+   fromValue = boolValue
+
+boolValue :: ValueParser Bool
+boolValue =
+    ValueParser $ \v ->
+        case v of
+          Bool b -> (Just b, mempty)
+          _ -> (Nothing, typeErr v (typeOf True))
+  where
+    fn = "boolValue"
+    typeErr v t = singleError (typeError fn v t)
+
+instance FromMaybeValue Value where
+    fromMaybeValue = MaybeParser $ \mv -> (mv, mempty)
+instance FromValue Value where
+    fromValue = ValueParser $ \v -> (Just v, mempty)
+
+instance FromMaybeValue Int
+instance FromValue Int where
+    fromValue = boundedIntegerValue
+
+instance FromMaybeValue Integer
+instance FromValue Integer where
+    fromValue = integralValue
+
+instance FromMaybeValue Int8
+instance FromValue Int8 where
+    fromValue = boundedIntegerValue
+
+instance FromMaybeValue Int16
+instance FromValue Int16 where
+    fromValue = boundedIntegerValue
+
+instance FromMaybeValue Int32
+instance FromValue Int32 where
+    fromValue = boundedIntegerValue
+
+instance FromMaybeValue Int64
+instance FromValue Int64 where
+    fromValue = boundedIntegerValue
+
+instance FromMaybeValue Word
+instance FromValue Word where
+    fromValue = boundedIntegerValue
+
+instance FromMaybeValue Word8
+instance FromValue Word8 where
+    fromValue = boundedIntegerValue
+
+instance FromMaybeValue Word16
+instance FromValue Word16 where
+    fromValue = boundedIntegerValue
+
+instance FromMaybeValue Word32
+instance FromValue Word32 where
+    fromValue = boundedIntegerValue
+
+instance FromMaybeValue Word64
+instance FromValue Word64 where
+    fromValue = boundedIntegerValue
+
+instance FromMaybeValue Double
+instance FromValue Double where
+    fromValue = realFloatValue
+
+instance FromMaybeValue Float
+instance FromValue Float where
+    fromValue = realFloatValue
+
+instance FromMaybeValue CDouble
+instance FromValue CDouble where
+    fromValue = realFloatValue
+
+instance FromMaybeValue CFloat
+instance FromValue CFloat where
+    fromValue = realFloatValue
+
+instance (Typeable a, Integral a) => FromMaybeValue (Ratio a)
+instance (Typeable a, Integral a) => FromValue (Ratio a) where
+    fromValue = fractionalValue
+
+instance FromMaybeValue Scientific
+instance FromValue Scientific where
+    fromValue = scientificValue
+
+scientificValue :: ValueParser Scientific
+scientificValue =
+    ValueParser $ \v ->
+        case v of
+          Number r -> (Just r, mempty)
+          _ -> (Nothing, typeErr v)
+  where
+    fn = "scientificValue"
+    typeErr v = singleError (typeError fn v (typeOf (undefined :: Scientific)))
+
+instance (Typeable a, RealFloat a) => FromMaybeValue (Complex a)
+instance (Typeable a, RealFloat a) => FromValue (Complex a) where
+    fromValue = (:+ 0) <$> realFloatValue_ (typeOf (undefined :: Complex a))
+
+instance (Typeable a, HasResolution a) => FromMaybeValue (Fixed a)
+instance (Typeable a, HasResolution a) => FromValue (Fixed a) where
+    fromValue = fixedValue
+
+instance FromMaybeValue Text
+instance FromValue Text where
+    fromValue = textValue
+
+textValue :: ValueParser Text
+textValue = textValue_ (typeOf (undefined :: Text))
+
+textValue_ :: TypeRep -> ValueParser Text
+textValue_ typ =
+    ValueParser $ \v ->
+        case v of
+          String r -> (Just r, mempty)
+          _ -> (Nothing, typeErr v typ)
+  where
+    fn = "textValue"
+    typeErr v t = singleError (typeError fn v t)
+
+instance FromMaybeValue Char
+instance FromValue Char where
+    fromValue = charValue
+
+charValue :: ValueParser Char
+charValue =
+    ValueParser $ \v ->
+        case v of
+          String txt ->
+              case T.uncons txt of
+                Nothing           -> (Nothing, charErr txt)
+                Just (c,txt')
+                    | T.null txt' -> (Just  c, mempty)
+                    | otherwise   -> (Nothing, charErr txt)
+          _ -> (Nothing, typeErr v)
+  where
+    fn  = "charValue"
+    typ = typeOf (undefined :: Char)
+    msg = "expecting exactly one character"
+    charErr v = singleError (valueError fn (String v) typ msg)
+    typeErr v = singleError (typeError fn v typ)
+
+instance FromMaybeValue L.Text
+instance FromValue L.Text where
+    fromValue = L.fromStrict <$> textValue_ (typeOf (undefined :: L.Text))
+
+instance FromMaybeValue B.ByteString
+instance FromValue B.ByteString where
+    fromValue = encodeUtf8 <$> textValue_ (typeOf (undefined :: B.ByteString))
+
+instance FromMaybeValue LB.ByteString
+instance FromValue LB.ByteString where
+    fromValue = convert <$> textValue_ (typeOf (undefined :: LB.ByteString))
+      where convert = LB.fromStrict . encodeUtf8
+
+instance FromMaybeValue String
+instance FromValue String where
+    fromValue = T.unpack <$> textValue_ (typeOf (undefined :: String))
+
+instance ( Typeable a, FromValue a
+         , Typeable b, FromValue b ) => FromMaybeValue (a,b)
+instance ( Typeable a, FromValue a
+         , Typeable b, FromValue b ) => FromValue (a,b) where
+    fromValue = listValue fromListValue
+instance ( Typeable a, FromValue a
+         , Typeable b, FromValue b ) => FromListValue (a,b) where
+    fromListValue = (,) <$> listElem fromValue <*> listElem fromValue
+
+instance ( Typeable a, FromValue a
+         , Typeable b, FromValue b
+         , Typeable c, FromValue c ) => FromMaybeValue (a,b,c)
+instance ( Typeable a, FromValue a
+         , Typeable b, FromValue b
+         , Typeable c, FromValue c ) => FromValue (a,b,c) where
+    fromValue = listValue fromListValue
+instance ( Typeable a, FromValue a
+         , Typeable b, FromValue b
+         , Typeable c, FromValue c ) => FromListValue (a,b,c) where
+    fromListValue = (,,) <$> listElem fromValue <*> listElem fromValue
+                         <*> listElem fromValue
+
+instance (Typeable a, FromValue a) => FromMaybeValue [a]
+instance (Typeable a, FromValue a) => FromValue [a] where
+    fromValue = listValue (many (listElem fromValue))
+
+instance ( Typeable a, FromValue a
+         , Typeable b, FromValue b
+         , Typeable c, FromValue c
+         , Typeable d, FromValue d ) => FromMaybeValue (a,b,c,d)
+instance ( Typeable a, FromValue a
+         , Typeable b, FromValue b
+         , Typeable c, FromValue c
+         , Typeable d, FromValue d ) => FromValue (a,b,c,d) where
+    fromValue = listValue fromListValue
+instance ( Typeable a, FromValue a
+         , Typeable b, FromValue b
+         , Typeable c, FromValue c
+         , Typeable d, FromValue d ) => FromListValue (a,b,c,d) where
+    fromListValue = (,,,) <$> listElem fromValue <*> listElem fromValue
+                          <*> listElem fromValue <*> listElem fromValue
+
+{--
+parserFail :: forall a. Typeable a => T.Text -> Maybe T.Text -> ValueParser a
+parserFail loc msg = ValueParser $ \st -> (Nothing, failError, st)
+       where
+         failError = singleError defaultConversionError {
+                       conversionErrorLoc  = loc
+                       conversionErrorWhy  = MonadFail,
+                       conversionErrorType = Just (typeRep (undefined :: a)),
+                       conversionErrorMsg  = msg
+                     }
+--}
+
+{--
+defaultValue :: Typeable a => a -> ValueParser a -> ValueParser a
+defaultValue def m =
+    ValueParser $ \vs ->
+        case vs of
+          (Nothing:vs') -> (Just def, mempty, vs')
+          _
+--}

--- a/deps/Data/Configurator/FromValue/Implementation.hs
+++ b/deps/Data/Configurator/FromValue/Implementation.hs
@@ -1,7 +1,8 @@
+
 {-# LANGUAGE CPP, DeriveDataTypeable, DeriveFunctor #-}
 {-# LANGUAGE FlexibleInstances, DefaultSignatures #-}
 {-# LANGUAGE ScopedTypeVariables, BangPatterns, ViewPatterns #-}
-{-# LANGUAGE OverloadedStrings, OverlappingInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 -- |
 -- Module:      Data.Configurator.FromValue.Implementation
@@ -617,8 +618,8 @@ instance FromValue LB.ByteString where
     fromValue = convert <$> textValue_ (typeOf (undefined :: LB.ByteString))
       where convert = LB.fromStrict . encodeUtf8
 
-instance FromMaybeValue String
-instance FromValue String where
+instance {-# Overlapping #-} FromMaybeValue String
+instance {-# Overlapping #-} FromValue String where
     fromValue = T.unpack <$> textValue_ (typeOf (undefined :: String))
 
 instance ( Typeable a, FromValue a

--- a/deps/Data/Configurator/FromValue/Internal.hs
+++ b/deps/Data/Configurator/FromValue/Internal.hs
@@ -1,0 +1,15 @@
+-- |
+-- Module:      Data.Configurator.FromValue.Internal
+-- Copyright:   (c) 2016 Leon P Smith
+-- License:     BSD3
+-- Maintainer:  Leon P Smith <leon@melding-monads.com>
+
+module Data.Configurator.FromValue.Internal
+     ( ConversionErrors
+     , ValueParser(..)
+     , MaybeParser(..)
+     , ListParserResult(..)
+     , ListParser(..)
+     ) where
+
+import Data.Configurator.FromValue.Implementation

--- a/deps/Data/Configurator/Parser.hs
+++ b/deps/Data/Configurator/Parser.hs
@@ -1,0 +1,249 @@
+{-# LANGUAGE CPP, OverloadedStrings, ScopedTypeVariables #-}
+{-# LANGUAGE BangPatterns, ViewPatterns, TupleSections   #-}
+
+-- |
+-- Module:      Data.Configurator.Parser
+-- Copyright:   (c) 2015 Leon P Smith
+-- License:     BSD3
+-- Maintainer:  Leon P Smith <leon@melding-monads.com>
+-- Stability:   experimental
+-- Portability: portable
+--
+-- A set of combinators for high-level configuration parsing.
+
+module Data.Configurator.Parser
+    (
+    -- * High level parsing computations
+      ConfigParser
+    , runParser
+    , ConfigParserA
+    , runParserA
+    , parserA
+    , unsafeBind
+    , ConfigParserM
+    , runParserM
+    , parserM
+    , recover
+    -- * Looking up values by name
+    , key
+    , keyWith
+    -- * Discovering names
+    , subgroups
+    , subassocs
+    , subassocs'
+    -- * Modifying the configuration context
+    , Config
+    , ConfigTransform
+    , localConfig
+    , union
+    , subconfig
+    , superconfig
+    -- * Error / warning messages
+    , ConfigError (..)
+    , ConfigErrorLocation (..)
+    , ConversionError (..)
+    , ConversionErrorWhy (..)
+    ) where
+
+import           Prelude hiding (null)
+
+import           Data.DList (DList)
+import qualified Data.DList as DL
+
+#if !(MIN_VERSION_base(4,8,0))
+import           Data.Monoid(Monoid(..))
+#endif
+import           Data.Monoid((<>))
+import           Data.Configurator.Config
+                   ( Config )
+import           Data.Configurator.Types.Internal hiding (Group)
+import           Data.Configurator.FromValue
+                   ( FromMaybeValue(fromMaybeValue)
+                   , MaybeParser
+                   , runMaybeParser
+                   )
+import qualified Data.Configurator.Config as C
+import qualified Data.Configurator.Config.Internal as CI
+import           Data.Configurator.Parser.Implementation
+
+runParser :: ConfigParser m => m a -> Config -> (Maybe a, [ConfigError])
+runParser m conf = let (ma, errs) = unConfigParser_ m conf
+                    in (ma, toErrors errs)
+
+{- |
+Returns all the value bindings from the current configuration context that is
+contained within the given subgroup, in lexicographic order. For example,
+given the following context:
+
+@
+x = 1
+foo {
+  x = 2
+  bar {
+    y = on
+  }
+}
+foo = \"Hello\"
+@
+
+Then the following arguments to 'subassocs' would return the following lists:
+
+@
+subassocs \"\"         ==>  [(\"foo\",String \"Hello\"),(\"x\",Number 1)]
+subassocs \"foo\"      ==>  [(\"foo.x\",Number 2)]
+subassocs \"foo.bar\"  ==>  [(\"foo.bar.x\",Bool True)]
+@
+
+All other arguments to @subassocs@ would return @[]@ in the given context.
+-}
+
+subassocs :: ConfigParser m => Name -> m [(Name, Value)]
+subassocs t = configParser_ (\c -> (Just (C.subassocs t c), mempty))
+
+{- |
+Returns all the value bindings from the current configuration context that is
+contained within the given subgroup and all of it's subgroups in lexicographic
+order. For example, given the following context:
+
+@
+x = 1
+foo {
+  x = 2
+  bar {
+    y = on
+  }
+}
+foo = \"Hello\"
+@
+
+Then the following arguments to 'subassocs\'' would return the following lists:
+
+@
+subassocs\' \"\"         ==>  [ (\"foo\"       , String \"Hello\")
+                           , (\"foo.bar.y\" , Bool True     )
+                           , (\"foo.x\"     , Number 2      )
+                           , (\"x\"         , Number 1      )
+                           ]
+subassocs\' \"foo\"      ==>  [ (\"foo.bar.y\" , Bool True     )
+                           , (\"foo.x\"     , Number 2      )
+                           ]
+subassocs\' \"foo.bar\"  ==>  [ (\"foo.bar.y\" , Bool True     )
+                           ]
+@
+
+All other arguments to @subassocs\'@ would return @[]@ in the given context.
+-}
+
+subassocs' :: ConfigParser m => Name -> m [(Name, Value)]
+subassocs' t = configParser_ (\c -> (Just (C.subassocs' t c), mempty))
+
+{- |
+Returns all the non-empty value groupings that is directly under the argument
+grouping in the current configuration context.  For example, given the
+following context:
+
+@
+foo { }
+bar {
+  a {
+    x = 1
+  }
+  b {
+    c {
+      y = 2
+    }
+  }
+}
+default
+  a {
+    x = 3
+  }
+}
+@
+
+Then the following arguments to 'subgroups' would return the following lists:
+
+@
+subgroups \"\"         ==>  [ \"bar\", \"default\" ]
+subgroups \"bar\"      ==>  [ \"bar.a\", \"bar.b\" ]
+subgroups \"bar.b\"    ==>  [ \"bar.b.c\" ]
+subgroups \"default\"  ==>  [ \"default.a\" ]
+@
+
+All other arguments to @subgroups@ would return @[]@ in the given context.
+-}
+
+subgroups :: ConfigParser m => Name -> m [Name]
+subgroups t = configParser_ (\c -> (Just (C.subgroups t c), mempty))
+
+-- |  Modifies the 'Config' that a subparser is operating on.
+--    This is perfectly analogous to 'Control.Monad.Reader.local'.
+
+localConfig :: ConfigParser m => ConfigTransform -> m a -> m a
+localConfig f m = configParser_ (\r -> unConfigParser_ m (interpConfigTransform f r))
+
+-- |  Exactly the same as 'runParser',  except less polymorphic
+
+runParserA :: ConfigParserA a -> Config -> (Maybe a, [ConfigError])
+runParserA = runParser
+
+-- |  Exactly the same as 'runParser',  except less polymorphic
+
+runParserM :: ConfigParserM a -> Config -> (Maybe a, [ConfigError])
+runParserM = runParser
+
+-- |  Lift a 'ConfigParserM' action into a generic 'ConfigParser'
+--    action.  Note that this does not change the semantics of the
+--    argument,  it just allows a 'ConfigParserM' computation to be
+--    embedded in another 'ConfigParser' computation of either variant.
+
+parserM :: ConfigParser m => ConfigParserM a -> m a
+parserM (ConfigParserM m) = configParser_ m
+
+-- |  Lift a 'ConfigParserA' action into a generic 'ConfigParser'
+--    action.  Note that this does not change the semantics of the
+--    argument,  it just allows a 'ConfigParserA' computation to be
+--    embedded in another 'ConfigParser' computation of either variant.
+
+parserA :: ConfigParser m => ConfigParserA a -> m a
+parserA (ConfigParserA m) = configParser_ m
+
+-- |  Given the expression @'recover' action@, the @action@ will be
+--    run,  and if it returns no value,  @recover action@ will return
+--    'Nothing'.   If @action@ returns the value @a@, then
+--    @recover action@ will return the value @'Just' a@.  Any errors
+--    or warnings are passed through as-is.
+
+recover :: ConfigParser m => m a -> m (Maybe a)
+recover m = configParser_ $ \r -> let (ma, errs) = unConfigParser_ m r
+                                   in (Just ma, errs)
+
+-- | Look up a given value in the current configuration context,  and convert
+-- the value using the 'fromMaybeValue' method.
+
+key :: (ConfigParser m, FromMaybeValue a) => Name -> m a
+key name = keyWith name fromMaybeValue
+
+-- | Look up a given value in the current configuration context,  and convert
+-- the value using the 'MaybeParser' argument.
+
+keyWith :: (ConfigParser m) => Name -> MaybeParser a -> m a
+keyWith name parser =
+    configParser_ $ \(CI.Config c) ->
+        case CI.lookupWithName name c of
+          Nothing ->
+              convert (KeyMissing (DL.toList (getLookupPlan name c))) Nothing
+          Just (name', v) ->
+              convert (Key "" name') (Just v)
+  where
+    convert loc mv =
+        case runMaybeParser parser mv of
+          (Nothing, errs) ->
+              (Nothing, singleError (ConfigError loc (Just errs)))
+          (Just a, []) ->
+              (Just a, mempty)
+          (Just a, errs@(_:_)) ->
+              (Just a,  singleError (ConfigError loc (Just errs)))
+
+getLookupPlan :: Name -> CI.ConfigPlan a -> DList Name
+getLookupPlan = CI.foldPlan DL.empty (<>) (\k _ -> DL.singleton k)

--- a/deps/Data/Configurator/Parser/Implementation.hs
+++ b/deps/Data/Configurator/Parser/Implementation.hs
@@ -184,7 +184,7 @@ superconfig :: Text -> ConfigTransform -> ConfigTransform
 superconfig k (ConfigTransform x) = ConfigTransform (Superconfig k x)
 
 interpConfigTransform :: ConfigTransform -> Config -> Config
-interpConfigTransform (ConfigTransform x) config = go x
+interpConfigTransform (ConfigTransform x0) config = go x0
   where
     go Empty             = C.empty
     go (ConfigPlan _)    = config

--- a/deps/Data/Configurator/Parser/Implementation.hs
+++ b/deps/Data/Configurator/Parser/Implementation.hs
@@ -1,0 +1,192 @@
+{-# LANGUAGE CPP, DeriveDataTypeable, DeriveFunctor #-}
+
+-- |
+-- Module:      Data.Configurator.Parser.Implementation
+-- Copyright:   (c) 2015-2016 Leon P Smith
+-- License:     BSD3
+-- Maintainer:  Leon P Smith <leon@melding-monads.com>
+
+module Data.Configurator.Parser.Implementation where
+
+#if !(MIN_VERSION_base(4,8,0))
+import           Control.Applicative
+#endif
+import           Control.Monad (ap)
+import           Data.Configurator.Config (Config)
+import qualified Data.Configurator.Config as C
+import           Data.Configurator.Config.Implementation (ConfigPlan(..))
+import           Data.Configurator.Types (ConfigError)
+import           Data.DList (DList)
+import           Data.Monoid
+import           Data.Text (Text)
+import           Data.Typeable (Typeable)
+
+type RMW r w a = r -> (Maybe a, w)
+
+type ConfigErrors = Maybe (DList ConfigError)
+
+-- | If the value returned by a computation is 'Nothing', then no subsequent
+--   actions (e.g. via '<*>' or '>>=') will be performed.
+
+newtype ConfigParserM a
+    = ConfigParserM { unConfigParserM :: RMW Config ConfigErrors a }
+      deriving (Typeable, Functor)
+
+instance Applicative ConfigParserM where
+    pure a = ConfigParserM $ \_ -> (pure a, mempty)
+    (<*>) = ap
+
+instance Monad ConfigParserM where
+#if !(MIN_VERSION_base(4,8,0))
+    return = pure
+#endif
+    m >>= k  = ConfigParserM $ \r ->
+                   let (ma, w ) = unConfigParserM m r
+                    in case ma of
+                         Nothing -> (Nothing, w)
+                         Just a  -> let (mb, w') = unConfigParserM (k a) r
+                                     in (mb, w <> w')
+
+-- | After executing a subcomputation that returns a 'Nothing' value,
+--   computations of type 'ConfigParserA' will continue to run in order to
+--   produce more error messages.  For this reason,  'ConfigParserA' does
+--   not have a proper 'Monad' instance.  (But see 'unsafeBind')
+
+newtype ConfigParserA a
+    = ConfigParserA { unConfigParserA :: RMW Config ConfigErrors a }
+      deriving (Typeable, Functor)
+
+instance Applicative ConfigParserA where
+    pure a  = ConfigParserA $ \_ -> (pure a, mempty)
+    f <*> a = ConfigParserA $ \r ->
+                  let (mf, w ) = unConfigParserA f r
+                      (ma, w') = unConfigParserA a r
+                   in (mf <*> ma, w <> w')
+
+#if __GLASGOW_HASKELL__ >= 800
+{-# DEPRECATED unsafeBind "Use the ApplicativeDo language extension instead" #-}
+#endif
+
+-- |  The purpose of this function is to make it convenient to use do-notation
+--    with 'ConfigParserA',  either by defining a Monad instance or locally
+--    rebinding '>>='.    Be warned that this is an abuse,  and incorrect
+--    usage can result in exceptions.   A safe way to use this function
+--    would be to treat is as applicative-do notation.  A safer alternative
+--    would be to use the @ApplicativeDo@ language extension available in
+--    GHC 8.0 and not use this function at all.
+
+unsafeBind :: ConfigParserA a -> (a -> ConfigParserA b) -> ConfigParserA b
+unsafeBind m k = ConfigParserA $ \r ->
+                   case unConfigParserA m r of
+                     (Nothing, w) -> let (_, w')  = unConfigParserA (k err) r
+                                      in (Nothing, w <> w')
+                     (Just a,  w) -> let (mb, w') = unConfigParserA (k a) r
+                                      in (mb, w <> w')
+  where err = error "unsafeBind on ConfigParserA used incorrectly"
+
+
+{--
+--- There are at least three obvious "implementations" of <|> on ConfigParserM
+--- TODO: check alternative laws and pick an appropriate instance for each
+
+instance Alternative ConfigParserM where
+    empty   = ConfigParserM $ \_ -> (Nothing, mempty)
+    f <|> g = ConfigParserM $ \r ->
+                  case unConfigParserM m0 r of
+                    (Nothing, _errs0) -> unConfigParserM m1 r
+                    res -> res
+
+instance Alternative ConfigParserA where
+    empty   = ConfigParserA $ \_ -> (Nothing, mempty)
+    f <|> g = ConfigParserA $ \r -> let (mf, w ) = unConfigParserA f r
+                                        (mg, w') = unConfigParserA g r
+                                     in (mf <|> mg, w <> w')
+
+
+instance Alternative ConfigParserA where
+    empty   = ConfigParserA $ \_ -> (Nothing, mempty)
+    f <|> g = ConfigParserA $ \r -> let (mf, w ) = unConfigParserA f r
+                                        (mg, w') = unConfigParserA g r
+                                     in case mf of
+                                          (Just f) -> (mf, w)
+                                          Nothing  -> (mg, w <> w')
+
+--}
+
+-- | A 'ConfigParser' computation produces a value of type @'Maybe' a@
+--   from a given 'Config',  in addition to a list of diagnostic messages,
+--   which may be interpreted as warnings or errors as deemed appropriate.
+--   The type class abstracts over 'ConfigParserM' and 'ConfigParserA'
+--   variants,  which are isomorphic but have different 'Applicative' and
+--   'Monad' instances.  This is intended to be a closed typeclass, without
+--   any additional instances.
+
+class Applicative m => ConfigParser m where
+    configParser_   :: RMW Config ConfigErrors a -> m a
+    unConfigParser_ :: m a -> RMW Config ConfigErrors a
+
+{--
+--- Unfortunately,  this doesn't work (yet?) because of MonadReader's
+--- Monad superclass.
+
+instance ConfigParser m => MonadReader m where
+     ask = configParser_ $ \c -> (Just c, mempty)
+
+
+Data.Configurator.Parser.Internal
+
+--}
+
+instance ConfigParser ConfigParserM where
+    configParser_   = ConfigParserM
+    unConfigParser_ = unConfigParserM
+
+instance ConfigParser ConfigParserA where
+    configParser_   = ConfigParserA
+    unConfigParser_ = unConfigParserA
+
+-- | Conceptually, a 'ConfigTransform' is a function 'Config' @->@ 'Config'.
+--   It's a restricted subset of such functions as to preserve the possibility
+--   of reliable dependency tracking in later versions of configurator-ng.
+newtype ConfigTransform = ConfigTransform (ConfigPlan ())
+
+-- | 'mempty' is the identity 'ConfigTransform',  'mappend' is the composition
+--   of two 'ConfigTransform's.
+instance Monoid ConfigTransform where
+   mempty = ConfigTransform (ConfigPlan ())
+   (ConfigTransform x) `mappend` (ConfigTransform y) = (ConfigTransform (go x))
+     where
+       go (ConfigPlan _)      = y
+       go (Union a b)         = Union (go a) (go b)
+       go (Superconfig pre a) = Superconfig pre (go a)
+       go (Subconfig pre a)   = Subconfig pre (go a)
+       go Empty               = Empty
+
+-- | Conceptually,  @'union' f g = \\config -> union\' (f config) (g config)@,
+-- where @union\'@ is the left-biased union of two 'Config's.
+union :: ConfigTransform -> ConfigTransform -> ConfigTransform
+union (ConfigTransform x) (ConfigTransform y) = ConfigTransform (Union x y)
+
+-- | @'subconfig' group@ restricts the configuration to those values that
+-- are contained within @group@ (either directly,  or contained within a
+-- descendant value grouping),  and removes the @group@ prefix from all
+-- of the keys in the map.  It's analogous to the @cd@ (change directory)
+-- command on common operating systems,  except that @subconfig@ can only
+-- descend down the directory tree,  and cannot ascend into a parent
+-- directory.
+subconfig :: Text -> ConfigTransform -> ConfigTransform
+subconfig k (ConfigTransform x) = ConfigTransform (Subconfig k x)
+
+-- | @'superconfig' group@ adds the @group@ prefix to all keys in the map.
+-- It is vaguely analogous to the @mount@ command on unix operating systems.
+superconfig :: Text -> ConfigTransform -> ConfigTransform
+superconfig k (ConfigTransform x) = ConfigTransform (Superconfig k x)
+
+interpConfigTransform :: ConfigTransform -> Config -> Config
+interpConfigTransform (ConfigTransform x) config = go x
+  where
+    go Empty             = C.empty
+    go (ConfigPlan _)    = config
+    go (Superconfig k x) = C.superconfig k (go x)
+    go (Subconfig   k x) = C.subconfig k (go x)
+    go (Union       x y) = C.union (go x) (go y)

--- a/deps/Data/Configurator/Parser/Implementation.hs
+++ b/deps/Data/Configurator/Parser/Implementation.hs
@@ -8,6 +8,7 @@
 
 module Data.Configurator.Parser.Implementation where
 
+import           Prelude
 #if !(MIN_VERSION_base(4,8,0))
 import           Control.Applicative
 #endif

--- a/deps/Data/Configurator/Parser/Internal.hs
+++ b/deps/Data/Configurator/Parser/Internal.hs
@@ -1,0 +1,18 @@
+-- |
+-- Module:      Data.Configurator.Parser.Internal
+-- Copyright:   (c) 2015-2016 Leon P Smith
+-- License:     BSD3
+-- Maintainer:  Leon P Smith <leon@melding-monads.com>
+
+
+module Data.Configurator.Parser.Internal 
+    ( RMW
+    , ConfigErrors
+    , ConfigParser (..)
+    , ConfigParserM (..)
+    , ConfigParserA (..)
+    , ConfigTransform(..)
+    , interpConfigTransform
+    ) where
+
+import Data.Configurator.Parser.Implementation

--- a/deps/Data/Configurator/Syntax.hs
+++ b/deps/Data/Configurator/Syntax.hs
@@ -17,6 +17,7 @@ module Data.Configurator.Syntax
     , interp
     ) where
 
+import Prelude
 import Control.Applicative
 import Control.Exception (throw)
 import Control.Monad (when)

--- a/deps/Data/Configurator/Syntax.hs
+++ b/deps/Data/Configurator/Syntax.hs
@@ -1,0 +1,180 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module:      Data.Configurator.Syntax
+-- Copyright:   (c) 2011 MailRank, Inc.
+--              (c) 2015-2016 Leon P Smith
+-- License:     BSD3
+-- Maintainer:  Leon P Smith <leon@melding-monads.com>
+-- Stability:   experimental
+-- Portability: portable
+--
+-- A parser for configuration files.
+
+module Data.Configurator.Syntax
+    (
+      topLevel
+    , interp
+    ) where
+
+import Control.Applicative
+import Control.Exception (throw)
+import Control.Monad (when)
+import Data.Attoparsec.Text as A
+import Data.Bits (shiftL)
+import Data.Char (chr, isAlpha, isAlphaNum, isSpace)
+import Data.Configurator.Types.Internal
+import Data.Monoid (Monoid(..))
+import Data.Text (Text)
+import Data.Text.Lazy.Builder (fromText, singleton, toLazyText)
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as L
+
+topLevel :: Parser [Directive]
+topLevel = directives <* skipLWS <* endOfInput
+
+directive :: Parser Directive
+directive =
+  mconcat [
+    string "import" *> skipLWS *> (Import <$> string_)
+  , string "#;" *> skipHWS *> (DirectiveComment <$> directive)
+  , Bind <$> try (ident <* skipLWS <* char '=' <* skipLWS) <*> value
+  , Group <$> try (ident <* skipLWS <* char '{' <* skipLWS)
+          <*> directives <* skipLWS <* char '}'
+  ]
+
+directives :: Parser [Directive]
+directives = (skipLWS *> directive <* skipHWS) `sepBy`
+             (satisfy $ \c -> c == '\r' || c == '\n')
+
+data Skip = Space | Comment
+
+-- | Skip lines, comments, or horizontal white space.
+skipLWS :: Parser ()
+skipLWS = loop
+  where
+    loop = A.takeWhile isSpace >> ((comment >> loop) <|> return ())
+
+    comment = try beginComment >> A.takeWhile (\c -> c /= '\r' && c /= '\n')
+
+    beginComment = do
+      _ <- A.char '#'
+      mc <- peekChar
+      case mc of
+        Just ';' -> fail ""
+        _ -> return ()
+
+-- | Skip comments or horizontal white space.
+skipHWS :: Parser ()
+skipHWS = scan Space go *> pure ()
+  where go Space ' '           = Just Space
+        go Space '\t'          = Just Space
+        go Space '#'           = Just Comment
+        go Space _             = Nothing
+        go Comment '\r'        = Nothing
+        go Comment '\n'        = Nothing
+        go Comment _           = Just Comment
+
+data IdentState = First | Follow
+
+ident :: Parser Name
+ident = do
+  n <- scan First go
+  when (n == "import") $
+    throw (ParseError "" $ "reserved word (" ++ show n ++ ") used as identifier")
+  when (T.null n) $ fail "no identifier found"
+  when (T.last n == '.') $ fail "identifier must not end with a dot"
+  return n
+ where
+  go First c =
+      if isAlpha c
+      then Just Follow
+      else Nothing
+  go Follow c =
+      if isAlphaNum c || c == '_' || c == '-'
+      then Just Follow
+      else if c == '.'
+           then Just First
+           else Nothing
+
+value :: Parser Value
+value = mconcat [
+          string "on" *> pure (Bool True)
+        , string "off" *> pure (Bool False)
+        , string "true" *> pure (Bool True)
+        , string "false" *> pure (Bool False)
+        , String <$> string_
+        , Number <$> scientific
+        , List <$> brackets '[' ']'
+                   ((value <* skipLWS) `sepBy` (char ',' <* skipLWS))
+        ]
+
+string_ :: Parser Text
+string_ = do
+  s <- char '"' *> scan False isChar <* char '"'
+  if "\\" `T.isInfixOf` s
+    then unescape s
+    else return s
+ where
+  isChar True _ = Just False
+  isChar _ '"'  = Nothing
+  isChar _ c    = Just (c == '\\')
+
+brackets :: Char -> Char -> Parser a -> Parser a
+brackets open close p = char open *> skipLWS *> p <* char close
+
+embed :: Parser a -> Text -> Parser a
+embed p s = case parseOnly p s of
+              Left err -> fail err
+              Right v  -> return v
+
+unescape :: Text -> Parser Text
+unescape = fmap (L.toStrict . toLazyText) . embed (p mempty)
+ where
+  p acc = do
+    h <- A.takeWhile (/='\\')
+    let rest = do
+          let cont c = p (acc `mappend` fromText h `mappend` singleton c)
+          c <- char '\\' *> satisfy (inClass "ntru\"\\")
+          case c of
+            'n'  -> cont '\n'
+            't'  -> cont '\t'
+            'r'  -> cont '\r'
+            '"'  -> cont '"'
+            '\\' -> cont '\\'
+            _    -> cont =<< hexQuad
+    done <- atEnd
+    if done
+      then return (acc `mappend` fromText h)
+      else rest
+
+hexQuad :: Parser Char
+hexQuad = do
+  a <- embed hexadecimal =<< A.take 4
+  if a < 0xd800 || a > 0xdfff
+    then return (chr a)
+    else do
+      b <- embed hexadecimal =<< string "\\u" *> A.take 4
+      if a <= 0xdbff && b >= 0xdc00 && b <= 0xdfff
+        then return $! chr (((a - 0xd800) `shiftL` 10) + (b - 0xdc00) + 0x10000)
+        else fail "invalid UTF-16 surrogates"
+
+-- | Parse a string interpolation spec.
+--
+-- The sequence @$$@ is treated as a single @$@ character.  The
+-- sequence @$(@ begins a section to be interpolated, and @)@ ends it.
+interp :: Parser [Interpolate]
+interp = reverse <$> p []
+ where
+  p acc = do
+    h <- Literal <$> A.takeWhile (/='$')
+    let rest = do
+          let cont x = p (x : h : acc)
+          c <- char '$' *> satisfy (\c -> c == '$' || c == '(')
+          case c of
+            '$' -> cont (Literal (T.singleton '$'))
+            _   -> (cont . Interpolate) =<< A.takeWhile1 (/=')') <* char ')'
+    done <- atEnd
+    if done
+      then return (h : acc)
+      else rest

--- a/deps/Data/Configurator/Types.hs
+++ b/deps/Data/Configurator/Types.hs
@@ -1,0 +1,32 @@
+-- |
+-- Module:      Data.Configurator.Types
+-- Copyright:   (c) 2011 MailRank, Inc.
+--              (c) 2015-2016 Leon P Smith
+-- License:     BSD3
+-- Maintainer:  Leon P Smith <leon@melding-monads.com>
+-- Stability:   experimental
+-- Portability: portable
+--
+-- Types for working with configuration files.
+
+module Data.Configurator.Types
+    (
+      AutoConfig(..)
+    , ConfigCache
+    , Name
+    , Value(..)
+    , Worth(..)
+    -- * Exceptions
+    , ParseError(..)
+    , ConfigError(..)
+    , ConfigErrorLocation(..)
+    , ConversionError(..)
+    , ConversionErrorWhy(..)
+    , defaultConversionError
+    , KeyError(..)
+    -- * Notification of configuration changes
+    , Pattern
+    , ChangeHandler
+    ) where
+
+import Data.Configurator.Types.Internal

--- a/deps/Data/Configurator/Types/Internal.hs
+++ b/deps/Data/Configurator/Types/Internal.hs
@@ -1,0 +1,261 @@
+{-# LANGUAGE DeriveDataTypeable, FlexibleInstances, OverloadedStrings #-}
+
+-- |
+-- Module:      Data.Configurator.Types.Internal
+-- Copyright:   (c) 2011 MailRank, Inc.
+--              (c) 2015-2016 Leon P Smith
+-- License:     BSD3
+-- Maintainer:  Leon P Smith <leon@melding-monads.com>
+-- Stability:   experimental
+-- Portability: portable
+--
+-- Types for working with configuration files.
+
+module Data.Configurator.Types.Internal
+    (
+      ConfigCache(..)
+    , AutoConfig(..)
+    , Worth(..)
+    , Name
+    , Value(..)
+    , Binding
+    , Path
+    , Directive(..)
+    , ParseError(..)
+    , ConfigError(..)
+    , ConfigErrorLocation(..)
+    , ConversionError(..)
+    , ConversionErrorWhy(..)
+    , defaultConversionError
+    , MultiErrors
+    , singleError
+    , toErrors
+    , KeyError(..)
+    , Interpolate(..)
+    , Pattern(..)
+    , exact
+    , prefix
+    , ChangeHandler
+    ) where
+
+import Control.Exception
+import Data.Data (Data)
+import Data.DList (DList)
+import qualified Data.DList as DList
+import Data.Hashable (Hashable(..))
+import Data.IORef (IORef)
+import Data.List (isSuffixOf)
+import Data.String (IsString(..))
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.Typeable (Typeable, TypeRep)
+import Data.Scientific(Scientific)
+import Prelude hiding (lookup)
+import qualified Data.HashMap.Lazy as H
+import qualified Data.CritBit.Map.Lazy as CB
+
+data Worth a = Required { worth :: a }
+             | Optional { worth :: a }
+               deriving (Show, Typeable)
+
+instance IsString (Worth FilePath) where
+    fromString = Required
+
+instance (Eq a) => Eq (Worth a) where
+    a == b = worth a == worth b
+
+instance (Hashable a) => Hashable (Worth a) where
+    hashWithSalt salt v = hashWithSalt salt (worth v)
+
+-- | Global configuration data.  This is the top-level config from which
+-- 'Config' values are derived by choosing a root location.
+data ConfigCache = ConfigCache {
+      cfgAuto :: Maybe AutoConfig
+    , cfgPaths :: IORef [(Name, Worth Path)]
+    -- ^ The files from which the 'Config' was loaded.
+    , cfgMap :: IORef (CB.CritBit Name Value)
+    , cfgSubs :: IORef (H.HashMap Pattern [ChangeHandler])
+    }
+
+instance Functor Worth where
+    fmap f (Required a) = Required (f a)
+    fmap f (Optional a) = Optional (f a)
+
+-- | An action to be invoked if a configuration property is changed.
+--
+-- If this action is invoked and throws an exception, the 'onError'
+-- function will be called.
+type ChangeHandler = Name
+                   -- ^ Name of the changed property.
+                   -> Maybe Value
+                   -- ^ Its new value, or 'Nothing' if it has
+                   -- vanished.
+                   -> IO ()
+
+-- | A pattern specifying the name of a property that has changed.
+--
+-- This type is an instance of the 'IsString' class.  If you use the
+-- @OverloadedStrings@ language extension and want to write a
+-- 'prefix'-matching pattern as a literal string, do so by suffixing
+-- it with \"@.*@\", for example as follows:
+--
+-- > "foo.*"
+--
+-- If a pattern written as a literal string does not end with
+-- \"@.*@\", it is assumed to be 'exact'.
+data Pattern = Exact Name
+             -- ^ An exact match.
+             | Prefix Name
+             -- ^ A prefix match.  Given @'Prefix' \"foo\"@, this will
+             -- match @\"foo.bar\"@, but not @\"foo\"@ or
+             -- @\"foobar\"@.
+               deriving (Eq, Show, Typeable, Data)
+
+-- | A pattern that must match exactly.
+exact :: Text -> Pattern
+exact = Exact
+
+-- | A pattern that matches on a prefix of a property name.  Given
+-- @\"foo\"@, this will match @\"foo.bar\"@, but not @\"foo\"@ or
+-- @\"foobar\"@.
+prefix :: Text -> Pattern
+prefix p = Prefix (p `T.snoc` '.')
+
+instance IsString Pattern where
+    fromString s
+        | ".*" `isSuffixOf` s = Prefix . T.init . T.pack $ s
+        | otherwise           = Exact (T.pack s)
+
+instance Hashable Pattern where
+    hashWithSalt salt (Exact n)  = hashWithSalt salt n
+    hashWithSalt salt (Prefix n) = hashWithSalt salt n
+
+-- | An error occurred during the low-level parsing of a configuration file.
+data ParseError  = ParseError FilePath String
+                     deriving (Show, Typeable)
+
+instance Exception ParseError
+
+-- | An error (or warning) from a higher-level parser of a configuration file.
+data ConfigError = ConfigError {
+      configErrorLocation   :: ConfigErrorLocation
+    , configConversionError :: Maybe [ConversionError]
+    } deriving (Eq, Show, Typeable)
+
+instance Exception ConfigError
+
+data ConfigErrorLocation
+    = KeyMissing [Name]
+    | Key FilePath Name
+      deriving (Eq, Show, Typeable)
+
+data ConversionError = ConversionError {
+      conversionErrorLoc  :: Text,
+      conversionErrorWhy  :: ConversionErrorWhy,
+      conversionErrorVal  :: !(Maybe Value),
+      conversionErrorType :: !(Maybe TypeRep),
+      conversionErrorMsg  :: !(Maybe Text)
+    } deriving (Eq, Show, Typeable)
+
+instance Exception ConversionError
+
+data ConversionErrorWhy =
+    MissingValue
+  | ExtraValues
+  | ExhaustedValues
+  | TypeError
+  | ValueError
+  | MonadFail
+  | OtherError
+    deriving (Eq, Typeable, Show)
+
+defaultConversionError :: ConversionError
+defaultConversionError =
+    ConversionError "" OtherError Nothing Nothing Nothing
+
+type MultiErrors a = Maybe (DList a)
+
+singleError :: a -> MultiErrors a
+singleError = Just . DList.singleton
+
+toErrors :: MultiErrors a -> [a]
+toErrors = maybe [] DList.toList
+
+-- | An error occurred while lookup up the given 'Name'.
+data KeyError = KeyError Name
+              deriving (Show, Typeable)
+
+instance Exception KeyError
+
+-- | Directions for automatically reloading 'Config' data.
+data AutoConfig = AutoConfig {
+      interval :: Int
+    -- ^ Interval (in seconds) at which to check for updates to config
+    -- files.  The smallest allowed interval is one second.
+    , onError :: SomeException -> IO ()
+    -- ^ Action invoked when an attempt to reload a 'Config' or notify
+    -- a 'ChangeHandler' causes an exception to be thrown.
+    --
+    -- If this action rethrows its exception or throws a new
+    -- exception, the modification checking thread will be killed.
+    -- You may want your application to treat that as a fatal error,
+    -- as its configuration may no longer be consistent.
+    } deriving (Typeable)
+
+instance Show AutoConfig where
+    show c = "AutoConfig {interval = " ++ show (interval c) ++ "}"
+
+-- | The name of a 'Config' value.
+type Name = Text
+
+-- | A packed 'FilePath'.
+type Path = Text
+
+-- | A name-value binding.
+type Binding = (Name,Value)
+
+-- | A directive in a configuration file.
+data Directive = Import Path
+               | Bind Name Value
+               | Group Name [Directive]
+               | DirectiveComment Directive
+                 deriving (Eq, Show, Typeable, Data)
+
+-- | A value in a 'Config'.
+data Value = Bool Bool
+           -- ^ A Boolean. Represented in a configuration file as @on@
+           -- or @off@, @true@ or @false@ (case sensitive).
+           | String Text
+           -- ^ A Unicode string.  Represented in a configuration file
+           -- as text surrounded by double quotes.
+           --
+           -- Escape sequences:
+           --
+           -- * @\\n@ - newline
+           --
+           -- * @\\r@ - carriage return
+           --
+           -- * @\\t@ - horizontal tab
+           --
+           -- * @\\\\@ - backslash
+           --
+           -- * @\\\"@ - quotes
+           --
+           -- * @\\u@/xxxx/ - Unicode character, encoded as four
+           --   hexadecimal digits
+           --
+           -- * @\\u@/xxxx/@\\u@/xxxx/ - Unicode character (as two
+           --   UTF-16 surrogates)
+           | Number Scientific
+           -- ^ Integer.
+           | List [Value]
+           -- ^ Heterogeneous list.  Represented in a configuration
+           -- file as an opening square bracket \"@[@\", followed by a
+           -- comma-separated series of values, ending with a closing
+           -- square bracket \"@]@\".
+             deriving (Eq, Show, Typeable, Data)
+
+-- | An interpolation directive.
+data Interpolate = Literal Text
+                 | Interpolate Text
+                   deriving (Eq, Show)

--- a/deps/Data/CritBit/Core.hs
+++ b/deps/Data/CritBit/Core.hs
@@ -1,0 +1,300 @@
+{-# LANGUAGE BangPatterns, RecordWildCards, ScopedTypeVariables #-}
+-- |
+-- Module      :  Data.CritBit.Core
+-- Copyright   :  (c) Bryan O'Sullivan 2013
+-- License     :  BSD-style
+-- Maintainer  :  bos@serpentine.com
+-- Stability   :  experimental
+-- Portability :  GHC
+--
+-- "Core" functions that implement the crit-bit tree algorithms.
+--
+-- I plopped these functions into their own source file to demonstrate
+-- just how small the core of the crit-bit tree concept is.
+--
+-- I have also commented this module a bit more heavily than I usually
+-- do, in the hope that the comments will make the code more
+-- approachable to less experienced Haskellers.
+module Data.CritBit.Core
+    (
+    -- * Public functions
+      insertWithKey
+    , insertLookupWithKey
+    , insertLookupGen
+    , lookupWith
+    , updateLookupWithKey
+    , leftmost
+    , rightmost
+    -- * Internal functions
+    , Diff(..)
+    , diffOrd
+    , followPrefixes
+    , followPrefixesFrom
+    , followPrefixesByteFrom
+    , findPosition
+    -- ** Predicates
+    , onLeft
+    , above
+    -- ** Smart constructors
+    , setLeft
+    , setRight
+    , setLeft'
+    , setRight'
+    , internal
+    ) where
+
+import Data.Bits ((.|.), (.&.), complement, shiftR, xor)
+import Data.CritBit.Types.Internal
+
+-- | /O(k)/. Insert with a function, combining key, new value and old value.
+-- @'insertWithKey' f key value cb@
+-- will insert the pair (key, value) into cb if key does not exist in the map.
+-- If the key does exist, the function will insert the pair
+-- @(key,f key new_value old_value)@.
+-- Note that the key passed to f is the same key passed to insertWithKey.
+--
+-- > let f key new_value old_value = byteCount key + new_value + old_value
+-- > insertWithKey f "a" 1 (fromList [("a",5), ("b",3)]) == fromList [("a",7), ("b",3)]
+-- > insertWithKey f "c" 1 (fromList [("a",5), ("b",3)]) == fromList [("a",5), ("b",3), ("c",1)]
+-- > insertWithKey f "a" 1 empty                         == singleton "a" 1
+insertWithKey :: CritBitKey k => (k -> v -> v -> v) -> k -> v -> CritBit k v
+              -> CritBit k v
+insertWithKey f k v m = insertLookupGen (flip const) f k v m
+{-# INLINABLE insertWithKey #-}
+
+-- | /O(k)/. Combines insert operation with old value retrieval.
+-- The expression (@'insertLookupWithKey' f k x map@)
+-- is a pair where the first element is equal to (@'lookup' k map@)
+-- and the second element equal to (@'insertWithKey' f k x map@).
+--
+-- > let f key new_value old_value = length key + old_value + new_value
+-- > insertLookupWithKey f "a" 2 (fromList [("a",5), ("b",3)]) == (Just 5, fromList [("a",8), ("b",3)])
+-- > insertLookupWithKey f "c" 2 (fromList [(5,"a"), (3,"b")]) == (Nothing, fromList [("a",5), ("b",3), ("c",2)])
+-- > insertLookupWithKey f "a" 2 empty                         == (Nothing, singleton "a" 2)
+--
+-- This is how to define @insertLookup@ using @insertLookupWithKey@:
+--
+-- > let insertLookup kx x t = insertLookupWithKey (\_ a _ -> a) kx x t
+-- > insertLookup "a" 1 (fromList [("a",5), ("b",3)]) == (Just 5, fromList [("a",1), ("b",3)])
+-- > insertLookup "c" 1 (fromList [("a",5), ("b",3)]) == (Nothing,  fromList [("a",5), ("b",3), ("c",1)])
+insertLookupWithKey :: CritBitKey k
+                    => (k -> v -> v -> v)
+                    -> k -> v -> CritBit k v
+                    -> (Maybe v, CritBit k v)
+insertLookupWithKey f k v m = insertLookupGen (,) f k v m
+{-# INLINABLE insertLookupWithKey #-}
+
+-- | General function used to implement all insert functions.
+insertLookupGen :: CritBitKey k
+                => (Maybe v -> CritBit k v -> a)
+                -> (k -> v -> v -> v)
+                -> k -> v -> CritBit k v -> a
+insertLookupGen ret f !k v m = findPosition ret' finish setLeft setRight k m
+  where
+    finish _ Empty           = Leaf k v
+    finish diff (Leaf _ v')
+      | diffOrd diff == EQ   = Leaf k $ f k v v'
+    finish diff node         = internal diff node (Leaf k v)
+
+    ret' a b = ret a (CritBit b)
+{-# INLINE insertLookupGen #-}
+
+-- | Common part of key finding/insert functions
+findPosition :: (CritBitKey k)
+             => (Maybe v -> r -> t) -> (Diff -> Node k v -> r)
+             -> (Node k v -> r -> r) -> (Node k v -> r -> r)
+             -> k -> CritBit k v -> t
+findPosition ret finish toLeft toRight k (CritBit root) = go root
+  where
+    go i@(Internal {..})
+      | k `onLeft` i = go ileft
+      | otherwise    = go iright
+    go (Leaf lk lv)
+      | diffOrd diff == EQ = ret (Just lv) $ rewalk root
+      | otherwise          = ret Nothing   $ rewalk root
+      where
+        rewalk i@(Internal left right _ _)
+          | diff `above` i = finish diff i
+          | k `onLeft` i   = toLeft  i (rewalk left )
+          | otherwise      = toRight i (rewalk right)
+        rewalk i           = finish diff i
+
+        diff               = followPrefixes k lk
+    go Empty = ret Nothing $ finish undefined Empty
+{-# INLINE findPosition #-}
+
+data Diff = Diff {-# UNPACK #-} !Int
+                 {-# UNPACK #-} !BitMask
+                 {-# UNPACK #-} !BitMask
+
+-- | Smart consturctor for Internal nodes
+internal :: Diff -> Node k v -> Node k v -> Node k v
+internal diff@(Diff byte bits _) child1 child2 = case diffOrd diff of
+  LT -> Internal child1 child2 byte bits
+  GT -> Internal child2 child1 byte bits
+  EQ -> error "Data.CritBit.Cord.internal: Equal."
+{-# INLINE internal #-}
+
+setLeft :: Node k v -> Node k v -> Node k v
+setLeft i@(Internal{}) node = i { ileft = node }
+setLeft _ _ = error "Data.CritBit.Core.setLeft: Non-Internal node"
+{-# INLINE setLeft #-}
+
+setRight :: Node k v -> Node k v -> Node k v
+setRight i@(Internal{}) node = i { iright = node }
+setRight _ _ = error "Data.CritBit.Core.setRight: Non-Internal node"
+{-# INLINE setRight #-}
+
+setLeft' :: Node k v -> Node k v -> Node k v
+setLeft' i@(Internal{}) Empty = iright i
+setLeft' i@(Internal{}) child = i { ileft = child }
+setLeft' _ _ = error "Data.CritBit.Core.setLeft': Non-internal node"
+{-# INLINE setLeft' #-}
+
+setRight' :: Node k v -> Node k v -> Node k v
+setRight' i@(Internal{}) Empty = ileft i
+setRight' i@(Internal{}) child = i { iright = child }
+setRight' _ _ = error "Data.CritBit.Core.alter.setRight': Non-internal node"
+{-# INLINE setRight' #-}
+
+above :: Diff -> Node k v -> Bool
+above (Diff dbyte dbits _) (Internal _ _ byte bits) =
+    dbyte < byte || dbyte == byte && dbits < bits
+above _ _ = error "Data.CritBit.Core.above: Non-Internal node"
+{-# INLINE above #-}
+
+lookupWith :: (CritBitKey k) =>
+              a                 -- ^ Failure continuation
+           -> (v -> a)          -- ^ Success continuation
+           -> k
+           -> CritBit k v -> a
+-- We use continuations here to avoid reimplementing the lookup
+-- algorithm with trivial variations.
+lookupWith notFound found k (CritBit root) = go root
+  where
+    go i@(Internal {..})
+       | k `onLeft` i = go ileft
+       | otherwise    = go iright
+    go (Leaf lk v)
+       | k == lk      = found v
+    go _              = notFound
+{-# INLINE lookupWith #-}
+
+-- | /O(k)/. Lookup and update; see also 'updateWithKey'.
+-- This function returns the changed value if it is updated, or
+-- the original value if the entry is deleted.
+--
+-- > let f k x = if x == 5 then Just (x + fromEnum (k < "d")) else Nothing
+-- > updateLookupWithKey f "a" (fromList [("b",3), ("a",5)]) == (Just 6, fromList [("a", 6), ("b",3)])
+-- > updateLookupWithKey f "c" (fromList [("a",5), ("b",3)]) == (Nothing, fromList [("a",5), ("b",3)])
+-- > updateLookupWithKey f "b" (fromList [("a",5), ("b",3)]) == (Just 3, singleton "a" 5)
+updateLookupWithKey :: (CritBitKey k) => (k -> v -> Maybe v) -> k
+                       -> CritBit k v -> (Maybe v, CritBit k v)
+-- Once again with the continuations! It's somewhat faster to do
+-- things this way than to expicitly unwind our recursion once we've
+-- found the leaf to delete. It's also a ton less code.
+--
+-- (If you want a good little exercise, rewrite this function without
+-- using continuations, and benchmark the two versions.)
+updateLookupWithKey f k t@(CritBit root) = go root (CritBit Empty) CritBit
+  where
+    go i@(Internal left right _ _) _ cont = dispatch i left right cont
+    go (Leaf lk lv) other cont
+      | k == lk   = case f lk lv of
+                      Just lv' -> (Just lv', cont $! Leaf lk lv')
+                      Nothing  -> (Just lv, other)
+      | otherwise = (Nothing, t)
+    go Empty _ _  = (Nothing, t)
+    {-# INLINE go #-}
+
+    dispatch i left right cont
+      | k `onLeft` i = go left (cont right) $ (cont $!) . setLeft'  i
+      | otherwise    = go right (cont left) $ (cont $!) . setRight' i
+{-# INLINABLE updateLookupWithKey #-}
+
+-- | Determine whether specified key is on the left subtree of the
+-- 'Internal' node.
+onLeft :: (CritBitKey k) => k -> Node k v -> Bool
+onLeft k (Internal _ _ byte bits) =
+  (1 + (bits .|. getByte k byte)) `shiftR` 9 == 0
+onLeft _ _ = error "Data.CritBit.Core.onLeft: Non-Internal node"
+{-# INLINE onLeft #-}
+
+-- | Given a diff of two keys determines result of comparison of them.
+diffOrd :: Diff -> Ordering
+diffOrd (Diff _ bits c)
+  | bits == 0x1ff                      = EQ
+  | (1 + (bits .|. c)) `shiftR` 9 == 0 = LT
+  | otherwise                          = GT
+{-# INLINE diffOrd #-}
+
+-- | Figure out the byte offset at which the key we are interested in
+-- differs from the leaf we reached when we initially walked the tree.
+--
+-- We return some auxiliary stuff that we'll bang on to help us figure
+-- out which direction to go in to insert a new node.
+followPrefixes :: (CritBitKey k) =>
+                  k             -- ^ The key from "outside" the tree.
+               -> k             -- ^ Key from the leaf we reached.
+               -> Diff
+followPrefixes = followPrefixesFrom 0
+{-# INLINE followPrefixes #-}
+
+-- | Figure out the offset of the first different byte in two keys,
+-- starting from specified position.
+--
+-- We return some auxiliary stuff that we'll bang on to help us figure
+-- out which direction to go in to insert a new node.
+followPrefixesFrom :: (CritBitKey k) =>
+                      Int           -- ^ Positition to start from
+                   -> k             -- ^ First key.
+                   -> k             -- ^ Second key.
+                   -> Diff
+followPrefixesFrom !position !k !l = Diff n (maskLowerBits (b `xor` c)) c
+  where
+    n = followPrefixesByteFrom position k l
+    b = getByte k n
+    c = getByte l n
+
+    maskLowerBits v = (n3 .&. complement (n3 `shiftR` 1)) `xor` 0x1FF
+      where
+        n3 = n2 .|. (n2 `shiftR` 8)
+        n2 = n1 .|. (n1 `shiftR` 4)
+        n1 = n0 .|. (n0 `shiftR` 2)
+        n0 = v  .|. (v  `shiftR` 1)
+{-# INLINE followPrefixesFrom #-}
+
+-- | Figure out the offset of the first different byte in two keys,
+-- starting from specified position.
+followPrefixesByteFrom :: (CritBitKey k) =>
+                          Int           -- ^ Positition to start from
+                       -> k             -- ^ First key.
+                       -> k             -- ^ Second key.
+                       -> Int
+followPrefixesByteFrom !position !k !l = go position
+  where
+    go !n | b /= c || b == 0 || c == 0 = n
+          | otherwise                  = go (n + 1)
+      where b = getByte k n
+            c = getByte l n
+{-# INLINE followPrefixesByteFrom #-}
+
+leftmost, rightmost :: a -> (k -> v -> a) -> Node k v -> a
+leftmost  = extremity ileft
+{-# INLINE leftmost #-}
+rightmost = extremity iright
+{-# INLINE rightmost #-}
+
+-- | Generic function so we can easily implement 'leftmost' and 'rightmost'.
+extremity :: (Node k v -> Node k v) -- ^ Either 'ileft' or 'iright'.
+          -> a                      -- ^ 'Empty' continuation.
+          -> (k -> v -> a)          -- ^ 'Leaf' continuation.
+          -> Node k v
+          -> a
+extremity direct onEmpty onLeaf node = go node
+  where
+    go i@(Internal{}) = go $ direct i
+    go (Leaf k v)     = onLeaf k v
+    go _              = onEmpty
+    {-# INLINE go #-}
+{-# INLINE extremity #-}

--- a/deps/Data/CritBit/Core.hs
+++ b/deps/Data/CritBit/Core.hs
@@ -43,6 +43,7 @@ module Data.CritBit.Core
     , internal
     ) where
 
+import Prelude
 import Data.Bits ((.|.), (.&.), complement, shiftR, xor)
 import Data.CritBit.Types.Internal
 

--- a/deps/Data/CritBit/Map/Lazy.hs
+++ b/deps/Data/CritBit/Map/Lazy.hs
@@ -1,0 +1,22 @@
+-- |
+-- Module      :  Data.CritBit.Map.Lazy
+-- Copyright   :  (c) Bryan O'Sullivan 2013
+-- License     :  BSD-style
+-- Maintainer  :  bos@serpentine.com
+-- Stability   :  experimental
+-- Portability :  GHC
+--
+-- A crit-bit tree that does not evaluate its values by default.
+--
+-- For every /n/ key-value pairs stored, a crit-bit tree uses /n/-1
+-- internal nodes, for a total of 2/n/-1 internal nodes and leaves.
+module Data.CritBit.Map.Lazy
+    (
+    -- * Types
+      CritBitKey(..)
+    , CritBit
+    , module Data.CritBit.Tree
+    ) where
+
+import Data.CritBit.Tree
+import Data.CritBit.Types.Internal

--- a/deps/Data/CritBit/Set.hs
+++ b/deps/Data/CritBit/Set.hs
@@ -1,0 +1,456 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- |
+-- Module      :  Data.CritBit.Set
+-- Copyright   :  (c) Bryan O'Sullivan and others 2013-2014
+-- License     :  BSD-style
+-- Maintainer  :  bos@serpentine.com
+-- Stability   :  experimental
+-- Portability :  GHC
+--
+-- A set type that uses crit-bit trees internally.
+--
+-- For every /n/ key-value pairs stored, a crit-bit tree uses /n/-1
+-- internal nodes, for a total of 2/n/-1 internal nodes and leaves.
+module Data.CritBit.Set
+    (
+    -- * Set type
+    Set
+
+    -- * Operators
+    , (\\)
+
+    -- * Query
+    , null
+    , size
+    , member
+    , notMember
+    , lookupLT
+    , lookupGT
+    , lookupLE
+    , lookupGE
+    , isSubsetOf
+    , isProperSubsetOf
+
+    -- * Construction
+    , empty
+    , singleton
+    , insert
+    , delete
+
+    -- * Combine
+    , union
+    , unions
+    , difference
+    , intersection
+
+    -- * Filter
+    , filter
+    , partition
+    , split
+    , splitMember
+
+    -- * Map
+    , map
+    , mapMonotonic
+
+    -- * Folds
+    , foldr
+    , foldl
+    -- ** Strict folds
+    , foldr'
+    , foldl'
+
+    -- * Min\/Max
+    , findMin
+    , findMax
+    , deleteMin
+    , deleteMax
+    , deleteFindMin
+    , deleteFindMax
+    , maxView
+    , minView
+
+    -- * Conversion
+
+    -- ** List
+    , elems
+    , toList
+    , fromList
+
+    -- ** Ordered list
+    , toAscList
+    , toDescList
+    , fromAscList
+    , fromDistinctAscList
+    ) where
+
+import Control.Arrow ((***))
+import Data.CritBit.Types.Internal (CritBit(..), Set(..), CritBitKey, Node(..))
+import Data.Foldable (Foldable, foldMap)
+import Data.Maybe (isJust)
+import Data.Monoid (Monoid(..))
+import Prelude hiding (null, filter, map, foldl, foldr)
+import qualified Data.CritBit.Tree as T
+import qualified Data.List as List
+
+instance (Show a) => Show (Set a) where
+    show s = "fromList " ++ show (toList s)
+
+instance CritBitKey k => Monoid (Set k) where
+    mempty  = empty
+    mappend = union
+    mconcat = unions
+
+instance Foldable Set where
+    foldMap f (Set (CritBit n)) = foldSet f n
+
+foldSet :: (Monoid m) => (a -> m) -> Node a () -> m
+foldSet f (Internal l r _ _) = mappend (foldSet f l) (foldSet f r)
+foldSet f (Leaf k _)         = f k
+foldSet _ Empty              = mempty
+{-# INLINABLE foldSet #-}
+
+-- | Same as 'difference'.
+(\\) :: CritBitKey a => Set a -> Set a -> Set a
+s \\ p = difference s p
+{-# INLINABLE (\\) #-}
+
+-- | /O(1)/. Is the set empty?
+--
+-- > null (empty)         == True
+-- > null (singleton "a") == False
+null :: Set a -> Bool
+null (Set a) = T.null a
+
+-- | /O(1)/. The empty set.
+--
+-- > empty      == fromList []
+-- > size empty == 0
+empty :: Set a
+empty = Set T.empty
+{-# INLINABLE empty #-}
+
+-- | /O(1)/. A set with a single element.
+--
+-- > singleton "a"        == fromList ["a"]
+singleton :: a -> Set a
+singleton a = Set $ T.singleton a ()
+{-# INLINE singleton #-}
+
+-- | /O(k)/. Build a set from a list of values.
+--
+-- > fromList [] == empty
+-- > fromList ["a", "b", "a"] == fromList ["a", "b"]
+fromList :: (CritBitKey a) => [a] -> Set a
+fromList = liftFromList T.fromList
+{-# INLINABLE fromList #-}
+
+-- | /O(n)/. An alias of 'toList'.
+--
+-- Returns the elements of a set in ascending order.
+elems :: Set a -> [a]
+elems = toList
+
+-- | /O(n)/. Convert the set to a list of values. The list returned
+-- will be sorted in lexicographically ascending order.
+--
+-- > toList (fromList ["b", "a"]) == ["a", "b"]
+-- > toList empty == []
+toList :: Set a -> [a]
+toList = wrapS id T.keys
+{-# INLINABLE toList #-}
+
+-- | /O(n)/. The number of elements in the set.
+--
+-- > size empty                      == 0
+-- > size (singleton "a")            == 1
+-- > size (fromList ["a", "c", "b"]) == 3
+size :: Set a -> Int
+size = wrapS id T.size
+{-# INLINABLE size #-}
+
+-- | /O(k)/. Is the element in the set?
+--
+-- > member "a" (fromList ["a", "b"]) == True
+-- > member "c" (fromList ["a", "b"]) == False
+--
+-- See also 'notMember'.
+member :: (CritBitKey a) => a -> Set a -> Bool
+member a (Set s) = T.member a s
+{-# INLINABLE member #-}
+
+-- | /O(k)/. Is the element not in the set?
+--
+-- > notMember "a" (fromList ["a", "b"]) == False
+-- > notMember "c" (fromList ["a", "b"]) == True
+--
+-- See also 'member'.
+notMember :: (CritBitKey a) => a -> Set a -> Bool
+notMember a (Set s) = T.notMember a s
+{-# INLINABLE notMember #-}
+
+-- | /O(k)/. Find largest element smaller than the given one.
+--
+-- > lookupLT "b"  (fromList ["a", "b"]) == Just "a"
+-- > lookupLT "aa" (fromList ["a", "b"]) == Just "a"
+-- > lookupLT "a"  (fromList ["a", "b"]) == Nothing
+lookupLT :: (CritBitKey a) => a -> Set a -> Maybe a
+lookupLT = wrapVS (fmap fst) T.lookupLT
+{-# INLINABLE lookupLT #-}
+
+-- | /O(k)/. Find smallest element greater than the given one.
+--
+-- > lookupGT "b"  (fromList ["a", "b"]) == Nothing
+-- > lookupGT "aa" (fromList ["a", "b"]) == Just "b"
+-- > lookupGT "a"  (fromList ["a", "b"]) == Just "b"
+lookupGT :: (CritBitKey a) => a -> Set a -> Maybe a
+lookupGT = wrapVS (fmap fst) T.lookupGT
+{-# INLINABLE lookupGT #-}
+
+-- | /O(k)/. Find largest element smaller than or equal to the given one.
+--
+-- > lookupGE "b"  (fromList ["a", "b"]) == Just "b"
+-- > lookupGE "aa" (fromList ["a", "b"]) == Just "b"
+-- > lookupGE "a"  (fromList ["a", "b"]) == Just "a"
+-- > lookupGE ""   (fromList ["a", "b"]) == Nothing
+lookupLE :: (CritBitKey a) => a -> Set a -> Maybe a
+lookupLE = wrapVS (fmap fst) T.lookupLE
+{-# INLINABLE lookupLE #-}
+
+-- | /O(k)/. Find smallest element greater than or equal to the given one.
+--
+-- > lookupGE "aa" (fromList ["a", "b"]) == Just "b"
+-- > lookupGE "b"  (fromList ["a", "b"]) == Just "b"
+-- > lookupGE "bb" (fromList ["a", "b"]) == Nothing
+lookupGE :: (CritBitKey a) => a -> Set a -> Maybe a
+lookupGE = wrapVS (fmap fst) T.lookupGE
+{-# INLINABLE lookupGE #-}
+
+-- | /O(n+m)/. Is this a subset?
+-- @(s1 `isSubsetOf` s2)@ tells whether @s1@ is a subset of @s2@.
+isSubsetOf :: (CritBitKey a) => Set a -> Set a -> Bool
+isSubsetOf = wrapSS id T.isSubmapOf
+{-# INLINABLE isSubsetOf #-}
+
+-- | /O(n+m)/. Is this a proper subset (ie. a subset but not equal)?
+-- @(s1 `isSubsetOf` s2)@ tells whether @s1@ is a proper subset of @s2@.
+isProperSubsetOf :: (CritBitKey a) => Set a -> Set a -> Bool
+isProperSubsetOf = wrapSS id T.isProperSubmapOf
+{-# INLINABLE isProperSubsetOf #-}
+
+-- | /O(k)/. Insert an element in a set.
+-- If the set already contains an element equal to the given value,
+-- it is replaced with the new value.
+insert :: (CritBitKey a) => a -> Set a -> Set a
+insert = wrapVS Set (`T.insert` ())
+{-# INLINABLE insert #-}
+
+-- | /O(k)/. Delete an element from a set.
+delete :: (CritBitKey a) => a -> Set a -> Set a
+delete = wrapVS Set T.delete
+{-# INLINABLE delete #-}
+
+-- | /O(k)/. The union of two sets, preferring the first set when
+-- equal elements are encountered.
+union :: (CritBitKey a) => Set a -> Set a -> Set a
+union = wrapSS Set T.union
+{-# INLINABLE union #-}
+
+-- | The union of a list of sets: (@'unions' == 'foldl' 'union' 'empty'@).
+unions :: (CritBitKey a) => [Set a] -> Set a
+unions = List.foldl' union empty
+{-# INLINABLE unions #-}
+
+-- | /O(k)/. The difference of two sets.
+difference :: (CritBitKey a) => Set a -> Set a -> Set a
+difference = wrapSS Set T.difference
+{-# INLINABLE difference #-}
+
+-- | /O(k)/. The intersection of two sets. Elements of the
+-- result come from the first set.
+intersection :: (CritBitKey a) => Set a -> Set a -> Set a
+intersection = wrapSS Set T.intersection
+{-# INLINABLE intersection #-}
+
+-- | /O(n)/. Filter all elements that satisfy the predicate.
+--
+-- > filter (> "a") (fromList ["a", "b"]) == fromList [("3","b")]
+-- > filter (> "x") (fromList ["a", "b"]) == empty
+-- > filter (< "a") (fromList ["a", "b"]) == empty
+filter :: (a -> Bool) -> Set a -> Set a
+filter = wrapVS Set (T.filterWithKey . (const .))
+{-# INLINABLE filter #-}
+
+-- | /O(n)/. Partition the set into two sets, one with all elements that satisfy
+-- the predicate and one with all elements that don't satisfy the predicate.
+-- See also 'split'.
+partition :: (CritBitKey a) => (a -> Bool) -> Set a -> (Set a, Set a)
+partition = wrapVS (Set *** Set) (T.partitionWithKey . (const .))
+{-# INLINABLE partition #-}
+
+-- | /O(k)/. The expression (@'split' x set@) is a pair @(set1,set2)@
+-- where @set1@ comprises the elements of @set@ less than @x@ and @set2@
+-- comprises the elements of @set@ greater than @x@.
+--
+-- > split "a" (fromList ["b", "d"]) == (empty, fromList ["b", "d")])
+-- > split "b" (fromList ["b", "d"]) == (empty, singleton "d")
+-- > split "c" (fromList ["b", "d"]) == (singleton "b", singleton "d")
+-- > split "d" (fromList ["b", "d"]) == (singleton "b", empty)
+-- > split "e" (fromList ["b", "d"]) == (fromList ["b", "d"], empty)
+split :: (CritBitKey a) => a -> Set a -> (Set a, Set a)
+split = wrapVS (Set *** Set) T.split
+{-# INLINABLE split #-}
+
+-- | /O(k)/. Performs a 'split' but also returns whether the pivot
+-- element was found in the original set.
+--
+-- > splitMember "a" (fromList ["b", "d"]) == (empty, False, fromList ["b", "d"])
+-- > splitMember "b" (fromList ["b", "d"]) == (empty, True, singleton "d")
+-- > splitMember "c" (fromList ["b", "d"]) == (singleton "b", False, singleton "d")
+-- > splitMember "d" (fromList ["b", "d"]) == (singleton "b", True, empty)
+-- > splitMember "e" (fromList ["b", "d"]) == (fromList ["b", "d"], False, empty)
+splitMember :: (CritBitKey a) => a -> Set a -> (Set a, Bool, Set a)
+splitMember = wrapVS pack T.splitLookup
+  where pack (l, m, r) = (Set l, isJust m, Set r)
+{-# INLINABLE splitMember #-}
+
+-- | /O(k)/. @'map' f s@ is the set obtained by applying @f@ to each
+-- element of @s@.
+--
+-- It's worth noting that the size of the result may be smaller if,
+-- for some @(x,y)@, @x \/= y && f x == f y@
+map :: (CritBitKey a2) => (a1 -> a2) -> Set a1 -> Set a2
+map = wrapVS Set T.mapKeys
+{-# INLINABLE map #-}
+
+-- | /O(n)/. The @'mapMonotonic' f s == 'map' f s@, but works only when
+-- @f@ is monotonic.
+-- /The precondition is not checked./
+-- Semi-formally, we have:
+--
+-- > and [x < y ==> f x < f y | x <- ls, y <- ls]
+-- >                     ==> mapMonotonic f s == map f s
+-- >     where ls = toList s
+mapMonotonic :: (CritBitKey a2) => (a1 -> a2) -> Set a1 -> Set a2
+mapMonotonic = wrapVS Set T.mapKeysMonotonic
+{-# INLINABLE mapMonotonic #-}
+
+-- | /O(n)/. Fold the elements in the set using the given left-associative
+-- binary operator, such that @'foldl' f z == 'Prelude.foldl' f z . 'toAscList'@.
+--
+-- For example,
+--
+-- > toDescList set = foldl (flip (:)) [] set
+foldl :: (a -> b -> a) -> a -> Set b -> a
+foldl f = wrapVS id (T.foldlWithKey ((const .) . f))
+{-# INLINE foldl #-}
+
+-- | /O(n)/. A strict version of 'foldl'. Each application of the operator is
+-- evaluated before using the result in the next application. This
+-- function is strict in the starting value.
+foldl' :: (a -> b -> a) -> a -> Set b -> a
+foldl' f = wrapVS id (T.foldlWithKey' ((const .) . f))
+{-# INLINE foldl' #-}
+
+-- | /O(n)/. Fold the elements in the set using the given right-associative
+-- binary operator, such that @'foldr' f z == 'Prelude.foldr' f z . 'toAscList'@.
+--
+-- For example,
+--
+-- > toAscList set = foldr (:) [] set
+foldr :: (a -> b -> b) -> b -> Set a -> b
+foldr f = wrapVS id (T.foldrWithKey (const . f))
+{-# INLINE foldr #-}
+
+-- | /O(n)/. A strict version of 'foldr'. Each application of the operator is
+-- evaluated before using the result in the next application. This
+-- function is strict in the starting value.
+foldr' :: (a -> b -> b) -> b -> Set a -> b
+foldr' f = wrapVS id (T.foldrWithKey' (const . f))
+{-# INLINE foldr' #-}
+
+-- | /O(k')/. The minimal element of a set.
+findMin :: Set a -> a
+findMin = wrapS fst T.findMin
+{-# INLINE findMin #-}
+
+-- | /O(k)/. The maximal element of a set.
+findMax :: Set a -> a
+findMax = wrapS fst T.findMax
+{-# INLINE findMax #-}
+
+-- | /O(k')/. Delete the minimal element. Returns an empty set if the
+-- set is empty.
+deleteMin :: Set a -> Set a
+deleteMin = wrapS Set T.deleteMin
+{-# INLINE deleteMin #-}
+
+-- | /O(k)/. Delete the maximal element. Returns an empty set if the
+-- set is empty.
+deleteMax :: Set a -> Set a
+deleteMax = wrapS Set T.deleteMax
+{-# INLINE deleteMax #-}
+
+-- | /O(k')/. Delete and find the minimal element.
+--
+-- > deleteFindMin set = (findMin set, deleteMin set)
+deleteFindMin :: Set a -> (a, Set a)
+deleteFindMin = wrapS (fst *** Set) T.deleteFindMin
+{-# INLINE deleteFindMin #-}
+
+-- | /O(k)/. Delete and find the maximal element.
+--
+-- > deleteFindMax set = (findMax set, deleteMax set)
+deleteFindMax :: Set a -> (a, Set a)
+deleteFindMax = wrapS (fst *** Set) T.deleteFindMax
+{-# INLINE deleteFindMax #-}
+
+-- | /O(k')/. Retrieves the minimal key of the set, and the set
+-- stripped of that element, or 'Nothing' if passed an empty set.
+minView :: Set a -> Maybe (a, Set a)
+minView = wrapS (fmap (fst *** Set)) T.minViewWithKey
+{-# INLINE minView #-}
+
+-- | /O(k)/. Retrieves the maximal key of the set, and the set
+-- stripped of that element, or 'Nothing' if passed an empty set.
+maxView :: Set a -> Maybe (a, Set a)
+maxView = wrapS (fmap (fst *** Set)) T.maxViewWithKey
+{-# INLINE maxView #-}
+
+-- | /O(n)/. Convert the set to an ascending list of elements.
+toAscList :: Set a -> [a]
+toAscList = toList
+
+-- | /O(n)/. Convert the set to a descending list of elements.
+toDescList :: Set a -> [a]
+toDescList = reverse . toAscList
+
+-- | /O(n)/. Build a set from an ascending list in linear time.
+-- /The precondition (input list is ascending) is not checked./
+fromAscList :: (CritBitKey a) => [a] -> Set a
+fromAscList = liftFromList T.fromAscList
+
+-- | /O(n)/. Build a set from an ascending list in linear time.
+-- /The precondition (input list is ascending) is not checked./
+fromDistinctAscList :: (CritBitKey a) => [a] -> Set a
+fromDistinctAscList = liftFromList T.fromDistinctAscList
+
+-- | Wraps tree operation to set operation
+wrapS :: (r -> q) -> (CritBit a () -> r) -> Set a -> q
+wrapS f g (Set s) = f $ g s
+{-# INLINE wrapS #-}
+
+-- | Wraps (value, tree) operation to (value, set) operation
+wrapVS :: (r -> q) -> (t -> CritBit a () -> r) -> t -> Set a -> q
+wrapVS f g a (Set s) = f $ g a s
+{-# INLINE wrapVS #-}
+
+-- | Wraps (tree, tree) operation to (set, set) operation
+wrapSS :: (r -> q) -> (CritBit a () -> CritBit a () -> r) -> Set a -> Set a -> q
+wrapSS f g (Set s1) (Set s2) = f $ g s1 s2
+{-# INLINE wrapSS #-}
+
+liftFromList :: ([(a, ())] -> CritBit a ()) -> [a] -> Set a
+liftFromList f xs = Set . f . zip xs . repeat $ ()
+{-# INLINE liftFromList #-}

--- a/deps/Data/CritBit/Tree.hs
+++ b/deps/Data/CritBit/Tree.hs
@@ -1,0 +1,1519 @@
+{-# LANGUAGE BangPatterns, RecordWildCards, ScopedTypeVariables #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- |
+-- Module      :  Data.CritBit.Tree
+-- Copyright   :  (c) Bryan O'Sullivan and others 2013-2014
+-- License     :  BSD-style
+-- Maintainer  :  bos@serpentine.com
+-- Stability   :  experimental
+-- Portability :  GHC
+module Data.CritBit.Tree
+    (
+    -- * Operators
+      (!)
+    , (\\)
+
+    -- * Query
+    , null
+    , size
+    , member
+    , notMember
+    , lookup
+    , findWithDefault
+    , lookupGT
+    , lookupGE
+    , lookupLT
+    , lookupLE
+
+    -- * Construction
+    , empty
+    , singleton
+
+    -- * Insertion
+    , insert
+    , insertWith
+    , insertWithKey
+    , insertLookupWithKey
+
+    -- * Deletion
+    , delete
+    , adjust
+    , adjustWithKey
+    , update
+    , updateWithKey
+    , updateLookupWithKey
+    , alter
+
+    -- * Combination
+    -- ** Union
+    , union
+    , unionWith
+    , unionWithKey
+    , unions
+    , unionsWith
+    , unionL
+    , unionR
+
+    -- ** Difference
+    , difference
+    , differenceWith
+    , differenceWithKey
+
+    -- ** Intersection
+    , intersection
+    , intersectionWith
+    , intersectionWithKey
+
+    -- * Traversal
+    -- ** Map
+    , map
+    , mapWithKey
+    , traverseWithKey
+    , mapAccum
+    , mapAccumWithKey
+    , mapAccumRWithKey
+    , mapKeys
+    , mapKeysWith
+    , mapKeysMonotonic
+
+    -- * Folds
+    , foldl
+    , foldr
+    , foldlWithKey
+    , foldrWithKey
+
+    -- ** Strict folds
+    , foldl'
+    , foldr'
+    , foldlWithKey'
+    , foldrWithKey'
+
+    -- * Conversion
+    , elems
+    , keys
+    , assocs
+    , keysSet
+    , fromSet
+
+    -- ** Lists
+    , toList
+    , fromList
+    , fromListWith
+    , fromListWithKey
+
+    -- ** Ordered lists
+    , toAscList
+    , toDescList
+    , fromAscList
+    , fromAscListWith
+    , fromAscListWithKey
+    , fromDistinctAscList
+
+    -- * Filter
+    , filter
+    , filterWithKey
+    , partition
+    , partitionWithKey
+
+    , mapMaybe
+    , mapMaybeWithKey
+    , mapEither
+    , mapEitherWithKey
+
+    , split
+    , splitLookup
+
+    -- * Submap
+    , isSubmapOf
+    , isSubmapOfBy
+    , isProperSubmapOf
+    , isProperSubmapOfBy
+
+    -- -- * Min\/Max
+    , findMin
+    , findMax
+    , deleteMin
+    , deleteMax
+    , deleteFindMin
+    , deleteFindMax
+    , updateMin
+    , updateMax
+    , updateMinWithKey
+    , updateMaxWithKey
+    , minView
+    , maxView
+    , minViewWithKey
+    , maxViewWithKey
+    ) where
+
+import Control.Applicative (Applicative(..), (<$>), (<|>))
+import Control.Arrow (second, (***))
+import Data.CritBit.Core
+import Data.CritBit.Types.Internal
+import Data.Maybe (fromMaybe)
+import Data.Monoid (Monoid(..))
+import Data.Traversable (Traversable(traverse))
+import Prelude hiding (foldl, foldr, lookup, null, map, filter)
+import qualified Data.Array as A
+import qualified Data.Foldable as Foldable
+import qualified Data.List as List
+
+instance CritBitKey k => Monoid (CritBit k v) where
+    mempty  = empty
+    mappend = union
+    mconcat = unions
+
+instance CritBitKey k => Traversable (CritBit k) where
+    traverse f m = traverseWithKey (\_ v -> f v) m
+
+infixl 9 !, \\
+
+-- | /O(k)/. Find the value at a key.
+-- Calls 'error' when the element can not be found.
+--
+-- > fromList [("a",5), ("b",3)] ! "c"    Error: element not in the map
+-- > fromList [("a",5), ("b",3)] ! "a" == 5
+(!) :: CritBitKey k => CritBit k v -> k -> v
+(!) m k = lookupWith err id k m
+  where err = error "CritBit.!: given key is not an element in the map"
+{-# INLINABLE (!) #-}
+
+-- | Same as 'difference'.
+(\\) :: CritBitKey k => CritBit k v -> CritBit k w -> CritBit k v
+(\\) m n = difference m n
+{-# INLINABLE (\\) #-}
+
+-- | /O(1)/. Is the map empty?
+--
+-- > null (empty)           == True
+-- > null (singleton 1 'a') == False
+null :: CritBit k v -> Bool
+null (CritBit Empty) = True
+null _               = False
+
+-- | /O(1)/. The empty map.
+--
+-- > empty      == fromList []
+-- > size empty == 0
+empty :: CritBit k v
+empty = CritBit Empty
+
+-- | /O(k)/. Is the key a member of the map?
+--
+-- > member "a" (fromList [("a",5), ("b",3)]) == True
+-- > member "c" (fromList [("a",5), ("b",3)]) == False
+--
+-- See also 'notMember'.
+member :: (CritBitKey k) => k -> CritBit k v -> Bool
+member k m = lookupWith False (const True) k m
+{-# INLINABLE member #-}
+
+-- | /O(k)/. Is the key not a member of the map?
+--
+-- > notMember "a" (fromList [("a",5), ("b",3)]) == False
+-- > notMember "c" (fromList [("a",5), ("b",3)]) == True
+--
+-- See also 'member'.
+notMember :: (CritBitKey k) => k -> CritBit k v -> Bool
+notMember k m = lookupWith True (const False) k m
+{-# INLINE notMember #-}
+
+-- | /O(k)/. Lookup the value at a key in the map.
+--
+-- The function will return the corresponding value as @('Just' value)@,
+-- or 'Nothing' if the key isn't in the map.
+--
+-- An example of using @lookup@:
+--
+-- > {-# LANGUAGE OverloadedStrings #-}
+-- > import Data.Text
+-- > import Prelude hiding (lookup)
+-- > import Data.CritBit.Map.Lazy
+-- >
+-- > employeeDept, deptCountry, countryCurrency :: CritBit Text Text
+-- > employeeDept = fromList [("John","Sales"), ("Bob","IT")]
+-- > deptCountry = fromList [("IT","USA"), ("Sales","France")]
+-- > countryCurrency = fromList [("USA", "Dollar"), ("France", "Euro")]
+-- >
+-- > employeeCurrency :: Text -> Maybe Text
+-- > employeeCurrency name = do
+-- >   dept <- lookup name employeeDept
+-- >   country <- lookup dept deptCountry
+-- >   lookup country countryCurrency
+-- >
+-- > main = do
+-- >   putStrLn $ "John's currency: " ++ show (employeeCurrency "John")
+-- >   putStrLn $ "Pete's currency: " ++ show (employeeCurrency "Pete")
+--
+-- The output of this program:
+--
+-- >   John's currency: Just "Euro"
+-- >   Pete's currency: Nothing
+lookup :: (CritBitKey k) => k -> CritBit k v -> Maybe v
+lookup k m = lookupWith Nothing Just k m
+{-# INLINABLE lookup #-}
+
+-- | /O(k)/. Delete a key and its value from the map. When the key
+-- is not a member of the map, the original map is returned.
+--
+-- > delete "a" (fromList [("a",5), ("b",3)]) == singleton "b" 3
+-- > delete "c" (fromList [("a",5), ("b",3)]) == fromList [("a",5), ("b",3)]
+-- > delete "a" empty                         == empty
+delete :: (CritBitKey k) => k -> CritBit k v -> CritBit k v
+delete k t@(CritBit root) = go root empty CritBit
+  where
+    go i@(Internal left right _ _) _ cont
+      | k `onLeft` i = go left (cont right) $ ((cont $!) . setLeft  i)
+      | otherwise    = go right (cont left) $ ((cont $!) . setRight i)
+    go (Leaf lk _) other _
+      | k == lk      = other
+      | otherwise    = t
+    go Empty _ _     = t
+{-# INLINABLE delete #-}
+
+-- | /O(k)/. The expression (@'update' f k map@ updates the value @x@
+-- at @k@ (if it is in the map). If (@f x@) is 'Nothing', the element is
+-- deleted. If it is (@'Just' y@), the key @k@ is bound to the new value @y@.
+--
+-- > let f x = if x == 5 then Just 50 else Nothing
+-- > update f "a" (fromList [("b",3), ("a",5)]) == fromList [("a", 50), ("b",3)]
+-- > update f "c" (fromList [("b",3), ("a",5)]) == fromList [("a", 50), ("b",3)]
+-- > update f "b" (fromList [("b",3), ("a",5)]) == singleton "a" 5
+update :: (CritBitKey k) => (v -> Maybe v) -> k -> CritBit k v -> CritBit k v
+update f = updateWithKey (const f)
+{-# INLINABLE update #-}
+
+-- | /O(log n)/. The expression (@'updateWithKey' f k map@) updates the
+-- value @x@ at @k@ (if it is in the map). If (@f k x@) is 'Nothing',
+-- the element is deleted. If it is (@'Just' y@), the key @k@ is bound
+-- to the new value @y@.
+--
+-- > let f k x = if x == 5 then Just (x + fromEnum (k < "d")) else Nothing
+-- > updateWithKey f "a" (fromList [("b",3), ("a",5)]) == fromList [("a", 6), ("b",3)]
+-- > updateWithKey f "c" (fromList [("a",5), ("b",3)]) == fromList [("a",5), ("b",3)]
+-- > updateWithKey f "b" (fromList [("a",5), ("b",3)]) == singleton "a" 5
+updateWithKey :: (CritBitKey k) => (k -> v -> Maybe v) -> k -> CritBit k v
+              -> CritBit k v
+updateWithKey f k = snd . updateLookupWithKey f k
+{-# INLINABLE updateWithKey #-}
+
+-- | /O(k)/. Update a value at a specific key with the result of the
+-- provided function. When the key is not a member of the map, the original
+-- map is returned.
+--
+-- > let f k x = x + 1
+-- > adjustWithKey f "a" (fromList [("b",3), ("a",5)]) == fromList [("a", 6), ("b",3)]
+-- > adjustWithKey f "c" (fromList [("a",5), ("b",3)]) == fromList [("a",5), ("b",3)]
+-- > adjustWithKey f "c" empty                         == empty
+adjust :: (CritBitKey k) => (v -> v) -> k -> CritBit k v -> CritBit k v
+adjust f = updateWithKey (\_ v -> Just (f v))
+{-# INLINABLE adjust #-}
+
+-- | /O(k)/. Adjust a value at a specific key. When the key is not
+-- a member of the map, the original map is returned.
+--
+-- > let f k x = x + fromEnum (k < "d")
+-- > adjustWithKey f "a" (fromList [("b",3), ("a",5)]) == fromList [("a", 6), ("b",3)]
+-- > adjustWithKey f "c" (fromList [("a",5), ("b",3)]) == fromList [("a",5), ("b",3)]
+-- > adjustWithKey f "c" empty                         == empty
+adjustWithKey :: (CritBitKey k) => (k -> v -> v) -> k -> CritBit k v
+              -> CritBit k v
+adjustWithKey f = updateWithKey (\k v -> Just (f k v))
+{-# INLINABLE adjustWithKey #-}
+
+-- | /O(k)/. Returns the value associated with the given key, or
+-- the given default value if the key is not in the map.
+--
+-- > findWithDefault 1 "x" (fromList [("a",5), ("b",3)]) == 1
+-- > findWithDefault 1 "a" (fromList [("a",5), ("b",3)]) == 5
+findWithDefault :: (CritBitKey k) =>
+                   v -- ^ Default value to return if lookup fails.
+                -> k -> CritBit k v -> v
+findWithDefault d k m = lookupWith d id k m
+{-# INLINABLE findWithDefault #-}
+
+-- | /O(k)/. Find smallest key greater than the given one and
+-- return the corresponding (key, value) pair.
+--
+-- > lookupGT "aa" (fromList [("a",3), ("b",5)]) == Just ("b",5)
+-- > lookupGT "b"  (fromList [("a",3), ("b",5)]) == Nothing
+lookupGT :: (CritBitKey k) => k -> CritBit k v -> Maybe (k, v)
+lookupGT k r = lookupOrd (GT ==) k r
+{-# INLINABLE lookupGT #-}
+
+-- | /O(k)/. Find smallest key greater than or equal to the given one and
+-- return the corresponding (key, value) pair.
+--
+-- > lookupGE "aa" (fromList [("a",3), ("b",5)]) == Just("b",5)
+-- > lookupGE "b"  (fromList [("a",3), ("b",5)]) == Just("b",5)
+-- > lookupGE "bb" (fromList [("a",3), ("b",5)]) == Nothing
+lookupGE :: (CritBitKey k) => k -> CritBit k v -> Maybe (k, v)
+lookupGE k r = lookupOrd (LT /=) k r
+{-# INLINABLE lookupGE #-}
+
+-- | /O(k)/. Find largest key smaller than the given one and
+-- return the corresponding (key, value) pair.
+--
+-- > lookupLT "aa" (fromList [("a",3), ("b",5)]) == Just ("a",3)
+-- > lookupLT "a"  (fromList [("a",3), ("b",5)]) == Nothing
+lookupLT :: (CritBitKey k) => k -> CritBit k v -> Maybe (k, v)
+lookupLT k r = lookupOrd (LT ==) k r
+{-# INLINABLE lookupLT #-}
+
+-- | /O(k)/. Find largest key smaller than or equal to the given one and
+-- return the corresponding (key, value) pair.
+--
+-- > lookupGE "bb" (fromList [("aa",3), ("b",5)]) == Just("b",5)
+-- > lookupGE "aa" (fromList [("aa",3), ("b",5)]) == Just("aa",5)
+-- > lookupGE "a"  (fromList [("aa",3), ("b",5)]) == Nothing
+lookupLE :: (CritBitKey k) => k -> CritBit k v -> Maybe (k, v)
+lookupLE k r = lookupOrd (GT /=) k r
+{-# INLINABLE lookupLE #-}
+
+-- | /O(k)/. Common part of lookupXX functions.
+lookupOrd :: (CritBitKey k) =>
+             (Ordering -> Bool) -> k -> CritBit k v -> Maybe (k, v)
+lookupOrd accepts k m = findPosition (const id) finish toLeft toRight k m
+  where
+    finish _ Empty = Nothing
+    finish diff (Leaf lk lv)
+      | accepts (diffOrd diff) = pair lk lv
+      | otherwise              = Nothing
+    finish diff i@(Internal{}) = case diffOrd diff of
+      LT -> ifLT i
+      GT -> ifGT i
+      EQ -> error "Data.CritBit.Tree.lookupOrd.finish: Unpossible."
+
+    toLeft  i = (<|> ifGT (iright i))
+    toRight i = (<|> ifLT (ileft  i))
+    pair a b = Just (a, b)
+    ifGT = test GT  leftmost
+    ifLT = test LT rightmost
+    test v f node
+      | accepts v = f Nothing pair node
+      | otherwise = Nothing
+{-# INLINE lookupOrd #-}
+
+-- | /O(k)/. Build a map from a list of key\/value pairs.  If
+-- the list contains more than one value for the same key, the last
+-- value for the key is retained.
+--
+-- > fromList [] == empty
+-- > fromList [("a",5), ("b",3), ("a",2)] == fromList [("a",2), ("b",3)]
+fromList :: (CritBitKey k) => [(k, v)] -> CritBit k v
+fromList = List.foldl' ins empty
+    where
+    ins t (k,x) = insert k x t
+{-# INLINABLE fromList #-}
+
+-- | /O(k)/. Build a map from a list of key\/value pairs
+-- with a combining function. See also 'fromAscListWith'.
+--
+-- > fromListWith (+) [("a",5), ("b",5), ("b",3), ("a",3), ("a",5)] ==
+-- >                        fromList [("a",13), ("b",8)]
+-- > fromListWith (+) [] == empty
+fromListWith :: (CritBitKey k) => (v -> v -> v) -> [(k,v)] -> CritBit k v
+fromListWith f xs = fromListWithKey (const f) xs
+{-# INLINABLE fromListWith #-}
+
+-- | /O(k)/. Build a map from a list of key\/value pairs
+-- with a combining function. See also 'fromAscListWithKey'.
+--
+-- > let f key a1 a2 = byteCount key + a1 + a2
+-- > fromListWithKey f [("a",5), ("b",5), ("b",3), ("a",3), ("a",5)] ==
+-- >                        fromList [("a",16), ("b",10)]
+-- > fromListWithKey f [] == empty
+fromListWithKey :: (CritBitKey k) =>
+                   (k -> v -> v -> v) -> [(k,v)] -> CritBit k v
+fromListWithKey f xs
+  = List.foldl' ins empty xs
+  where
+    ins t (k,x) = insertWithKey f k x t
+{-# INLINABLE fromListWithKey #-}
+
+-- | /O(1)/. A map with a single element.
+--
+-- > singleton "a" 1        == fromList [("a",1)]
+singleton :: k -> v -> CritBit k v
+singleton k v = CritBit (Leaf k v)
+{-# INLINE singleton #-}
+
+-- | /O(n)/. The number of elements in the map.
+--
+-- > size empty                                  == 0
+-- > size (singleton "a" 1)                      == 1
+-- > size (fromList [("a",1), ("c",2), ("b",3)]) == 3
+size :: CritBit k v -> Int
+size (CritBit root) = go root 0
+  where
+    go (Internal{..}) !c = go iright (go ileft c)
+    go (Leaf{})        c = c + 1
+    go Empty           c = c
+
+-- | /O(n)/. Fold the values in the map using the given
+-- left-associative function, such that
+-- @'foldl' f z == 'Prelude.foldl' f z . 'elems'@.
+--
+-- Examples:
+--
+-- > elems = reverse . foldl (flip (:)) []
+--
+-- > foldl (+) 0 (fromList [("a",5), ("bbb",3)]) == 8
+foldl :: (a -> v -> a) -> a -> CritBit k v -> a
+foldl f z m = Foldable.foldl f z m
+{-# INLINE foldl #-}
+
+-- | /O(n)/. A strict version of 'foldl'. Each application of the
+-- function is evaluated before using the result in the next
+-- application. This function is strict in the starting value.
+foldl' :: (a -> v -> a) -> a -> CritBit k v -> a
+foldl' f z m = foldlWithKey' (\a _ v -> f a v) z m
+{-# INLINABLE foldl' #-}
+
+-- | /O(n)/. Fold the values in the map using the given
+-- right-associative function, such that
+-- @'foldr' f z == 'Prelude.foldr' f z . 'elems'@.
+--
+-- Example:
+--
+-- > elems map = foldr (:) [] map
+foldr :: (v -> a -> a) -> a -> CritBit k v -> a
+foldr f z m = Foldable.foldr f z m
+{-# INLINE foldr #-}
+
+-- | /O(n)/. A strict version of 'foldr'. Each application of the
+-- function is evaluated before using the result in the next
+-- application. This function is strict in the starting value.
+foldr' :: (v -> a -> a) -> a -> CritBit k v -> a
+foldr' f z m = foldrWithKey' (const f) z m
+{-# INLINABLE foldr' #-}
+
+-- | /O(n)/. Return all the elements of the map in ascending order of
+-- their keys.
+--
+-- > elems (fromList [("b",5), ("a",3)]) == [3,5]
+-- > elems empty == []
+elems :: CritBit k v -> [v]
+elems m = foldr (:) [] m
+{-# INLINE elems #-}
+
+-- | /O(n)/. An alias for 'toAscList'. Return all key/value pairs in the map in
+-- ascending order.
+--
+-- > assocs (fromList [(5,"a"), (3,"b")]) == [(3,"b"), (5,"a")]
+-- > assocs empty == []
+assocs :: CritBit k v -> [(k,v)]
+assocs m = toAscList m
+
+-- | /O(n)/. Return set of all keys of the map.
+--
+-- > keysSet (fromList [("b",5), ("a",3)]) == Set.fromList ["a", "b"]
+-- > keysSet empty == []
+keysSet :: CritBit k v -> Set k
+keysSet m = Set (fmap (const ()) m)
+{-# INLINABLE keysSet #-}
+
+-- | /O(n)/. Build a map from a set of keys and a function which for each key
+-- computes its value.
+--
+-- > fromSet (\k -> length k) (Data.IntSet.fromList ["a", "bb"]) == fromList [("a",1), ("bb",2)]
+-- > fromSet undefined Data.IntSet.empty == empty
+fromSet :: (k -> v) -> Set k -> CritBit k v
+fromSet f (Set s) = mapWithKey (const . f) s
+{-# INLINABLE fromSet #-}
+
+-- | /O(n)/. Return all keys of the map in ascending order.
+--
+-- > keys (fromList [("b",5), ("a",3)]) == ["a","b"]
+-- > keys empty == []
+keys :: CritBit k v -> [k]
+keys (CritBit root) = go root []
+  where
+    go (Internal{..}) acc = go ileft $ go iright acc
+    go (Leaf k _)     acc = k : acc
+    go Empty          acc = acc
+{-# INLINABLE keys #-}
+
+unionL :: (CritBitKey k) => CritBit k v -> CritBit k v -> CritBit k v
+unionL a b = unionWithKey (\_ x _ -> x) a b
+{-# INLINABLE unionL #-}
+
+unionR :: (CritBitKey k) => CritBit k v -> CritBit k v -> CritBit k v
+unionR a b = unionWithKey (\_ x _ -> x) b a
+{-# INLINABLE unionR #-}
+
+-- | /O(n+m)/.  The expression (@'union' t1 t2@) takes the left-biased
+-- union of @t1@ and @t2@.
+--
+-- It prefers @t1@ when duplicate keys are encountered,
+-- i.e. (@'union' == 'unionWith' 'const'@).
+--
+-- > union (fromList [("a", 5), ("b", 3)]) (fromList [("a", 4), ("c", 7)]) == fromList [("a", 5), ("b", "3"), ("c", 7)]
+union :: (CritBitKey k) => CritBit k v -> CritBit k v -> CritBit k v
+union a b = unionL a b
+{-# INLINE union #-}
+
+-- | Union with a combining function.
+--
+-- > let l = fromList [("a", 5), ("b", 3)]
+-- > let r = fromList [("A", 5), ("b", 7)]
+-- > unionWith (+) l r == fromList [("A",5),("a",5),("b",10)]
+unionWith :: (CritBitKey k) => (v -> v -> v)
+          -> CritBit k v -> CritBit k v -> CritBit k v
+unionWith f a b = unionWithKey (const f) a b
+
+-- | Union with a combining function.
+--
+-- > let f key new_value old_value = byteCount key + new_value + old_value
+-- > let l = fromList [("a", 5), ("b", 3)]
+-- > let r = fromList [("A", 5), ("C", 7)]
+-- > unionWithKey f l r == fromList [("A",5),("C",7),("a",5),("b",3)]
+unionWithKey :: (CritBitKey k) => (k -> v -> v -> v)
+             -> CritBit k v -> CritBit k v -> CritBit k v
+unionWithKey f (CritBit lt) (CritBit rt) = CritBit (top lt rt)
+  where
+    -- Assumes that empty nodes exist only on the top level
+    top Empty b = b
+    top a Empty = a
+    top a b = go a (minKey a) b (minKey b)
+
+    -- Each node is followed by the minimum key in that node.
+    -- This trick assures that overall time spend by minKey in O(n+m)
+    go a@(Leaf ak av) _ b@(Leaf bk bv) _
+        | ak == bk  = Leaf ak (f ak av bv)
+        | otherwise = fork a ak b bk
+    go a@(Leaf{}) ak b@(Internal{}) bk =
+      leafBranch a b bk (splitB a ak b bk) (fork a ak b bk)
+    go a@(Internal{}) ak b@(Leaf{}) bk =
+      leafBranch b a ak (splitA a ak b bk) (fork a ak b bk)
+    go a@(Internal al ar abyte abits) ak b@(Internal bl br bbyte bbits) bk
+      | (dbyte, dbits) < min (abyte, abits) (bbyte, bbits) = fork a ak b bk
+      | otherwise =
+           case compare (abyte, abits) (bbyte, bbits) of
+             LT -> splitA a ak b bk
+             GT -> splitB a ak b bk
+             EQ -> setBoth' a (go al ak bl bk) (go ar (minKey ar) br (minKey br))
+      where
+        Diff dbyte dbits _ = followPrefixes ak bk
+    -- Assumes that empty nodes exist only on the top level
+    go _ _ _ _ = error "Data.CritBit.Tree.unionWithKey.go: Empty"
+
+    splitA a@(Internal al ar _ _) ak b bk =
+      switch bk a (go al ak b bk) ar al (go ar (minKey ar) b bk)
+    splitA _ _ _ _ =
+      error "Data.CritBit.Tree.unionWithKey.splitA: unpossible"
+    {-# INLINE splitA #-}
+
+    splitB a ak b@(Internal bl br _ _) bk =
+      switch ak b (go a ak bl bk) br bl (go a ak br (minKey br))
+    splitB _ _ _ _ =
+      error "Data.CritBit.Tree.unionWithKey.splitB: unpossible"
+    {-# INLINE splitB #-}
+
+    fork a ak b bk = internal (followPrefixes ak bk) b a
+    {-# INLINE fork #-}
+{-# INLINEABLE unionWithKey #-}
+
+-- | The union of a list of maps:
+-- (@'unions' == 'List.foldl' 'union' 'empty'@).
+--
+-- > unions [(fromList [("a", 5), ("b", 3)]), (fromList [("a", 6), ("c", 7)]), (fromList [("a", 9), ("b", 5)])]
+-- >     == fromList [("a", 5), ("b", 4), (c, 7)]
+-- > unions [(fromList [("a", 9), ("b", 8)]), (fromList [("ab", 5), ("c",7)]), (fromList [("a", 5), ("b", 3)])]
+-- >     == fromList [("a", 9), ("ab", 5), ("b", 8), ("c", 7)]
+unions :: (CritBitKey k) => [CritBit k v] -> CritBit k v
+unions cs = List.foldl' union empty cs
+
+-- | The union of a list of maps, with a combining operation:
+-- (@'unionsWith' f == 'List.foldl' ('unionWith' f) 'empty'@).
+--
+-- > unionsWith (+) [(fromList [("a",5), ("b", 3)]), (fromList [("a", 3), ("c", 7)]), (fromList [("a", 5), ("b", 5)])]
+-- >     == fromList [("a", 12), ("b", 8), ("c")]
+unionsWith :: (CritBitKey k) => (v -> v -> v) -> [CritBit k v] -> CritBit k v
+unionsWith f cs = List.foldl' (unionWith f) empty cs
+
+-- | /O(n+m)/. Difference of two maps.
+-- | Return data in the first map not existing in the second map.
+--
+-- > let l = fromList [("a", 5), ("b", 3)]
+-- > let r = fromList [("A", 2), ("b", 7)]
+-- > difference l r == fromList [("a", 5)]
+difference :: (CritBitKey k) => CritBit k v -> CritBit k w -> CritBit k v
+difference a b = differenceWithKey (\_ _ _ -> Nothing) a b
+{-# INLINEABLE difference #-}
+
+-- | /O(n+m)/. Difference with a combining function.
+-- | When two equal keys are encountered, the combining function is applied
+-- | to the values of theese keys. If it returns 'Nothing', the element is
+-- | discarded (proper set difference). If it returns (@'Just' y@),
+-- | the element is updated with a new value @y@.
+--
+-- > let f av bv = if av == 3 then Just (av + bv) else Nothing
+-- > let l = fromList [(pack "a", 5), (pack "b", 3), (pack "c", 8)]
+-- > let r = fromList [(pack "a", 2), (pack "b", 7), (pack "d", 8)]
+-- > differenceWith f l r == fromList [(pack "b", 10), (pack "c", 8)]
+differenceWith :: (CritBitKey k) => (v -> w -> Maybe v)
+                 -> CritBit k v -> CritBit k w -> CritBit k v
+differenceWith f a b = differenceWithKey (const f) a b
+{-# INLINEABLE differenceWith #-}
+
+-- | /O(n+m)/. Difference with a combining function.
+-- | When two equal keys are encountered, the combining function is applied
+-- | to the key and both values. If it returns 'Nothing', the element is
+-- | discarded (proper set difference). If it returns (@'Just' y@),
+-- | the element is updated with a new value @y@.
+--
+-- > let f k av bv = if k == "b" then Just (length k + av + bv) else Nothing
+-- > let l = fromList [("a", 5), ("b", 3), ("c", 8)]
+-- > let r = fromList [("a", 2), ("b", 7), ("d", 8)]
+-- > differenceWithKey f l r == fromList [("b", 11), ("c", 8)]
+differenceWithKey :: (CritBitKey k) => (k -> v -> w -> Maybe v)
+                    -> CritBit k v -> CritBit k w -> CritBit k v
+differenceWithKey = binarySetOpWithKey id
+{-# INLINEABLE differenceWithKey #-}
+
+-- | /O(n+m)/. Intersection of two maps.
+-- | Return data in the first map for the keys existing in both maps.
+--
+-- > let l = fromList [("a", 5), ("b", 3)]
+-- > let r = fromList [("A", 2), ("b", 7)]
+-- > intersection l r == fromList [("b", 3)]
+intersection :: (CritBitKey k) => CritBit k v -> CritBit k w -> CritBit k v
+intersection a b = intersectionWithKey (\_ x _ -> x) a b
+{-# INLINEABLE intersection #-}
+
+-- | /O(n+m)/. Intersection with a combining function.
+--
+-- > let l = fromList [("a", 5), ("b", 3)]
+-- > let r = fromList [("A", 2), ("b", 7)]
+-- > intersectionWith (+) l r == fromList [("b", 10)]
+intersectionWith :: (CritBitKey k) => (v -> w -> x)
+                 -> CritBit k v -> CritBit k w -> CritBit k x
+intersectionWith f a b = intersectionWithKey (const f) a b
+{-# INLINEABLE intersectionWith #-}
+
+-- | /O(n+m)/. Intersection with a combining function.
+--
+-- > let f key new_value old_value = length key + new_value + old_value
+-- > let l = fromList [("a", 5), ("b", 3)]
+-- > let r = fromList [("A", 2), ("b", 7)]
+-- > intersectionWithKey f l r == fromList [("b", 11)]
+intersectionWithKey :: (CritBitKey k) => (k -> v -> w -> x)
+                    -> CritBit k v -> CritBit k w -> CritBit k x
+intersectionWithKey f = binarySetOpWithKey (const Empty) f'
+  where
+    f' k v1 v2 = Just (f k v1 v2)
+
+-- | Perform binary set operation on two maps.
+binarySetOpWithKey :: (CritBitKey k)
+    => (Node k v -> Node k x) -- ^ Process unmatched node in first map
+    -> (k -> v -> w -> Maybe x) -- ^ Process matching values
+    -> CritBit k v -- ^ First map
+    -> CritBit k w -- ^ Second map
+    -> CritBit k x
+binarySetOpWithKey left both (CritBit lt) (CritBit rt) = CritBit $ top lt rt
+  where
+    -- Assumes that empty nodes exist only on the top level.
+    top Empty _ = Empty
+    top a Empty = left a
+    top a b = go a (minKey a) b (minKey b)
+
+    -- Each node is followed by the minimum key in that node.
+    -- This trick assures that overall time spend by minKey is O(n+m).
+    go a@(Leaf ak av) _ (Leaf bk bv) _
+        | ak == bk = case both ak av bv of
+                       Just v  -> Leaf ak v
+                       Nothing -> Empty
+        | otherwise = left a
+    go a@(Leaf{}) ak b@(Internal{}) bk =
+      leafBranch a b bk (splitB a ak b bk) (left a)
+    go a@(Internal{}) ak b@(Leaf{}) bk =
+      leafBranch b a ak (splitA a ak b bk) (left a)
+    go a@(Internal al ar abyte abits) ak b@(Internal bl br bbyte bbits) bk =
+      case compare (abyte, abits) (bbyte, bbits) of
+        LT -> splitA a ak b bk
+        GT -> splitB a ak b bk
+        EQ -> setBoth' a (go al ak bl bk) (go ar (minKey ar) br (minKey br))
+    -- Assumes that empty nodes exist only on the top level.
+    go _ _ _ _ = error "Data.CritBit.Tree.binarySetOpWithKey.go: Empty"
+
+    splitA a@(Internal al ar _ _) ak b bk =
+        switch bk a (go al ak b bk) (left ar) (left al) (go ar (minKey ar) b bk)
+    splitA _ _ _ _ =
+        error "Data.CritBit.Tree.binarySetOpWithKey.splitA: unpossible"
+    {-# INLINE splitA #-}
+
+    splitB a ak b@(Internal bl br _ _) bk =
+        switch ak b (go a ak bl bk) Empty Empty (go a ak br (minKey br))
+    splitB _ _ _ _ =
+        error "Data.CritBit.Tree.binarySetOpWithKey.splitB: unpossible"
+    {-# INLINE splitB #-}
+{-# INLINEABLE binarySetOpWithKey #-}
+
+-- | Detect whether branch in 'Internal' node comes 'before' or
+-- 'after' branch initiated by 'Leaf'.
+leafBranch :: CritBitKey k => Node k v -> Node k w -> k -> t -> t -> t
+leafBranch (Leaf lk _) i@(Internal{}) sk before after
+    | followPrefixes lk sk `above` i = after
+    | otherwise                      = before
+leafBranch _ _ _ _ _ = error "Data.CritBit.Tree.leafBranch: unpossible"
+{-# INLINE leafBranch #-}
+
+-- | Select child to link under node 'n' by 'k'.
+switch :: (CritBitKey k) => k -> Node k v -> Node k w -> Node k w
+       -> Node k w -> Node k w -> Node k w
+switch k n a0 b0 a1 b1
+  | k `onLeft` n = setBoth' n a0 b0
+  | otherwise    = setBoth' n a1 b1
+{-# INLINE switch #-}
+
+-- | Extract minimum key from the subtree.
+minKey :: (CritBitKey k) => Node k v -> k
+minKey n = leftmost
+    (error "Data.CritBit.Tree.minKey: Empty")
+    const n
+{-# INLINE minKey #-}
+
+-- | Extract maximum key from the subtree.
+maxKey :: (CritBitKey k) => Node k v -> k
+maxKey n = rightmost
+    (error "Data.CritBit.Tree.maxKey: Empty")
+    const n
+{-# INLINE maxKey #-}
+
+-- | Sets both children to the parent node.
+setBoth' :: Node k v -> Node k w -> Node k w -> Node k w
+setBoth' _ Empty b = b
+setBoth' _ a Empty = a
+setBoth' (Internal _ _ byte bits) !a !b = Internal a b byte bits
+setBoth' _ _ _ = error "Data.CritBit.Tree.setBoth': unpossible"
+{-# INLINE setBoth' #-}
+
+setBoth :: Node k v -> Node k w -> Node k w -> Node k w
+setBoth (Internal _ _ byte bits) !a !b = Internal a b byte bits
+setBoth _ _ _ = error "Data.CritBit.Tree.setBoth: unpossible"
+{-# INLINE setBoth #-}
+
+-- | /O(n)/. Apply a function to all values.
+--
+-- > map show (fromList [("b",5), ("a",3)]) == fromList [("b","5"), ("a","3")]
+map :: (CritBitKey k) => (v -> w) -> CritBit k v -> CritBit k w
+map = fmap
+
+-- | /O(k)/.
+-- @mapKeys f@ applies the function @f@ to the keys of the map.
+--
+-- If @f@ maps multiple keys to the same new key, the new key is
+-- associated with the value of the greatest of the original keys.
+--
+-- > let f = fromString . (++ "1") . show
+-- > mapKeys f (fromList [("a", 5), ("b", 3)])            == fromList ([("a1", 5), ("b1", 3)])
+-- > mapKeys (\ _ -> "a") (fromList [("a", 5), ("b", 3)]) == singleton "a" 3
+mapKeys :: (CritBitKey k2) => (k1 -> k2) -> CritBit k1 v -> CritBit k2 v
+mapKeys f m = mapKeysWith (\_ v -> v) f m
+{-# INLINABLE mapKeys #-}
+
+-- | /O(k)/.
+-- @'mapKeysWith' c f s@ is the map obtained by applying @f@ to each key of @s@.
+--
+-- The size of the result may be smaller if @f@ maps two or more distinct
+-- keys to the same new key.  In this case the associated values will be
+-- combined using @c@.
+--
+-- > mapKeysWith (+) (\ _ -> "a") (fromList [("b",1), ("a",2), ("d",3), ("c",4)]) == singleton "a" 10
+mapKeysWith :: (CritBitKey k2)
+            => (v -> v -> v)
+            -> (k1 -> k2)
+            -> CritBit k1 v -> CritBit k2 v
+mapKeysWith c f m = foldrWithKey ins empty m
+  where ins k v nm = insertWith c (f k) v nm
+{-# INLINABLE mapKeysWith #-}
+
+-- | /O(k)/.
+-- @'mapKeysMonotonic' f s == 'mapKeys' f s@, but works only when @f@
+-- is strictly monotonic.
+-- That is, for any values @x@ and @y@, if @x@ < @y@ then @f x@ < @f y@.
+-- /The precondition is not checked./
+-- Semi-formally, we have:
+--
+-- > and [x < y ==> f x < f y | x <- ls, y <- ls]
+-- >                     ==> mapKeysMonotonic f s == mapKeys f s
+-- >     where ls = keys s
+--
+-- This means that @f@ maps distinct original keys to distinct resulting keys.
+-- This function has slightly better performance than 'mapKeys'.
+--
+-- > mapKeysMonotonic (\ k -> succ k) (fromList [("a",5), ("b",3)]) == fromList [("b",5), ("c",3)]
+mapKeysMonotonic :: (CritBitKey k)
+                 => (a -> k) -> CritBit a v -> CritBit k v
+mapKeysMonotonic f m = foldlWithKey (insertRight f) empty m
+{-# INLINABLE mapKeysMonotonic #-}
+
+insertRight :: CritBitKey k
+            => (a -> k) -> CritBit k v -> a -> v -> CritBit k v
+insertRight f (CritBit root) ok v
+  | Empty <- root = CritBit $ Leaf k v
+  | otherwise     = CritBit $ go root
+  where
+    k = f ok
+    go i@(Internal _ right _ _)
+      | diff `above` i = append i
+      | otherwise      = setRight' i $ go right
+    go i = append i
+
+    append i = internal diff i (Leaf k v)
+
+    diff = followPrefixes k $ maxKey root
+{-# INLINE insertRight #-}
+
+-- | /O(n)/. Convert the map to a list of key/value pairs where the keys are in
+-- ascending order.
+--
+-- > toAscList (fromList [(5,"a"), (3,"b")]) == [(3,"b"), (5,"a")]
+toAscList :: CritBit k v -> [(k,v)]
+toAscList m = foldrWithKey f [] m
+  where f k v vs = (k,v) : vs
+
+-- | /O(n)/. Convert the map to a list of key/value pairs where the keys are in
+-- descending order.
+--
+-- > toDescList (fromList [(5,"a"), (3,"b")]) == [(5,"a"), (3,"b")]
+toDescList :: CritBit k v -> [(k,v)]
+toDescList m = foldlWithKey f [] m
+  where f vs k v = (k,v):vs
+
+-- | /O(n)/. Build a tree from an ascending list in linear time.
+-- /The precondition (input list is ascending) is not checked./
+--
+-- > fromAscList [(3,"b"), (5,"a")]          == fromList [(3, "b"), (5, "a")]
+-- > fromAscList [(3,"b"), (5,"a"), (5,"b")] == fromList [(3, "b"), (5, "b")]
+-- > valid (fromAscList [(3,"b"), (5,"a"), (5,"b")]) == True
+-- > valid (fromAscList [(5,"a"), (3,"b"), (5,"b")]) == False
+fromAscList :: (CritBitKey k) => [(k, v)] -> CritBit k v
+fromAscList = fromAscListWithKey (\_ x _ -> x)
+{-# INLINABLE fromAscList #-}
+
+-- | /O(n)/. Build a tree from an ascending list in linear time
+-- with a combining function for equal keys.
+-- /The precondition (input list is ascending) is not checked./
+--
+-- > fromAscListWith (++) [(3,"b"), (5,"a"), (5,"b")] == fromList [(3, "b"), (5, "ba")]
+-- > valid (fromAscListWith (++) [(3,"b"), (5,"a"), (5,"b")]) == True
+-- > valid (fromAscListWith (++) [(5,"a"), (3,"b"), (5,"b")]) == False
+fromAscListWith :: (CritBitKey k) => (v -> v -> v) -> [(k,v)] -> CritBit k v
+fromAscListWith f = fromAscListWithKey (const f)
+{-# INLINABLE fromAscListWith #-}
+
+-- | /O(n)/. Build a map from an ascending list in linear time with a
+-- combining function for equal keys.
+-- /The precondition (input list is ascending) is not checked./
+--
+-- > let f k a1 a2 = (show k) ++ ":" ++ a1 ++ a2
+-- > fromAscListWithKey f [(3,"b"), (5,"a"), (5,"b"), (5,"b")] == fromList [(3, "b"), (5, "5:b5:ba")]
+-- > valid (fromAscListWithKey f [(3,"b"), (5,"a"), (5,"b"), (5,"b")]) == True
+-- > valid (fromAscListWithKey f [(5,"a"), (3,"b"), (5,"b"), (5,"b")]) == False
+fromAscListWithKey :: (CritBitKey k) =>
+                      (k -> v -> v -> v) -> [(k,v)] -> CritBit k v
+fromAscListWithKey _ [] = empty
+fromAscListWithKey _ [(k, v)] = singleton k v
+fromAscListWithKey f kvs = build 0 1 upper fromContext kvs RCNil
+  -- This implementation is based on the idea of binary search in
+  -- a suffix array using LCP array.
+  --
+  -- Input list is converted to array and processed top-down.
+  -- When building tree for interval we finds the length of
+  -- the common prefix of all keys in this interval. We never
+  -- compare known common prefixes, thus reducing number of
+  -- comparisons. Then we merge trees, building recursively on
+  -- halves of this interval.
+  --
+  -- This algorithm runs in /O(n+K)/ time, where /K/ is the total
+  -- length of all keys minus . When many keys have equal prefixes,
+  -- the second summand may be much smaller.
+  --
+  -- See also:
+  --
+  -- Manber, Udi; Myers, Gene (1990). "Suffix arrays: a new method for
+  -- on-line string searches". In Proceedings of the first annual
+  -- ACM-SIAM symposium on Discrete algorithms 90 (319): 327.
+  where
+    upper = length kvs - 1
+    array = fst . (A.listArray (0, upper) kvs A.!)
+
+    fromContext = add (Diff 0 0 0)
+        (const $ \(RCCons node _ _ _) -> CritBit node)
+
+    build z left right cont xs cx
+      | left == right = add diffI cont xs cx
+      | otherwise     = (build diffO left      mid    $
+                         build diffO (mid + 1) right  cont) xs cx
+      where
+        mid = (left + right - 1) `div` 2
+        diffO = followPrefixesByteFrom z (fst (head xs)) (array right)
+        diffI = followPrefixesFrom     z (fst (head xs)) (array right)
+    {-# INLINE build #-}
+
+    add (Diff byte bits _) cont (x:xs) cx
+        | bits == 0x1ff = let (k, v1) = x; (_, v2) = head xs
+                          in cont ((k, f k v2 v1) : tail xs) cx
+        | otherwise     = cont xs $ pop (uncurry Leaf x) cx
+      where
+        pop right cs@(RCCons left cbyte cbits cs')
+          | cbyte > byte || cbyte == byte && cbits > bits
+                = pop (Internal left right cbyte cbits) cs'
+          | otherwise = RCCons right byte bits cs
+        pop right cs  = RCCons right byte bits cs
+    add _ _ _ _ = error "CritBit.fromAscListWithKey.add: Unpossible"
+    {-# INLINE add #-}
+{-# INLINABLE fromAscListWithKey #-}
+
+-- | /O(n)/. Build a tree from an ascending list of distinct elements
+-- in linear time.
+-- /The precondition is not checked./
+--
+-- > fromDistinctAscList [(3,"b"), (5,"a")] == fromList [(3, "b"), (5, "a")]
+-- > valid (fromDistinctAscList [(3,"b"), (5,"a")])          == True
+-- > valid (fromDistinctAscList [(3,"b"), (5,"a"), (5,"b")]) == False
+fromDistinctAscList :: (CritBitKey k) => [(k,v)] -> CritBit k v
+fromDistinctAscList = fromAscListWithKey undefined
+{-# INLINABLE fromDistinctAscList #-}
+
+-- | One-hole CritBit context focused on the maximum leaf
+data RightContext k v
+    = RCNil
+    | RCCons !(Node k v) !Int !BitMask !(RightContext k v)
+
+-- | /O(n)/. Filter all values that satisfy the predicate.
+--
+-- > filter (> "a") (fromList [("5","a"), ("3","b")]) == fromList [("3","b")]
+-- > filter (> "x") (fromList [("5","a"), ("3","b")]) == empty
+-- > filter (< "a") (fromList [("5","a"), ("3","b")]) == empty
+filter :: (v -> Bool) -> CritBit k v -> CritBit k v
+filter p m = filterWithKey (const p) m
+
+-- | /O(n)/. Filter all keys\/values that satisfy the predicate.
+--
+-- > filterWithKey (\k _ -> k > "4") (fromList [("5","a"), ("3","b")]) == fromList[("5","a")]
+filterWithKey :: (k -> v -> Bool) -> CritBit k v -> CritBit k v
+filterWithKey p (CritBit root) = CritBit $ go root
+  where
+    go i@(Internal left right _ _) = setBoth' i (go left) (go right)
+    go leaf@(Leaf k v) | p k v = leaf
+    go _ = Empty
+{-# INLINABLE filterWithKey #-}
+
+-- | /O(n)/. Map values and collect the 'Just' results.
+--
+-- > let f x = if x == 5 then Just 10 else Nothing
+-- > mapMaybe f (fromList [("a",5), ("b",3)]) == singleton "a" 10
+mapMaybe :: (v -> Maybe w) -> CritBit k v -> CritBit k w
+mapMaybe = mapMaybeWithKey . const
+
+-- | /O(n)/. Map keys\/values and collect the 'Just' results.
+--
+-- > let f k v = if k == "a" then Just ("k,v: " ++ show k ++ "," ++ show v) else Nothing
+-- > mapMaybeWithKey f (fromList [("a",5), ("b",3)]) == singleton "a" "k,v: \"a\",3"
+mapMaybeWithKey :: (k -> v -> Maybe v') -> CritBit k v -> CritBit k v'
+mapMaybeWithKey f (CritBit root) = CritBit $ go root
+  where
+    go i@(Internal left right _ _) = setBoth' i (go left) (go right)
+    go (Leaf k v) = maybe Empty (Leaf k) $ f k v
+    go Empty      = Empty
+{-# INLINABLE mapMaybeWithKey #-}
+
+-- | /O(n)/. Map values and separate the 'Left' and 'Right' results.
+--
+-- > let f a = if a < 5 then Left a else Right a
+-- > mapEither f (fromList [("a",5), ("b",3), ("x",1), ("z",7)])
+-- >     == (fromList [("b",3), ("x",1)], fromList [("a",5), ("z",7)])
+-- >
+-- > mapEither (\ a -> Right a) (fromList [("a",5), ("b",3), ("x",1), ("z",7)])
+-- >     == (empty, fromList [("a",5), ("b",3), ("x",1), ("z",7)])
+mapEither :: (v -> Either w x) -> CritBit k v -> (CritBit k w, CritBit k x)
+mapEither = mapEitherWithKey . const
+
+-- | /O(n)/. Map keys\/values and separate the 'Left' and 'Right' results.
+--
+-- > let f k a = if k < "c" then Left (k ++ k) else Right (a * 2)
+-- > mapEitherWithKey f (fromList [("a",5), ("b",3), ("x",1), ("z",7)])
+-- >     == (fromList [("a","aa"), ("b","bb")], fromList [("x",2), ("z",14)])
+-- >
+-- > mapEitherWithKey (\_ a -> Right a) (fromList [("a",5), ("b",3), ("x",1), ("z",7)])
+-- >     == (empty, fromList [("x",1), ("b",3), ("a",5), ("z",7)])
+mapEitherWithKey :: (k -> v -> Either w x) ->
+                    CritBit k v -> (CritBit k w, CritBit k x)
+mapEitherWithKey f (CritBit root) = (CritBit *** CritBit) $ go root
+  where
+    go i@(Internal l r _ _) = (setBoth' i ll rl, setBoth' i lr rr)
+      where
+        (ll, lr) = go l
+        (rl, rr) = go r
+    go (Leaf k v) = case f k v of
+                      Left  v' -> (Leaf k v', Empty)
+                      Right v' -> (Empty, Leaf k v')
+    go Empty = (Empty, Empty)
+{-# INLINABLE mapEitherWithKey #-}
+
+-- | /O(k)/. The expression (@'split' k map@) is a pair
+-- @(map1,map2)@ where the keys in @map1@ are smaller than @k@ and the
+-- keys in @map2@ larger than @k@.  Any key equal to @k@ is found in
+-- neither @map1@ nor @map2@.
+--
+-- > split "a" (fromList [("b",1), ("d",2)]) == (empty, fromList [("b",1), ("d",2)])
+-- > split "b" (fromList [("b",1), ("d",2)]) == (empty, singleton "d" 2)
+-- > split "c" (fromList [("b",1), ("d",2)]) == (singleton "b" 1, singleton "d" 2)
+-- > split "d" (fromList [("b",1), ("d",2)]) == (singleton "b" 1, empty)
+-- > split "e" (fromList [("b",1), ("d",2)]) == (fromList [("b",1), ("d",2)], empty)
+split :: (CritBitKey k) => k -> CritBit k v -> (CritBit k v, CritBit k v)
+-- Note that this is nontrivially faster than an implementation
+-- in terms of 'splitLookup'.
+split k m = CritBit *** CritBit $
+            findPosition (const id) finish goLeft goRight k m
+  where
+    finish _ Empty = (Empty, Empty)
+    finish diff node = case diffOrd diff of
+      LT -> (node, Empty)
+      GT -> (Empty, node)
+      EQ -> (Empty, Empty)
+
+    goLeft i (lt, Empty) = (lt, iright i)
+    goLeft i (lt, gt   ) = (lt, setLeft i gt)
+
+    goRight i (Empty, gt) = (ileft i, gt)
+    goRight i (lt   , gt) = (setRight i lt, gt)
+{-# INLINABLE split #-}
+
+-- | /O(k)/. The expression (@'splitLookup' k map@) splits a map just
+-- like 'split' but also returns @'lookup' k map@.
+--
+-- > splitLookup "a" (fromList [("b",1), ("d",2)]) == (empty, Nothing, fromList [("b",1), ("d",2)])
+-- > splitLookup "b" (fromList [("b",1), ("d",2)]) == (empty, Just 1, singleton "d" 2)
+-- > splitLookup "c" (fromList [("b",1), ("d",2)]) == (singleton "b" 1, Nothing, singleton "d" 2)
+-- > splitLookup "d" (fromList [("b",1), ("d",2)]) == (singleton "b" 1, Just 2, empty)
+-- > splitLookup "e" (fromList [("b",1), ("d",2)]) == (fromList [("b",1), ("d",2)], Nothing, empty)
+splitLookup :: (CritBitKey k) =>
+               k -> CritBit k v -> (CritBit k v, Maybe v, CritBit k v)
+splitLookup k m = (\(lt, eq, gt) -> (CritBit lt, eq, CritBit gt)) $
+                  findPosition (const id) finish goLeft goRight k m
+  where
+    finish _ Empty = (Empty, Nothing, Empty)
+    finish diff node = case diffOrd diff of
+      LT -> (node,  Nothing  , Empty)
+      GT -> (Empty, Nothing  , node )
+      EQ -> (Empty, leaf node, Empty)
+
+    leaf (Leaf _ v) = Just v
+    leaf _ = error "Data.CritBit.Tree.splitLookup.leaf: Unpossible."
+
+    goLeft i (lt, eq, Empty) = (lt, eq, iright i)
+    goLeft i (lt, eq, gt   ) = (lt, eq, setLeft i gt)
+
+    goRight i (Empty, eq, gt) = (ileft i      , eq, gt)
+    goRight i (lt   , eq, gt) = (setRight i lt, eq, gt)
+{-# INLINABLE splitLookup #-}
+
+-- | /O(n+m)/. This function is defined as
+--   (@'isSubmapOf' = 'isSubmapOfBy' (==)@).
+isSubmapOf :: (CritBitKey k, Eq v) => CritBit k v -> CritBit k v -> Bool
+isSubmapOf = isSubmapOfBy (==)
+{-# INLINABLE isSubmapOf #-}
+
+-- | /O(n+m)/. The expression (@'isSubmapOfBy' f t1 t2@) returns 'True' if
+--   all keys in @t1@ are in map @t2@, and when @f@ returns 'True' when
+--   applied to their respective values. For example, the following
+--   expressions are all 'True':
+--
+-- > isSubmapOfBy (==) (fromList [("a",1)]) (fromList [("a",1),("b",2)])
+-- > isSubmapOfBy (<=) (fromList [("a",1)]) (fromList [("a",1),("b",2)])
+-- > isSubmapOfBy (==) (fromList [("a",1),("b",2)]) (fromList [("a",1),("b",2)])
+--
+-- But the following are all 'False':
+--
+-- > isSubmapOfBy (==) (fromList [("a",2)]) (fromList [("a",1),("b",2)])
+-- > isSubmapOfBy (<)  (fromList [("a",1)]) (fromList [("a",1),("b",2)])
+-- > isSubmapOfBy (==) (fromList [("a",1),("b",2)]) (fromList [("a",1)])
+isSubmapOfBy :: (CritBitKey k) =>
+                (v -> w -> Bool) -> CritBit k v -> CritBit k w -> Bool
+isSubmapOfBy f a b = submapTypeBy f a b /= No
+{-# INLINABLE isSubmapOfBy #-}
+
+-- | /O(n+m)/. Is this a proper submap? (ie. a submap but not equal).
+--   Defined as (@'isProperSubmapOf' = 'isProperSubmapOfBy' (==)@).
+isProperSubmapOf :: (CritBitKey k, Eq v) => CritBit k v -> CritBit k v -> Bool
+isProperSubmapOf = isProperSubmapOfBy (==)
+{-# INLINABLE isProperSubmapOf #-}
+
+-- | /O(n+m)/. Is this a proper submap? (ie. a submap but not equal).
+--   The expression (@'isProperSubmapOfBy' f m1 m2@) returns 'True' when
+--   @m1@ and @m2@ are not equal,
+--   all keys in @m1@ are in @m2@, and when @f@ returns 'True' when
+--   applied to their respective values. For example, the following
+--   expressions are all 'True':
+--
+-- > isProperSubmapOfBy (==) (fromList [("a",1)]) (fromList [("a",1),("b",2)])
+-- > isProperSubmapOfBy (<=) (fromList [("a",0)]) (fromList [("a",1),("b",2)])
+--
+-- But the following are all 'False':
+--
+-- > isProperSubmapOfBy (==) (fromList [("a",1),("b",2)]) (fromList [("a",1),("b",2)])
+-- > isProperSubmapOfBy (==) (fromList ["a",1),("b",2)])  (fromList [("a",1)])
+-- > isProperSubmapOfBy (<)  (fromList [("a",1)])         (fromList [("a",1),("b",2)])
+isProperSubmapOfBy :: (CritBitKey k) =>
+                      (v -> w -> Bool) -> CritBit k v -> CritBit k w -> Bool
+isProperSubmapOfBy f a b = submapTypeBy f a b == Yes
+{-# INLINABLE isProperSubmapOfBy #-}
+
+data SubmapType = No | Yes | Equal deriving (Eq, Ord)
+submapTypeBy :: (CritBitKey k) =>
+                (v -> w -> Bool) -> CritBit k v -> CritBit k w -> SubmapType
+submapTypeBy f (CritBit root1) (CritBit root2) = top root1 root2
+  where
+    -- Assumes that empty nodes exist only on the top level
+    top Empty Empty = Equal
+    top Empty _     = Yes
+    top _ Empty     = No
+    top a b = go a (minKey a) b (minKey b)
+    {-# INLINE top #-}
+
+    -- Each node is followed by the minimum key in that node.
+    -- This trick assures that overall time spend by minKey in O(n+m)
+    go (Leaf ak av) _ (Leaf bk bv) _
+        | ak == bk  = if f av bv then Equal else No
+        | otherwise = No
+    go a@(Leaf{}) ak b@(Internal{}) bk =
+      leafBranch a b bk (splitB a ak b bk) No
+    go (Internal{}) _ (Leaf{}) _ = No
+    go a@(Internal al ar abyte abits) ak b@(Internal bl br bbyte bbits) bk =
+      case compare (abyte, abits) (bbyte, bbits) of
+        LT -> No
+        GT -> splitB a ak b bk
+        EQ -> min (go al ak bl bk) (go ar (minKey ar) br (minKey br))
+    -- Assumes that empty nodes exist only on the top level
+    go _ _ _ _ = error "Data.CritBit.Tree.isSubmapOfBy.go: Empty"
+
+    splitB a ak b@(Internal bl br _ _) bk = if t == No then No else Yes
+      where
+        t = if ak `onLeft` b then go a ak bl bk
+                             else go a ak br (minKey br)
+
+    splitB _ _ _ _ =
+        error "Data.CritBit.Tree.isSubmapOfBy.splitB: unpossible"
+    {-# INLINE splitB #-}
+{-# INLINABLE submapTypeBy #-}
+
+-- | /O(minimum K)/. The minimal key of the map. Calls 'error' if the map
+-- is empty.
+--
+-- > findMin (fromList [("b",3), ("a",5)]) == ("a",5)
+-- > findMin empty                       Error: empty map has no minimal element
+findMin :: CritBit k v -> (k,v)
+findMin (CritBit root) = leftmost emptyMap (,) root
+  where
+    emptyMap = error "CritBit.findMin: empty map has no minimal element"
+{-# INLINABLE findMin #-}
+
+-- | /O(k)/. The maximal key of the map. Calls 'error' if the map
+-- is empty.
+--
+-- > findMax empty                       Error: empty map has no minimal element
+findMax :: CritBit k v -> (k,v)
+findMax (CritBit root) = rightmost emptyMap (,) root
+  where
+    emptyMap = error "CritBit.findMax: empty map has no maximal element"
+{-# INLINABLE findMax #-}
+
+-- | /O(k')/. Delete the minimal key. Returns an empty map if the
+-- map is empty.
+--
+-- > deleteMin (fromList [("a",5), ("b",3), ("c",7)]) == fromList [("b",3), ("c",7)]
+-- > deleteMin empty == empty
+deleteMin :: CritBit k v -> CritBit k v
+deleteMin m = updateMinWithKey (\_ _ -> Nothing) m
+{-# INLINABLE deleteMin #-}
+
+-- | /O(k)/. Delete the maximal key. Returns an empty map if the
+-- map is empty.
+--
+-- > deleteMin (fromList [("a",5), ("b",3), ("c",7)]) == fromList [("a",5), ("b","3")]
+-- > deleteMin empty == empty
+deleteMax :: CritBit k v -> CritBit k v
+deleteMax m = updateMaxWithKey (\_ _ -> Nothing) m
+{-# INLINABLE deleteMax #-}
+
+-- | /O(k')/. Delete and find the minimal element.
+--
+-- > deleteFindMin (fromList [("a",5), ("b",3), ("c",10)]) == (("a",5), fromList[("b",3), ("c",10)])
+-- > deleteFindMin     Error: can not return the minimal element of an empty map
+deleteFindMin :: CritBit k v -> ((k, v), CritBit k v)
+deleteFindMin = fromMaybe (error msg) . minViewWithKey
+  where msg = "CritBit.deleteFindMin: cannot return the minimal \
+              \element of an empty map"
+{-# INLINABLE deleteFindMin #-}
+
+-- | /O(k)/. Delete and find the maximal element.
+--
+-- > deleteFindMax (fromList [("a",5), ("b",3), ("c",10)]) == (("c",10), fromList[("a",5), ("b",3)])
+-- > deleteFindMax     Error: can not return the maximal element of an empty map
+deleteFindMax :: CritBit k v -> ((k, v), CritBit k v)
+deleteFindMax = fromMaybe (error msg) . maxViewWithKey
+  where msg = "CritBit.deleteFindMax: cannot return the minimal \
+              \element of an empty map"
+{-# INLINABLE deleteFindMax #-}
+
+-- | /O(k')/. Retrieves the value associated with minimal key of the
+-- map, and the map stripped of that element, or 'Nothing' if passed an
+-- empty map.
+--
+-- > minView (fromList [("a",5), ("b",3)]) == Just (5, fromList [("b",3)])
+-- > minView empty == Nothing
+minView :: CritBit k v -> Maybe (v, CritBit k v)
+minView = fmap (first snd) . minViewWithKey
+{-# INLINABLE minView #-}
+
+-- | /O(k)/. Retrieves the value associated with maximal key of the
+-- map, and the map stripped of that element, or 'Nothing' if passed an
+-- empty map.
+--
+-- > maxView (fromList [("a",5), ("b",3)]) == Just (3, fromList [("a",5)])
+-- > maxView empty == Nothing
+maxView :: CritBit k v -> Maybe (v, CritBit k v)
+maxView = fmap (first snd) . maxViewWithKey
+{-# INLINABLE maxView #-}
+
+-- | /O(k')/. Retrieves the minimal (key,value) pair of the map, and
+-- the map stripped of that element, or 'Nothing' if passed an empty map.
+--
+-- > minViewWithKey (fromList [("a",5), ("b",3)]) == Just (("a",5), fromList [("b",3)])
+-- > minViewWithKey empty == Nothing
+minViewWithKey :: CritBit k v -> Maybe ((k, v), CritBit k v)
+minViewWithKey (CritBit root) = go root CritBit
+  where
+    go (Internal (Leaf lk lv) right _ _) cont = Just ((lk,lv), cont right)
+    go i@(Internal left _ _ _) cont = go left $ (cont $!) . setLeft i
+    go (Leaf lk lv) _ = Just ((lk,lv),empty)
+    go _ _ = Nothing
+{-# INLINABLE minViewWithKey #-}
+
+-- | /O(k)/. Retrieves the maximal (key,value) pair of the map, and
+-- the map stripped of that element, or 'Nothing' if passed an empty map.
+--
+-- > maxViewWithKey (fromList [("a",5), ("b",3)]) == Just (("b",3), fromList [("a",5)])
+-- > maxViewWithKey empty == Nothing
+maxViewWithKey :: CritBit k v -> Maybe ((k,v), CritBit k v)
+maxViewWithKey (CritBit root) = go root CritBit
+  where
+    go (Internal left (Leaf lk lv) _ _) cont = Just ((lk,lv), cont left)
+    go i@(Internal _ right _ _) cont = go right $ (cont $!) . setRight i
+    go (Leaf lk lv) _ = Just ((lk,lv),empty)
+    go _ _ = Nothing
+{-# INLINABLE maxViewWithKey #-}
+
+first :: (a -> b) -> (a,c) -> (b,c)
+first f (x,y) = (f x, y)
+{-# INLINE first #-}
+
+-- | /O(k')/. Update the value at the minimal key.
+--
+-- > updateMin (\ a -> Just (a + 7)) (fromList [("a",5), ("b",3)]) == fromList [("a",12), ("b",3)]
+-- > updateMin (\ _ -> Nothing)      (fromList [("a",5), ("b",3)]) == fromList [("b",3)]
+updateMin :: (v -> Maybe v) -> CritBit k v -> CritBit k v
+updateMin f m = updateMinWithKey (const f) m
+{-# INLINABLE updateMin #-}
+
+-- | /O(k)/. Update the value at the maximal key.
+--
+-- > updateMax (\ a -> Just (a + 7)) (fromList [("a",5), ("b",3)]) == fromList [("a",5), ("b",10)]
+-- > updateMax (\ _ -> Nothing)      (fromList [("a",5), ("b",3)]) == fromList [("a",5)]
+updateMax :: (v -> Maybe v) -> CritBit k v -> CritBit k v
+updateMax f m = updateMaxWithKey (const f) m
+{-# INLINABLE updateMax #-}
+
+-- | /O(k')/. Update the value at the minimal key.
+--
+-- > updateMinWithKey (\ k a -> Just (length k + a)) (fromList [("a",5), ("b",3)]) == fromList [("a",6), ("b",3)]
+-- > updateMinWithKey (\ _ _ -> Nothing)             (fromList [("a",5), ("b",3)]) == fromList [("b",3)]
+updateMinWithKey :: (k -> v -> Maybe v) -> CritBit k v -> CritBit k v
+updateMinWithKey maybeUpdate (CritBit root) = CritBit $ go root
+  where
+    go i@(Internal left _ _ _) = setLeft' i (go left)
+    go (Leaf k v) = maybe Empty (Leaf k) $ maybeUpdate k v
+    go _ = Empty
+{-# INLINABLE updateMinWithKey #-}
+
+-- | /O(k)/. Update the value at the maximal key.
+--
+-- > updateMaxWithKey (\ k a -> Just (length k + a)) (fromList [("a",5), ("b",3)]) == fromList [("a",5), ("b",4)]
+-- > updateMaxWithKey (\ _ _ -> Nothing)             (fromList [("a",5), ("b",3)]) == fromList [("a",5)]
+updateMaxWithKey :: (k -> v -> Maybe v) -> CritBit k v -> CritBit k v
+updateMaxWithKey maybeUpdate (CritBit root) = CritBit $ go root
+  where
+    go i@(Internal _ right _ _) = setRight' i (go right)
+    go (Leaf k v) = maybe Empty (Leaf k) $ maybeUpdate k v
+    go _ = Empty
+{-# INLINABLE updateMaxWithKey #-}
+
+-- | /O(k)/. Insert a new key and value in the map.  If the key is
+-- already present in the map, the associated value is replaced with
+-- the supplied value. 'insert' is equivalent to @'insertWith'
+-- 'const'@.
+--
+-- > insert "b" 7 (fromList [("a",5), ("b",3)]) == fromList [("a",5), ("b",7)]
+-- > insert "x" 7 (fromList [("a",5), ("b",3)]) == fromList [("a",5), ("b",3), ("x",7)]
+-- > insert "x" 5 empty                         == singleton "x" 5
+insert :: (CritBitKey k) => k -> v -> CritBit k v -> CritBit k v
+insert = insertLookupGen (flip const) (\_ v _ -> v)
+{-# INLINABLE insert #-}
+
+-- | /O(k)/. Insert with a function, combining new value and old value.
+-- @'insertWith' f key value cb@
+-- will insert the pair (key, value) into @cb@ if key does
+-- not exist in the map. If the key does exist, the function will
+-- insert the pair @(key, f new_value old_value)@.
+--
+-- > insertWith (+) "a" 1 (fromList [("a",5), ("b",3)]) == fromList [("a",6), ("b",3)]
+-- > insertWith (+) "c" 7 (fromList [("a",5), ("b",3)]) == fromList [("a",5), ("b",3), ("c",7)]
+-- > insertWith (+) "x" 5 empty                         == singleton "x" 5
+--
+insertWith :: CritBitKey k =>
+              (v -> v -> v) -> k -> v -> CritBit k v -> CritBit k v
+insertWith f = insertLookupGen (flip const) (const f)
+{-# INLINABLE insertWith #-}
+
+-- | /O(n)/. Apply a function to all values.
+--
+-- >  let f key x = show key ++ ":" ++ show x
+-- >  mapWithKey f (fromList [("a",5), ("b",3)]) == fromList [("a","a:5"), ("b","b:3")]
+mapWithKey :: (k -> v -> w) -> CritBit k v -> CritBit k w
+mapWithKey f (CritBit root) = CritBit (go root)
+  where
+    go i@(Internal l r _ _) = setBoth i (go l) (go r)
+    go (Leaf k v)        = Leaf k (f k v)
+    go  Empty            = Empty
+{-# INLINABLE mapWithKey #-}
+
+-- | /O(n)/. The function 'mapAccumRWithKey' threads an accumulating
+-- argument through the map in descending order of keys.
+mapAccumRWithKey :: (CritBitKey k) => (a -> k -> v -> (a, w)) -> a
+                 -> CritBit k v -> (a, CritBit k w)
+mapAccumRWithKey f start (CritBit root) = second CritBit (go start root)
+  where
+    go a i@(Internal{..}) = let (a0, r')  = go a iright
+                                (a1, l')  = go a0 ileft
+                            in (a1, setBoth i l' r')
+    go a (Leaf k v)       = let (a0, w) = f a k v in (a0, Leaf k w)
+    go a Empty            = (a, Empty)
+{-# INLINABLE mapAccumRWithKey #-}
+
+-- | /O(n)/.
+-- @'traverseWithKey' f s == 'fromList' <$> 'traverse' (\(k, v) -> (,) k <$> f k v) ('toList' m)@
+--
+-- That is, behaves exactly like a regular 'traverse' except
+-- that the traversing function also has access to the key associated
+-- with a value.
+--
+-- > let f key value = show key ++ ":" ++ show value
+-- > traverseWithKey (\k v -> if odd v then Just (f k v) else Nothing) (fromList [("a",3), ("b",5)]) == Just (fromList [("a","a:3"), ("b","b:5")])
+-- > traverseWithKey (\k v -> if odd v then Just (f k v) else Nothing) (fromList [("c", 2)])           == Nothing
+traverseWithKey :: (CritBitKey k, Applicative t)
+                => (k -> v -> t w)
+                -> CritBit k v
+                -> t (CritBit k w)
+traverseWithKey f (CritBit root) = fmap CritBit (go root)
+  where
+    go i@(Internal l r _ _) = setBoth i <$> go l <*> go r
+    go (Leaf k v)           = Leaf k <$> f k v
+    go Empty                = pure Empty
+{-# INLINABLE traverseWithKey #-}
+
+-- | /O(n)/. The function 'mapAccum' threads an accumulating
+-- argument through the map in ascending order of keys.
+--
+-- > let f a b = (a ++ show b, show b ++ "X")
+-- > mapAccum f "Everything: " (fromList [("a",5), ("b",3)]) == ("Everything: 53", fromList [("a","5X"), ("b","3X")])
+mapAccum :: (CritBitKey k)
+         => (a -> v -> (a, w))
+         -> a
+         -> CritBit k v
+         -> (a, CritBit k w)
+mapAccum f = mapAccumWithKey (\a _ v -> f a v)
+{-# INLINE mapAccum #-}
+
+-- | /O(n)/. The function 'mapAccumWithKey' threads an accumulating
+-- argument through the map in ascending order of keys.
+--
+-- > let f a k b = (a ++ " " ++ show k ++ "-" ++ show b, show b ++ "X")
+-- > mapAccumWithKey f "Everything: " (fromList [("a",5), ("b",3)]) == ("Everything: a-5 b-3", fromList [("a","5X"), ("b","3X")])
+mapAccumWithKey :: (CritBitKey k)
+                => (a -> k -> v -> (a, w))
+                -> a
+                -> CritBit k v
+                -> (a, CritBit k w)
+mapAccumWithKey f start (CritBit root) = second CritBit (go start root)
+  where
+    go a i@(Internal{..}) = let (a0, l')  = go a ileft
+                                (a1, r')  = go a0 iright
+                            in (a1, setBoth i l' r')
+
+    go a (Leaf k v)       = let (a0, w) = f a k v in (a0, Leaf k w)
+    go a Empty            = (a, Empty)
+{-# INLINABLE mapAccumWithKey #-}
+
+-- | /O(k)/. The expression (@'alter' f k map@) alters the value @x@
+-- at @k@, or absence thereof.  'alter' can be used to insert, delete,
+-- or update a value in a 'CritBit'.  In short : @'lookup' k ('alter'
+-- f k m) = f ('lookup' k m)@.
+--
+-- > let f _ = Nothing
+-- > alter f "c" (fromList [("a",5), ("b",3)]) == fromList [("a",5), ("b",3)]
+-- > alter f "a" (fromList [("a",5), ("b",3)]) == fromList [("b",3)]
+-- >
+-- > let f _ = Just 1
+-- > alter f "c" (fromList [("a",5), ("b",3)]) == fromList [("a",5), ("b",3), ("c",1)]
+-- > alter f "a" (fromList [(5,"a"), (3,"b")]) == fromList [("a",1), ("b",3)]
+alter :: (CritBitKey k)
+      => (Maybe v -> Maybe v) -> k -> CritBit k v -> CritBit k v
+alter f !k m = findPosition (const CritBit) finish setLeft' setRight' k m
+  where
+    finish _ Empty = maybe Empty (Leaf k) $ f Nothing
+    finish diff (Leaf _ v) | diffOrd diff == EQ =
+      maybe Empty (Leaf k) $ f (Just v)
+    finish diff node = maybe node (internal diff node . Leaf k) $ f Nothing
+{-# INLINABLE alter #-}
+
+-- | /O(n)/. Partition the map according to a predicate. The first
+-- map contains all elements that satisfy the predicate, the second all
+-- elements that fail the predicate. See also 'split'.
+--
+-- > partitionWithKey (\ k _ -> k < "b") (fromList [("a",5), ("b",3)]) == (fromList [("a",5)], fromList [("b",3)])
+-- > partitionWithKey (\ k _ -> k < "c") (fromList [(5,"a"), (3,"b")]) == (fromList [("a",5), ("b",3)], empty)
+-- > partitionWithKey (\ k _ -> k > "c") (fromList [(5,"a"), (3,"b")]) == (empty, fromList [("a",5), ("b",3)])
+partitionWithKey :: (CritBitKey k)
+                 => (k -> v -> Bool)
+                 -> CritBit k v
+                 -> (CritBit k v, CritBit k v)
+partitionWithKey f (CritBit root) = CritBit *** CritBit $ go root
+  where
+    go l@(Leaf k v)
+      | f k v     = (l,Empty)
+      | otherwise = (Empty,l)
+    go i@(Internal{..}) = (setBoth' i l1 r1, setBoth' i l2 r2)
+      where
+        (!l1,!l2) = go ileft
+        (!r1,!r2) = go iright
+    go _ = (Empty,Empty)
+{-# INLINABLE partitionWithKey #-}
+
+-- | /O(n)/. Partition the map according to a predicate. The first
+-- map contains all elements that satisfy the predicate, the second all
+-- elements that fail the predicate. See also 'split'.
+--
+-- > partition (> 4) (fromList [("a",5), ("b",3)]) == (fromList [("a",5)], fromList [("b",3)])
+-- > partition (< 6) (fromList [("a",5), ("b",3)]) == (fromList [("a",5), ("b",3)], empty)
+-- > partition (> 6) (fromList [("a",5), ("b",3)]) == (empty, fromList [("a",5), ("b",3)])
+partition :: (CritBitKey k)
+          => (v -> Bool)
+          -> CritBit k v
+          -> (CritBit k v, CritBit k v)
+partition f m = partitionWithKey (const f) m
+{-# INLINABLE partition #-}

--- a/deps/Data/CritBit/Types/Internal.hs
+++ b/deps/Data/CritBit/Types/Internal.hs
@@ -25,10 +25,10 @@ module Data.CritBit.Types.Internal
     , toList
     ) where
 
+import Prelude
 import Control.DeepSeq (NFData(..))
 import Data.Bits (Bits, (.|.), (.&.), shiftL, shiftR)
 import Data.ByteString (ByteString)
-import Data.Foldable hiding (toList)
 import Data.Monoid (Monoid(..))
 import Data.Text ()
 import Data.Text.Internal (Text(..))

--- a/deps/Data/CritBit/Types/Internal.hs
+++ b/deps/Data/CritBit/Types/Internal.hs
@@ -1,0 +1,291 @@
+{-# LANGUAGE CPP, FlexibleInstances, GeneralizedNewtypeDeriving #-}
+-- |
+-- Module      :  Data.CritBit.Types.Internal
+-- Copyright   :  (c) Bryan O'Sullivan and others 2013-2014
+-- License     :  BSD-style
+-- Maintainer  :  bos@serpentine.com
+-- Stability   :  experimental
+-- Portability :  GHC
+
+#if defined(__GLASGOW_HASKELL__) && !defined(__HADDOCK__)
+#include "MachDeps.h"
+#endif
+
+module Data.CritBit.Types.Internal
+    (
+      CritBitKey(..)
+    , CritBit(..)
+    , Set(..)
+    , BitMask
+    , Node(..)
+    , foldlWithKey
+    , foldlWithKey'
+    , foldrWithKey
+    , foldrWithKey'
+    , toList
+    ) where
+
+import Control.DeepSeq (NFData(..))
+import Data.Bits (Bits, (.|.), (.&.), shiftL, shiftR)
+import Data.ByteString (ByteString)
+import Data.Foldable hiding (toList)
+import Data.Monoid (Monoid(..))
+import Data.Text ()
+import Data.Text.Internal (Text(..))
+import Data.Word (Word, Word8, Word16, Word32, Word64)
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Unsafe as B
+import qualified Data.Text.Array as T
+import qualified Data.Vector.Generic as G
+import qualified Data.Vector.Unboxed as U
+import qualified Data.Vector as V
+
+type BitMask = Word16
+
+data Node k v =
+    Internal {
+      ileft, iright :: !(Node k v)
+    , ibyte         :: !Int
+    -- ^ The byte at which the left and right subtrees differ.
+    , iotherBits    :: !BitMask
+    -- ^ The bitmask representing the critical bit within the
+    -- differing byte. If the critical bit is e.g. 0x8, the bitmask
+    -- will have every bit other than 0x8 set, hence 0x1F7
+    -- (the ninth bit is set because we're using 9 bits for representing
+    -- bytes).
+    }
+    | Leaf k v
+    | Empty
+    -- ^ Logically, the 'Empty' constructor is a property of the tree,
+    -- rather than a node (a non-empty tree will never contain any
+    -- 'Empty' constructors). In practice, turning 'CritBit' from a
+    -- newtype into an ADT with an 'Empty' constructor adds a
+    -- pattern-match and a memory indirection to every function, which
+    -- slows them all down.
+      deriving (Eq, Show)
+
+instance (NFData k, NFData v) => NFData (Node k v) where
+    rnf (Internal l r _ _) = rnf l `seq` rnf r
+    rnf (Leaf k v)         = rnf k `seq` rnf v
+    rnf Empty              = ()
+
+instance Functor (Node k) where
+    fmap f i@(Internal l r _ _) = i { ileft = fmap f l, iright = fmap f r }
+    fmap f (Leaf k v)           = Leaf k (f v)
+    fmap _ Empty                = Empty
+
+instance Foldable (Node k) where
+    foldl f z m = foldlWithKey (\a _ v -> f a v) z (CritBit m)
+    foldr f z m = foldrWithKey (\_ v a -> f v a) z (CritBit m)
+
+    foldMap f (Internal l r _ _) = mappend (foldMap f l) (foldMap f r)
+    foldMap f (Leaf _ v)         = f v
+    foldMap _ Empty              = mempty
+    {-# INLINABLE foldMap #-}
+
+-- | /O(n)/. Fold the keys and values in the map using the given
+-- left-associative function, such that
+-- @'foldlWithKey' f z == 'Prelude.foldl' (\\z' (kx, x) -> f z' kx x) z . 'toAscList'@.
+--
+-- Examples:
+--
+-- > keys = reverse . foldlWithKey (\ks k x -> k:ks) []
+--
+-- > let f result k a = result ++ "(" ++ show k ++ ":" ++ a ++ ")"
+-- > foldlWithKey f "Map: " (fromList [("a",5), ("b",3)]) == "Map: (b:3)(a:5)"
+foldlWithKey :: (a -> k -> v -> a) -> a -> CritBit k v -> a
+foldlWithKey f z m = foldlWithKeyWith (\_ b -> b) f z m
+{-# INLINABLE foldlWithKey #-}
+
+-- | /O(n)/. A strict version of 'foldlWithKey'. Each application of
+-- the function is evaluated before using the result in the next
+-- application. This function is strict in the starting value.
+foldlWithKey' :: (a -> k -> v -> a) -> a -> CritBit k v -> a
+foldlWithKey' f z m = foldlWithKeyWith seq f z m
+{-# INLINABLE foldlWithKey' #-}
+
+-- | /O(n)/. Fold the keys and values in the map using the given
+-- right-associative function, such that
+-- @'foldrWithKey' f z == 'Prelude.foldr' ('uncurry' f) z . 'toAscList'@.
+--
+-- Examples:
+--
+-- > keys map = foldrWithKey (\k x ks -> k:ks) [] map
+--
+-- > let f k a result = result ++ "(" ++ show k ++ ":" ++ a ++ ")"
+-- > foldrWithKey f "Map: " (fromList [("a",5), ("b",3)]) == "Map: (a:5)(b:3)"
+foldrWithKey :: (k -> v -> a -> a) -> a -> CritBit k v -> a
+foldrWithKey f z m = foldrWithKeyWith (\_ b -> b) f z m
+{-# INLINABLE foldrWithKey #-}
+
+-- | /O(n)/. A strict version of 'foldrWithKey'. Each application of
+-- the function is evaluated before using the result in the next
+-- application. This function is strict in the starting value.
+foldrWithKey' :: (k -> v -> a -> a) -> a -> CritBit k v -> a
+foldrWithKey' f z m = foldrWithKeyWith seq f z m
+{-# INLINABLE foldrWithKey' #-}
+
+foldlWithKeyWith :: (a -> a -> a) -> (a -> k -> v -> a) -> a -> CritBit k v -> a
+foldlWithKeyWith maybeSeq f z0 (CritBit root) = go z0 root
+  where
+    go z (Internal left right _ _) = let z' = go z left
+                                     in z' `maybeSeq` go z' right
+    go z (Leaf k v)                = f z k v
+    go z Empty                     = z
+{-# INLINE foldlWithKeyWith #-}
+
+foldrWithKeyWith :: (a -> a -> a) -> (k -> v -> a -> a) -> a -> CritBit k v -> a
+foldrWithKeyWith maybeSeq f z0 (CritBit root) = go root z0
+  where
+    go (Internal left right _ _) z = let z' = go right z
+                                     in z' `maybeSeq` go left z'
+    go (Leaf k v) z                = f k v z
+    go Empty z                     = z
+{-# INLINE foldrWithKeyWith #-}
+
+-- | A crit-bit tree.
+newtype CritBit k v = CritBit (Node k v)
+                      deriving (Eq, NFData, Functor, Foldable)
+
+instance (Show k, Show v) => Show (CritBit k v) where
+    show t = "fromList " ++ show (toList t)
+
+-- | A type that can be used as a key in a crit-bit tree.
+--
+-- We use 9 bits to represent 8-bit bytes so that we can distinguish
+-- between an interior byte that is zero (which must have the 9th bit
+-- set) and a byte past the end of the input (which must /not/ have
+-- the 9th bit set).
+--
+-- Without this trick, the critical bit calculations would fail on
+-- zero bytes /within/ a string, and our tree would be unable to
+-- handle arbitrary binary data.
+class (Eq k) => CritBitKey k where
+    -- | Return the number of bytes used by this key.
+    --
+    -- For reasonable performance, implementations must be inlined and
+    -- /O(1)/.
+    byteCount :: k -> Int
+
+    -- | Return the byte at the given offset (counted in bytes) of
+    -- this key, bitwise-ORed with 256. If the offset is past the end
+    -- of the key, return zero.
+    --
+    -- For reasonable performance, implementations must be inlined and
+    -- /O(1)/.
+    getByte :: k -> Int -> Word16
+
+instance CritBitKey ByteString where
+    byteCount = B.length
+    {-# INLINE byteCount #-}
+
+    getByte bs n
+        | n < B.length bs = fromIntegral (B.unsafeIndex bs n) .|. 256
+        | otherwise       = 0
+    {-# INLINE getByte #-}
+
+instance CritBitKey Text where
+    byteCount (Text _ _ len) = len `shiftL` 1
+    {-# INLINE byteCount #-}
+
+    getByte (Text arr off len) n
+        | n < len `shiftL` 1 =
+            let word       = T.unsafeIndex arr (off + (n `shiftR` 1))
+                byteInWord = (word `shiftR` ((n .&. 1) `shiftL` 3)) .&. 0xff
+            in byteInWord .|. 256
+        | otherwise       = 0
+    {-# INLINE getByte #-}
+
+#if WORD_SIZE_IN_BITS == 64
+# define WORD_SHIFT 3
+#else
+# define WORD_SHIFT 2
+#endif
+
+instance CritBitKey (U.Vector Word8) where
+    byteCount = G.length
+    getByte   = getByteV 0
+
+instance CritBitKey (U.Vector Word16) where
+    byteCount = (`shiftL` 1) . G.length
+    getByte   = getByteV 1
+
+instance CritBitKey (U.Vector Word32) where
+    byteCount = (`shiftL` 2) . G.length
+    getByte   = getByteV 2
+
+instance CritBitKey (U.Vector Word64) where
+    byteCount = (`shiftL` 3) . G.length
+    getByte   = getByteV 3
+
+instance CritBitKey (U.Vector Word) where
+    byteCount = (`shiftL` WORD_SHIFT) . G.length
+    getByte   = getByteV WORD_SHIFT
+
+instance CritBitKey (U.Vector Char) where
+    byteCount = (`shiftL` 2) . G.length
+    getByte   = getByteV_ fromEnum 2
+
+instance CritBitKey (V.Vector Word8) where
+    byteCount = G.length
+    getByte   = getByteV 0
+
+instance CritBitKey (V.Vector Word16) where
+    byteCount = (`shiftL` 1) . G.length
+    getByte   = getByteV 1
+
+instance CritBitKey (V.Vector Word32) where
+    byteCount = (`shiftL` 2) . G.length
+    getByte   = getByteV 2
+
+instance CritBitKey (V.Vector Word64) where
+    byteCount = (`shiftL` 3) . G.length
+    getByte   = getByteV 3
+
+instance CritBitKey (V.Vector Word) where
+    byteCount = (`shiftL` WORD_SHIFT) . G.length
+    getByte   = getByteV WORD_SHIFT
+
+instance CritBitKey (V.Vector Char) where
+    byteCount = (`shiftL` 2) . G.length
+    getByte   = getByteV_ fromEnum 2
+
+getByteV :: (Bits a, Integral a, G.Vector v a) => Int -> v a -> Int -> Word16
+getByteV = getByteV_ id
+{-# INLINE getByteV #-}
+
+getByteV_ :: (Bits a, Integral a, G.Vector v b) =>
+             (b -> a) -> Int -> v b -> Int -> Word16
+getByteV_ convert shiftSize = \v n ->
+  if n < G.length v `shiftL` shiftSize
+  then reindex shiftSize n $ \wordOffset shiftRight ->
+       let word       = convert (G.unsafeIndex v wordOffset)
+           byteInWord = (word `shiftR` shiftRight) .&. 255
+       in fromIntegral byteInWord .|. 256
+  else 0
+{-# INLINE getByteV_ #-}
+
+reindex :: Int -> Int -> (Int -> Int -> r) -> r
+reindex shiftSize n f = f wordOffset shiftRight
+  where
+    wordOffset = n `shiftR` shiftSize
+    shiftRight = (size - (n .&. size)) `shiftL` 3
+      where size = (1 `shiftL` shiftSize) - 1
+{-# INLINE reindex #-}
+
+-- | /O(n)/. Convert the map to a list of key\/value pairs. The list
+-- returned will be sorted in lexicographically ascending order.
+--
+-- > toList (fromList [("b",3), ("a",5)]) == [("a",5),("b",3)]
+-- > toList empty == []
+toList :: CritBit k v -> [(k, v)]
+toList (CritBit root) = go root []
+  where
+    go (Internal l r _ _) next = go l (go r next)
+    go (Leaf k v) next         = (k,v) : next
+    go Empty next              = next
+
+
+-- | A set based on crit-bit trees.
+newtype Set a = Set (CritBit a ())
+    deriving (Eq, NFData)

--- a/deps/LICENSE.configurator-ng
+++ b/deps/LICENSE.configurator-ng
@@ -1,0 +1,32 @@
+Copyright (c) 2011 MailRank, Inc.
+Copyright (c) 2011-2014 Bryan O'Sullivan
+Copyright (c) 2015-2016 Leon P Smith
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the author nor the names of his contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE CONTRIBUTORS ``AS IS'' AND ANY EXPRESS
+OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/deps/LICENSE.critbit
+++ b/deps/LICENSE.critbit
@@ -1,0 +1,26 @@
+Copyright (c) 2013-2014 Bryan O'Sullivan and others
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -59,7 +59,6 @@ library
                      , bytestring
                      , case-insensitive
                      , cassava
-                     , configurator-ng == 0.0.0.1
                      , containers
                      , contravariant
                      , contravariant-extras
@@ -108,7 +107,7 @@ library
                      , PostgREST.QueryBuilder
                      , PostgREST.RangeQuery
                      , PostgREST.Types
-  hs-source-dirs:      src
+  hs-source-dirs:      deps, src
 
 Test-Suite spec
   Type:                exitcode-stdio-1.0

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -101,6 +101,21 @@ library
                      , cookie
 
   Other-Modules:       Paths_postgrest
+                     , Data.Configurator
+                     , Data.Configurator.Config
+                     , Data.Configurator.Config.Implementation
+                     , Data.Configurator.Config.Internal
+                     , Data.Configurator.FromValue
+                     , Data.Configurator.FromValue.Implementation
+                     , Data.Configurator.Parser
+                     , Data.Configurator.Parser.Implementation
+                     , Data.Configurator.Syntax
+                     , Data.Configurator.Types
+                     , Data.Configurator.Types.Internal
+                     , Data.CritBit.Core
+                     , Data.CritBit.Map.Lazy
+                     , Data.CritBit.Tree
+                     , Data.CritBit.Types.Internal
   Exposed-Modules:     PostgREST.ApiRequest
                      , PostgREST.App
                      , PostgREST.Auth

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -54,6 +54,8 @@ library
   default-extensions:  OverloadedStrings, QuasiQuotes, NoImplicitPrelude
   build-depends:       aeson
                      , ansi-wl-pprint
+                     , attoparsec
+                     , array
                      , base >= 4.8 && < 4.10
                      , base64-bytestring
                      , bytestring
@@ -62,8 +64,12 @@ library
                      , containers
                      , contravariant
                      , contravariant-extras
+                     , data-ordlist
+                     , deepseq
+                     , dlist
                      , either
                      , gitrev
+                     , hashable
                      , hasql >= 1.3 && < 1.4
                      , hasql-pool >= 0.5 && < 0.6
                      , hasql-transaction >= 0.7 && < 0.8
@@ -85,6 +91,7 @@ library
                      , swagger2
                      , text
                      , time
+                     , unix-compat
                      , unordered-containers
                      , vector
                      , wai


### PR DESCRIPTION
To get unstuck on these orphaned and stale dependencies, I suggest bundling them with PostgREST as an intermediate step. This will allow easily updating them to build with newer GHC/base versions, and kicking them back out once a better alternative is found.
