### PR TITLE
Update cabal bounds

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -32,16 +32,16 @@ executable postgrest
     "-with-rtsopts=-N -I2"
   default-language:    Haskell2010
   build-depends:       auto-update
-                     , base >= 4.9 && < 4.10
+                     , base >= 4.9 && < 4.13
                      , base64-bytestring
                      , bytestring
                      , directory
                      , hasql >= 1.3 && < 1.4
                      , hasql-pool >= 0.5 && < 0.6
                      , hasql-transaction >= 0.7 && < 0.8
-                     , network == 2.6.3.2
+                     , network < 2.9
                      , postgrest
-                     , protolude == 0.2.2
+                     , protolude >= 0.2.2 && < 0.3
                      , retry
                      , text
                      , time
@@ -56,7 +56,7 @@ library
   default-extensions:  OverloadedStrings, QuasiQuotes, NoImplicitPrelude
   build-depends:       aeson
                      , ansi-wl-pprint
-                     , base >= 4.9 && < 4.10
+                     , base >= 4.9 && < 4.13
                      , base64-bytestring
                      , bytestring
                      , case-insensitive
@@ -76,14 +76,14 @@ library
                      , http-types >= 0.12.2
                      , insert-ordered-containers
                      , interpolatedstring-perl6
-                     , jose == 0.7.0.0
+                     , jose >= 0.7 && < 0.8
                      , lens
                      , lens-aeson
                      , network-uri
                      , optparse-applicative >= 0.13 && < 0.15
                      , parsec
-                     , protolude == 0.2.2
-                     , Ranged-sets == 0.3.0
+                     , protolude >= 0.2.2 && < 0.3
+                     , Ranged-sets >= 0.3 && < 0.5
                      , regex-tdfa
                      , scientific
                      , swagger2 < 2.4
@@ -149,7 +149,7 @@ Test-Suite spec
                      , aeson-qq
                      , async
                      , auto-update
-                     , base >= 4.9 && < 4.10
+                     , base >= 4.9 && < 4.13
                      , bytestring
                      , base64-bytestring
                      , case-insensitive
@@ -169,7 +169,7 @@ Test-Suite spec
                      , monad-control
                      , postgrest
                      , process
-                     , protolude == 0.2.2
+                     , protolude >= 0.2.2 && < 0.3
                      , regex-tdfa
                      , text
                      , time

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -31,21 +31,21 @@ executable postgrest
     -rtsopts
     "-with-rtsopts=-N -I2"
   default-language:    Haskell2010
-  build-depends:       auto-update
+  build-depends:       auto-update >= 0.1.4
                      , base >= 4.9 && < 4.13
-                     , base64-bytestring
-                     , bytestring
-                     , directory
+                     , base64-bytestring >= 1.0.0.1
+                     , bytestring >= 0.10.8.1
+                     , directory >= 1.2.6.2
                      , hasql >= 1.3 && < 1.4
                      , hasql-pool >= 0.5 && < 0.6
                      , hasql-transaction >= 0.7 && < 0.8
                      , network < 2.9
                      , postgrest
                      , protolude >= 0.2.2 && < 0.3
-                     , retry
-                     , text
-                     , time
-                     , warp
+                     , retry >= 0.7.4.2
+                     , text >= 1.2.2.2
+                     , time >= 1.6.0.1
+                     , warp >= 3.2.12
   if !os(windows)
     build-depends:     unix
 
@@ -54,47 +54,47 @@ executable postgrest
 library
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings, QuasiQuotes, NoImplicitPrelude
-  build-depends:       aeson
-                     , ansi-wl-pprint
+  build-depends:       aeson >= 0.11.3
+                     , ansi-wl-pprint >=0.6.7.3
                      , base >= 4.9 && < 4.13
-                     , base64-bytestring
-                     , bytestring
-                     , case-insensitive
-                     , cassava
+                     , base64-bytestring >= 1.0.0.1
+                     , bytestring >= 0.10.8.1
+                     , case-insensitive >= 1.2.0.9
+                     , cassava >= 0.4.5.1
                      , configurator-pg >= 0.1 && < 0.2
-                     , containers
-                     , contravariant
-                     , contravariant-extras
-                     , cookie
-                     , either
-                     , gitrev
+                     , containers >= 0.5.7.1
+                     , contravariant >= 1.4
+                     , contravariant-extras >= 0.3.3.1
+                     , cookie >= 0.4.2.1
+                     , either >= 4.4.1.1
+                     , gitrev >= 1.2
                      , hasql >= 1.3 && < 1.4
                      , hasql-pool >= 0.5 && < 0.6
                      , hasql-transaction >= 0.7 && < 0.8
