### PR TITLE
Windows build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,14 +13,6 @@ environment:
 
 test: off
 
-skip_non_tags: true
-
-skip_branch_with_pr: true
-
-branches:
-  only:
-    - master
-
 install:
 - set PATH=C:\Program Files\PostgreSQL\9.6\bin\;%PATH%
 - curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-x86_64

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,6 +12,12 @@ extra-deps:
 - text-builder-0.6.5.1
 - deferred-folds-0.9.10.1
 - primitive-0.6.4.0
+
+# text-printer without problematic SPECIALIZE pragmas:
+# https://github.com/mvv/text-printer/issues/1
+- git: https://github.com/robx/text-printer.git
+  commit: 4a861c1cab97d55dbd94a175e6c30367320af6eb
+
 ghc-options:
   postgrest: -O2 -Werror -Wall -fwarn-identities -fno-warn-redundant-constraints -optP-Wno-nonportable-include-path
 nix:

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,10 +13,10 @@ extra-deps:
 - deferred-folds-0.9.10.1
 - primitive-0.6.4.0
 
-# text-printer without problematic SPECIALIZE pragmas:
+# text-printer with fixed problematic SPECIALIZE pragmas:
 # https://github.com/mvv/text-printer/issues/1
-- git: https://github.com/robx/text-printer.git
-  commit: 4a861c1cab97d55dbd94a175e6c30367320af6eb
+- git: https://github.com/mvv/text-printer.git
+  commit: dd8a404ea44411285bad0d21b438f01fe7da0447
 
 ghc-options:
   postgrest: -O2 -Werror -Wall -fwarn-identities -fno-warn-redundant-constraints -optP-Wno-nonportable-include-path


### PR DESCRIPTION
This pulls in a fixed text-printer and should result in a successful Windows build.

It's branched before the jose 0.8 update since jose 0.8 causes Windows build trouble, too: https://github.com/frasertweedale/hs-jose/issues/83