### PR TITLE
Support jose 0.8.0

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -63,7 +63,7 @@ library
                     , http-types                >= 0.12.2 && < 0.13
                     , insert-ordered-containers >= 0.1 && < 0.3
                     , interpolatedstring-perl6  >= 1 && < 1.1
-                    , jose                      >= 0.7 && < 0.8
+                    , jose                      >= 0.8 && < 0.9
                     , lens                      >= 4.14 && < 4.18
                     , lens-aeson                >= 1.0.1 && < 1.1
                     , network-uri               >= 2.6.1 && < 2.7

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,6 +12,7 @@ extra-deps:
 - text-builder-0.6.5.1
 - deferred-folds-0.9.10.1
 - primitive-0.6.4.0
+- jose-0.8.0.0
 ghc-options:
   postgrest: -O2 -Werror -Wall -fwarn-identities -fno-warn-redundant-constraints -optP-Wno-nonportable-include-path
 nix:

--- a/test/Feature/AuthSpec.hs
+++ b/test/Feature/AuthSpec.hs
@@ -117,11 +117,11 @@ spec actualPgVersion = describe "authorization" $ do
   it "hides tables from users with invalid JWT" $ do
     let auth = authHeaderJWT "ey9zdGdyZXN0X3Rlc3RfYXV0aG9yIiwiaWQiOiJqZG9lIn0.y4vZuu1dDdwAl0-S00MCRWRYMlJ5YAMSir6Es6WtWx0"
     request methodGet "/authors_only" [auth] ""
-      `shouldRespondWith` [json| {"message":"JWSError (CompactDecodeError \"expected 3 parts, got 2\")"} |]
+      `shouldRespondWith` [json| {"message":"JWSError (CompactDecodeError CompactDecodeError: Expected 3 parts; got 2)"} |]
         { matchStatus = 401
         , matchHeaders = [
             "WWW-Authenticate" <:>
-            "Bearer error=\"invalid_token\", error_description=\"JWSError (CompactDecodeError \\\"expected 3 parts, got 2\\\")\""
+            "Bearer error=\"invalid_token\", error_description=\"JWSError (CompactDecodeError CompactDecodeError: Expected 3 parts; got 2)\""
           ]
         }
 


### PR DESCRIPTION
Not sure this is necessarily a good change, but I'd like to put it up for discussion. While raising the cabal bounds, I ran into a test failure with jose 0.8.0 because the `Show` instance of a certain error message changes. (Compare https://github.com/frasertweedale/hs-jose/issues/72.)

This generalizes the corresponding test to pass with both versions. Thoughts:
- I'd assume that PostgREST doesn't want to make any guarantees about precise wording of error messages, hence testing for precise error messages is rather because that's easier to test than because we want to check the precise error message
- the generalised test code is annoyingly complicated
- maybe it would be better to make some better test helper that understands how postgrest errors look `shouldRespondWithError request (checkErrorValue :: Text -> Bool)`?
- it's also perfectly fine to just decide to keep the upper bound and just switch over to `>= 0.8 && < 0.9` at some point when needed

I ran into this because current stackage includes jose 0.8.0.