-                     , heredoc
-                     , HTTP
+                     , heredoc >= 0.2
+                     , HTTP >= 4000.3.7
                      , http-types >= 0.12.2
-                     , insert-ordered-containers
-                     , interpolatedstring-perl6
+                     , insert-ordered-containers >= 0.1.0.1
+                     , interpolatedstring-perl6 >= 1
                      , jose >= 0.7 && < 0.8
-                     , lens
-                     , lens-aeson
-                     , network-uri
+                     , lens >= 4.14
+                     , lens-aeson >= 1.0.1
+                     , network-uri >= 2.6.1
                      , optparse-applicative >= 0.13 && < 0.15
-                     , parsec
+                     , parsec >= 3.1.11
                      , protolude >= 0.2.2 && < 0.3
                      , Ranged-sets >= 0.3 && < 0.5
-                     , regex-tdfa
-                     , scientific
-                     , swagger2 < 2.4
-                     , text
-                     , time
-                     , unordered-containers
-                     , vector
-                     , wai
-                     , wai-cors
-                     , wai-extra
-                     , wai-middleware-static
+                     , regex-tdfa >= 1.2.2
+                     , scientific >= 0.3.4.9
+                     , swagger2 >= 2.1.4 && < 2.4
+                     , text >= 1.2.2.2
+                     , time >= 1.6.0.1
+                     , unordered-containers >= 0.2.8
+                     , vector >= 0.11
+                     , wai >= 3.2.1.1
+                     , wai-cors >= 0.2.5
+                     , wai-extra >= 3.0.19.1
+                     , wai-middleware-static >= 0.8.1
 
   Other-Modules:       Paths_postgrest
   Exposed-Modules:     PostgREST.ApiRequest
@@ -145,34 +145,34 @@ Test-Suite spec
                      , Feature.UpsertSpec
                      , SpecHelper
                      , TestTypes
-  Build-Depends:       aeson
-                     , aeson-qq
-                     , async
-                     , auto-update
+  Build-Depends:       aeson >= 0.11.3
+                     , aeson-qq >= 0.8.1
+                     , async >= 2.1.1.1
+                     , auto-update >= 0.1.4
                      , base >= 4.9 && < 4.13
-                     , bytestring
-                     , base64-bytestring
-                     , case-insensitive
-                     , cassava
-                     , containers
-                     , contravariant
+                     , bytestring >= 0.10.8.1
+                     , base64-bytestring >= 1.0.0.1
+                     , case-insensitive >= 1.2.0.9
+                     , cassava >= 0.4.5.1
+                     , containers >= 0.5.7.1
+                     , contravariant >= 1.4
                      , hasql >= 1.3 && < 1.4
                      , hasql-pool >= 0.5 && < 0.6
                      , hasql-transaction >= 0.7 && < 0.8
-                     , heredoc
-                     , hspec
-                     , hspec-wai >= 0.7.0
-                     , hspec-wai-json
-                     , http-types
-                     , lens
-                     , lens-aeson
-                     , monad-control
+                     , heredoc >= 0.2
+                     , hspec >= 2.3
+                     , hspec-wai >= 0.7
+                     , hspec-wai-json >= 0.7
+                     , http-types >= 0.12.3
+                     , lens >= 4.14
+                     , lens-aeson >= 1.0.1
+                     , monad-control >= 1.0.1
                      , postgrest
-                     , process
+                     , process >= 1.4.2
                      , protolude >= 0.2.2 && < 0.3
-                     , regex-tdfa
-                     , text
-                     , time
-                     , transformers-base
-                     , wai
-                     , wai-extra
+                     , regex-tdfa >= 1.2.2
+                     , text >= 1.2.2.2
+                     , time >= 1.6.0.1
+                     , transformers-base >= 0.4.4
+                     , wai >= 3.2.1.1
+                     , wai-extra >= 3.0.19.1

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -33,6 +33,9 @@ executable postgrest
   default-language:    Haskell2010
   build-depends:       auto-update
                      , base >= 4.8 && < 4.10
+                     , base64-bytestring
+                     , bytestring
+                     , directory
                      , hasql >= 1.3 && < 1.4
                      , hasql-pool >= 0.5 && < 0.6
                      , hasql-transaction >= 0.7 && < 0.8
@@ -43,10 +46,6 @@ executable postgrest
                      , text
                      , time
                      , warp
-                     , bytestring
-                     , base64-bytestring
-                     , retry
-                     , directory
   if !os(windows)
     build-depends:     unix
 

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -32,7 +32,7 @@ executable postgrest
     "-with-rtsopts=-N -I2"
   default-language:    Haskell2010
   build-depends:       auto-update
