### PR TITLE
Add HEAD http method support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- #1383, Add support for HEAD request - @steve-chavez
+
 ### Fixed
 
 ## [6.0.2] - 2019-08-22

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -78,6 +78,8 @@ data ApiRequest = ApiRequest {
     iAction                      :: Action
   -- | Requested range of rows within response
   , iRange                       :: M.HashMap ByteString NonnegRange
+  -- | Requested range of rows from the top level
+  , iTopLevelRange               :: NonnegRange
   -- | The target, be it calling a proc or accessing a table
   , iTarget                      :: Target
   -- | Content types the client will accept, [CTAny] if no Accept header
@@ -122,6 +124,7 @@ userApiRequest schema rootSpec req reqBody
       iAction = action
       , iTarget = target
       , iRange = ranges
+      , iTopLevelRange = topLevelRange
       , iAccepts = maybe [CTAny] (map decodeContentType . parseHttpAccept) $ lookupHeader "accept"
       , iPayload = relevantPayload
       , iPreferRepresentation = representation
@@ -186,7 +189,7 @@ userApiRequest schema rootSpec req reqBody
         Right $ ProcessedJSON (JSON.encode json) PJObject keys
       (ct, _) ->
         Left $ toS $ "Content-Type not acceptable: " <> toMime ct
-  topLevelRange = fromMaybe allRange $ M.lookup "limit" ranges
+  topLevelRange = fromMaybe allRange $ M.lookup "limit" ranges -- if no limit is specified, get all the request rows
   action =
     case method of
       "GET"      | target == TargetDefaultSpec -> ActionInspect

--- a/src/PostgREST/DbRequestBuilder.hs
+++ b/src/PostgREST/DbRequestBuilder.hs
@@ -72,7 +72,9 @@ readRequest maxRows allRels proc apiRequest  =
     buildReadRequest :: [Tree SelectItem] -> ReadRequest
     buildReadRequest fieldTree =
       let rootDepth = 0
-          rootNodeName = if action == ActionRead then rootTableName else sourceCTEName in
+          rootNodeName = case action of
+            ActionRead _ -> rootTableName
+            _            -> sourceCTEName in
       foldr (treeEntry rootDepth) (Node (Select [] rootNodeName Nothing [] [] [] [] allRange, (rootNodeName, Nothing, Nothing, Nothing, rootDepth)) []) fieldTree
       where
         treeEntry :: Depth -> Tree SelectItem -> ReadRequest -> ReadRequest
@@ -278,7 +280,7 @@ addFiltersOrdersRanges apiRequest = foldr1 (liftA2 (.)) [
     (flts, logFrst) =
       case action of
         ActionInvoke _ -> (iFilters apiRequest, iLogic apiRequest)
-        ActionRead     -> (iFilters apiRequest, iLogic apiRequest)
+        ActionRead _   -> (iFilters apiRequest, iLogic apiRequest)
         _              -> join (***) (filter (( "." `isInfixOf` ) . fst)) (iFilters apiRequest, iLogic apiRequest)
     orders :: Either ApiRequestError [(EmbedPath, [OrderTerm])]
     orders = mapM pRequestOrder $ iOrder apiRequest

--- a/src/PostgREST/QueryBuilder/Private.hs
+++ b/src/PostgREST/QueryBuilder/Private.hs
@@ -40,6 +40,10 @@ param = HE.param . HE.nonNullable
 -}
 type ResultsWithCount = (Maybe Int64, Int64, [BS.ByteString], BS.ByteString)
 
+{-| Read and Write api requests use a similar response format which includes
+    various record counts and possible location header. This is the decoder
+    for that common type of query.
+-}
 standardRow :: HD.Row ResultsWithCount
 standardRow = (,,,) <$> nullableColumn HD.int8 <*> column HD.int8
                     <*> column header <*> column HD.bytea
@@ -48,18 +52,6 @@ standardRow = (,,,) <$> nullableColumn HD.int8 <*> column HD.int8
 
 noLocationF :: Text
 noLocationF = "array[]::text[]"
-
-{-| Read and Write api requests use a similar response format which includes
-    various record counts and possible location header. This is the decoder
-    for that common type of query.
--}
-decodeStandard :: HD.Result ResultsWithCount
-decodeStandard =
-  HD.singleRow standardRow
-
-decodeStandardMay :: HD.Result (Maybe ResultsWithCount)
-decodeStandardMay =
-  HD.rowMaybe standardRow
 
 removeSourceCTESchema :: Schema -> TableName -> QualifiedIdentifier
 removeSourceCTESchema schema tbl = QualifiedIdentifier (if tbl == sourceCTEName then "" else schema) tbl

--- a/src/PostgREST/QueryBuilder/ReadStatement.hs
+++ b/src/PostgREST/QueryBuilder/ReadStatement.hs
@@ -2,6 +2,7 @@ module PostgREST.QueryBuilder.ReadStatement where
 
 import           Data.Maybe
 import           Data.Text                      (intercalate)
+import qualified Hasql.Decoders                 as HD
 import qualified Hasql.Encoders                 as HE
 import qualified Hasql.Statement                as H
 import           PostgREST.QueryBuilder.Private
@@ -30,3 +31,7 @@ createReadStatement selectQuery countQuery isSingle countTotal asCsv binaryField
     | isSingle = asJsonSingleF
     | isJust binaryField = asBinaryF $ fromJust binaryField
     | otherwise = asJsonF
+
+decodeStandard :: HD.Result ResultsWithCount
+decodeStandard =
+  HD.singleRow standardRow

--- a/src/PostgREST/QueryBuilder/WriteStatement.hs
+++ b/src/PostgREST/QueryBuilder/WriteStatement.hs
@@ -2,6 +2,7 @@ module PostgREST.QueryBuilder.WriteStatement where
 
 import           Data.Maybe
 import           Data.Text                      (intercalate, unwords)
+import qualified Hasql.Decoders                 as HD
 import qualified Hasql.Encoders                 as HE
 import qualified Hasql.Statement                as H
 import           PostgREST.ApiRequest           (PreferRepresentation (..))
@@ -13,7 +14,7 @@ import           Text.InterpolatedString.Perl6  (qc)
 
 createWriteStatement :: SqlQuery -> SqlQuery -> Bool -> Bool -> Bool ->
                         PreferRepresentation -> [Text] ->
-                        H.Statement ByteString (Maybe ResultsWithCount)
+                        H.Statement ByteString ResultsWithCount
 createWriteStatement selectQuery mutateQuery wantSingle isInsert asCsv rep pKeys =
   unicodeStatement sql (param HE.unknown) decodeStandardMay True
 
@@ -51,3 +52,7 @@ createWriteStatement selectQuery mutateQuery wantSingle isInsert asCsv rep pKeys
     | asCsv = asCsvF
     | wantSingle = asJsonSingleF
     | otherwise = asJsonF
+
+decodeStandardMay :: HD.Result ResultsWithCount
+decodeStandardMay =
+ fromMaybe (Nothing, 0, [], "") <$> HD.rowMaybe standardRow

--- a/test/Feature/RangeSpec.hs
+++ b/test/Feature/RangeSpec.hs
@@ -155,9 +155,14 @@ spec = do
           , matchHeaders = ["Content-Range" <:> "0-0/*"]
           }
 
