### PR TITLE
Improvement singular/plural logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- #1417, Improvement singular/plural logic - @dwagin
 - #1415, Add support for user defined socket permission via `server-unix-socket-mode` config option - @Dansvidania
 - #1383, Add support for HEAD request - @steve-chavez
 - #1378, Add support for `Prefer: count=planned` and `Prefer: count=estimated` on GET /table - @steve-chavez

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- #1417, Improvement singular/plural logic - @dwagin
+- #1417, `Accept: application/vnd.pgrst.object+json` behavior is now enforced for POST/PATCH/DELETE regardless of `Prefer: return=representation/minimal` - @dwagin
 - #1415, Add support for user defined socket permission via `server-unix-socket-mode` config option - @Dansvidania
 - #1383, Add support for HEAD request - @steve-chavez
 - #1378, Add support for `Prefer: count=planned` and `Prefer: count=estimated` on GET /table - @steve-chavez

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -251,7 +251,7 @@ app dbStructure proc cols conf apiRequest =
                     (iPreferRepresentation apiRequest) []
               row <- H.statement mempty stm
               let (_, queryTotal, _, body) = row
-                  r = contentRangeH 1 0 $
+                  contentRangeHeader = contentRangeH 1 0 $
                         if shouldCount then Just queryTotal else Nothing
               if contentType == CTSingularJSON
                  && queryTotal /= 1
@@ -260,7 +260,7 @@ app dbStructure proc cols conf apiRequest =
                   return . errorResponseFor . singularityError $ queryTotal
                 else
                   return $ if iPreferRepresentation apiRequest == Full
-                    then responseLBS status200 [toHeader contentType, r] (toS body)
+                    then responseLBS status200 [toHeader contentType, contentRangeHeader] (toS body)
                     else responseLBS status204 [r] ""
 
         (ActionInfo, TargetIdent (QualifiedIdentifier tSchema tTable), Nothing) ->

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -193,10 +193,10 @@ app dbStructure proc cols conf apiRequest =
               row <- H.statement (toS $ pjRaw pJson) stm
               let (_, queryTotal, _, body) = row
                   updateIsNoOp = S.null cols
-                  r = contentRangeH 0 (queryTotal - 1) $
+                  contentRangeHeader = contentRangeH 0 (queryTotal - 1) $
                         if shouldCount then Just queryTotal else Nothing
-                  headers | iPreferRepresentation apiRequest == Full = [toHeader contentType, r]
-                          | otherwise                                = [r]
+                  headers | iPreferRepresentation apiRequest == Full = [toHeader contentType, contentRangeHeader]
+                          | otherwise                                = [contentRangeHeader]
                   status | queryTotal == 0 && not updateIsNoOp      = status404
                          | iPreferRepresentation apiRequest == Full = status200
                          | otherwise                                = status204

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -261,7 +261,7 @@ app dbStructure proc cols conf apiRequest =
                 else
                   return $ if iPreferRepresentation apiRequest == Full
                     then responseLBS status200 [toHeader contentType, contentRangeHeader] (toS body)