-                     , base >= 4.8 && < 4.10
+                     , base >= 4.9 && < 4.10
                      , base64-bytestring
                      , bytestring
                      , directory
@@ -56,7 +56,7 @@ library
   default-extensions:  OverloadedStrings, QuasiQuotes, NoImplicitPrelude
   build-depends:       aeson
                      , ansi-wl-pprint
-                     , base >= 4.8 && < 4.10
+                     , base >= 4.9 && < 4.10
                      , base64-bytestring
                      , bytestring
                      , case-insensitive
@@ -149,7 +149,7 @@ Test-Suite spec
                      , aeson-qq
                      , async
                      , auto-update
-                     , base >= 4.8 && < 4.10
+                     , base >= 4.9 && < 4.10
                      , bytestring
                      , base64-bytestring
                      , case-insensitive

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -1,178 +1,181 @@
-name:                  postgrest
-description:           Reads the schema of a PostgreSQL database and creates RESTful routes
-                       for the tables and views, supporting all HTTP verbs that security
-                       permits.
-version:               5.2.0
-synopsis:              REST API for any Postgres database
-license:               MIT
-license-file:          LICENSE
-author:                Joe Nelson, Adam Baker
-homepage:              https://postgrest.org
-maintainer:            Steve Chávez <stevechavezast@gmail.com>
-bug-reports:           https://github.com/PostgREST/postgrest/issues
-category:              Executable, PostgreSQL, Network APIs
-extra-source-files:    CHANGELOG.md
-build-type:            Simple
-cabal-version:         >=1.10
+name:               postgrest
+version:            5.2.0
+synopsis:           REST API for any Postgres database
+description:        Reads the schema of a PostgreSQL database and creates RESTful routes
+                    for the tables and views, supporting all HTTP verbs that security
+                    permits.
+license:            MIT
+license-file:       LICENSE
+author:             Joe Nelson, Adam Baker
+maintainer:         Steve Chávez <stevechavezast@gmail.com>
+category:           Executable, PostgreSQL, Network APIs
+homepage:           https://postgrest.org
+bug-reports:        https://github.com/PostgREST/postgrest/issues
+build-type:         Simple
+extra-source-files: CHANGELOG.md
+cabal-version:      >= 1.10
+
 source-repository head
-  type: git
+  type:     git
   location: git://github.com/PostgREST/postgrest.git
 
-Flag CI
-  Description: No warnings allowed in continuous integration
-  Manual:      True
-  Default:     False
-
-executable postgrest
-  main-is:             Main.hs
-  default-extensions:  OverloadedStrings, QuasiQuotes, NoImplicitPrelude
-  ghc-options:
-    -threaded
-    -rtsopts
-    "-with-rtsopts=-N -I2"
-  default-language:    Haskell2010
-  build-depends:       auto-update >= 0.1.4 && < 0.2
-                     , base >= 4.9 && < 4.13
-                     , base64-bytestring >= 1 && < 1.1
-                     , bytestring >= 0.10.8 && < 0.11
-                     , directory >= 1.2.6 && < 1.4
-                     , hasql >= 1.3 && < 1.4
-                     , hasql-pool >= 0.5 && < 0.6
-                     , hasql-transaction >= 0.7 && < 0.8
-                     , network < 2.9
-                     , postgrest
-                     , protolude >= 0.2.2 && < 0.3
-                     , retry >= 0.7.4 && < 0.9
-                     , text >= 1.2.2 && < 1.3
-                     , time >= 1.6 && < 1.9
-                     , warp >= 3.2.12 && < 3.3
-  if !os(windows)
-    build-depends:     unix
-
-  hs-source-dirs:      main
+flag ci
+  default:     False
+  manual:      True
+  description: No warnings allowed in continuous integration
 
 library
