### PR TITLE
Fix release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ jobs:
       - image: circleci/buildpack-deps:trusty
         environment:
           - PGHOST=localhost
-      - image: circleci/postgres:11
+      - image: circleci/postgres:11.3
         environment:
           - POSTGRES_USER=circleci
           - POSTGRES_DB=circleci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+## Travis is used for building an OSX binary on new tag releases,
+## it also compiles the project on OSX for each commit to master.
+##
+## Building the whole project can take longer than 50 minutes. Since Travis has a global timeout of 50 minutes
+## we compile for 30 minutes tops(see `gtimeout 1800` below) and quit compiling with no error.
+## Since we CACHE the compile results we can continue compiling from where we left off
+## on the next commit.
 language: generic
 
 sudo: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+## AppVeyor is used for building a Windows binary on new tag releases
 platform: x64
 
 cache:
@@ -8,6 +9,7 @@ environment:
   global:
     STACK_ROOT: "c:\\sr"
     GOPATH: c:\gopath
+    TMP: "c:\\tmp"
 
 test: off
 
@@ -28,7 +30,7 @@ install:
 
 build_script:
 - stack setup --no-terminal > nul
-- stack build -j1 --copy-bins --local-bin-path .
+- bash -lc "timeout 2700 'C:\projects\postgrest\stack.exe' build -j1 --copy-bins --local-bin-path . || true"
 
 artifacts:
 - path: postgrest.exe

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,8 @@ ENV PGRST_DB_URI= \
     PGRST_JWT_AUD= \
     PGRST_MAX_ROWS= \
     PGRST_PRE_REQUEST= \
-    PGRST_ROLE_CLAIM_KEY=".role"
+    PGRST_ROLE_CLAIM_KEY=".role" \
+    PGRST_ROOT_SPEC=
 
 RUN groupadd -g 1000 postgrest && \
     useradd -r -u 1000 -g postgrest postgrest && \

--- a/docker/config.conf
+++ b/docker/config.conf
@@ -1,3 +1,0 @@
-db-uri = "postgres://app_user:password@postgres:5432/app_db"
-db-schema = "public"
-db-anon-role = "app_user"

--- a/docker/distro_release/Dockerfile.centos6
+++ b/docker/distro_release/Dockerfile.centos6
@@ -1,13 +1,14 @@
+## Centos 6 missing ghc 8.4.4 support, see https://github.com/commercialhaskell/stack/issues/4161
 FROM centos:centos6
 
 RUN yum -y update
 RUN yum -y install perl make automake gcc gmp-devel libffi zlib zlib-devel xz tar
-RUN yum -y install https://download.postgresql.org/pub/repos/yum/9.3/redhat/rhel-6-x86_64/pgdg-centos93-9.3-2.noarch.rpm
-RUN yum -y install postgresql93-devel
+RUN yum -y install https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-6-x86_64/pgdg-centos10-10-2.noarch.rpm
+RUN yum -y install postgresql10-devel
 RUN yum clean all
 RUN curl -sSL https://get.haskellstack.org/ | sh
 
-ENV PATH $PATH:/usr/pgsql-9.3/bin
+ENV PATH $PATH:/usr/pgsql-10/bin
 
 # To disable warning when building
 ENV PATH $PATH:/root/.local/bin

--- a/docker/distro_release/Dockerfile.centos7
+++ b/docker/distro_release/Dockerfile.centos7
@@ -2,12 +2,12 @@ FROM centos:centos7
 
 RUN yum -y update
 RUN yum -y install perl make automake gcc gmp-devel libffi zlib zlib-devel xz tar
-RUN yum -y install yum install https://download.postgresql.org/pub/repos/yum/9.3/redhat/rhel-7-x86_64/pgdg-centos93-9.3-2.noarch.rpm
-RUN yum -y install postgresql93-devel
+RUN yum -y install yum install https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-7-x86_64/pgdg-centos10-10-2.noarch.rpm
+RUN yum -y install postgresql10-devel
 RUN yum clean all
 RUN curl -sSL https://get.haskellstack.org/ | sh
 
-ENV PATH $PATH:/usr/pgsql-9.3/bin
+ENV PATH $PATH:/usr/pgsql-10/bin
 
 # To disable warning when building
 ENV PATH $PATH:/root/.local/bin

--- a/docker/distro_release/Dockerfile.ubuntu
+++ b/docker/distro_release/Dockerfile.ubuntu
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+## TODO pin the stack version
+#
 RUN BUILD_DEPS="curl ca-certificates build-essential" && \
     apt-get -qq update && \
     apt-get -qqy --no-install-recommends install \

--- a/docker/distro_release/Dockerfile.ubuntui386
+++ b/docker/distro_release/Dockerfile.ubuntui386
@@ -1,4 +1,6 @@
-FROM 32bit/ubuntu:16.04
+FROM i386/ubuntu:16.04
+
+## TODO pin the stack version
 
 RUN BUILD_DEPS="curl ca-certificates build-essential" && \
     apt-get -qq update && \

--- a/docker/postgrest.conf
+++ b/docker/postgrest.conf
@@ -15,3 +15,4 @@ role-claim-key = "$(PGRST_ROLE_CLAIM_KEY)"
 
 max-rows = "$(PGRST_MAX_ROWS)"
 pre-request = "$(PGRST_PRE_REQUEST)"
+root-spec = "$(PGRST_ROOT_SPEC)"


### PR DESCRIPTION
Trying to fix the release process and trying to build the binaries manually for each platform. PR not necessarily to be merged, I'm mostly documenting the workarounds I'm trying.

The [ubuntu failure](https://circleci.com/gh/PostgREST/postgrest/3311?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) is a fresh one reported in https://github.com/commercialhaskell/stack/issues/4888. I think It could be solved by pinning the stack version instead of using the latest one in the container.

Right now I'm trying manual builds on an ec2 instance but I keep getting `Unable to commit 1048576 bytes of memory` errors. Seems there's [no](https://www.reddit.com/r/haskell/comments/83ks19/unsure_how_to_deal_with_this_error/) [fix](https://gitlab.haskell.org/ghc/ghc/issues/15500) for this error, so I'll have to upgrade the ec2 to another that has more ram.

Appveyor was timing out(60 mins build time max) so I'm using something like we do for travis with the `timeout` command to not surpass that limit. However the `45 mins` cap doesn't seem to be enough for building `text-printer` https://ci.appveyor.com/project/steve-chavez/postgrest. I'll try seeing how to solve this on a Windows machine soon.

Centos images had some outdate urls so I've fixed them, however now I'm getting another error `/home/centos/.stack/indices/Hackage/01-index.cache: /home/centos/.stack/indices/Hackage/01-index.cache: openBinaryFile: does not exist`.