### PR TITLE
Allow self join resource embedding on PATCH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - #1383, Add support for HEAD request - @steve-chavez
 - #1378, Add support for `Prefer: count=planned` and `Prefer: count=estimated` on GET /table - @steve-chavez
+- #1301, Allow self join resource embedding on PATCH - @herulume, @steve-chavez
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - #1383, Add support for HEAD request - @steve-chavez
 - #1378, Add support for `Prefer: count=planned` and `Prefer: count=estimated` on GET /table - @steve-chavez
-- #1301, Allow self join resource embedding on PATCH - @herulume, @steve-chavez
+- #1301, Fix self join resource embedding on PATCH - @herulume, @steve-chavez
+- #1389, Fix many to many resource embedding on RPC/PATCH - @steve-chavez
 
 ### Changed
 

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -104,7 +104,7 @@ data ApiRequest = ApiRequest {
   -- | &and and &or parameters used for complex boolean logic
   , iLogic                :: [(Text, Text)]
   -- | &select parameter used to shape the response
-  , iSelect               :: Text
+  , iSelect               :: Maybe Text
   -- | &columns parameter used to shape the payload
   , iColumns              :: Maybe Text
   -- | &order parameters for each level
@@ -145,7 +145,7 @@ userApiRequest schema rootSpec req reqBody
                                | otherwise                         -> Nothing
       , iFilters = filters
       , iLogic = [(toS k, toS $ fromJust v) | (k,v) <- qParams, isJust v, endingIn ["and", "or"] k ]
-      , iSelect = toS $ fromMaybe "*" $ join $ lookup "select" qParams
+      , iSelect = toS <$> join (lookup "select" qParams)
       , iColumns = columns
       , iOrder = [(toS k, toS $ fromJust v) | (k,v) <- qParams, isJust v, endingIn ["order"] k ]
       , iCanonicalQS = toS $ urlEncodeVars

--- a/src/PostgREST/DbRequestBuilder.hs
+++ b/src/PostgREST/DbRequestBuilder.hs
@@ -336,9 +336,13 @@ returningCols rr@(Node _ forest) = returnings
     -- `RETURNING name`(see QueryBuilder).
     -- This would make the embedding fail because the following JOIN would need the "client_id" column from projects.
     -- So this adds the foreign key columns to ensure the embedding succeeds, result would be `RETURNING name, client_id`.
+    -- This also works for the other relType's.
     fkCols = concat $ mapMaybe (\case
-        Node (_, (_, Just Relation{relFColumns=cols, relType=Parent}, _, _, _)) _ -> Just cols
-        Node (_, (_, Just Relation{relFColumns=cols, relType=Child}, _, _, _)) _  -> Just cols
+        Node (_, (_, Just Relation{relFColumns=cols, relType=relTyp}, _, _, _)) _ -> case relTyp of
+          Parent -> Just cols
+          Child  -> Just cols
+          Many   -> Just cols
+          _      -> Nothing
         _ -> Nothing
       ) forest
     -- However if the "client_id" is present, e.g. mutateRequest to /projects?select=client_id,name,clients(name)

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -434,13 +434,10 @@ type MutateRequest = MutateQuery
 type ReadNode = (ReadQuery, (NodeName, Maybe Relation, Maybe Alias, Maybe RelationDetail, Depth))
 type Depth = Integer
 
-fieldNames :: ReadRequest -> [FieldName]
-fieldNames (Node (sel, _) forest) =
-  map (fst . view _1) (select sel) ++ map colName fks
-  where
-    fks = concatMap (fromMaybe [] . f) forest
-    f (Node (_, (_, Just Relation{relFColumns=cols, relType=Parent}, _, _, _)) _) = Just cols
-    f _ = Nothing
+-- First level FieldNames(e.g get a,b from /table?select=a,b,other(c,d))
+fstFieldNames :: ReadRequest -> [FieldName]
+fstFieldNames (Node (sel, _) _) =
+  fst . view _1 <$> select sel
 
 data PgVersion = PgVersion {
   pgvNum  :: Int32

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -428,12 +428,11 @@ data MutateQuery =
   , returning :: [FieldName]
   } deriving (Show, Eq)
 
-data DbRequest = DbRead ReadRequest | DbMutate MutateRequest
 type ReadRequest = Tree ReadNode
-type ReadNode = (ReadQuery, (NodeName, Maybe Relation, Maybe Alias, Maybe RelationDetail, Depth))
--- Depth of the ReadRequest tree
-type Depth = Integer
 type MutateRequest = MutateQuery
+
+type ReadNode = (ReadQuery, (NodeName, Maybe Relation, Maybe Alias, Maybe RelationDetail, Depth))
+type Depth = Integer
 
 fieldNames :: ReadRequest -> [FieldName]
 fieldNames (Node (sel, _) forest) =

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -644,3 +644,23 @@ spec actualPgVersion = do
         { matchStatus  = 200,
           matchHeaders = [matchContentTypeJson]
         }
+
+    it "embeds an M2M relationship plus parent after update" $
+      request methodPatch "/users?id=eq.1&select=name,tasks(name,project:projects(name))"
+              [("Prefer", "return=representation")]
+        [json|{"name": "Kevin Malone"}|]
+        `shouldRespondWith`
+        [json|[
+          {
+            "name": "Kevin Malone",
+            "tasks": [
+                { "name": "Design w7", "project": { "name": "Windows 7" } },
+                { "name": "Code w7", "project": { "name": "Windows 7" } },
+                { "name": "Design w10", "project": { "name": "Windows 10" } },
+                { "name": "Code w10", "project": { "name": "Windows 10" } }
+            ]
+          }
+        ]|]
+        { matchStatus  = 200,
+          matchHeaders = [matchContentTypeJson]
+        }

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -633,8 +633,7 @@ spec actualPgVersion = do
           matchHeaders = [matchContentTypeJson]
         }
 
