### PR TITLE
Upgrade hasql to 1.4

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -56,9 +56,9 @@ library
                     , cookie                    >= 0.4.2 && < 0.5
                     , either                    >= 4.4.1 && < 5.1
                     , gitrev                    >= 1.2 && < 1.4
-                    , hasql                     >= 1.3 && < 1.4
+                    , hasql                     >= 1.4 && < 1.5
                     , hasql-pool                >= 0.5 && < 0.6
-                    , hasql-transaction         >= 0.7 && < 0.8
+                    , hasql-transaction         >= 0.7.2 && < 0.8
                     , heredoc                   >= 0.2 && < 0.3
                     , http-types                >= 0.12.2 && < 0.13
                     , insert-ordered-containers >= 0.1 && < 0.3
@@ -94,9 +94,9 @@ executable postgrest
                     , base64-bytestring >= 1 && < 1.1
                     , bytestring        >= 0.10.8 && < 0.11
                     , directory         >= 1.2.6 && < 1.4
-                    , hasql             >= 1.3 && < 1.4
+                    , hasql             >= 1.4 && < 1.5
                     , hasql-pool        >= 0.5 && < 0.6
-                    , hasql-transaction >= 0.7 && < 0.8
+                    , hasql-transaction >= 0.7.2 && < 0.8
                     , network           < 2.9
                     , postgrest
                     , protolude         >= 0.2.2 && < 0.3
@@ -155,9 +155,9 @@ test-suite spec
                     , cassava           >= 0.4.5 && < 0.6
                     , containers        >= 0.5.7 && < 0.7
                     , contravariant     >= 1.4 && < 1.6
-                    , hasql             >= 1.3 && < 1.4
+                    , hasql             >= 1.4 && < 1.5
                     , hasql-pool        >= 0.5 && < 0.6
-                    , hasql-transaction >= 0.7 && < 0.8
+                    , hasql-transaction >= 0.7.2 && < 0.8
                     , heredoc           >= 0.2 && < 0.3
                     , hspec             >= 2.3 && < 2.8
                     , hspec-wai         >= 0.7 && < 0.10

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,6 +6,12 @@ extra-deps:
 - Ranged-sets-0.4.0
 - configurator-pg-0.1.0.3
 - http-types-0.12.3
+- hasql-1.4
+- hasql-pool-0.5.1
+- hasql-transaction-0.7.2
+- text-builder-0.6.5.1
+- deferred-folds-0.9.10.1
+- primitive-0.6.4.0
 ghc-options:
   postgrest: -O2 -Werror -Wall -fwarn-identities -fno-warn-redundant-constraints
 nix:


### PR DESCRIPTION
Another PR that's more meant to document/not lose work, not necessarily to be merged. Perhaps at some point it will be desirable to use the latest hasql version?

hasql version 1.4 changes how nullable/non-nullable values are de- and encoded. Perhaps the new API has advantages, but for now it seems to just add verbosity. For now, this PR simply emulates the old API (redundantly in both affected modules).