-      it "limit and offset works on first level" $
+      it "limit and offset works on first level" $ do
         get "/items?select=id&order=id.asc&limit=3&offset=2"
           `shouldRespondWith` [json|[{"id":3},{"id":4},{"id":5}]|]
+          { matchStatus  = 200
+          , matchHeaders = ["Content-Range" <:> "2-4/*"]
+          }
+        request methodHead "/items?select=id&order=id.asc&limit=3&offset=2" [] mempty
+          `shouldRespondWith` ""
           { matchStatus  = 200
           , matchHeaders = ["Content-Range" <:> "2-4/*"]
           }

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -34,6 +34,12 @@ spec actualPgVersion =
             { matchStatus = 200
             , matchHeaders = ["Content-Range" <:> "0-0/*"]
             }
+        request methodHead "/rpc/getitemrange?min=2&max=4"
+                (rangeHdrs (ByteRangeFromTo 0 0)) ""
+           `shouldRespondWith` ""
+            { matchStatus = 200
+            , matchHeaders = ["Content-Range" <:> "0-0/*"]
+            }
 
       it "includes total count if requested" $ do
         request methodPost "/rpc/getitemrange"
@@ -46,6 +52,12 @@ spec actualPgVersion =
         request methodGet "/rpc/getitemrange?min=2&max=4"
                 (rangeHdrsWithCount (ByteRangeFromTo 0 0)) ""
            `shouldRespondWith` [json| [{"id":3}] |]
