### PR TITLE
Improve disambiguation error message

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2014 Joe Nelson
+Copyright (c) 2019 Steve Chavez
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -6,8 +6,8 @@ description:        Reads the schema of a PostgreSQL database and creates RESTfu
                     permits.
 license:            MIT
 license-file:       LICENSE
-author:             Joe Nelson, Adam Baker
-maintainer:         Steve Chávez <stevechavezast@gmail.com>
+author:             Joe Nelson, Adam Baker, Steve Chavez
+maintainer:         Steve Chavez <stevechavezast@gmail.com>
 category:           Executable, PostgreSQL, Network APIs
 homepage:           https://postgrest.org
 bug-reports:        https://github.com/PostgREST/postgrest/issues

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -107,7 +107,7 @@ compressedRel rel =
   , "target"      .= fmt (tableSchema fTab) (tableName fTab) (colName <$> relFColumns rel)
   , "cardinality" .= (show $ relType rel :: Text)
   ] ++
-  if relType rel == Many
+  if relType rel == M2M
     then [
      "junction" .= case (relLinkTable rel, relLinkCols1 rel, relLinkCols2 rel) of
         (Just lt, Just lc1, Just lc2) -> fmtMany (tableSchema lt) (tableName lt) (colName <$> lc1) (colName <$> lc2)

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -259,10 +259,14 @@ data QualifiedIdentifier = QualifiedIdentifier {
 
 -- | The relationship [cardinality](https://en.wikipedia.org/wiki/Cardinality_(data_modeling)).
 -- | TODO: missing one-to-one
-data Cardinality = Child  -- ^ a.k.a. many-to-one
-                 | Parent -- ^ a.k.a. one-to-many
-                 | Many   -- ^ a.k.a. many-to-many
-                 deriving (Show, Eq)
+data Cardinality = O2M -- ^ one-to-many,  previously known as Parent
+                 | M2O -- ^ many-to-one,  previously known as Child
+                 | M2M -- ^ many-to-many, previously known as Many
+                 deriving Eq
+instance Show Cardinality where
+  show O2M = "one-to-many"
+  show M2O = "many-to-one"
+  show M2M = "many-to-many"
 
 {-|
   The name 'Relation' here is used with the meaning

--- a/test/Feature/EmbedDisambiguationSpec.hs
+++ b/test/Feature/EmbedDisambiguationSpec.hs
@@ -20,14 +20,14 @@ spec =
           {
             "details": [
             {
-              "cardinality": "Parent",
-              "source": "test.person[id]",
-              "target": "test.message[sender]"
+              "cardinality": "many-to-one",
+              "source": "test.message[sender]",
+              "target": "test.person[id]"
             },
             {
-              "cardinality": "Parent",
-              "source": "test.person_detail[id]",
-              "target": "test.message[sender]"
+              "cardinality": "many-to-one",
+              "source": "test.message[sender]",
+              "target": "test.person_detail[id]"
             }
             ],
             "hint": "Disambiguate by choosing a relationship from the `details` key",
@@ -42,85 +42,85 @@ spec =
         [json|
           {
             "details": [
-                {
-                    "cardinality": "Child",
-                    "source": "test.articleStars[userId]",
-                    "target": "test.users[id]"
-                },
-                {
-                    "cardinality": "Child",
-                    "source": "test.limited_article_stars[user_id]",
-                    "target": "test.users[id]"
-                },
-                {
-                    "cardinality": "Child",
-                    "source": "test.comments[commenter_id]",
-                    "target": "test.users[id]"
-                },
-                {
-                    "cardinality": "Child",
-                    "source": "test.users_projects[user_id]",
-                    "target": "test.users[id]"
-                },
-                {
-                    "cardinality": "Child",
-                    "source": "test.users_tasks[user_id]",
-                    "target": "test.users[id]"
-                },
-                {
-                    "cardinality": "Many",
-                    "junction": "private.article_stars[article_id][user_id]",
-                    "source": "test.articles[id]",
-                    "target": "test.users[id]"
-                },
-                {
-                    "cardinality": "Many",
-                    "junction": "test.articleStars[articleId][userId]",
-                    "source": "test.articles[id]",
-                    "target": "test.users[id]"
-                },
-                {
-                    "cardinality": "Many",
-                    "junction": "test.limited_article_stars[article_id][user_id]",
-                    "source": "test.articles[id]",
-                    "target": "test.users[id]"
-                },
-                {
-                    "cardinality": "Many",
-                    "junction": "test.users_projects[project_id][user_id]",
-                    "source": "test.projects[id]",
-                    "target": "test.users[id]"
-                },
-                {
-                    "cardinality": "Many",
-                    "junction": "test.users_projects[project_id][user_id]",
-                    "source": "test.materialized_projects[id]",
-                    "target": "test.users[id]"
-                },
-                {
-                    "cardinality": "Many",
-                    "junction": "test.users_projects[project_id][user_id]",
-                    "source": "test.projects_view[id]",
-                    "target": "test.users[id]"
-                },
-                {
-                    "cardinality": "Many",
-                    "junction": "test.users_projects[project_id][user_id]",
-                    "source": "test.projects_view_alt[t_id]",
-                    "target": "test.users[id]"
-                },
-                {
-                    "cardinality": "Many",
-                    "junction": "test.users_tasks[task_id][user_id]",
-                    "source": "test.tasks[id]",
-                    "target": "test.users[id]"
-                },
-                {
-                    "cardinality": "Many",
-                    "junction": "test.users_tasks[task_id][user_id]",
-                    "source": "test.filtered_tasks[myId]",
-                    "target": "test.users[id]"
-                }
+              {
+                "cardinality": "one-to-many",
+                "source": "test.users[id]",
+                "target": "test.articleStars[userId]"
+              },
+              {
+                "cardinality": "one-to-many",
+                "source": "test.users[id]",
+                "target": "test.limited_article_stars[user_id]"
+              },
+              {
+                "cardinality": "one-to-many",
+                "source": "test.users[id]",
+                "target": "test.comments[commenter_id]"
+              },
+              {
+                "cardinality": "one-to-many",
+                "source": "test.users[id]",
+                "target": "test.users_projects[user_id]"
+              },
+              {
+                "cardinality": "one-to-many",
+                "source": "test.users[id]",
+                "target": "test.users_tasks[user_id]"
+              },
+              {
+                "cardinality": "many-to-many",
+                "junction": "private.article_stars[user_id][article_id]",
+                "source": "test.users[id]",
+                "target": "test.articles[id]"
+              },
+              {
+                "cardinality": "many-to-many",
+                "junction": "test.articleStars[userId][articleId]",
+                "source": "test.users[id]",
+                "target": "test.articles[id]"
+              },
+              {
+                "cardinality": "many-to-many",
+                "junction": "test.limited_article_stars[user_id][article_id]",
+                "source": "test.users[id]",
+                "target": "test.articles[id]"
+              },
+              {
+                "cardinality": "many-to-many",
+                "junction": "test.users_projects[user_id][project_id]",
+                "source": "test.users[id]",
+                "target": "test.projects[id]"
+              },
+              {
+                "cardinality": "many-to-many",
+                "junction": "test.users_projects[user_id][project_id]",
+                "source": "test.users[id]",
+                "target": "test.materialized_projects[id]"
+              },
+              {
+                "cardinality": "many-to-many",
+                "junction": "test.users_projects[user_id][project_id]",
+                "source": "test.users[id]",
+                "target": "test.projects_view[id]"
+              },
+              {
+                "cardinality": "many-to-many",
+                "junction": "test.users_projects[user_id][project_id]",
+                "source": "test.users[id]",
+                "target": "test.projects_view_alt[t_id]"
+              },
+              {
+                "cardinality": "many-to-many",
+                "junction": "test.users_tasks[user_id][task_id]",
+                "source": "test.users[id]",
+                "target": "test.tasks[id]"
+              },
+              {
+                "cardinality": "many-to-many",
+                "junction": "test.users_tasks[user_id][task_id]",
+                "source": "test.users[id]",
+                "target": "test.filtered_tasks[myId]"
+              }
             ],
             "hint": "Disambiguate by choosing a relationship from the `details` key",
             "message": "More than one relationship was found for users and id"


### PR DESCRIPTION
As noted in https://github.com/PostgREST/postgrest/pull/1358#issue-300720791 we had the relationships backward(getting the cardinality from parent to child) on the request tree. This made things really confusing, not only for development/debugging but also for error reporting. With this change, we now get a better error message for disambiguation(added in https://github.com/PostgREST/postgrest/pull/1401).
 
```http
GET /message?select=*,sender(*)
```

```json
{
  "details": [
    {
        "cardinality": "many-to-one",
        "source": "test.message[sender]",
        "target": "test.person[id]"
    },
    {
        "cardinality": "many-to-one",
        "source": "test.message[sender]",
        "target": "test.person_detail[id]"
    }
  ],
  "hint": "Disambiguate by choosing a relationship from the `details` key",
  "message": "More than one relationship was found for message and sender"
}
```
Also renamed the cardinality types from `Parent/Child` to the more proper `O2M/M2O`. Parent and Child terms are usually meant for referring to the ends of a relationship and not the cardinality.