### PR TITLE
Add support for `Prefer: count=planned/estimated` on GET /table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - #1383, Add support for HEAD request - @steve-chavez
+- #1378, Add support for `Prefer: count=estimated` on GET /table - @steve-chavez
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - #1383, Add support for HEAD request - @steve-chavez
-- #1378, Add support for `Prefer: count=estimated` on GET /table - @steve-chavez
+- #1378, Add support for `Prefer: count=estimated` and `Prefer: count=estimated-overfetched` on GET /table - @steve-chavez
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - #1383, Add support for HEAD request - @steve-chavez
-- #1378, Add support for `Prefer: count=estimated` and `Prefer: count=estimated-overfetched` on GET /table - @steve-chavez
+- #1378, Add support for `Prefer: count=planned` and `Prefer: count=estimated` on GET /table - @steve-chavez
 
 ### Changed
 

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -70,6 +70,7 @@ data Target = TargetIdent QualifiedIdentifier
 -- | How to return the inserted data
 data PreferRepresentation = Full | HeadersOnly | None deriving Eq
 
+
 {-|
   Describes what the user wants to do. This data type is a
   translation of the raw elements of an HTTP request into domain
@@ -94,8 +95,8 @@ data ApiRequest = ApiRequest {
   , iPreferRepresentation :: PreferRepresentation
   -- | How to pass parameters to a stored procedure
   , iPreferParameters     :: Maybe PreferParameters
-  -- | Whether the client wants a result count (slower)
-  , iPreferCount          :: Bool
+  -- | Whether the client wants a result count
+  , iPreferCount          :: Maybe PreferCount
   -- | Whether the client wants to UPSERT or ignore records on PK conflict
   , iPreferResolution     :: Maybe PreferResolution
   -- | Filters on the result ("id", "eq.10")
@@ -135,7 +136,9 @@ userApiRequest schema rootSpec req reqBody
       , iPreferParameters = if | hasPrefer (show SingleObject)     -> Just SingleObject
                                | hasPrefer (show MultipleObjects)  -> Just MultipleObjects
                                | otherwise                         -> Nothing
-      , iPreferCount = hasPrefer "count=exact"
+      , iPreferCount      = if | hasPrefer (show ExactCount)       -> Just ExactCount
+                               | hasPrefer (show EstimatedCount)   -> Just EstimatedCount
+                               | otherwise                         -> Nothing
       , iPreferResolution = if | hasPrefer (show MergeDuplicates)  -> Just MergeDuplicates
                                | hasPrefer (show IgnoreDuplicates) -> Just IgnoreDuplicates
                                | otherwise                         -> Nothing

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -138,6 +138,7 @@ userApiRequest schema rootSpec req reqBody
                                | otherwise                         -> Nothing
       , iPreferCount      = if | hasPrefer (show ExactCount)       -> Just ExactCount
                                | hasPrefer (show EstimatedCount)   -> Just EstimatedCount
+                               | hasPrefer (show OverfetchedCount) -> Just OverfetchedCount
                                | otherwise                         -> Nothing
       , iPreferResolution = if | hasPrefer (show MergeDuplicates)  -> Just MergeDuplicates
                                | hasPrefer (show IgnoreDuplicates) -> Just IgnoreDuplicates

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -136,9 +136,9 @@ userApiRequest schema rootSpec req reqBody
       , iPreferParameters = if | hasPrefer (show SingleObject)     -> Just SingleObject
                                | hasPrefer (show MultipleObjects)  -> Just MultipleObjects
                                | otherwise                         -> Nothing
-      , iPreferCount      = if | hasPrefer (show ExactCount)       -> Just ExactCount
-                               | hasPrefer (show EstimatedCount)   -> Just EstimatedCount
-                               | hasPrefer (show OverfetchedCount) -> Just OverfetchedCount
+      , iPreferCount      = if | hasPrefer (show ExactCount)     -> Just ExactCount
+                               | hasPrefer (show PlannedCount)   -> Just PlannedCount
+                               | hasPrefer (show EstimatedCount) -> Just EstimatedCount
                                | otherwise                         -> Nothing
       , iPreferResolution = if | hasPrefer (show MergeDuplicates)  -> Just MergeDuplicates
                                | hasPrefer (show IgnoreDuplicates) -> Just IgnoreDuplicates

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -141,7 +141,8 @@ app dbStructure proc cols conf apiRequest =
               let (tableTotal, queryTotal, _ , body) = row
               total <- if | estimatedCount   -> H.statement () explStm
                           | overfetchedCount -> if tableTotal > (fromIntegral <$> maxRows)
-                                                  then H.statement () explStm
+                                                  then do estTotal <- H.statement () explStm
+                                                          pure $ if estTotal > tableTotal then estTotal else tableTotal
                                                   else pure tableTotal
                           | otherwise        -> pure tableTotal
               let (status, contentRange) = rangeStatusHeader topLevelRange queryTotal total

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -14,6 +14,7 @@ module PostgREST.QueryBuilder (
     requestToQuery
   , requestToCountQuery
   , requestToCallProcQuery
+  , limitedQuery
   , setLocalQuery
   , setLocalSearchPathQuery
   ) where
@@ -167,19 +168,21 @@ requestToCallProcQuery qi pgArgs returnsScalar preferParams =
     callIt = fromQi qi <> "(" <> args <> ")"
 
 
--- | SQL query that only counts the root node of the DbRead Tree. It doesn't consider other nodes of the tree.
--- | It only takes WHERE into account and doesn't include LIMIT/OFFSET because it would reduce the real COUNT.
--- | doCount is used for actual COUNTing, if it's not used, EXPLAIN is used for obtaining an estimate COUNT.
-requestToCountQuery :: Schema -> Bool -> DbRequest -> SqlQuery
-requestToCountQuery _ _ (DbMutate _) = witness
-requestToCountQuery schema doCount (DbRead (Node (Select{where_=logicForest}, (mainTbl, _, _, _, _)) _)) =
+-- | SQL query meant for COUNTing the root node of the DbRead Tree.
+-- It only takes WHERE into account and doesn't include LIMIT/OFFSET because it would reduce the COUNT.
+requestToCountQuery :: Schema -> DbRequest -> SqlQuery
+requestToCountQuery _ (DbMutate _) = witness
+requestToCountQuery schema (DbRead (Node (Select{where_=logicForest}, (mainTbl, _, _, _, _)) _)) =
  unwords [
-   "SELECT " <> if doCount then "pg_catalog.count(*)" else "*",
-   "FROM ", fromQi qi,
-    ("WHERE " <> intercalate " AND " (map (pgFmtLogicTree qi) logicForest)) `emptyOnFalse` null logicForest
+   "SELECT 1",
+   "FROM " <> fromQi qi,
+   ("WHERE " <> intercalate " AND " (map (pgFmtLogicTree qi) logicForest)) `emptyOnFalse` null logicForest
    ]
  where
    qi = removeSourceCTESchema schema mainTbl
+
+limitedQuery :: SqlQuery -> Maybe Integer -> SqlQuery
+limitedQuery query maxRows = query <> maybe mempty (\x -> " LIMIT " <> show x) maxRows
 
 setLocalQuery :: Text -> (Text, Text) -> SqlQuery
 setLocalQuery prefix (k, v) =

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -170,6 +170,8 @@ requestToCallProcQuery qi pgArgs returnsScalar preferParams =
 
 -- | SQL query meant for COUNTing the root node of the DbRead Tree.
 -- It only takes WHERE into account and doesn't include LIMIT/OFFSET because it would reduce the COUNT.
+-- SELECT 1 is done instead of SELECT * to prevent doing expensive operations(like functions based on the columns)
+-- inside the FROM target.
 requestToCountQuery :: Schema -> DbRequest -> SqlQuery
 requestToCountQuery _ (DbMutate _) = witness
 requestToCountQuery schema (DbRead (Node (Select{where_=logicForest}, (mainTbl, _, _, _, _)) _)) =

--- a/src/PostgREST/QueryBuilder/Private.hs
+++ b/src/PostgREST/QueryBuilder/Private.hs
@@ -185,3 +185,13 @@ trimNullChars = T.takeWhile (/= '\x0')
 
 removeSourceCTESchema :: Schema -> TableName -> QualifiedIdentifier
 removeSourceCTESchema schema tbl = QualifiedIdentifier (if tbl == sourceCTEName then "" else schema) tbl
+
+countF :: SqlQuery -> Bool -> (SqlFragment, SqlFragment)
+countF countQuery shouldCount =
+  if shouldCount
+    then (
+        ", pg_source_count AS (" <> countQuery <> ")"
+      , "(SELECT pg_catalog.count(*) FROM pg_source_count)" )
+    else (
+        mempty
+      , "null::bigint")

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -77,15 +77,15 @@ instance Show PreferParameters where
   show MultipleObjects = "params=multiple-objects"
 
 data PreferCount
-  = ExactCount       -- ^ exact count(slower)
-  | EstimatedCount   -- ^ estimated count using EXPLAIN rows
-  | OverfetchedCount -- ^ use EXPLAIN rows if the count is superior to max-rows, otherwise get the real count.
+  = ExactCount     -- ^ exact count(slower)
+  | PlannedCount   -- ^ PostgreSQL query planner rows count guess. Done by using EXPLAIN {query}.
+  | EstimatedCount -- ^ use the query planner rows if the count is superior to max-rows, otherwise get the exact count.
   deriving Eq
 
 instance Show PreferCount where
-  show ExactCount       = "count=exact"
-  show EstimatedCount   = "count=estimated"
-  show OverfetchedCount = "count=estimated-overfetched"
+  show ExactCount     = "count=exact"
+  show PlannedCount   = "count=planned"
+  show EstimatedCount = "count=estimated"
 
 data DbStructure = DbStructure {
   dbTables      :: [Table]

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -76,6 +76,15 @@ instance Show PreferParameters where
   show SingleObject    = "params=single-object"
   show MultipleObjects = "params=multiple-objects"
 
+data PreferCount
+  = ExactCount     -- ^ exact count(slower)
+  | EstimatedCount -- ^ estimated count using EXPLAIN rows
+  deriving Eq
+
+instance Show PreferCount where
+  show ExactCount     = "count=exact"
+  show EstimatedCount = "count=estimated"
+
 data DbStructure = DbStructure {
   dbTables      :: [Table]
 , dbColumns     :: [Column]

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -77,13 +77,15 @@ instance Show PreferParameters where
   show MultipleObjects = "params=multiple-objects"
 
 data PreferCount
-  = ExactCount     -- ^ exact count(slower)
-  | EstimatedCount -- ^ estimated count using EXPLAIN rows
+  = ExactCount       -- ^ exact count(slower)
+  | EstimatedCount   -- ^ estimated count using EXPLAIN rows
+  | OverfetchedCount -- ^ use EXPLAIN rows if the count is superior to max-rows, otherwise get the real count.
   deriving Eq
 
 instance Show PreferCount where
-  show ExactCount     = "count=exact"
-  show EstimatedCount = "count=estimated"
+  show ExactCount       = "count=exact"
+  show EstimatedCount   = "count=estimated"
+  show OverfetchedCount = "count=estimated-overfetched"
 
 data DbStructure = DbStructure {
   dbTables      :: [Table]

--- a/test/Feature/QueryLimitedSpec.hs
+++ b/test/Feature/QueryLimitedSpec.hs
@@ -43,23 +43,23 @@ spec =
         , matchHeaders = ["Content-Range" <:> "0-1/*"]
         }
 
-    context "count=estimated-overfetched" $ do
-      it "estimates when query rows > maxRows" $
-        request methodHead "/getallprojects_view" [("Prefer", "count=estimated-overfetched")] ""
+    context "count=estimated" $ do
+      it "uses the query planner guess when query rows > maxRows" $
+        request methodHead "/getallprojects_view" [("Prefer", "count=estimated")] ""
           `shouldRespondWith` ""
           { matchStatus  = 206
           , matchHeaders = ["Content-Range" <:> "0-1/2019"]
           }
 
       it "gives exact count when query rows <= maxRows" $
-        request methodHead "/getallprojects_view?id=lt.3" [("Prefer", "count=estimated-overfetched")] ""
+        request methodHead "/getallprojects_view?id=lt.3" [("Prefer", "count=estimated")] ""
           `shouldRespondWith` ""
           { matchStatus  = 200
           , matchHeaders = ["Content-Range" <:> "0-1/2"]
           }
 
-      it "only uses the estimate if it's indeed greater than maxRows" $
-        request methodHead "/get_projects_above_view" [("Prefer", "count=estimated-overfetched")] ""
+      it "only uses the query planner guess if it's indeed greater than the exact count" $
+        request methodHead "/get_projects_above_view" [("Prefer", "count=estimated")] ""
           `shouldRespondWith` ""
           { matchStatus  = 206
           , matchHeaders = ["Content-Range" <:> "0-1/3"]

--- a/test/Feature/QueryLimitedSpec.hs
+++ b/test/Feature/QueryLimitedSpec.hs
@@ -13,7 +13,7 @@ import SpecHelper
 
 spec :: SpecWith Application
 spec =
-  describe "Requesting many items with server limits enabled" $ do
+  describe "Requesting many items with server limits(max-rows) enabled" $ do
     it "restricts results" $
       get "/items"
         `shouldRespondWith` [json| [{"id":1},{"id":2}] |]
@@ -29,16 +29,31 @@ spec =
           matchHeader "Content-Range" "0-0/*"
         simpleStatus r `shouldBe` ok200
 
-    it "limit works on all levels" $
+    it "works on all levels" $
       get "/users?select=id,tasks(id)&order=id.asc&tasks.order=id.asc"
         `shouldRespondWith` [json|[{"id":1,"tasks":[{"id":1},{"id":2}]},{"id":2,"tasks":[{"id":5},{"id":6}]}]|]
         { matchStatus  = 200
         , matchHeaders = ["Content-Range" <:> "0-1/*"]
         }
 
-    it "limit is not applied to parent embeds" $
+    it "is not applied to parent embeds" $
       get "/tasks?select=id,project(id)&id=gt.5"
         `shouldRespondWith` [json|[{"id":6,"project":{"id":3}},{"id":7,"project":{"id":4}}]|]
         { matchStatus  = 200
         , matchHeaders = ["Content-Range" <:> "0-1/*"]
         }
+
+    context "count=estimated-overfetched" $ do
+      it "estimates when query rows > maxRows" $
+        request methodHead "/getallprojects_view" [("Prefer", "count=estimated-overfetched")] ""
+          `shouldRespondWith` ""
+          { matchStatus  = 206
+          , matchHeaders = ["Content-Range" <:> "0-1/2019"]
+          }
+
+      it "gives exact count when query rows <= maxRows" $
+        request methodHead "/getallprojects_view?id=lt.3" [("Prefer", "count=estimated-overfetched")] ""
+          `shouldRespondWith` ""
+          { matchStatus  = 200
+          , matchHeaders = ["Content-Range" <:> "0-1/2"]
+          }

--- a/test/Feature/QueryLimitedSpec.hs
+++ b/test/Feature/QueryLimitedSpec.hs
@@ -57,3 +57,10 @@ spec =
           { matchStatus  = 200
           , matchHeaders = ["Content-Range" <:> "0-1/2"]
           }
+
+      it "only uses the estimate if it's indeed greater than maxRows" $
+        request methodHead "/get_projects_above_view" [("Prefer", "count=estimated-overfetched")] ""
+          `shouldRespondWith` ""
+          { matchStatus  = 206
+          , matchHeaders = ["Content-Range" <:> "0-1/3"]
+          }

--- a/test/Feature/RangeSpec.hs
+++ b/test/Feature/RangeSpec.hs
@@ -197,6 +197,65 @@ spec = do
           , matchHeaders = [matchContentTypeJson]
           }
 
+    context "when count=estimated" $ do
+      it "obtains a filtered range" $ do
+        request methodGet "/items?select=id&id=gt.8" [("Prefer", "count=estimated")] ""
+          `shouldRespondWith` [json|[{"id":9}, {"id":10}, {"id":11}, {"id":12}, {"id":13}, {"id":14}, {"id":15}]|]
+          { matchStatus  = 206
+          , matchHeaders = ["Content-Range" <:> "0-6/8"]
+          }
+        request methodGet "/child_entities?select=id&id=gt.3" [("Prefer", "count=estimated")] ""
+          `shouldRespondWith` [json|[{"id":4}, {"id":5}, {"id":6}]|]
+          { matchStatus  = 206
+          , matchHeaders = ["Content-Range" <:> "0-2/4"]
+          }
+        request methodGet "/getallprojects_view?select=id&id=lt.3" [("Prefer", "count=estimated")] ""
+          `shouldRespondWith` [json|[{"id":1}, {"id":2}]|]
+          { matchStatus  = 206
+          , matchHeaders = ["Content-Range" <:> "0-1/673"]
+          }
+
+      it "obtains the full range" $ do
+        request methodHead "/items" [("Prefer", "count=estimated")] ""
+          `shouldRespondWith` ""
+          { matchStatus  = 200
+          , matchHeaders = ["Content-Range" <:> "0-14/15"]
+          }
+        request methodHead "/child_entities" [("Prefer", "count=estimated")] ""
+          `shouldRespondWith` ""
+          { matchStatus  = 200
+          , matchHeaders = ["Content-Range" <:> "0-5/6"]
+          }
+        request methodHead "/getallprojects_view" [("Prefer", "count=estimated")] ""
+          `shouldRespondWith` ""
+          { matchStatus  = 206
+          , matchHeaders = ["Content-Range" <:> "0-4/2019"]
+          }
+
+      it "ignores limit/offset on the estimated count" $ do
+        request methodHead "/items?limit=2&offset=3" [("Prefer", "count=estimated")] ""
+          `shouldRespondWith` ""
+          { matchStatus  = 206
+          , matchHeaders = ["Content-Range" <:> "3-4/15"]
+          }
+        request methodHead "/child_entities?limit=2" [("Prefer", "count=estimated")] ""
+          `shouldRespondWith` ""
+          { matchStatus  = 206
+          , matchHeaders = ["Content-Range" <:> "0-1/6"]
+          }
+        request methodHead "/getallprojects_view?limit=2" [("Prefer", "count=estimated")] ""
+          `shouldRespondWith` ""
+          { matchStatus  = 206
+          , matchHeaders = ["Content-Range" <:> "0-1/2019"]
+          }
+
+      it "works with two levels" $
+        request methodHead "/child_entities?select=*,entities(*)" [("Prefer", "count=estimated")] ""
+          `shouldRespondWith` ""
+          { matchStatus  = 200
+          , matchHeaders = ["Content-Range" <:> "0-5/6"]
+          }
+
     context "with range headers" $ do
       context "of acceptable range" $ do
         it "succeeds with partial content" $ do

--- a/test/Feature/RangeSpec.hs
+++ b/test/Feature/RangeSpec.hs
@@ -197,60 +197,60 @@ spec = do
           , matchHeaders = [matchContentTypeJson]
           }
 
-    context "when count=estimated" $ do
+    context "when count=planned" $ do
       it "obtains a filtered range" $ do
-        request methodGet "/items?select=id&id=gt.8" [("Prefer", "count=estimated")] ""
+        request methodGet "/items?select=id&id=gt.8" [("Prefer", "count=planned")] ""
           `shouldRespondWith` [json|[{"id":9}, {"id":10}, {"id":11}, {"id":12}, {"id":13}, {"id":14}, {"id":15}]|]
           { matchStatus  = 206
           , matchHeaders = ["Content-Range" <:> "0-6/8"]
           }
-        request methodGet "/child_entities?select=id&id=gt.3" [("Prefer", "count=estimated")] ""
+        request methodGet "/child_entities?select=id&id=gt.3" [("Prefer", "count=planned")] ""
           `shouldRespondWith` [json|[{"id":4}, {"id":5}, {"id":6}]|]
           { matchStatus  = 206
           , matchHeaders = ["Content-Range" <:> "0-2/4"]
           }
-        request methodGet "/getallprojects_view?select=id&id=lt.3" [("Prefer", "count=estimated")] ""
+        request methodGet "/getallprojects_view?select=id&id=lt.3" [("Prefer", "count=planned")] ""
           `shouldRespondWith` [json|[{"id":1}, {"id":2}]|]
           { matchStatus  = 206
           , matchHeaders = ["Content-Range" <:> "0-1/673"]
           }
 
       it "obtains the full range" $ do
-        request methodHead "/items" [("Prefer", "count=estimated")] ""
+        request methodHead "/items" [("Prefer", "count=planned")] ""
           `shouldRespondWith` ""
           { matchStatus  = 200
           , matchHeaders = ["Content-Range" <:> "0-14/15"]
           }
-        request methodHead "/child_entities" [("Prefer", "count=estimated")] ""
+        request methodHead "/child_entities" [("Prefer", "count=planned")] ""
           `shouldRespondWith` ""
           { matchStatus  = 200
           , matchHeaders = ["Content-Range" <:> "0-5/6"]
           }
-        request methodHead "/getallprojects_view" [("Prefer", "count=estimated")] ""
+        request methodHead "/getallprojects_view" [("Prefer", "count=planned")] ""
           `shouldRespondWith` ""
           { matchStatus  = 206
           , matchHeaders = ["Content-Range" <:> "0-4/2019"]
           }
 
-      it "ignores limit/offset on the estimated count" $ do
-        request methodHead "/items?limit=2&offset=3" [("Prefer", "count=estimated")] ""
+      it "ignores limit/offset on the planned count" $ do
+        request methodHead "/items?limit=2&offset=3" [("Prefer", "count=planned")] ""
           `shouldRespondWith` ""
           { matchStatus  = 206
           , matchHeaders = ["Content-Range" <:> "3-4/15"]
           }
-        request methodHead "/child_entities?limit=2" [("Prefer", "count=estimated")] ""
+        request methodHead "/child_entities?limit=2" [("Prefer", "count=planned")] ""
           `shouldRespondWith` ""
           { matchStatus  = 206
           , matchHeaders = ["Content-Range" <:> "0-1/6"]
           }
-        request methodHead "/getallprojects_view?limit=2" [("Prefer", "count=estimated")] ""
+        request methodHead "/getallprojects_view?limit=2" [("Prefer", "count=planned")] ""
           `shouldRespondWith` ""
           { matchStatus  = 206
           , matchHeaders = ["Content-Range" <:> "0-1/2019"]
           }
 
       it "works with two levels" $
-        request methodHead "/child_entities?select=*,entities(*)" [("Prefer", "count=estimated")] ""
+        request methodHead "/child_entities?select=*,entities(*)" [("Prefer", "count=planned")] ""
           `shouldRespondWith` ""
           { matchStatus  = 200
           , matchHeaders = ["Content-Range" <:> "0-5/6"]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -65,7 +65,7 @@ main = do
   refDbStructure <- newIORef $ Just dbStructure
 
   let withApp              = return $ postgrest (testCfg testDbConn)                  refDbStructure pool getTime $ pure ()
-      ltdApp               = return $ postgrest (testLtdRowsCfg testDbConn)           refDbStructure pool getTime $ pure ()
+      maxRowsApp           = return $ postgrest (testMaxRowsCfg testDbConn)           refDbStructure pool getTime $ pure ()
       unicodeApp           = return $ postgrest (testUnicodeCfg testDbConn)           refDbStructure pool getTime $ pure ()
       proxyApp             = return $ postgrest (testProxyCfg testDbConn)             refDbStructure pool getTime $ pure ()
       noJwtApp             = return $ postgrest (testCfgNoJWT testDbConn)             refDbStructure pool getTime $ pure ()
@@ -123,7 +123,7 @@ main = do
       describe "Feature.HtmlRawOutputSpec" Feature.HtmlRawOutputSpec.spec
 
     -- this test runs with a different server flag
-    before ltdApp $
+    before maxRowsApp $
       describe "Feature.QueryLimitedSpec" Feature.QueryLimitedSpec.spec
 
     -- this test runs with a different schema

--- a/test/QueryCost.hs
+++ b/test/QueryCost.hs
@@ -37,7 +37,7 @@ main = do
         cost <- exec pool mempty $
           requestToCallProcQuery (QualifiedIdentifier "test" "getallprojects") [] False Nothing
         liftIO $
-          cost `shouldSatisfy` (< Just 20)
+          cost `shouldSatisfy` (< Just 30)
 
       it "should not exceed cost when calling scalar proc" $ do
         cost <- exec pool [str| {"a": 3, "b": 4} |] $

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -93,8 +93,8 @@ testCfgNoJWT testDbConn = (testCfg testDbConn) { configJwtSecret = Nothing }
 testUnicodeCfg :: Text -> AppConfig
 testUnicodeCfg testDbConn = (testCfg testDbConn) { configSchema = "تست" }
 
-testLtdRowsCfg :: Text -> AppConfig
-testLtdRowsCfg testDbConn = (testCfg testDbConn) { configMaxRows = Just 2 }
+testMaxRowsCfg :: Text -> AppConfig
+testMaxRowsCfg testDbConn = (testCfg testDbConn) { configMaxRows = Just 2 }
 
 testProxyCfg :: Text -> AppConfig
 testProxyCfg testDbConn = (testCfg testDbConn) { configProxyUri = Just "https://postgrest.com/openapi.json" }

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -149,6 +149,10 @@ setupDb dbConn = do
 resetDb :: Text -> IO ()
 resetDb dbConn = loadFixture dbConn "data"
 
+analyzeTable :: Text -> Text -> IO ()
+analyzeTable dbConn tableName =
+  void $ readProcess "psql" ["--set", "ON_ERROR_STOP=1", toS dbConn, "-a", "-c", toS $ "ANALYZE test.\"" <> tableName <> "\""] []
+
 loadFixture :: Text -> FilePath -> IO()
 loadFixture dbConn name =
   void $ readProcess "psql" ["--set", "ON_ERROR_STOP=1", toS dbConn, "-a", "-f", "test/fixtures/" ++ name ++ ".sql"] []

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -102,6 +102,7 @@ GRANT ALL ON TABLE
     , authors_w_entities
     , openapi_types
     , getallprojects_view
+    , get_projects_above_view
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -101,6 +101,7 @@ GRANT ALL ON TABLE
     , pgrst_reserved_chars
     , authors_w_entities
     , openapi_types
+    , getallprojects_view
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1100,7 +1100,7 @@ CREATE FUNCTION getallprojects() RETURNS SETOF projects
     LANGUAGE sql
     AS $_$
     SELECT * FROM test.projects;
-$_$;
+$_$ ROWS 2019;
 
 CREATE FUNCTION setprojects(id_l int, id_h int, name text) RETURNS SETOF projects
     LANGUAGE sql
@@ -1730,3 +1730,6 @@ select $$
 </html>
 $$::text;
 $_$ language sql;
+
+create view getallprojects_view as
+select * from getallprojects();

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1096,6 +1096,12 @@ CREATE FUNCTION get_projects_below(id int) RETURNS SETOF projects
     SELECT * FROM test.projects WHERE id < $1;
 $_$;
 
+CREATE FUNCTION get_projects_above(id int) RETURNS SETOF projects
+    LANGUAGE sql
+    AS $_$
+    SELECT * FROM test.projects WHERE id > $1;
+$_$ ROWS 1;
+
 CREATE FUNCTION getallprojects() RETURNS SETOF projects
     LANGUAGE sql
     AS $_$
@@ -1733,3 +1739,6 @@ $_$ language sql;
 
 create view getallprojects_view as
 select * from getallprojects();
+
+create view get_projects_above_view as
+select * from get_projects_above(1);


### PR DESCRIPTION
This should solve #1378.

For including some reproducible tests when using EXPLAIN, I've used ROWS from [CREATE FUNCTION](https://www.postgresql.org/docs/11/sql-createfunction.html) and wrapped the function in a VIEW.