### PR TITLE
Fix parsing of embedded quoted JSON with PostgreSQL version 10 and later

### DIFF
--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -165,25 +165,11 @@ callProc qi pgArgs returnsScalar selectQuery countQuery countTotal isSingle para
       | paramsAsSingleObject = ("_args_record AS (SELECT NULL)", "$1::json")
       | null pgArgs = (ignoredBody, "")
       | otherwise = (
-          let explicit = pgVer >= pgVersion100
-              rawType a = if explicit
-                then case pgaType a of
-                       "json"  -> "text"
-                       "jsonb" -> "text"
-                       t       -> t
-                else pgaType a
-              conversion = unwords [
-                "SELECT",
-                intercalate ", " ((\a -> pgFmtIdent (pgaName a) <> "::" <> pgaType a) <$> pgArgs),
-                "FROM ("]
-          in
           unwords [
             normalizedBody <> ",",
             "_args_record AS (",
-            if explicit then conversion else "",
-            "SELECT * FROM json_to_recordset(" <> selectBody <> ") AS _(" <>
-                intercalate ", " ((\a -> pgFmtIdent (pgaName a) <> " " <> rawType a) <$> pgArgs) <> ")",
-            if explicit then ") _x" else "",
+              "SELECT * FROM json_to_recordset(" <> selectBody <> ") AS _(" <>
+                intercalate ", " ((\a -> pgFmtIdent (pgaName a) <> " " <> pgaType a) <$> pgArgs) <> ")",
             ")"]
          , intercalate ", " ((\a -> pgFmtIdent (pgaName a) <> " := _args_record." <> pgFmtIdent (pgaName a)) <$> pgArgs))
 

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -165,11 +165,25 @@ callProc qi pgArgs returnsScalar selectQuery countQuery countTotal isSingle para
       | paramsAsSingleObject = ("_args_record AS (SELECT NULL)", "$1::json")
       | null pgArgs = (ignoredBody, "")
       | otherwise = (
+          let explicit = pgVer >= pgVersion100
+              rawType a = if explicit
+                then case pgaType a of
+                       "json"  -> "text"
+                       "jsonb" -> "text"
+                       t       -> t
+                else pgaType a
+              conversion = unwords [
+                "SELECT",
+                intercalate ", " ((\a -> pgFmtIdent (pgaName a) <> "::" <> pgaType a) <$> pgArgs),
+                "FROM ("]
+          in
           unwords [
             normalizedBody <> ",",
             "_args_record AS (",
-              "SELECT * FROM json_to_recordset(" <> selectBody <> ") AS _(" <>
-                intercalate ", " ((\a -> pgFmtIdent (pgaName a) <> " " <> pgaType a) <$> pgArgs) <> ")",
+            if explicit then conversion else "",
+            "SELECT * FROM json_to_recordset(" <> selectBody <> ") AS _(" <>
+                intercalate ", " ((\a -> pgFmtIdent (pgaName a) <> " " <> rawType a) <$> pgArgs) <> ")",
+            if explicit then ") _x" else "",
             ")"]
          , intercalate ", " ((\a -> pgFmtIdent (pgaName a) <> " := _args_record." <> pgFmtIdent (pgaName a)) <$> pgArgs))
 

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -288,7 +288,7 @@ requestToQuery schema _ (DbMutate (Insert mainTbl iCols onConflct putConditions 
     "INSERT INTO ", fromQi qi, if S.null iCols then " " else "(" <> cols <> ")",
     unwords [
       "SELECT " <> cols <> " FROM",
-      "json_populate_recordset", "(null::", fromQi qi, ", " <> selectBody <> ") _",
+      "jsonb_populate_recordset", "(null::", fromQi qi, ", " <> selectBody <> ") _",
       -- Only used for PUT
       ("WHERE " <> intercalate " AND " (pgFmtLogicTree (QualifiedIdentifier "" "_") <$> putConditions)) `emptyOnFalse` null putConditions],
     maybe "" (\(oncDo, oncCols) -> (
@@ -311,7 +311,7 @@ requestToQuery schema _ (DbMutate (Update mainTbl uCols logicForest returnings))
       unwords [
         "WITH " <> normalizedBody,
         "UPDATE " <> fromQi qi <> " SET " <> cols,
-        "FROM (SELECT * FROM json_populate_recordset", "(null::", fromQi qi, ", " <> selectBody <> ")) _ ",
+        "FROM (SELECT * FROM jsonb_populate_recordset", "(null::", fromQi qi, ", " <> selectBody <> ")) _ ",
         ("WHERE " <> intercalate " AND " (pgFmtLogicTree qi <$> logicForest)) `emptyOnFalse` null logicForest,
         ("RETURNING " <> intercalate ", " (pgFmtColumn qi <$> returnings)) `emptyOnFalse` null returnings
         ]
@@ -342,12 +342,12 @@ ignoredBody = "ignored_body AS (SELECT $1::text) "
 normalizedBody :: SqlFragment
 normalizedBody =
   unwords [
-    "pgrst_payload AS (SELECT $1::json AS json_data),",
+    "pgrst_payload AS (SELECT $1::jsonb AS json_data),",
     "pgrst_body AS (",
       "SELECT",
-        "CASE WHEN json_typeof(json_data) = 'array'",
+        "CASE WHEN jsonb_typeof(json_data) = 'array'",
           "THEN json_data",
-          "ELSE json_build_array(json_data)",
+          "ELSE jsonb_build_array(json_data)",
         "END AS val",
       "FROM pgrst_payload)"]
 

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -168,7 +168,8 @@ callProc qi pgArgs returnsScalar selectQuery countQuery countTotal isSingle para
           unwords [
             normalizedBody <> ",",
             "_args_record AS (",
-              "SELECT * FROM json_to_recordset(" <> selectBody <> ") AS _(" <>
+              "SELECT * FROM jsonb_to_recordset(" <> selectBody <> ") AS _(" <>
+
                 intercalate ", " ((\a -> pgFmtIdent (pgaName a) <> " " <> pgaType a) <$> pgArgs) <> ")",
             ")"]
          , intercalate ", " ((\a -> pgFmtIdent (pgaName a) <> " := _args_record." <> pgFmtIdent (pgaName a)) <$> pgArgs))

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -223,22 +223,22 @@ spec actualPgVersion = do
     context "jsonb" $ do
       it "serializes nested object" $ do
         let inserted = [json| { "data": { "foo":"bar" } } |]
-            location = "/json?data=eq.%7B%22foo%22%3A%22bar%22%7D"
+            location = "/json?data=eq.%7B%22foo%22%3A%20%22bar%22%7D"
         request methodPost "/json"
                      [("Prefer", "return=representation")]
                      inserted
-          `shouldRespondWith` [str|[{"data":{"foo":"bar"}}]|]
+          `shouldRespondWith` [str|[{"data":{"foo": "bar"}}]|]
           { matchStatus  = 201
           , matchHeaders = ["Location" <:> location]
           }
 
       it "serializes nested array" $ do
         let inserted = [json| { "data": [1,2,3] } |]
-            location = "/json?data=eq.%5B1%2C2%2C3%5D"
+            location = "/json?data=eq.%5B1%2C%202%2C%203%5D"
         request methodPost "/json"
                      [("Prefer", "return=representation")]
                      inserted
-          `shouldRespondWith` [str|[{"data":[1,2,3]}]|]
+          `shouldRespondWith` [str|[{"data":[1, 2, 3]}]|]
           { matchStatus  = 201
           , matchHeaders = ["Location" <:> location]
           }
@@ -332,7 +332,7 @@ spec actualPgVersion = do
               "code": "22023",
               "details": null,
               "hint": null,
-              "message": "argument of json_populate_recordset must be an array of objects"}|]
+              "message": "argument of jsonb_populate_recordset must be an array of objects"}|]
           { matchStatus  = 400
           , matchHeaders = []
           }

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -233,7 +233,19 @@ spec actualPgVersion =
     context "proc argument types" $ do
       it "accepts a variety of arguments" $
         post "/rpc/varied_arguments"