-  default-language:    Haskell2010
-  default-extensions:  OverloadedStrings, QuasiQuotes, NoImplicitPrelude
-  build-depends:       aeson >= 0.11.3 && < 1.5
-                     , ansi-wl-pprint >= 0.6.7 && < 0.7
-                     , base >= 4.9 && < 4.13
-                     , base64-bytestring >= 1 && < 1.1
-                     , bytestring >= 0.10.8 && < 0.11
-                     , case-insensitive >= 1.2 && < 1.3
-                     , cassava >= 0.4.5 && < 0.6
-                     , configurator-pg >= 0.1 && < 0.2
-                     , containers >= 0.5.7 && < 0.7
-                     , contravariant >= 1.4 && < 1.6
-                     , contravariant-extras >= 0.3.3 && < 0.4
-                     , cookie >= 0.4.2 && < 0.5
-                     , either >= 4.4.1 && < 5.1
-                     , gitrev >= 1.2 && < 1.4
-                     , hasql >= 1.3 && < 1.4
-                     , hasql-pool >= 0.5 && < 0.6
-                     , hasql-transaction >= 0.7 && < 0.8
-                     , heredoc >= 0.2 && < 0.3
-                     , HTTP >= 4000.3.7 && < 4000.4
-                     , http-types >= 0.12.2 && < 0.13
-                     , insert-ordered-containers >= 0.1 && < 0.3
-                     , interpolatedstring-perl6 >= 1 && < 1.1
-                     , jose >= 0.7 && < 0.8
-                     , lens >= 4.14 && < 4.18
-                     , lens-aeson >= 1.0.1 && < 1.1
-                     , network-uri >= 2.6.1 && < 2.7
-                     , optparse-applicative >= 0.13 && < 0.15
-                     , parsec >= 3.1.11 && < 3.2
-                     , protolude >= 0.2.2 && < 0.3
-                     , Ranged-sets >= 0.3 && < 0.5
-                     , regex-tdfa >= 1.2.2 && < 1.3
-                     , scientific >= 0.3.4 && < 0.4
-                     , swagger2 >= 2.1.4 && < 2.4
-                     , text >= 1.2.2 && < 1.3
-                     , time >= 1.6 && < 1.9
-                     , unordered-containers >= 0.2.8 && < 0.3
-                     , vector >= 0.11 && < 0.13
-                     , wai >= 3.2.1 && < 3.3
-                     , wai-cors >= 0.2.5 && < 0.3
-                     , wai-extra >= 3.0.19 && < 3.1
-                     , wai-middleware-static >= 0.8.1 && < 0.9
+  exposed-modules:    PostgREST.ApiRequest
+                      PostgREST.App
+                      PostgREST.Auth
+                      PostgREST.Config
+                      PostgREST.DbRequestBuilder
+                      PostgREST.DbStructure
+                      PostgREST.Error
+                      PostgREST.Middleware
+                      PostgREST.OpenAPI
+                      PostgREST.Parsers
+                      PostgREST.QueryBuilder
+                      PostgREST.RangeQuery
+                      PostgREST.Types
+  other-modules:      Paths_postgrest
+  hs-source-dirs:     src
+  build-depends:      base                      >= 4.9 && < 4.13
+                    , HTTP                      >= 4000.3.7 && < 4000.4
+                    , Ranged-sets               >= 0.3 && < 0.5
+                    , aeson                     >= 0.11.3 && < 1.5
+                    , ansi-wl-pprint            >= 0.6.7 && < 0.7
+                    , base64-bytestring         >= 1 && < 1.1
+                    , bytestring                >= 0.10.8 && < 0.11
+                    , case-insensitive          >= 1.2 && < 1.3
+                    , cassava                   >= 0.4.5 && < 0.6
+                    , configurator-pg           >= 0.1 && < 0.2
+                    , containers                >= 0.5.7 && < 0.7
+                    , contravariant             >= 1.4 && < 1.6
+                    , contravariant-extras      >= 0.3.3 && < 0.4
+                    , cookie                    >= 0.4.2 && < 0.5
+                    , either                    >= 4.4.1 && < 5.1
+                    , gitrev                    >= 1.2 && < 1.4
+                    , hasql                     >= 1.3 && < 1.4
+                    , hasql-pool                >= 0.5 && < 0.6
+                    , hasql-transaction         >= 0.7 && < 0.8
+                    , heredoc                   >= 0.2 && < 0.3
+                    , http-types                >= 0.12.2 && < 0.13
+                    , insert-ordered-containers >= 0.1 && < 0.3
+                    , interpolatedstring-perl6  >= 1 && < 1.1
+                    , jose                      >= 0.7 && < 0.8
+                    , lens                      >= 4.14 && < 4.18
+                    , lens-aeson                >= 1.0.1 && < 1.1
+                    , network-uri               >= 2.6.1 && < 2.7
+                    , optparse-applicative      >= 0.13 && < 0.15
+                    , parsec                    >= 3.1.11 && < 3.2
+                    , protolude                 >= 0.2.2 && < 0.3
+                    , regex-tdfa                >= 1.2.2 && < 1.3
+                    , scientific                >= 0.3.4 && < 0.4
+                    , swagger2                  >= 2.1.4 && < 2.4
+                    , text                      >= 1.2.2 && < 1.3
+                    , time                      >= 1.6 && < 1.9
+                    , unordered-containers      >= 0.2.8 && < 0.3
+                    , vector                    >= 0.11 && < 0.13
+                    , wai                       >= 3.2.1 && < 3.3
+                    , wai-cors                  >= 0.2.5 && < 0.3
+                    , wai-extra                 >= 3.0.19 && < 3.1
+                    , wai-middleware-static     >= 0.8.1 && < 0.9
+  default-language:   Haskell2010
+  default-extensions: OverloadedStrings
+                      QuasiQuotes
+                      NoImplicitPrelude
 
