### PR TITLE
Support PATCH for self-referencing entities

### DIFF
--- a/src/PostgREST/DbRequestBuilder.hs
+++ b/src/PostgREST/DbRequestBuilder.hs
@@ -162,6 +162,14 @@ findRelation schema allRelations nodeTableName parentNodeTableName relationDetai
           length relFColumns == 1 &&
           -- match common foreign key names(table_name_id, table_name_fk) to table_name
           (toS ("^" <> colName (unsafeHead relFColumns) <> "_?(?:|[iI][dD]|[fF][kK])$") :: BS.ByteString) =~ (toS nodeTableName :: BS.ByteString)
+        ) ||
+
+        -- self relations
+        (
+          tableName relTable == tableName relFTable &&
+          length relFColumns == 1 &&
+          -- match common foreign key names(table_name_id, table_name_fk) to table_name
+          (toS ("^" <> colName (unsafeHead relFColumns) <> "_?(?:|[iI][dD]|[fF][kK])$") :: BS.ByteString) =~ (toS nodeTableName :: BS.ByteString)
         )
 
         -- (request)        => project_id { ..., client_id{...} }

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -482,23 +482,14 @@ spec actualPgVersion = do
           [json| [{ a: "keepme", b: null }] |]
           { matchHeaders = [matchContentTypeJson] }
 
-      it "meh" $ do
-        g <- get "/s_web_content?id=eq.0"
-        liftIO $ simpleHeaders g
-          `shouldSatisfy` matchHeader "Content-Range" "0-0/*"
-        p <- request methodPatch "/s_web_content?id=eq.0&select=p_web(id, name)" [] [json| { "name":"ff" } |]
+      it "can patch a self-refering entity" $ do
+        p <- request methodPatch "/web_content?id=eq.1&select=p_web(id, name)" [] [json| { "name":"ff" } |]
         pure p `shouldRespondWith` ""
           { matchStatus  = 204,
             matchHeaders = ["Content-Range" <:> "0-0/*"]
           }
         liftIO $ lookup hContentType (simpleHeaders p) `shouldBe` Nothing
-
-        -- check it really got updated
-        g' <- get "/s_web_content?id=eq.0"
-        liftIO $ simpleHeaders g'
-          `shouldSatisfy` matchHeader "Content-Range" "0-0/*"
-        -- put value back for other tests
-        void $ request methodPatch "/s_web_content?id=eq.0&select=p_web(id, name)"[] [json| { "name":"sonic" } |]
+        void $ request methodPatch "/web_content?id=eq.1&select=p_web(id, name)" [] [json| { "name":"fezz" } |]
 
       context "filtering by a computed column" $ do
         it "is successful" $

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -482,6 +482,24 @@ spec actualPgVersion = do
           [json| [{ a: "keepme", b: null }] |]
           { matchHeaders = [matchContentTypeJson] }
 
+      it "meh" $ do
+        g <- get "/s_web_content?id=eq.0"
+        liftIO $ simpleHeaders g
+          `shouldSatisfy` matchHeader "Content-Range" "0-0/*"
+        p <- request methodPatch "/s_web_content?id=eq.0&select=p_web(id, name)" [] [json| { "name":"ff" } |]
+        pure p `shouldRespondWith` ""
+          { matchStatus  = 204,
+            matchHeaders = ["Content-Range" <:> "0-0/*"]
+          }
+        liftIO $ lookup hContentType (simpleHeaders p) `shouldBe` Nothing
+
+        -- check it really got updated
+        g' <- get "/s_web_content?id=eq.0"
+        liftIO $ simpleHeaders g'
+          `shouldSatisfy` matchHeader "Content-Range" "0-0/*"
+        -- put value back for other tests
+        void $ request methodPatch "/s_web_content?id=eq.0&select=p_web(id, name)"[] [json| { "name":"sonic" } |]
+
       context "filtering by a computed column" $ do
         it "is successful" $
           request methodPatch

--- a/test/fixtures/data.sql
+++ b/test/fixtures/data.sql
@@ -54,13 +54,6 @@ INSERT INTO web_content VALUES (0, 'tardis', null);
 INSERT INTO web_content VALUES (1, 'fezz', 0);
 
 
---
--- Data for Name: s_web_content; Type: TABLE DATA; Schema: test; Owner: -
---
-TRUNCATE TABLE s_web_content CASCADE;
-INSERT INTO s_web_content VALUES (0, 'sonic', 0);
-
-
 SET search_path = private, pg_catalog;
 
 --

--- a/test/fixtures/data.sql
+++ b/test/fixtures/data.sql
@@ -46,6 +46,21 @@ INSERT INTO users VALUES (2, 'Michael Scott');
 INSERT INTO users VALUES (3, 'Dwight Schrute');
 
 
+--
+-- Data for Name: web_content; Type: TABLE DATA; Schema: test; Owner: -
+--
+TRUNCATE TABLE web_content CASCADE;
+INSERT INTO web_content VALUES (0, 'tardis', null);
+INSERT INTO web_content VALUES (1, 'fezz', 0);
+
+
+--
+-- Data for Name: s_web_content; Type: TABLE DATA; Schema: test; Owner: -
+--
+TRUNCATE TABLE s_web_content CASCADE;
+INSERT INTO s_web_content VALUES (0, 'sonic', 0);
+
+
 SET search_path = private, pg_catalog;
 
 --

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -101,6 +101,8 @@ GRANT ALL ON TABLE
     , pgrst_reserved_chars
     , authors_w_entities
     , openapi_types
+    , web_content
+    , s_web_content
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -102,7 +102,6 @@ GRANT ALL ON TABLE
     , authors_w_entities
     , openapi_types
     , web_content
-    , s_web_content
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -757,16 +757,6 @@ CREATE TABLE web_content (
 
 
 --
--- Name: s_web_content; Type: TABLE; Schema: test; Owner: -
---
-CREATE TABLE s_web_content (
-    id integer,
-    name text,
-    p_web_id integer references web_content(id),
-    primary key (id)
-);
-
---
 -- Name: users_tasks; Type: TABLE; Schema: test; Owner: -
 --
 

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -745,6 +745,26 @@ CREATE TABLE users (
 );
 
 
+--
+-- Name: web_content; Type: TABLE; Schema: test; Owner: -
+--
+CREATE TABLE web_content (
+    id integer,
+    name text,
+    p_web_id integer references web_content(id),
+    primary key (id)
+);
+
+
+--
+-- Name: s_web_content; Type: TABLE; Schema: test; Owner: -
+--
+CREATE TABLE s_web_content (
+    id integer,
+    name text,
+    p_web_id integer references web_content(id),
+    primary key (id)
+);
 
 --
 -- Name: users_tasks; Type: TABLE; Schema: test; Owner: -


### PR DESCRIPTION
Hey
This PR aims to close #1301.

### Code duplication
I know there's a bit of code duplication but I think the `findRelation` function is easier to read this way. 

### Doubt about Relation
I was a bit confused about the `Relation` values in the `findRelation` function. 
When patching from something like `/wc?id=eq.0&select=parent(id, name)`, where `parent_id` refers to another table, say table `xyz`, the relation that is found by `findRelation` has the following:
- relTable name: xyz
- relFTable name: pg_source
- FColumns table name: wc
- relType: Parent

Shouldn't this be `relType: Child`? Since the foreign key is in `wc`. 
I'm pretty sure I'm confusing basic stuff but wanted to clear this. Is there any resource/PR/issue to read more about the `Relation` type? 