### PR TITLE
Allow PATCH/DELETE w/o return=minimal when not having SELECT privileges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - #1383, Add support for HEAD request - @steve-chavez
 - #1378, Add support for `Prefer: count=planned` and `Prefer: count=estimated` on GET /table - @steve-chavez
+
+### Fixed
+
 - #1301, Fix self join resource embedding on PATCH - @herulume, @steve-chavez
 - #1389, Fix many to many resource embedding on RPC/PATCH - @steve-chavez
+- #1355, Allow PATCH/DELETE without `return=minimal` on tables with no select privileges - @steve-chavez
 
 ### Changed
 
 - #1385, bulk RPC call now should be done by specifying a `Prefer: params=multiple-objects` header - @steve-chavez
-
-### Fixed
 
 ## [6.0.2] - 2019-08-22
 

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -40,7 +40,8 @@ library
                       PostgREST.RangeQuery
                       PostgREST.Types
   other-modules:      Paths_postgrest
-                      PostgREST.QueryBuilder.Private
+                      PostgREST.Private.Common
+                      PostgREST.Private.QueryFragment
   hs-source-dirs:     src
   build-depends:      base                      >= 4.9 && < 4.13
                     , HTTP                      >= 4000.3.7 && < 4000.4

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -41,10 +41,8 @@ import Network.Wai
 
 import PostgREST.ApiRequest       (Action (..), ApiRequest (..),
                                    ContentType (..),
-                                   InvokeMethod (..),
-                                   PreferRepresentation (..),
-                                   Target (..), mutuallyAgreeable,
-                                   userApiRequest)
+                                   InvokeMethod (..), Target (..),
+                                   mutuallyAgreeable, userApiRequest)
 import PostgREST.Auth             (containsRole, jwtClaims,
                                    parseSecret)
 import PostgREST.Config           (AppConfig (..))

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -333,24 +333,23 @@ app dbStructure proc cols conf apiRequest =
         topLevelRange = iTopLevelRange apiRequest
         returnsScalar = maybe False procReturnsScalar proc
 
-        selectQuery = readRequestToQuery schema False
-        countQuery = readRequestToCountQuery schema
+        selectQuery = readRequestToQuery False
         readSqlParts tableName =
           let
             readReq = readRequest schema tableName maxRows (dbRelations dbStructure) apiRequest
           in
           (,,) <$>
           (selectQuery <$> readReq) <*>
-          (countQuery <$> readReq) <*>
+          (readRequestToCountQuery <$> readReq) <*>
           (binaryField contentType rawContentTypes returnsScalar =<< readReq)
         mutateSqlParts s t =
           let
             readReq = readRequest s t maxRows (dbRelations dbStructure) apiRequest
-            mutReq = mutateRequest apiRequest t cols (tablePKCols dbStructure s t) =<< readReq
+            mutReq = mutateRequest s t apiRequest cols (tablePKCols dbStructure s t) =<< readReq
           in
           (,) <$>
           (selectQuery <$> readReq) <*>
-          (mutateRequestToQuery s <$> mutReq)
+          (mutateRequestToQuery <$> mutReq)
 
 responseContentTypeOrError :: [ContentType] -> [ContentType] -> Action -> Target -> Either Response ContentType
 responseContentTypeOrError accepts rawContentTypes action target = serves contentTypesForRequest accepts

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -335,22 +335,22 @@ app dbStructure proc cols conf apiRequest =
         topLevelRange = iTopLevelRange apiRequest
         returnsScalar = maybe False procReturnsScalar proc
 
-        selectQuery = readRequestToQuery False
         readSqlParts s t =
           let
             readReq = readRequest s t maxRows (dbRelations dbStructure) apiRequest
           in
           (,,) <$>
-          (selectQuery <$> readReq) <*>
+          (readRequestToQuery <$> readReq) <*>
           (readRequestToCountQuery <$> readReq) <*>
           (binaryField contentType rawContentTypes returnsScalar =<< readReq)
+
         mutateSqlParts s t =
           let
             readReq = readRequest s t maxRows (dbRelations dbStructure) apiRequest
             mutReq = mutateRequest s t apiRequest cols (tablePKCols dbStructure s t) =<< readReq
           in
           (,) <$>