-  Other-Modules:       Paths_postgrest
-  Exposed-Modules:     PostgREST.ApiRequest
-                     , PostgREST.App
-                     , PostgREST.Auth
-                     , PostgREST.Config
-                     , PostgREST.DbStructure
-                     , PostgREST.DbRequestBuilder
-                     , PostgREST.Error
-                     , PostgREST.Middleware
-                     , PostgREST.OpenAPI
-                     , PostgREST.Parsers
-                     , PostgREST.QueryBuilder
-                     , PostgREST.RangeQuery
-                     , PostgREST.Types
-  hs-source-dirs:      src
+executable postgrest
+  main-is:            Main.hs
+  hs-source-dirs:     main
+  build-depends:      base              >= 4.9 && < 4.13
+                    , auto-update       >= 0.1.4 && < 0.2
+                    , base64-bytestring >= 1 && < 1.1
+                    , bytestring        >= 0.10.8 && < 0.11
+                    , directory         >= 1.2.6 && < 1.4
+                    , hasql             >= 1.3 && < 1.4
+                    , hasql-pool        >= 0.5 && < 0.6
+                    , hasql-transaction >= 0.7 && < 0.8
+                    , network           < 2.9
+                    , postgrest
+                    , protolude         >= 0.2.2 && < 0.3
+                    , retry             >= 0.7.4 && < 0.9
+                    , text              >= 1.2.2 && < 1.3
+                    , time              >= 1.6 && < 1.9
+                    , warp              >= 3.2.12 && < 3.3
+  default-language:   Haskell2010
+  default-extensions: OverloadedStrings
+                      QuasiQuotes
+                      NoImplicitPrelude
+  ghc-options:        -threaded -rtsopts "-with-rtsopts=-N -I2"
 