+            { matchStatus = 206
+            , matchHeaders = ["Content-Range" <:> "0-0/2"]
+            }
+        request methodHead "/rpc/getitemrange?min=2&max=4"
+                (rangeHdrsWithCount (ByteRangeFromTo 0 0)) ""
+           `shouldRespondWith` ""
             { matchStatus = 206
             , matchHeaders = ["Content-Range" <:> "0-0/2"]
             }
@@ -69,6 +81,12 @@ spec actualPgVersion =
         request methodGet "/rpc/getitemrange?min=2&max=4"
                 (acceptHdrs "text/csv") ""
            `shouldRespondWith` "id\n3\n4"
+            { matchStatus = 200
+            , matchHeaders = ["Content-Type" <:> "text/csv; charset=utf-8"]
+            }
+        request methodHead "/rpc/getitemrange?min=2&max=4"
+                (acceptHdrs "text/csv") ""
+           `shouldRespondWith` ""
             { matchStatus = 200
             , matchHeaders = ["Content-Type" <:> "text/csv; charset=utf-8"]
             }

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -21,8 +21,10 @@ spec :: SpecWith Application
 spec = do
 
   describe "OpenAPI" $ do
-    it "root path returns a valid openapi spec" $
+    it "root path returns a valid openapi spec" $ do
       validateOpenApiResponse [("Accept", "application/openapi+json")]
+      request methodHead "/" (acceptHdrs "application/openapi+json") ""
+        `shouldRespondWith` "" { matchStatus  = 200 }
 
     it "should respond to openapi request on none root path with 415" $
       request methodGet "/items"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -92,65 +92,71 @@ main = do
         , ("Feature.RawOutputTypesSpec"     , Feature.RawOutputTypesSpec.spec)
         , ("Feature.ConcurrentSpec"         , Feature.ConcurrentSpec.spec)
         , ("Feature.CorsSpec"               , Feature.CorsSpec.spec)
-        , ("Feature.DeleteSpec"             , Feature.DeleteSpec.spec)
-        , ("Feature.InsertSpec"             , Feature.InsertSpec.spec actualPgVersion)
         , ("Feature.JsonOperatorSpec"       , Feature.JsonOperatorSpec.spec actualPgVersion)
         , ("Feature.QuerySpec"              , Feature.QuerySpec.spec actualPgVersion)
         , ("Feature.RpcSpec"                , Feature.RpcSpec.spec actualPgVersion)
         , ("Feature.RangeSpec"              , Feature.RangeSpec.spec)
-        , ("Feature.SingularSpec"           , Feature.SingularSpec.spec)
         , ("Feature.StructureSpec"          , Feature.StructureSpec.spec)
         , ("Feature.AndOrParamsSpec"        , Feature.AndOrParamsSpec.spec actualPgVersion)
         ] ++ extraSpecs
 