-    it "embeds childs after update without explicitly including the id in the ?select" $ do
-      pendingWith "currently failing"
+    it "embeds childs after update without explicitly including the id in the ?select" $
       request methodPatch "/web_content?id=eq.0&select=name,web_content(name)"
               [("Prefer", "return=representation")]
         [json|{"name": "tardis-patched"}|]

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -179,6 +179,29 @@ spec actualPgVersion =
           `shouldRespondWith` [json|[{"id": 2, "articleStars": [{"userId": 3}]}]|]
           { matchHeaders = [matchContentTypeJson] }
 
+      it "can embed an M2M relationship table" $
+        get "/rpc/getallusers?select=name,tasks(name)&id=gt.1"
+          `shouldRespondWith` [json|[
+            {"name":"Michael Scott", "tasks":[{"name":"Design IOS"}, {"name":"Code IOS"}, {"name":"Design OSX"}]},
+            {"name":"Dwight Schrute","tasks":[{"name":"Design w7"}, {"name":"Design IOS"}]}
+          ]|]
+          { matchHeaders = [matchContentTypeJson] }
+
+      it "can embed an M2M relationship table that has a parent relationship table" $
+        get "/rpc/getallusers?select=name,tasks(name,project:projects(name))&id=gt.1"
+          `shouldRespondWith` [json|[
+            {"name":"Michael Scott","tasks":[
+              {"name":"Design IOS","project":{"name":"IOS"}},
+              {"name":"Code IOS","project":{"name":"IOS"}},
+              {"name":"Design OSX","project":{"name":"OSX"}}
+            ]},
+            {"name":"Dwight Schrute","tasks":[
+              {"name":"Design w7","project":{"name":"Windows 7"}},
+              {"name":"Design IOS","project":{"name":"IOS"}}
+            ]}
+          ]|]
+          { matchHeaders = [matchContentTypeJson] }
+
     context "a proc that returns an empty rowset" $
       it "returns empty json array" $ do
         post "/rpc/test_empty_rowset" [json| {} |] `shouldRespondWith`

--- a/test/fixtures/data.sql
+++ b/test/fixtures/data.sql
@@ -499,3 +499,11 @@ COPY pgrst_reserved_chars ("*id*", ":arr->ow::cast", "(inside,parens)", "a.dotte
 2 | arrow-2 | parens-2 | dotted-2 | space-2
 3 | arrow-3 | parens-3 | dotted-3 | space-3
 \.
+
+TRUNCATE TABLE web_content CASCADE;
+INSERT INTO web_content VALUES (5, 'wat', null);
+INSERT INTO web_content VALUES (0, 'tardis', 5);
+INSERT INTO web_content VALUES (1, 'fezz', 0);
+INSERT INTO web_content VALUES (2, 'foo', 0);
+INSERT INTO web_content VALUES (3, 'bar', 0);
+INSERT INTO web_content VALUES (4, 'wut', 1);

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -103,6 +103,7 @@ GRANT ALL ON TABLE
     , openapi_types
     , getallprojects_view
     , get_projects_above_view
+    , web_content
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1749,3 +1749,7 @@ CREATE TABLE web_content (
   p_web_id integer references web_content(id),
   primary key (id)
 );
+
+CREATE FUNCTION getallusers() RETURNS SETOF users AS $$
+  SELECT * FROM test.users;
+$$ LANGUAGE sql;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1742,3 +1742,10 @@ select * from getallprojects();
 
 create view get_projects_above_view as
 select * from get_projects_above(1);
+
+CREATE TABLE web_content (
+  id integer,
+  name text,
+  p_web_id integer references web_content(id),
+  primary key (id)
+);


### PR DESCRIPTION
Fixes #1301. Continuing the work on #1358.

The main problem was in the `toSourceRelation` function, which was added in this PR https://github.com/PostgREST/postgrest/pull/331. Specifically in https://github.com/PostgREST/postgrest/commit/f02b8381eaeb8b1a26872e8be4e1c9f8830201db#diff-0721c0195214a5855036d6df3d06e076R488-R493.

The first line of that function contained some logic to replace the source tableName from the `Relation` to `pg_source` which was making the self reference case not be found by `findRelation`.

The third line of the function seems to contain some logic for handling the M2M case, however since we have https://github.com/PostgREST/postgrest/issues/1389 reported it probably means that logic never worked.

So I removed the unnecessary lines in that function(which actually didn't cause any test to fail) and just left it with the logic that converted the Relation fk tableName to `pg_source`(which actually makes sense to me). My guess is that the other lines weren't thoroughly reviewed and just something that slipped by.

Also did some refactoring and added comments, the `DbRequestBuilder` module is probably what needs it the most now. Seeing the `mapMs` in there makes me think that it could be somehow simplified with `Traversable`. I'm also hoping to refactor the `Relation` type in a next PR, it also seems backward to me as pointed in https://github.com/PostgREST/postgrest/pull/1358#issue-300720791.