-Test-Suite spec
-  Type:                exitcode-stdio-1.0
-  Default-Language:    Haskell2010
-  default-extensions:  OverloadedStrings, QuasiQuotes, NoImplicitPrelude
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
-  Hs-Source-Dirs:      test
-  Main-Is:             Main.hs
-  Other-Modules:       Feature.AudienceJwtSecretSpec
-                     , Feature.AuthSpec
-                     , Feature.AsymmetricJwtSpec
-                     , Feature.BinaryJwtSecretSpec
-                     , Feature.ConcurrentSpec
-                     , Feature.CorsSpec
-                     , Feature.DeleteSpec
-                     , Feature.ExtraSearchPathSpec
-                     , Feature.InsertSpec
-                     , Feature.JsonOperatorSpec
-                     , Feature.NoJwtSpec
-                     , Feature.PgVersion95Spec
-                     , Feature.PgVersion96Spec
-                     , Feature.ProxySpec
-                     , Feature.QueryLimitedSpec
-                     , Feature.QuerySpec
-                     , Feature.RangeSpec
-                     , Feature.SingularSpec
-                     , Feature.StructureSpec
-                     , Feature.UnicodeSpec
-                     , Feature.AndOrParamsSpec
-                     , Feature.RpcSpec
-                     , Feature.NonexistentSchemaSpec
-                     , Feature.UpsertSpec
-                     , SpecHelper
-                     , TestTypes
-  Build-Depends:       aeson >= 0.11.3 && < 1.5
-                     , aeson-qq >= 0.8.1 && < 0.9
-                     , async >= 2.1.1 && < 2.3
-                     , auto-update >= 0.1.4 && < 0.2
-                     , base >= 4.9 && < 4.13
-                     , bytestring >= 0.10.8 && < 0.11
-                     , base64-bytestring >= 1 && < 1.1
-                     , case-insensitive >= 1.2 && < 1.3
-                     , cassava >= 0.4.5 && < 0.6
-                     , containers >= 0.5.7 && < 0.7
-                     , contravariant >= 1.4 && < 1.6
-                     , hasql >= 1.3 && < 1.4
-                     , hasql-pool >= 0.5 && < 0.6
-                     , hasql-transaction >= 0.7 && < 0.8
-                     , heredoc >= 0.2 && < 0.3
-                     , hspec >= 2.3 && < 2.8
-                     , hspec-wai >= 0.7 && < 0.10
-                     , hspec-wai-json >= 0.7 && < 0.10
-                     , http-types >= 0.12.3 && < 0.13
-                     , lens >= 4.14 && < 4.18
-                     , lens-aeson >= 1.0.1 && < 1.1
-                     , monad-control >= 1.0.1 && < 1.1
-                     , postgrest
-                     , process >= 1.4.2 && < 1.7
-                     , protolude >= 0.2.2 && < 0.3
-                     , regex-tdfa >= 1.2.2 && < 1.3
-                     , text >= 1.2.2 && < 1.3
-                     , time >= 1.6 && < 1.9
-                     , transformers-base >= 0.4.4 && < 0.5
-                     , wai >= 3.2.1 && < 3.3
-                     , wai-extra >= 3.0.19 && < 3.1
+  if !os(windows)
+    build-depends: unix
+
+test-suite spec
+  type:               exitcode-stdio-1.0
+  main-is:            Main.hs
+  other-modules:      Feature.AndOrParamsSpec
+                      Feature.AsymmetricJwtSpec
+                      Feature.AudienceJwtSecretSpec
+                      Feature.AuthSpec
+                      Feature.BinaryJwtSecretSpec
+                      Feature.ConcurrentSpec
+                      Feature.CorsSpec
+                      Feature.DeleteSpec
+                      Feature.ExtraSearchPathSpec
+                      Feature.InsertSpec
+                      Feature.JsonOperatorSpec
+                      Feature.NoJwtSpec
+                      Feature.NonexistentSchemaSpec
+                      Feature.PgVersion95Spec
+                      Feature.PgVersion96Spec
+                      Feature.ProxySpec
+                      Feature.QueryLimitedSpec
+                      Feature.QuerySpec
+                      Feature.RangeSpec
+                      Feature.RpcSpec
+                      Feature.SingularSpec
+                      Feature.StructureSpec
+                      Feature.UnicodeSpec
+                      Feature.UpsertSpec
+                      SpecHelper
+                      TestTypes
+  hs-source-dirs:     test
+  build-depends:      base              >= 4.9 && < 4.13
+                    , aeson             >= 0.11.3 && < 1.5
+                    , aeson-qq          >= 0.8.1 && < 0.9
+                    , async             >= 2.1.1 && < 2.3
+                    , auto-update       >= 0.1.4 && < 0.2
+                    , base64-bytestring >= 1 && < 1.1
+                    , bytestring        >= 0.10.8 && < 0.11
+                    , case-insensitive  >= 1.2 && < 1.3
+                    , cassava           >= 0.4.5 && < 0.6
+                    , containers        >= 0.5.7 && < 0.7
+                    , contravariant     >= 1.4 && < 1.6
+                    , hasql             >= 1.3 && < 1.4
+                    , hasql-pool        >= 0.5 && < 0.6
+                    , hasql-transaction >= 0.7 && < 0.8
+                    , heredoc           >= 0.2 && < 0.3
+                    , hspec             >= 2.3 && < 2.8
+                    , hspec-wai         >= 0.7 && < 0.10
+                    , hspec-wai-json    >= 0.7 && < 0.10
+                    , http-types        >= 0.12.3 && < 0.13
+                    , lens              >= 4.14 && < 4.18
+                    , lens-aeson        >= 1.0.1 && < 1.1
+                    , monad-control     >= 1.0.1 && < 1.1
+                    , postgrest
+                    , process           >= 1.4.2 && < 1.7
+                    , protolude         >= 0.2.2 && < 0.3
+                    , regex-tdfa        >= 1.2.2 && < 1.3
+                    , text              >= 1.2.2 && < 1.3
+                    , time              >= 1.6 && < 1.9
+                    , transformers-base >= 0.4.4 && < 0.5
+                    , wai               >= 3.2.1 && < 3.3
+                    , wai-extra         >= 3.0.19 && < 3.1
+  default-language:   Haskell2010
+  default-extensions: OverloadedStrings
+                      QuasiQuotes
+                      NoImplicitPrelude
+  ghc-options:        -threaded -rtsopts -with-rtsopts=-N

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -86,7 +86,7 @@ library
                      , Ranged-sets == 0.3.0
                      , regex-tdfa
                      , scientific
-                     , swagger2
+                     , swagger2 < 2.4
                      , text
                      , time
                      , unordered-containers

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -31,21 +31,21 @@ executable postgrest
     -rtsopts
     "-with-rtsopts=-N -I2"
   default-language:    Haskell2010