-          (selectQuery <$> readReq) <*>
+          (readRequestToQuery <$> readReq) <*>
           (mutateRequestToQuery <$> mutReq)
 
 responseContentTypeOrError :: [ContentType] -> [ContentType] -> Action -> Target -> Either Response ContentType

--- a/src/PostgREST/DbRequestBuilder.hs
+++ b/src/PostgREST/DbRequestBuilder.hs
@@ -33,8 +33,7 @@ import Control.Applicative
 import Data.Tree
 import Network.Wai
 
-import PostgREST.ApiRequest (Action (..), ApiRequest (..),
-                             PreferRepresentation (..))
+import PostgREST.ApiRequest (Action (..), ApiRequest (..))
 import PostgREST.Error      (ApiRequestError (..), errorResponseFor)
 import PostgREST.Parsers
 import PostgREST.RangeQuery (NonnegRange, allRange, restrictRange)

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -40,20 +40,9 @@ import Unsafe                        (unsafeHead)
 
 import Control.Applicative
 
+import PostgREST.Private.Common
 import PostgREST.Types
 import Protolude
-
-column :: HD.Value a -> HD.Row a
-column = HD.column . HD.nonNullable
-
-nullableColumn :: HD.Value a -> HD.Row (Maybe a)
-nullableColumn = HD.column . HD.nullable
-
-element :: HD.Value a -> HD.Array a
-element = HD.element . HD.nonNullable
-
-param :: HE.Value a -> HE.Params a
-param = HE.param . HE.nonNullable
 
 getDbStructure :: Schema -> PgVersion -> HT.Transaction DbStructure
 getDbStructure schema pgVer = do

--- a/src/PostgREST/Private/Common.hs
+++ b/src/PostgREST/Private/Common.hs
@@ -1,0 +1,22 @@
+{-|
+Module      : PostgREST.Common
+Description : Common helper functions.
+-}
+module PostgREST.Private.Common where
+
+import           Data.Maybe
+import qualified Hasql.Decoders as HD
+import qualified Hasql.Encoders as HE
+import           Protolude
+
+column :: HD.Value a -> HD.Row a
+column = HD.column . HD.nonNullable
+
+nullableColumn :: HD.Value a -> HD.Row (Maybe a)
+nullableColumn = HD.column . HD.nullable
+
+element :: HD.Value a -> HD.Array a
+element = HD.element . HD.nonNullable
+
+param :: HE.Value a -> HE.Params a
+param = HE.param . HE.nonNullable

--- a/src/PostgREST/Private/QueryFragment.hs
+++ b/src/PostgREST/Private/QueryFragment.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE LambdaCase #-}
 {-|
-Module      : PostgREST.QueryBuilder.Private
+Module      : PostgREST.Private.QueryFragment
 Description : Helper functions for PostgREST.QueryBuilder.
 
 Any function that outputs a SqlFragment should be in this module.
 -}
-module PostgREST.QueryBuilder.Private where
+module PostgREST.Private.QueryFragment where
 
 import qualified Data.HashMap.Strict           as HM
 import           Data.Maybe

--- a/src/PostgREST/Private/QueryFragment.hs
+++ b/src/PostgREST/Private/QueryFragment.hs
@@ -191,3 +191,9 @@ countF countQuery shouldCount =
     else (
         mempty
       , "null::bigint")
+
+returningF :: QualifiedIdentifier -> [FieldName] -> SqlFragment
+returningF qi returnings =
+  if null returnings
+    then "RETURNING 1" -- For mutation cases where there's no ?select, we return 1 to know how many rows were modified
+    else "RETURNING " <> intercalate ", " (pgFmtColumn qi <$> returnings)

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -27,12 +27,12 @@ import Data.Tree (Tree (..))
 
 import Data.Maybe
 
-import PostgREST.QueryBuilder.Private
-import PostgREST.RangeQuery           (allRange, rangeLimit,
-                                       rangeOffset)
+import PostgREST.Private.QueryFragment
+import PostgREST.RangeQuery            (allRange, rangeLimit,
+                                        rangeOffset)
 import PostgREST.Types