+            [json| { "double": 3.1, "varchar": "hello", "boolean": true, "date": "20190101", "money": 0, "enum": "foo", "integer": 43 } |]
+          `shouldRespondWith`
+            [json|"Hi"|]
+            { matchHeaders = [matchContentTypeJson] }
+      it "accepts quoted embedded JSON" $
+        post "/rpc/varied_arguments"
             [json| { "double": 3.1, "varchar": "hello", "boolean": true, "date": "20190101", "money": 0, "enum": "foo", "integer": 43, "jsonb": "{\"this is embedded\": 5}" } |]
+          `shouldRespondWith`
+            [json|"Hi"|]
+            { matchHeaders = [matchContentTypeJson] }
+      it "accepts unquoted embedded JSON" $
+        post "/rpc/varied_arguments"
+            [json| { "double": 3.1, "varchar": "hello", "boolean": true, "date": "20190101", "money": 0, "enum": "foo", "integer": 43, "jsonb": {"this is embedded": 5} } |]
           `shouldRespondWith`
             [json|"Hi"|]
             { matchHeaders = [matchContentTypeJson] }

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -249,6 +249,18 @@ spec actualPgVersion =
           `shouldRespondWith`
             [json|"Hi"|]
             { matchHeaders = [matchContentTypeJson] }
