### PR TITLE
Add lower bound for http-types

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -70,7 +70,7 @@ library
                      , hasql-transaction >= 0.7 && < 0.8
                      , heredoc
                      , HTTP
-                     , http-types
+                     , http-types >= 0.12.2
                      , insert-ordered-containers
                      , interpolatedstring-perl6
                      , jose == 0.7.0.0


### PR DESCRIPTION
parseQueryReplacePlus was introduced with version 0.12.2

I ran into this trying to build postgrest against stackage, which has http-types 0.12.2 only.
