### PR TITLE
appveyor: cache stack appdata directory

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ platform: x64
 cache:
 - "c:\\sr"
 - .stack-work
+- "c:\\Users\\appveyor\\AppData\\Local\\Programs\\stack"
 
 environment:
   global:


### PR DESCRIPTION
This is where stack installs GHC versions.

This fixes appveyor builds downloading GHC every single run for me.