+      it "parses quoted JSON arguments as JSON" $
+        post "/rpc/json_argument"
+            [json| { "arg": "{ \"key\": 3 }" } |]
+          `shouldRespondWith`
+            [json|"object"|]
+            { matchHeaders = [matchContentTypeJson] }
+      it "parses embedded JSON arguments as JSON" $
+        post "/rpc/json_argument"
+            [json| { "arg": { "key": 3 } } |]
+          `shouldRespondWith`
+            [json|"object"|]
+            { matchHeaders = [matchContentTypeJson] }
 
     context "improper input" $ do
       it "rejects unknown content type even if payload is good" $ do

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -230,6 +230,14 @@ spec actualPgVersion =
           [json|null|]
           { matchHeaders = [matchContentTypeJson] }
 
+    context "proc argument types" $ do
+      it "accepts a variety of arguments" $
+        post "/rpc/varied_arguments"
+            [json| { "double": 3.1, "varchar": "hello", "boolean": true, "date": "20190101", "money": 0, "enum": "foo", "integer": 43, "jsonb": "{\"this is embedded\": 5}" } |]
+          `shouldRespondWith`
+            [json|"Hi"|]
+            { matchHeaders = [matchContentTypeJson] }
+
     context "improper input" $ do
       it "rejects unknown content type even if payload is good" $ do
         request methodPost "/rpc/sayhello"

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -427,6 +427,10 @@ spec = do
                   "integer": {
                     "format": "integer",
                     "type": "integer"
+                  },
+                  "jsonb": {
+                    "format": "jsonb",
+                    "type": "string"
                   }
                 },
                 "type": "object",

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -138,7 +138,7 @@ resetDb dbConn = loadFixture dbConn "data"
 
 loadFixture :: Text -> FilePath -> IO()
 loadFixture dbConn name =
-  void $ readProcess "psql" [toS dbConn, "-a", "-f", "test/fixtures/" ++ name ++ ".sql"] []
+  void $ readProcess "psql" ["--set", "ON_ERROR_STOP=1", toS dbConn, "-a", "-f", "test/fixtures/" ++ name ++ ".sql"] []
 
 rangeHdrs :: ByteRange -> [Header]
 rangeHdrs r = [rangeUnit, (hRange, renderByteRange r)]

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -219,6 +219,14 @@ $_$An RPC function
 
 Just a test for RPC function arguments$_$;
 
+
+CREATE FUNCTION json_argument(arg json) RETURNS text
+
+LANGUAGE sql
+AS $_$
+  SELECT json_typeof(arg);
+$_$;
+
 --
 -- Name: jwt_test(); Type: FUNCTION; Schema: test; Owner: -
 --

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -206,14 +206,15 @@ CREATE FUNCTION varied_arguments(
   date date,
   money money,
   enum enum_menagerie_type,
-  "integer" integer default 42
+  "integer" integer default 42,
+  jsonb jsonb default '{}'
 ) RETURNS text
     LANGUAGE sql
 AS $_$
   SELECT 'Hi'::text;
 $_$;
 
-COMMENT ON FUNCTION varied_arguments(double precision, character varying, boolean, date, money, enum_menagerie_type, integer) IS
+COMMENT ON FUNCTION varied_arguments(double precision, character varying, boolean, date, money, enum_menagerie_type, integer, jsonb) IS
 $_$An RPC function
 
 Just a test for RPC function arguments$_$;


### PR DESCRIPTION
* Add test cases to check whether RPCs accept quoted and raw embedded JSON (some of these are expected to fail while it's unclear what the desired behavior should be)
* Add a shim for PostgreSQL >= 10 to ensure postgREST keeps accepting quoted JSON fields

The underlying PostgreSQL change seems like a regression as a side-effect to changes to `record_to_json` to better deal with composite values, as mentioned in the release notes: https://www.postgresql.org/docs/10/release-10.html#id-1.11.6.13.5.