### PR TITLE
Fix long column descriptions being truncated at 63 characters in pg12

### DIFF
--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -437,7 +437,7 @@ allColumns tabs =
                 nc.nspname::information_schema.sql_identifier AS table_schema,
                 c.relname::information_schema.sql_identifier AS table_name,
                 a.attname::information_schema.sql_identifier AS column_name,
-                d.description::information_schema.sql_identifier AS description,
+                d.description AS description,
                 a.attnum::information_schema.cardinal_number AS ordinal_position,
                 pg_get_expr(ad.adbin, ad.adrelid)::information_schema.character_data AS column_default,
                     CASE

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -125,7 +125,7 @@ spec = do
                     "type": "integer"
                   },
                   "name": {
-                    "description": "child_entities name comment",
+                    "description": "child_entities name comment. Can be longer than sixty-three characters long",
                     "format": "text",
                     "type": "string"
                   },

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1226,7 +1226,7 @@ create table ranges (
 
 comment on table child_entities is 'child_entities comment';
 comment on column child_entities.id is 'child_entities id comment';
-comment on column child_entities.name is 'child_entities name comment';
+comment on column child_entities.name is 'child_entities name comment. Can be longer than sixty-three characters long';
 
 comment on table grandchild_entities is
 $$grandchild_entities summary


### PR DESCRIPTION
When testing postgREST's openAPI output, I noticed column descriptions being truncated. It turned out the issue was postgres version 12, which made this change:
([pg12 release notes](https://www.postgresql.org/docs/12/release-12.html#id-1.11.6.5.5.3.6.3))

`
Force information_schema outputs to honor the system-defined maximum 63-byte identifier length (Tom Lane)
`

Which interacts with https://github.com/PostgREST/postgrest/blob/master/src/PostgREST/DbStructure.hs#L440, where comments on columns are being cast to the `sql_identifier` type.

I don't think comments need to be cast to this type (?), so this PR
* makes the test comment a little longer to confirm there is no truncation
* removes the typecast

One can replicate this on this PR by spinning up pg12 as the db with
`docker run --name db-scripting-test -e POSTGRES_PASSWORD=pwd -p 5434:5432 -d postgres:12`

And testing

` POSTGREST_TEST_CONNECTION=$(test/create_test_db "postgres://postgres:pwd@localhost:5434" test_db) stack test --test-arguments "-m Feature.StructureSpec.OpenAPI.table"
`

The first commit in the PR fails the test (specifically `includes definitions to tables`), and then the 2nd one makes the test pass.

Unfortunately I am unfamiliar with the postgREST codebase, there may be other places where this breaks later when pg12 comes out of beta. This is only case that I have actually encountered. A (very cursory) quick skim of the other identifiers seems ok.

Have a nice day :) !