### PR TITLE
Tweaks to circle-ci profiling build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,8 +74,8 @@ jobs:
       - run:
           name: install stack & dependencies
           command: |
-            curl -L https://github.com/commercialhaskell/stack/releases/download/v1.1.2/stack-1.1.2-linux-x86_64.tar.gz | tar zx -C /tmp
-            sudo mv /tmp/stack-1.1.2-linux-x86_64/stack /usr/bin
+            curl -L https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-x86_64.tar.gz | tar zx -C /tmp
+            sudo mv /tmp/stack-1.9.3-linux-x86_64/stack /usr/bin
             sudo apt-get update
             sudo apt-get install -y libgmp-dev
             sudo apt-get install -y --only-upgrade binutils
@@ -122,8 +122,8 @@ jobs:
       - run:
           name: install stack & dependencies
           command: |
-            curl -L https://github.com/commercialhaskell/stack/releases/download/v1.1.2/stack-1.1.2-linux-x86_64.tar.gz | tar zx -C /tmp
-            sudo mv /tmp/stack-1.1.2-linux-x86_64/stack /usr/bin
+            curl -L https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-x86_64.tar.gz | tar zx -C /tmp
+            sudo mv /tmp/stack-1.9.3-linux-x86_64/stack /usr/bin
             sudo apt-get update
             sudo apt-get install -y libgmp-dev
             sudo apt-get install -y postgresql-client
@@ -154,8 +154,8 @@ jobs:
       - run:
           name: install stack & dependencies
           command: |
-            curl -L https://github.com/commercialhaskell/stack/releases/download/v1.1.2/stack-1.1.2-linux-x86_64.tar.gz | tar zx -C /tmp
-            sudo mv /tmp/stack-1.1.2-linux-x86_64/stack /usr/bin
+            curl -L https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-x86_64.tar.gz | tar zx -C /tmp
+            sudo mv /tmp/stack-1.9.3-linux-x86_64/stack /usr/bin
             sudo apt-get update
             sudo apt-get install -y libgmp-dev
             sudo apt-get install -y postgresql-client
@@ -186,8 +186,8 @@ jobs:
       - run:
           name: install stack & dependencies
           command: |
-            curl -L https://github.com/commercialhaskell/stack/releases/download/v1.1.2/stack-1.1.2-linux-x86_64.tar.gz | tar zx -C /tmp
-            sudo mv /tmp/stack-1.1.2-linux-x86_64/stack /usr/bin
+            curl -L https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-x86_64.tar.gz | tar zx -C /tmp
+            sudo mv /tmp/stack-1.9.3-linux-x86_64/stack /usr/bin
             sudo apt-get update
             sudo apt-get install -y libgmp-dev
             sudo apt-get install -y postgresql-client
@@ -219,8 +219,8 @@ jobs:
       - run:
           name: install stack & dependencies
           command: |
-            curl -L https://github.com/commercialhaskell/stack/releases/download/v1.1.2/stack-1.1.2-linux-x86_64.tar.gz | tar zx -C /tmp
-            sudo mv /tmp/stack-1.1.2-linux-x86_64/stack /usr/bin
+            curl -L https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-x86_64.tar.gz | tar zx -C /tmp
+            sudo mv /tmp/stack-1.9.3-linux-x86_64/stack /usr/bin
             sudo apt-get update
             sudo apt-get install -y libgmp-dev
             sudo apt-get install -y postgresql-client

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
             sudo apt-get install -y postgresql-client
             stack setup
             rm -rf $(stack path --dist-dir) $(stack path --local-install-root)
-            stack install hlint packdeps cabal-install stylish-haskell
+            stack install hlint stylish-haskell
       - run:
           name: build src and tests
           command: |

--- a/test/memory-tests.sh
+++ b/test/memory-tests.sh
@@ -90,8 +90,6 @@ postJsonArrayTest(){
   fi
 }
 
-stack build --profile
-
 setUp
 
 echo "Running memory usage tests.."


### PR DESCRIPTION
- update stack version (required to build with GHC 8.6 stackage releases)
- remove some unused packages (packdeps, cabal-install) (these aren't used and cause trouble with newer stackage releases)
- avoid rebuilding in `memory-tests.sh` (no idea why this was there)

Split out from #1319 which was getting unwieldy.