-import Protolude                      hiding (cast, intercalate,
-                                       replace)
+import Protolude                       hiding (cast, intercalate,
+                                        replace)
 
 readRequestToQuery :: Bool -> ReadRequest -> SqlQuery
 readRequestToQuery isParent (Node (Select colSelects mainQi tblAlias implJoins logicForest joinConditions_ ordts range, _) forest) =

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -7,7 +7,7 @@ Module      : PostgREST.QueryBuilder
 Description : PostgREST SQL queries generating functions.
 
 This module provides functions to consume data types that
-represent database objects (e.g. Relation, Schema) and SqlFragment
+represent database queries (e.g. ReadRequest, MutateRequest) and SqlFragment
 to produce SqlQuery type outputs.
 -}
 module PostgREST.QueryBuilder (
@@ -34,8 +34,8 @@ import PostgREST.Types
 import Protolude                      hiding (cast, intercalate,
                                        replace)
 
-readRequestToQuery :: Schema -> Bool -> ReadRequest -> SqlQuery
-readRequestToQuery schema isParent (Node (Select colSelects tbl tblAlias implJoins logicForest joinConditions_ ordts range, _) forest) =
+readRequestToQuery :: Bool -> ReadRequest -> SqlQuery
+readRequestToQuery isParent (Node (Select colSelects mainQi tblAlias implJoins logicForest joinConditions_ ordts range, _) forest) =
   unwords [
     "SELECT " <> intercalate ", " (map (pgFmtSelectItem qi) colSelects ++ selects),
     "FROM " <> intercalate ", " (tabl : implJs),
@@ -46,8 +46,7 @@ readRequestToQuery schema isParent (Node (Select colSelects tbl tblAlias implJoi
     ("LIMIT " <> maybe "ALL" show (rangeLimit range) <> " OFFSET " <> show (rangeOffset range)) `emptyOnFalse` (isParent || range == allRange) ]
 
   where
-    implJs = fromQi . QualifiedIdentifier schema <$> implJoins
-    mainQi = removeSourceCTESchema schema tbl
+    implJs = fromQi <$> implJoins
     tabl = fromQi mainQi <> maybe mempty (\a -> " AS " <> pgFmtIdent a) tblAlias
     qi = maybe mainQi (QualifiedIdentifier mempty) tblAlias
 
@@ -60,37 +59,37 @@ readRequestToQuery schema isParent (Node (Select colSelects tbl tblAlias implJoi
            <> "SELECT json_agg(" <> pgFmtIdent table <> ".*) "
            <> "FROM (" <> subquery <> ") " <> pgFmtIdent table
            <> "), '[]') AS " <> pgFmtIdent (fromMaybe name alias)
-           where subquery = readRequestToQuery schema False (Node n forst)
+           where subquery = readRequestToQuery False (Node n forst)
     getQueryParts (Node n@(_, (name, Just Relation{relType=Parent,relTable=Table{tableName=table}}, alias, _, _)) forst) (j,s) = (joi:j,sel:s)
       where
         aliasOrName = fromMaybe name alias
         localTableName = pgFmtIdent $ table <> "_" <> aliasOrName
         sel = "row_to_json(" <> localTableName <> ".*) AS " <> pgFmtIdent aliasOrName
         joi = " LEFT JOIN LATERAL( " <> subquery <> " ) AS " <> localTableName <> " ON TRUE "
-          where subquery = readRequestToQuery schema True (Node n forst)
+          where subquery = readRequestToQuery True (Node n forst)
     getQueryParts (Node n@(_, (name, Just Relation{relType=Many,relTable=Table{tableName=table}}, alias, _, _)) forst) (j,s) = (j,sel:s)
       where
         sel = "COALESCE (("
            <> "SELECT json_agg(" <> pgFmtIdent table <> ".*) "
            <> "FROM (" <> subquery <> ") " <> pgFmtIdent table
            <> "), '[]') AS " <> pgFmtIdent (fromMaybe name alias)
-           where subquery = readRequestToQuery schema False (Node n forst)
+           where subquery = readRequestToQuery False (Node n forst)
     --the following is just to remove the warning
     --getQueryParts is not total but readRequestToQuery is called only after addJoinConditions which ensures the only
     --posible relations are Child Parent Many
     getQueryParts _ _ = witness
 
 
-mutateRequestToQuery :: Schema -> MutateRequest -> SqlQuery
-mutateRequestToQuery schema (Insert mainTbl iCols onConflct putConditions returnings) =
+mutateRequestToQuery :: MutateRequest -> SqlQuery
+mutateRequestToQuery (Insert mainQi iCols onConflct putConditions returnings) =
   unwords [
     "WITH " <> normalizedBody,
-    "INSERT INTO ", fromQi qi, if S.null iCols then " " else "(" <> cols <> ")",
+    "INSERT INTO ", fromQi mainQi, if S.null iCols then " " else "(" <> cols <> ")",
     unwords [
       "SELECT " <> cols <> " FROM",
-      "json_populate_recordset", "(null::", fromQi qi, ", " <> selectBody <> ") _",
+      "json_populate_recordset", "(null::", fromQi mainQi, ", " <> selectBody <> ") _",
       -- Only used for PUT
-      ("WHERE " <> intercalate " AND " (pgFmtLogicTree (QualifiedIdentifier "" "_") <$> putConditions)) `emptyOnFalse` null putConditions],
+      ("WHERE " <> intercalate " AND " (pgFmtLogicTree (QualifiedIdentifier mempty "_") <$> putConditions)) `emptyOnFalse` null putConditions],
     maybe "" (\(oncDo, oncCols) -> (
       "ON CONFLICT(" <> intercalate ", " (pgFmtIdent <$> oncCols) <> ") " <> case oncDo of
       IgnoreDuplicates ->
@@ -100,33 +99,29 @@ mutateRequestToQuery schema (Insert mainTbl iCols onConflct putConditions return
            then "DO NOTHING"
            else "DO UPDATE SET " <> intercalate ", " (pgFmtIdent <> const " = EXCLUDED." <> pgFmtIdent <$> S.toList iCols)
                                    ) `emptyOnFalse` null oncCols) onConflct,
-    ("RETURNING " <> intercalate ", " (map (pgFmtColumn qi) returnings)) `emptyOnFalse` null returnings]
+    ("RETURNING " <> intercalate ", " (map (pgFmtColumn mainQi) returnings)) `emptyOnFalse` null returnings]
   where
-    qi = QualifiedIdentifier schema mainTbl
     cols = intercalate ", " $ pgFmtIdent <$> S.toList iCols
-mutateRequestToQuery schema (Update mainTbl uCols logicForest returnings) =
+mutateRequestToQuery (Update mainQi uCols logicForest returnings) =
   if S.null uCols
     then "WITH " <> ignoredBody <> "SELECT null WHERE false" -- if there are no columns we cannot do UPDATE table SET {empty}, it'd be invalid syntax
     else
       unwords [
         "WITH " <> normalizedBody,
-        "UPDATE " <> fromQi qi <> " SET " <> cols,
-        "FROM (SELECT * FROM json_populate_recordset", "(null::", fromQi qi, ", " <> selectBody <> ")) _ ",
-        ("WHERE " <> intercalate " AND " (pgFmtLogicTree qi <$> logicForest)) `emptyOnFalse` null logicForest,
-        ("RETURNING " <> intercalate ", " (pgFmtColumn qi <$> returnings)) `emptyOnFalse` null returnings
+        "UPDATE " <> fromQi mainQi <> " SET " <> cols,
+        "FROM (SELECT * FROM json_populate_recordset", "(null::", fromQi mainQi, ", " <> selectBody <> ")) _ ",
+        ("WHERE " <> intercalate " AND " (pgFmtLogicTree mainQi <$> logicForest)) `emptyOnFalse` null logicForest,
+        ("RETURNING " <> intercalate ", " (pgFmtColumn mainQi <$> returnings)) `emptyOnFalse` null returnings
         ]
   where
-    qi = QualifiedIdentifier schema mainTbl
     cols = intercalate ", " (pgFmtIdent <> const " = _." <> pgFmtIdent <$> S.toList uCols)
-mutateRequestToQuery schema (Delete mainTbl logicForest returnings) =
+mutateRequestToQuery (Delete mainQi logicForest returnings) =
   unwords [
     "WITH " <> ignoredBody,
-    "DELETE FROM ", fromQi qi,
-    ("WHERE " <> intercalate " AND " (map (pgFmtLogicTree qi) logicForest)) `emptyOnFalse` null logicForest,
-    ("RETURNING " <> intercalate ", " (map (pgFmtColumn qi) returnings)) `emptyOnFalse` null returnings
+    "DELETE FROM ", fromQi mainQi,
+    ("WHERE " <> intercalate " AND " (map (pgFmtLogicTree mainQi) logicForest)) `emptyOnFalse` null logicForest,
+    ("RETURNING " <> intercalate ", " (map (pgFmtColumn mainQi) returnings)) `emptyOnFalse` null returnings
     ]
-  where
-    qi = QualifiedIdentifier schema mainTbl
 
 requestToCallProcQuery :: QualifiedIdentifier -> [PgArg] -> Bool -> Maybe PreferParameters -> SqlQuery
 requestToCallProcQuery qi pgArgs returnsScalar preferParams =
@@ -176,15 +171,13 @@ requestToCallProcQuery qi pgArgs returnsScalar preferParams =
 -- It only takes WHERE into account and doesn't include LIMIT/OFFSET because it would reduce the COUNT.
 -- SELECT 1 is done instead of SELECT * to prevent doing expensive operations(like functions based on the columns)
 -- inside the FROM target.
-readRequestToCountQuery :: Schema -> ReadRequest -> SqlQuery
-readRequestToCountQuery schema (Node (Select{where_=logicForest}, (mainTbl, _, _, _, _)) _) =
+readRequestToCountQuery :: ReadRequest -> SqlQuery
+readRequestToCountQuery (Node (Select{from=qi, where_=logicForest}, _) _) =
  unwords [
    "SELECT 1",
    "FROM " <> fromQi qi,
    ("WHERE " <> intercalate " AND " (map (pgFmtLogicTree qi) logicForest)) `emptyOnFalse` null logicForest
    ]
- where
-   qi = removeSourceCTESchema schema mainTbl
 
 limitedQuery :: SqlQuery -> Maybe Integer -> SqlQuery
 limitedQuery query maxRows = query <> maybe mempty (\x -> " LIMIT " <> show x) maxRows

--- a/src/PostgREST/Statements.hs
+++ b/src/PostgREST/Statements.hs
@@ -17,22 +17,25 @@ module PostgREST.Statements (
 ) where
 
 
-import           Control.Lens                   ((^?))
-import           Data.Aeson                     as JSON
-import qualified Data.Aeson.Lens                as L
-import qualified Data.ByteString.Char8          as BS
+import           Control.Lens                    ((^?))
+import           Data.Aeson                      as JSON
+import qualified Data.Aeson.Lens                 as L
+import qualified Data.ByteString.Char8           as BS
 import           Data.Maybe
-import           Data.Text                      (intercalate, unwords)
-import           Data.Text.Encoding             (encodeUtf8)
-import qualified Hasql.Decoders                 as HD
-import qualified Hasql.Encoders                 as HE
-import qualified Hasql.Statement                as H
-import           PostgREST.ApiRequest           (PreferRepresentation (..))
-import           PostgREST.QueryBuilder.Private
+import           Data.Text                       (intercalate,
+                                                  unwords)
+import           Data.Text.Encoding              (encodeUtf8)
+import qualified Hasql.Decoders                  as HD
+import qualified Hasql.Encoders                  as HE
+import qualified Hasql.Statement                 as H
+import           PostgREST.ApiRequest            (PreferRepresentation (..))
+import           PostgREST.Private.Common
+import           PostgREST.Private.QueryFragment
 import           PostgREST.Types
-import           Protolude                      hiding (cast,
-                                                 intercalate, replace)
-import           Text.InterpolatedString.Perl6  (qc)
+import           Protolude                       hiding (cast,
+                                                  intercalate,
+                                                  replace)
+import           Text.InterpolatedString.Perl6   (qc)
 
 {-| The generic query result format used by API responses. The location header
     is represented as a list of strings containing variable bindings like
@@ -187,17 +190,3 @@ createExplainStatement countQuery =
 
 unicodeStatement :: Text -> HE.Params a -> HD.Result b -> Bool -> H.Statement a b
 unicodeStatement = H.Statement . encodeUtf8
-
--- Helper hasql functions
-
-column :: HD.Value a -> HD.Row a
-column = HD.column . HD.nonNullable
-
-nullableColumn :: HD.Value a -> HD.Row (Maybe a)
-nullableColumn = HD.column . HD.nullable
-
-element :: HD.Value a -> HD.Array a
-element = HD.element . HD.nonNullable
-
-param :: HE.Value a -> HE.Params a
-param = HE.param . HE.nonNullable

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -70,6 +70,16 @@ instance Show PreferResolution where
   show MergeDuplicates  = "resolution=merge-duplicates"
   show IgnoreDuplicates = "resolution=ignore-duplicates"
 
+-- | How to return the mutated data. From https://tools.ietf.org/html/rfc7240#section-4.2
+data PreferRepresentation = Full        -- ^ Return the body plus the Location header(in case of POST).
+                          | HeadersOnly -- ^ Return the Location header(in case of POST). This needs a SELECT privilege on the pk.
+                          | None        -- ^ Return nothing from the mutated data.
+                          deriving Eq
+instance Show PreferRepresentation where
+  show Full        = "return=representation"
+  show None        = "return=minimal"
+  show HeadersOnly = mempty
+
 data PreferParameters
   = SingleObject    -- ^ Pass all parameters as a single json object to a stored procedure
   | MultipleObjects -- ^ Pass an array of json objects as params to a stored procedure

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -188,6 +188,9 @@ data Table = Table {
 instance Eq Table where
   Table{tableSchema=s1,tableName=n1} == Table{tableSchema=s2,tableName=n2} = s1 == s2 && n1 == n2
 
+tableQi :: Table -> QualifiedIdentifier
+tableQi Table{tableSchema=s, tableName=n} = QualifiedIdentifier s n
+
 newtype ForeignKey = ForeignKey { fkCol :: Column } deriving (Show, Eq, Ord)
 
 data Column =
@@ -397,11 +400,11 @@ data JoinCondition = JoinCondition (QualifiedIdentifier, FieldName)
 
 data ReadQuery = Select {
     select         :: [SelectItem]
-  , from           :: TableName
+  , from           :: QualifiedIdentifier
 -- | A table alias is used in case of self joins
   , fromAlias      :: Maybe Alias
 -- | Only used for Many to Many joins. Parent and Child joins use explicit joins.
-  , implicitJoins  :: [TableName]
+  , implicitJoins  :: [QualifiedIdentifier]
   , where_         :: [LogicTree]
   , joinConditions :: [JoinCondition]
   , order          :: [OrderTerm]
@@ -410,20 +413,20 @@ data ReadQuery = Select {
 
 data MutateQuery =
   Insert {
-    in_        :: TableName
+    in_        :: QualifiedIdentifier
   , insCols    :: S.Set FieldName
   , onConflict :: Maybe (PreferResolution, [FieldName])
   , where_     :: [LogicTree]
   , returning  :: [FieldName]
   }|
   Update {
-    in_       :: TableName
+    in_       :: QualifiedIdentifier
   , updCols   :: S.Set FieldName
   , where_    :: [LogicTree]
   , returning :: [FieldName]
   }|
   Delete {
-    in_       :: TableName
+    in_       :: QualifiedIdentifier
   , where_    :: [LogicTree]
   , returning :: [FieldName]
   } deriving (Show, Eq)

--- a/test/Feature/QueryLimitedSpec.hs
+++ b/test/Feature/QueryLimitedSpec.hs
@@ -36,9 +36,16 @@ spec =
         , matchHeaders = ["Content-Range" <:> "0-1/*"]
         }
 
-    it "is not applied to parent embeds" $
+    it "succeeds in getting parent embeds despite the limit, see #647" $
       get "/tasks?select=id,project(id)&id=gt.5"
         `shouldRespondWith` [json|[{"id":6,"project":{"id":3}},{"id":7,"project":{"id":4}}]|]
+        { matchStatus  = 200
+        , matchHeaders = ["Content-Range" <:> "0-1/*"]
+        }
+
+    it "can offset the parent embed, being consistent with the other embed types" $
+      get "/tasks?select=id,project:projects(id)&id=gt.5&project.offset=1"
+        `shouldRespondWith` [json|[{"id":6,"project":null}, {"id":7,"project":null}]|]
         { matchStatus  = 200
         , matchHeaders = ["Content-Range" <:> "0-1/*"]
         }

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -23,7 +23,7 @@ import Test.Hspec.Wai
 import Text.Heredoc
 
 import PostgREST.Config (AppConfig (..))
-import PostgREST.Types  (JSPathExp (..), QualifiedIdentifier (..))
+import PostgREST.Types  (JSPathExp (..))
 import Protolude
 
 matchContentTypeJson :: MatchHeader
@@ -131,7 +131,7 @@ testCfgExtraSearchPath :: Text -> AppConfig
 testCfgExtraSearchPath testDbConn = (testCfg testDbConn) { configExtraSearchPath = ["public", "extensions"] }
 
 testCfgRootSpec :: Text -> AppConfig
-testCfgRootSpec testDbConn = (testCfg testDbConn) { configRootSpec = Just $ QualifiedIdentifier "test" "root"}
+testCfgRootSpec testDbConn = (testCfg testDbConn) { configRootSpec = Just "root"}
 
 testCfgHtmlRawOutput :: Text -> AppConfig
 testCfgHtmlRawOutput testDbConn = (testCfg testDbConn) { configRawMediaTypes = ["text/html"] }

--- a/test/fixtures/data.sql
+++ b/test/fixtures/data.sql
@@ -507,3 +507,8 @@ INSERT INTO web_content VALUES (1, 'fezz', 0);
 INSERT INTO web_content VALUES (2, 'foo', 0);
 INSERT INTO web_content VALUES (3, 'bar', 0);
 INSERT INTO web_content VALUES (4, 'wut', 1);
+
+TRUNCATE TABLE app_users CASCADE;
+INSERT INTO app_users (id, email, "password") VALUES (1, 'test@123.com','pass');
+INSERT INTO app_users (id, email, "password") VALUES (2, 'abc@123.com','pass');
+INSERT INTO app_users (id, email, "password") VALUES (3, 'def@123.com','pass');

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -123,6 +123,10 @@ GRANT SELECT (article_id, user_id) ON TABLE limited_article_stars TO postgrest_t
 GRANT INSERT (article_id, user_id) ON TABLE limited_article_stars TO postgrest_test_anonymous;
 GRANT UPDATE (article_id, user_id) ON TABLE limited_article_stars TO postgrest_test_anonymous;
 
+GRANT SELECT(id, email) ON TABLE app_users TO postgrest_test_anonymous;
+GRANT INSERT, UPDATE    ON TABLE app_users TO postgrest_test_anonymous;
+GRANT DELETE            ON TABLE app_users TO postgrest_test_anonymous;
+
 REVOKE EXECUTE ON FUNCTION privileged_hello(text) FROM PUBLIC; -- All functions are available to every role(PUBLIC) by default
 GRANT EXECUTE ON FUNCTION privileged_hello(text) TO postgrest_test_author;
 

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1753,3 +1753,9 @@ CREATE TABLE web_content (
 CREATE FUNCTION getallusers() RETURNS SETOF users AS $$
   SELECT * FROM test.users;
 $$ LANGUAGE sql;
+
+create table app_users (
+  id       integer    primary key,
+  email    text       unique not null,
+  password text       not null
+);


### PR DESCRIPTION
Fixes #1355.

Basically, `return=minimal` was introduced to prevent failure on a POST when the requester doesn't have SELECT rights on the table(see https://github.com/PostgREST/postgrest/issues/399). `return=minimal` is needed because POST by default generates a `Location` header based on the table PK.

However for PATCH/DELETE we don't need to look at the table PK since no special header is added for these methods. So, we can allow these requests to be successful by default w/o `return=minimal` by doing a `RETURNING 1` instead of `RETURNING *` on the generated queries. If `return=minimal` is specified for these methods, we get the same behavior, so no breaking change.

The `RETURNING 1` also ensures we get the correct http status response since we'll know if a row was updated/deleted without having SELECT privileges.

Also made some cleaning/refactoring in functions that took a `schema` argument. This will help pave the way towards implementing #1106.