-                    else responseLBS status204 [r] ""
+                    else responseLBS status204 [contentRangeHeader] ""
 
         (ActionInfo, TargetIdent (QualifiedIdentifier tSchema tTable), Nothing) ->
           let mTable = find (\t -> tableName t == tTable && tableSchema t == tSchema) (dbTables dbStructure) in

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -270,7 +270,7 @@ instance JSON.ToJSON SimpleError where
   toJSON (ContentTypeError cts)    = JSON.object [
     "message" .= ("None of these Content-Types are available: " <> (toS . intercalate ", " . map toS) cts :: Text)]
   toJSON (SingularityError n)      = JSON.object [
-    "message" .= ("JSON object requested, multiple (or no) rows returned" :: Text),
+    "message" .= ("JSON object requested, multiple rows returned" :: Text),
     "details" .= T.unwords ["Results contain", show n, "rows,", toS (toMime CTSingularJSON), "requires 1 row"]]
 
   toJSON JwtTokenMissing           = JSON.object [

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -270,7 +270,7 @@ instance JSON.ToJSON SimpleError where
   toJSON (ContentTypeError cts)    = JSON.object [
     "message" .= ("None of these Content-Types are available: " <> (toS . intercalate ", " . map toS) cts :: Text)]
   toJSON (SingularityError n)      = JSON.object [
-    "message" .= ("JSON object requested, multiple rows returned" :: Text),
+    "message" .= ("JSON object requested, multiple (or no) rows returned" :: Text),
     "details" .= T.unwords ["Results contain", show n, "rows,", toS (toMime CTSingularJSON), "requires 1 row"]]
 
   toJSON JwtTokenMissing           = JSON.object [

--- a/test/Feature/SingularSpec.hs
+++ b/test/Feature/SingularSpec.hs
@@ -56,7 +56,7 @@ spec =
         _ <- post "/addresses" [json| { id: 98, address: "xxx" } |]
         _ <- post "/addresses" [json| { id: 99, address: "yyy" } |]
         p <- request methodPatch "/addresses?id=gt.0"
-                [("Prefer", "return=representation"), singular]
+                [singular]
                 [json| { address: "zzz" } |]
         liftIO $ do
           simpleStatus p `shouldBe` notAcceptable406
@@ -67,7 +67,7 @@ spec =
 
       it "raises an error for zero rows" $
         request methodPatch "/items?id=gt.0&id=lt.0"
-                [("Prefer", "return=representation"), singular] [json|{"id":1}|]
+                [singular] [json|{"id":1}|]
           `shouldRespondWith`
                   [str|{"details":"Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned"}|]
                   { matchStatus  = 406
@@ -100,25 +100,13 @@ spec =
       it "raises an error when attempting to create multiple entities" $ do
         p <- request methodPost
           "/addresses"
-          [("Prefer", "return=representation"), singular]
+          [singular]
           [json| [ { id: 200, address: "xxx" }, { id: 201, address: "yyy" } ] |]
         liftIO $ simpleStatus p `shouldBe` notAcceptable406
 
-        -- the rows should not exist, either
-        get "/addresses?id=eq.200" `shouldRespondWith` "[]"
-
-      it "return=minimal allows request to create multiple elements" $
-        request methodPost "/addresses"
-          [("Prefer", "return=minimal"), singular]
-          [json| [ { id: 200, address: "xxx" }, { id: 201, address: "yyy" } ] |]
-          `shouldRespondWith` ""
-          { matchStatus  = 201
-          , matchHeaders = ["Content-Range" <:> "*/*"]
-          }
-
       it "raises an error when creating zero entities" $
         request methodPost "/addresses"
-                [("Prefer", "return=representation"), singular]
+                [singular]
                 [json| [ ] |]
           `shouldRespondWith`
                   [str|{"details":"Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned"}|]
@@ -136,7 +124,7 @@ spec =
       it "raises an error when attempting to delete multiple entities" $ do
         let firstItems = "/items?id=gt.0&id=lt.11"
         request methodDelete firstItems
-          [("Prefer", "return=representation"), singular] ""
+          [singular] ""
           `shouldRespondWith` 406
 
         get firstItems
@@ -147,7 +135,7 @@ spec =
 
       it "raises an error when deleting zero entities" $
         request methodDelete "/items?id=lt.0"
-                [("Prefer", "return=representation"), singular] ""
+                [singular] ""
           `shouldRespondWith`
                 [str|{"details":"Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned"}|]
                 { matchStatus  = 406

--- a/test/Feature/SingularSpec.hs
+++ b/test/Feature/SingularSpec.hs
@@ -139,7 +139,7 @@ spec =
         -- the rows should not exist, either
         get "/addresses?id=eq.202" `shouldRespondWith` "[]"
 
-      it "singular behavior holds priority over return=minimal" $ do
+      it "raises an error regardless of return=minimal" $ do
         request methodPost "/addresses"
                 [("Prefer", "return=minimal"), singular]
                 [json| [ { id: 204, address: "xxx" }, { id: 205, address: "yyy" } ] |]

--- a/test/Feature/SingularSpec.hs
+++ b/test/Feature/SingularSpec.hs
@@ -141,8 +141,8 @@ spec =
 
       it "singular behavior holds priority over return=minimal" $
         request methodPost "/addresses"
-          [("Prefer", "return=minimal"), singular]
-          [json| [ { id: 204, address: "xxx" }, { id: 205, address: "yyy" } ] |]
+                [("Prefer", "return=minimal"), singular]
+                [json| [ { id: 204, address: "xxx" }, { id: 205, address: "yyy" } ] |]
           `shouldRespondWith`
                   [str|{"details":"Results contain 2 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned"}|]
                   { matchStatus  = 406

--- a/test/Feature/SingularSpec.hs
+++ b/test/Feature/SingularSpec.hs
@@ -139,7 +139,7 @@ spec =
         -- the rows should not exist, either
         get "/addresses?id=eq.202" `shouldRespondWith` "[]"
 
-      it "singular behavior holds priority over return=minimal" $
+      it "singular behavior holds priority over return=minimal" $ do
         request methodPost "/addresses"
                 [("Prefer", "return=minimal"), singular]
                 [json| [ { id: 204, address: "xxx" }, { id: 205, address: "yyy" } ] |]


### PR DESCRIPTION
Hello

I get Incorrect statuses by using "Accept: application/vnd.pgrst.object+json" with and without "Prefer: return=representation".

for multiple entities on
POST expected 406, receive 201
PATCH expected 406, receive 204
DELETE expected 406, receive 204

for zero entities on
PATCH expected 404, receive 406 
DELETE expected 404, receive 204