+      mutSpecs = uncurry describe <$> [
+          ("Feature.DeleteSpec"             , Feature.DeleteSpec.spec)
+        , ("Feature.InsertSpec"             , Feature.InsertSpec.spec actualPgVersion)
+        , ("Feature.SingularSpec"           , Feature.SingularSpec.spec)
+        ]
+
   hspec $ do
-    mapM_ (beforeAll_ reset . before withApp) specs
+    -- Only certain Specs need a database reset, this should be used with care as it slows down the whole test suite.
+    mapM_ (afterAll_ reset . before withApp) mutSpecs
+
+    mapM_ (before withApp) specs
 
     -- this test runs with a raw-output-media-types set to text/html
-    beforeAll_ reset . before htmlRawOutputApp $
+    before htmlRawOutputApp $
       describe "Feature.HtmlRawOutputSpec" Feature.HtmlRawOutputSpec.spec
 
     -- this test runs with a different server flag
-    beforeAll_ reset . before ltdApp $
+    before ltdApp $
       describe "Feature.QueryLimitedSpec" Feature.QueryLimitedSpec.spec
 
     -- this test runs with a different schema
-    beforeAll_ reset . before unicodeApp $
+    before unicodeApp $
       describe "Feature.UnicodeSpec" Feature.UnicodeSpec.spec
 
     -- this test runs with a proxy
-    beforeAll_ reset . before proxyApp $
+    before proxyApp $
       describe "Feature.ProxySpec" Feature.ProxySpec.spec
 
     -- this test runs without a JWT secret
-    beforeAll_ reset . before noJwtApp $
+    before noJwtApp $
       describe "Feature.NoJwtSpec" Feature.NoJwtSpec.spec
 
     -- this test runs with a binary JWT secret
-    beforeAll_ reset . before binaryJwtApp $
+    before binaryJwtApp $
       describe "Feature.BinaryJwtSecretSpec" Feature.BinaryJwtSecretSpec.spec
 
     -- this test runs with a binary JWT secret and an audience claim
-    beforeAll_ reset . before audJwtApp $
+    before audJwtApp $
       describe "Feature.AudienceJwtSecretSpec" Feature.AudienceJwtSecretSpec.spec
 
     -- this test runs with asymmetric JWK
-    beforeAll_ reset . before asymJwkApp $
+    before asymJwkApp $
       describe "Feature.AsymmetricJwtSpec" Feature.AsymmetricJwtSpec.spec
 
     -- this test runs with asymmetric JWKSet
-    beforeAll_ reset . before asymJwkSetApp $
+    before asymJwkSetApp $
       describe "Feature.AsymmetricJwtSpec" Feature.AsymmetricJwtSpec.spec
 
     -- this test runs with a nonexistent db-schema
-    beforeAll_ reset . before nonexistentSchemaApp $
+    before nonexistentSchemaApp $
       describe "Feature.NonexistentSchemaSpec" Feature.NonexistentSchemaSpec.spec
 
     -- this test runs with an extra search path
-    beforeAll_ reset . before extraSearchPathApp $
+    before extraSearchPathApp $
       describe "Feature.ExtraSearchPathSpec" Feature.ExtraSearchPathSpec.spec
 
     -- this test runs with a root spec function override
     when (actualPgVersion >= pgVersion96) $
-      beforeAll_ reset . before rootSpecApp $
+      before rootSpecApp $
         describe "Feature.RootSpec" Feature.RootSpec.spec


### PR DESCRIPTION
For #1378.

- ~~Added support for `Prefer: count=estimate` for obtaining an EXPLAIN statement "Plan Rows". This only works for `GET /table` now. It's possible to extend it and support  `GET /rpc/func` later(it would involve changing how #1266 was implemented).~~ This will be finished on a next PR.

- Added support for HEAD requests. Basically a headers-only GET. This is for better HTTP compliance and will help later on when we focus on caching. Also helps in debugging headers with `curl -I`.

Also includes some reorganization around modules and some changes to the test suite to make it run faster.