-  build-depends:       auto-update >= 0.1.4
+  build-depends:       auto-update >= 0.1.4 && < 0.2
                      , base >= 4.9 && < 4.13
-                     , base64-bytestring >= 1.0.0.1
-                     , bytestring >= 0.10.8.1
-                     , directory >= 1.2.6.2
+                     , base64-bytestring >= 1 && < 1.1
+                     , bytestring >= 0.10.8 && < 0.11
+                     , directory >= 1.2.6 && < 1.4
                      , hasql >= 1.3 && < 1.4
                      , hasql-pool >= 0.5 && < 0.6
                      , hasql-transaction >= 0.7 && < 0.8
                      , network < 2.9
                      , postgrest
                      , protolude >= 0.2.2 && < 0.3
-                     , retry >= 0.7.4.2
-                     , text >= 1.2.2.2
-                     , time >= 1.6.0.1
-                     , warp >= 3.2.12
+                     , retry >= 0.7.4 && < 0.9
+                     , text >= 1.2.2 && < 1.3
+                     , time >= 1.6 && < 1.9
+                     , warp >= 3.2.12 && < 3.3
   if !os(windows)
     build-depends:     unix
 
@@ -54,47 +54,47 @@ executable postgrest
 library
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings, QuasiQuotes, NoImplicitPrelude
-  build-depends:       aeson >= 0.11.3
-                     , ansi-wl-pprint >=0.6.7.3
+  build-depends:       aeson >= 0.11.3 && < 1.5
+                     , ansi-wl-pprint >= 0.6.7 && < 0.7
                      , base >= 4.9 && < 4.13
-                     , base64-bytestring >= 1.0.0.1
-                     , bytestring >= 0.10.8.1
-                     , case-insensitive >= 1.2.0.9
-                     , cassava >= 0.4.5.1
+                     , base64-bytestring >= 1 && < 1.1
+                     , bytestring >= 0.10.8 && < 0.11
+                     , case-insensitive >= 1.2 && < 1.3
+                     , cassava >= 0.4.5 && < 0.6
                      , configurator-pg >= 0.1 && < 0.2
-                     , containers >= 0.5.7.1
-                     , contravariant >= 1.4
-                     , contravariant-extras >= 0.3.3.1
-                     , cookie >= 0.4.2.1
-                     , either >= 4.4.1.1
-                     , gitrev >= 1.2
+                     , containers >= 0.5.7 && < 0.7
+                     , contravariant >= 1.4 && < 1.6
+                     , contravariant-extras >= 0.3.3 && < 0.4
+                     , cookie >= 0.4.2 && < 0.5
+                     , either >= 4.4.1 && < 5.1
+                     , gitrev >= 1.2 && < 1.4
                      , hasql >= 1.3 && < 1.4
                      , hasql-pool >= 0.5 && < 0.6
                      , hasql-transaction >= 0.7 && < 0.8
-                     , heredoc >= 0.2
-                     , HTTP >= 4000.3.7
-                     , http-types >= 0.12.2
-                     , insert-ordered-containers >= 0.1.0.1
-                     , interpolatedstring-perl6 >= 1
+                     , heredoc >= 0.2 && < 0.3
+                     , HTTP >= 4000.3.7 && < 4000.4
+                     , http-types >= 0.12.2 && < 0.13
+                     , insert-ordered-containers >= 0.1 && < 0.3
+                     , interpolatedstring-perl6 >= 1 && < 1.1
                      , jose >= 0.7 && < 0.8
-                     , lens >= 4.14
-                     , lens-aeson >= 1.0.1
-                     , network-uri >= 2.6.1
+                     , lens >= 4.14 && < 4.18
+                     , lens-aeson >= 1.0.1 && < 1.1
+                     , network-uri >= 2.6.1 && < 2.7
                      , optparse-applicative >= 0.13 && < 0.15
-                     , parsec >= 3.1.11
+                     , parsec >= 3.1.11 && < 3.2
                      , protolude >= 0.2.2 && < 0.3
                      , Ranged-sets >= 0.3 && < 0.5
-                     , regex-tdfa >= 1.2.2
-                     , scientific >= 0.3.4.9
+                     , regex-tdfa >= 1.2.2 && < 1.3
+                     , scientific >= 0.3.4 && < 0.4
                      , swagger2 >= 2.1.4 && < 2.4
