### PR TITLE
Allow select in OpenAPI for POST requests

### DIFF
--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -218,7 +218,7 @@ makePathItem (t, cs, _) = ("/" ++ unpack tn, p $ tableInsertable t)
         )
       )
     postOp = tOp
-      & parameters .~ map ref ["body." <> tn, "preferReturn"]
+      & parameters .~ map ref ["body." <> tn, "select", "preferReturn"]
       & at 201 ?~ "Created"
     patchOp = tOp
       & parameters .~ map ref (rs <> ["body." <> tn, "preferReturn"])

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -45,6 +45,7 @@ spec = do
             childGetSummary = r ^? method "get" . key "summary"
             childGetDescription = r ^? method "get" . key "description"
             getParameters = r ^? method "get" . key "parameters"
+            postParameters = r ^? method "post" . key "parameters"
             postResponse = r ^? method "post" . key "responses" . key "201" . key "description"
             patchResponse = r ^? method "patch" . key "responses" . key "204" . key "description"
             deleteResponse = r ^? method "delete" . key "responses" . key "204" . key "description"
@@ -76,6 +77,15 @@ spec = do
                 { "$ref": "#/parameters/offset" },
                 { "$ref": "#/parameters/limit" },
                 { "$ref": "#/parameters/preferCount" }
+              ]
+            |]
+
+          postParameters `shouldBe` Just
+            [aesonQQ|
+              [
+                { "$ref": "#/parameters/body.child_entities" },
+                { "$ref": "#/parameters/select" },
+                { "$ref": "#/parameters/preferReturn" }
               ]
             |]
 


### PR DESCRIPTION
If you use `return=representation`, `select` is useful in `POST` requests.
It already works correctly, but is missing from the OpenAPI spec.