### PR TITLE
added config option server-unix-socket-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- #1415, Add support for user defined socket permission via `server-unix-socket-mode` config option - @Dansvidania
 - #1383, Add support for HEAD request - @steve-chavez
 - #1378, Add support for `Prefer: count=planned` and `Prefer: count=estimated` on GET /table - @steve-chavez
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -12,6 +12,7 @@ import Control.AutoUpdate       (defaultUpdateSettings, mkAutoUpdate,
 import Control.Retry            (RetryStatus, capDelay,
                                  exponentialBackoff, retrying,
                                  rsPreviousDelay)
+import Data.Either.Combinators  (whenLeft)
 import Data.IORef               (IORef, atomicWriteIORef, newIORef,
                                  readIORef)
 import Data.String              (IsString (..))
@@ -165,7 +166,7 @@ main = do
       port = configPort conf
       proxy = configProxyUri conf
       maybeSocketAddr = configSocket conf
-      maybeSocketFileMode = configSocketMode conf
+      socketFileMode = configSocketMode conf
       pgSettings = toS (configDatabase conf) -- is the db-uri
       roleClaimKey = configRoleClaimKey conf
       appSettings =
@@ -174,13 +175,15 @@ main = do
         . setServerName (toS $ "postgrest/" <> prettyVersion) $
         defaultSettings
 
+  whenLeft socketFileMode panic
+
   -- Checks that the provided proxy uri is formated correctly
   when (isMalformedProxyUri $ toS <$> proxy) $
     panic
       "Malformed proxy uri, a correct example: https://example.com:8443/basePath"
 
   -- Checks that the provided jspath is valid
-  when (isLeft roleClaimKey) $
+  whenLeft roleClaimKey $
     panic $ show roleClaimKey
 
   --
@@ -252,9 +255,8 @@ main = do
              putStrLn $ ("Listening on port " :: Text) <> show (configPort conf)
              runSettings appSettings postgrestApplication
          Just socketAddr -> do
-             let socketFileMode = fromMaybe 432 maybeSocketFileMode
              -- run postgrest application with user defined socket
-             sock <- createAndBindSocket (unpack socketAddr) socketFileMode
+             sock <- createAndBindSocket (unpack socketAddr) (rightToMaybe socketFileMode)
              listen sock maxListenQueue
              putStrLn $ ("Listening on unix socket " :: Text) <> show socketAddr
              runSettingsSocket appSettings sock postgrestApplication
@@ -328,12 +330,12 @@ loadDbUriFile conf = extractDbUri mDbUri
         Just filename -> strip <$> readFile (toS filename)
     setDbUri dbUri = conf {configDatabase = dbUri}
 
-createAndBindSocket :: FilePath -> FileMode -> IO Socket
-createAndBindSocket socketFilePath socketFileMode = do
+createAndBindSocket :: FilePath -> Maybe FileMode -> IO Socket
+createAndBindSocket socketFilePath maybeSocketFileMode = do
   deleteSocketFileIfExist socketFilePath
   sock <- socket AF_UNIX Stream defaultProtocol
   bind sock $ SockAddrUnix socketFilePath
-  setFileMode socketFilePath socketFileMode
+  mapM_ (setFileMode socketFilePath) maybeSocketFileMode
   return sock
   where
     deleteSocketFileIfExist path = removeFile path `catch` handleDoesNotExist

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -97,6 +97,7 @@ executable postgrest
                     , base64-bytestring >= 1 && < 1.1
                     , bytestring        >= 0.10.8 && < 0.11
                     , directory         >= 1.2.6 && < 1.4
+                    , either            >= 4.4.1 && < 5.1
                     , hasql             >= 1.4 && < 1.5
                     , hasql-pool        >= 0.5 && < 0.6
                     , hasql-transaction >= 0.7.2 && < 0.8

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -66,6 +66,8 @@ _baseCfg =  -- Connection Settings
   AppConfig mempty "postgrest_test_anonymous" Nothing "test" "localhost" 3000
             -- No user configured Unix Socket
             Nothing
+            -- No user configured Unix Socket file mode
+            Nothing
             -- Jwt settings
             (Just $ encodeUtf8 "reallyreallyreallyreallyverysafe") False Nothing
             -- Connection Modifiers

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -66,8 +66,8 @@ _baseCfg =  -- Connection Settings
   AppConfig mempty "postgrest_test_anonymous" Nothing "test" "localhost" 3000
             -- No user configured Unix Socket
             Nothing
-            -- No user configured Unix Socket file mode
-            Nothing
+            -- No user configured Unix Socket file mode (defaults to 755)
+            (Right 493)
             -- Jwt settings
             (Just $ encodeUtf8 "reallyreallyreallyreallyverysafe") False Nothing
             -- Connection Modifiers


### PR DESCRIPTION
started working on solving #1408 

Currently I apply a default (changed to 660) whenever the file mode is not specified, or (I think this part is problematic) whenever the mode provided is invalid (not in octal)

I also still need to validate that the octal provided is not above 777

 @steve-chavez is this the preferred way to set the permission, or should we rather go with a string in the more readable format "rwxrwxrwx" ?