-                     , text >= 1.2.2.2
-                     , time >= 1.6.0.1
-                     , unordered-containers >= 0.2.8
-                     , vector >= 0.11
-                     , wai >= 3.2.1.1
-                     , wai-cors >= 0.2.5
-                     , wai-extra >= 3.0.19.1
-                     , wai-middleware-static >= 0.8.1
+                     , text >= 1.2.2 && < 1.3
+                     , time >= 1.6 && < 1.9
+                     , unordered-containers >= 0.2.8 && < 0.3
+                     , vector >= 0.11 && < 0.13
+                     , wai >= 3.2.1 && < 3.3
+                     , wai-cors >= 0.2.5 && < 0.3
+                     , wai-extra >= 3.0.19 && < 3.1
+                     , wai-middleware-static >= 0.8.1 && < 0.9
 
   Other-Modules:       Paths_postgrest
   Exposed-Modules:     PostgREST.ApiRequest
@@ -145,34 +145,34 @@ Test-Suite spec
                      , Feature.UpsertSpec
                      , SpecHelper
                      , TestTypes
-  Build-Depends:       aeson >= 0.11.3
-                     , aeson-qq >= 0.8.1
-                     , async >= 2.1.1.1
-                     , auto-update >= 0.1.4
+  Build-Depends:       aeson >= 0.11.3 && < 1.5
+                     , aeson-qq >= 0.8.1 && < 0.9
+                     , async >= 2.1.1 && < 2.3
+                     , auto-update >= 0.1.4 && < 0.2
                      , base >= 4.9 && < 4.13
-                     , bytestring >= 0.10.8.1
-                     , base64-bytestring >= 1.0.0.1
-                     , case-insensitive >= 1.2.0.9
-                     , cassava >= 0.4.5.1
-                     , containers >= 0.5.7.1
-                     , contravariant >= 1.4
+                     , bytestring >= 0.10.8 && < 0.11
+                     , base64-bytestring >= 1 && < 1.1
+                     , case-insensitive >= 1.2 && < 1.3
+                     , cassava >= 0.4.5 && < 0.6
+                     , containers >= 0.5.7 && < 0.7
+                     , contravariant >= 1.4 && < 1.6
                      , hasql >= 1.3 && < 1.4
                      , hasql-pool >= 0.5 && < 0.6
                      , hasql-transaction >= 0.7 && < 0.8
-                     , heredoc >= 0.2
-                     , hspec >= 2.3
-                     , hspec-wai >= 0.7
-                     , hspec-wai-json >= 0.7
-                     , http-types >= 0.12.3
-                     , lens >= 4.14
-                     , lens-aeson >= 1.0.1
-                     , monad-control >= 1.0.1
+                     , heredoc >= 0.2 && < 0.3
+                     , hspec >= 2.3 && < 2.8
+                     , hspec-wai >= 0.7 && < 0.10
+                     , hspec-wai-json >= 0.7 && < 0.10
+                     , http-types >= 0.12.3 && < 0.13
+                     , lens >= 4.14 && < 4.18
+                     , lens-aeson >= 1.0.1 && < 1.1
+                     , monad-control >= 1.0.1 && < 1.1
                      , postgrest
-                     , process >= 1.4.2
+                     , process >= 1.4.2 && < 1.7
                      , protolude >= 0.2.2 && < 0.3
-                     , regex-tdfa >= 1.2.2
-                     , text >= 1.2.2.2
-                     , time >= 1.6.0.1
-                     , transformers-base >= 0.4.4
-                     , wai >= 3.2.1.1
-                     , wai-extra >= 3.0.19.1
+                     , regex-tdfa >= 1.2.2 && < 1.3
+                     , text >= 1.2.2 && < 1.3
+                     , time >= 1.6 && < 1.9
+                     , transformers-base >= 0.4.4 && < 0.5
+                     , wai >= 3.2.1 && < 3.3
+                     , wai-extra >= 3.0.19 && < 3.1


### PR DESCRIPTION
I went over the PostgREST dependencies now that the problematic hjsonschema and configurator-ng dependencies are gone, with the results in this PR.

The important changes are:
- Add `base >= 4.9` to force GHC >= 8.0 for the `DuplicateRecordFields` extension.
- Add `swagger2 < 2.4` since it has incompatible changes.
- Relax the base upper bound to `< 4.13`, allowing GHC 8.6.
- Allow Ranged-sets 0.4.0 and protolude 0.2.3.

The current restrictive upper bounds seem to be:
- swagger2 < 2.4 as mentioned above.
- hasql < 1.4 due to incompatible changes in 1.4.
- jose < 0.8 due to an error message change in jose-0.8 that causes a unit test failure.

~~I've included stack configurations that I've built edge cases successfully with.~~ I compiled with tests but didn't actually run the tests in all cases.
