### PR TITLE
Resource embedding disambiguation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - #1385, bulk RPC call now should be done by specifying a `Prefer: params=multiple-objects` header - @steve-chavez
 - #1401, resource embedding now outputs an error when multiple relationships between two tables are found - @steve-chavez
+- Remove embedding with duck typed column names `GET /projects?select=client_id(*)`- @steve-chavez
 
 ## [6.0.2] - 2019-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - #1385, bulk RPC call now should be done by specifying a `Prefer: params=multiple-objects` header - @steve-chavez
 - #1401, resource embedding now outputs an error when multiple relationships between two tables are found - @steve-chavez
-- Remove embedding with duck typed column names `GET /projects?select=client_id(*)`- @steve-chavez
+- Removed the ability to embed with duck typed column names `GET /projects?select=client_id(*)`- @steve-chavez
+- Removed the `.` symbol for disambiguating resource embedding. '!' should be used instead `GET /projects?select=clients!client_id(*)`.
 
 ## [6.0.2] - 2019-08-22
 

--- a/src/PostgREST/DbRequestBuilder.hs
+++ b/src/PostgREST/DbRequestBuilder.hs
@@ -16,9 +16,8 @@ module PostgREST.DbRequestBuilder (
 , mutateRequest
 ) where
 
-import qualified Data.ByteString.Char8 as BS
-import qualified Data.HashMap.Strict   as M
-import qualified Data.Set              as S
+import qualified Data.HashMap.Strict as M
+import qualified Data.Set            as S
 
 import Control.Arrow           ((***))
 import Data.Either.Combinators (mapLeft)
@@ -26,7 +25,6 @@ import Data.Foldable           (foldr1)
 import Data.List               (delete, head, (!!))
 import Data.Maybe              (fromJust)
 import Data.Text               (isInfixOf)
-import Text.Regex.TDFA         ((=~))
 import Unsafe                  (unsafeHead)
 
 import Control.Applicative
@@ -141,31 +139,8 @@ findRelation schema allRelations parentTableName nodeName relationDetail =
         -- (relation type)  => M2O
         -- (entity)         => clients  {id}
         -- (foriegn entity) => projects {client_id}
-        (
-          parentTableName == tableName relTable && -- projects
-          nodeName == tableName relFTable -- clients
-        ) ||
-
-        -- (request)        => projects { ..., client_id{...} }
-        -- will match
-        -- (relation type)  => M2O
-        -- (entity)         => clients  {id}
-        -- (foriegn entity) => projects {client_id}
-        (
-          parentTableName == tableName relTable && -- projects
-          length relColumns == 1 &&
-          -- match common foreign key names(table_name_id, table_name_fk) to table_name
-          (toS ("^" <> colName (unsafeHead relColumns) <> "_?(?:|[iI][dD]|[fF][kK])$") :: BS.ByteString) =~
-          (toS nodeName :: BS.ByteString) -- client_id
-        )
-
-        -- (request)        => project_id { ..., client_id{...} }
-        -- will match
-        -- (relation type)  => M2O
-        -- (entity)         => clients  {id}
-        -- (foriegn entity) => projects {client_id}
-        -- this case works becasue before reaching this place
-        -- addRelation will turn project_id to project so the above condition will match
+        parentTableName == tableName relTable && -- projects
+        nodeName == tableName relFTable -- clients
 
       Just rd ->
 

--- a/src/PostgREST/DbRequestBuilder.hs
+++ b/src/PostgREST/DbRequestBuilder.hs
@@ -22,10 +22,8 @@ import qualified Data.Set            as S
 import Control.Arrow           ((***))
 import Data.Either.Combinators (mapLeft)
 import Data.Foldable           (foldr1)
-import Data.List               (delete, head, (!!))
-import Data.Maybe              (fromJust)
+import Data.List               (delete)
 import Data.Text               (isInfixOf)
-import Unsafe                  (unsafeHead)
 
 import Control.Applicative
 import Data.Tree
@@ -47,20 +45,20 @@ readRequest schema rootTableName maxRows allRels apiRequest  =
   (initReadRequest rootName <$> pRequestSelect sel)
   where
     sel = fromMaybe "*" $ iSelect apiRequest -- default to all columns requested (SELECT *) for a non existent ?select querystring param
-    (rootName, rootRels) = rootWithRelations schema rootTableName allRels (iAction apiRequest)
+    (rootName, rootRels) = rootWithRels schema rootTableName allRels (iAction apiRequest)
 
--- Get the root table name with its relations according to the Action type.
+-- Get the root table name with its relationships according to the Action type.
 -- This is done because of the shape of the final SQL Query. The mutation cases are wrapped in a WITH {sourceCTEName}(see Statements.hs).
 -- So we need a FROM {sourceCTEName} instead of FROM {tableName}.
-rootWithRelations :: Schema -> TableName -> [Relation] -> Action -> (QualifiedIdentifier, [Relation])
-rootWithRelations schema rootTableName allRels action = case action of
+rootWithRels :: Schema -> TableName -> [Relation] -> Action -> (QualifiedIdentifier, [Relation])
+rootWithRels schema rootTableName allRels action = case action of
   ActionRead _ -> (QualifiedIdentifier schema rootTableName, allRels) -- normal read case
-  _            -> (QualifiedIdentifier mempty sourceCTEName, mapMaybe toSourceRelation allRels ++ allRels) -- mutation cases and calling proc
+  _            -> (QualifiedIdentifier mempty sourceCTEName, mapMaybe toSourceRel allRels ++ allRels) -- mutation cases and calling proc
   where
     -- To enable embedding in the sourceCTEName cases we need to replace the foreign key tableName in the Relation
-    -- with {sourceCTEName}. This way findRelation can find Relations with sourceCTEName.
-    toSourceRelation :: Relation -> Maybe Relation
-    toSourceRelation r@Relation{relTable=t}
+    -- with {sourceCTEName}. This way findRel can find relationships with sourceCTEName.
+    toSourceRel :: Relation -> Maybe Relation
+    toSourceRel r@Relation{relTable=t}
       | rootTableName == tableName t = Just $ r {relTable=t {tableName=sourceCTEName}}
       | otherwise                    = Nothing
 
@@ -73,16 +71,16 @@ initReadRequest rootQi =
     rootDepth = 0
     rootSchema = qiSchema rootQi
     rootName = qiName rootQi
-    initial = Node (Select [] rootQi Nothing [] [] [] [] allRange, (rootName, Nothing, Nothing, Nothing, rootDepth)) []
+    initial = Node (Select [] rootQi Nothing [] [] [] [] allRange, (rootName, Nothing, Nothing, (Nothing, Nothing), rootDepth)) []
     treeEntry :: Depth -> Tree SelectItem -> ReadRequest -> ReadRequest
-    treeEntry depth (Node fld@((fn, _),_,alias,relationDetail) fldForest) (Node (q, i) rForest) =
+    treeEntry depth (Node fld@((fn, _),_,alias, embedHint) fldForest) (Node (q, i) rForest) =
       let nxtDepth = succ depth in
       case fldForest of
         [] -> Node (q {select=fld:select q}, i) rForest
         _  -> Node (q, i) $
               foldr (treeEntry nxtDepth)
               (Node (Select [] (QualifiedIdentifier rootSchema fn) Nothing [] [] [] [] allRange,
-                (fn, Nothing, alias, relationDetail, nxtDepth)) [])
+                (fn, Nothing, alias, embedHint, nxtDepth)) [])
               fldForest:rForest
 
 treeRestrictRange :: Maybe Integer -> ReadRequest -> Either ApiRequestError ReadRequest
@@ -93,126 +91,101 @@ treeRestrictRange maxRows request = pure $ nodeRestrictRange maxRows <$> request
 
 augumentRequestWithJoin :: Schema -> [Relation] -> ReadRequest -> Either ApiRequestError ReadRequest
 augumentRequestWithJoin schema allRels request =
-  addRelations schema allRels Nothing request
+  addRels schema allRels Nothing request
   >>= addJoinConditions Nothing
 
-addRelations :: Schema -> [Relation] -> Maybe ReadRequest -> ReadRequest -> Either ApiRequestError ReadRequest
-addRelations schema allRelations parentNode (Node (query@Select{from=tbl}, (nodeName, _, alias, relationDetail, depth)) forest) =
+addRels :: Schema -> [Relation] -> Maybe ReadRequest -> ReadRequest -> Either ApiRequestError ReadRequest
+addRels schema allRels parentNode (Node (query@Select{from=tbl}, (nodeName, _, alias, embedHint, depth)) forest) =
   case parentNode of
     Just (Node (Select{from=parentNodeQi}, _) _) ->
       let newFrom r = if qiName tbl == nodeName then tableQi (relFTable r) else tbl
-          newReadNode = (\r -> (query{from=newFrom r}, (nodeName, Just r, alias, Nothing, depth))) <$> rel
+          newReadNode = (\r -> (query{from=newFrom r}, (nodeName, Just r, alias, (Nothing, Nothing), depth))) <$> rel
           parentNodeTable = qiName parentNodeQi
-          results = findRelation schema allRelations parentNodeTable nodeName relationDetail
+          results = findRel schema allRels parentNodeTable nodeName embedHint
           rel :: Either ApiRequestError Relation
           rel = case results of
             []  -> Left $ NoRelBetween parentNodeTable nodeName
             [r] -> Right r
-            rs  ->
-              -- Hack for handling a self reference relationship.
-              -- In this case we get an O2M and M2O rels with the same relTable and relFtable.
-              -- We output the O2M rel, the M2O rel can be obtained by using the fk column as an embed hint in findRelation.
-              let rel0 = head rs
-                  rel1 = rs !! 1 in
-              if length rs == 2 && relTable rel0 == relTable rel1 && relFTable rel0 == relFTable rel1
-                then note (NoRelBetween parentNodeTable nodeName) (find (\r -> relType r == O2M) rs)
-                else Left $ AmbiguousRelBetween parentNodeTable nodeName rs
+            rs  -> Left $ AmbiguousRelBetween parentNodeTable nodeName rs
       in
       Node <$> newReadNode <*> (updateForest . hush $ Node <$> newReadNode <*> pure forest)
     _ ->
-      let rn = (query, (nodeName, Nothing, alias, Nothing, depth)) in
+      let rn = (query, (nodeName, Nothing, alias, (Nothing, Nothing), depth)) in
       Node rn <$> updateForest (Just $ Node rn forest)
   where
     updateForest :: Maybe ReadRequest -> Either ApiRequestError [ReadRequest]
-    updateForest rq = mapM (addRelations schema allRelations rq) forest
+    updateForest rq = mapM (addRels schema allRels rq) forest
 
-findRelation :: Schema -> [Relation] -> TableName -> NodeName -> Maybe RelationDetail -> [Relation]
-findRelation schema allRelations parentTableName nodeName relationDetail =
-  filter (\Relation{relTable, relColumns, relFTable, relFColumns, relType, relLinkTable} ->
-    -- Both relation ends need to be on the exposed schema
+findRel :: Schema -> [Relation] -> TableName -> NodeName -> EmbedHint -> [Relation]
+findRel schema allRels source target (fkHint, cardHint) =
+  filter (\Relation{relTable, relConstraint, relFTable, relType, relLinkTable} ->
+    -- Both relationship ends need to be on the exposed schema
     schema == tableSchema relTable && schema == tableSchema relFTable &&
-    case relationDetail of
-      Nothing ->
+    (
+      -- /projects?select=clients(*)
+      (
+        source == tableName relTable && -- projects
+        target == tableName relFTable   -- clients
+      ) ||
 
-        -- (request)        => projects { ..., clients{...} }
-        -- will match
-        -- (relation type)  => M2O
-        -- (entity)         => clients  {id}
-        -- (foriegn entity) => projects {client_id}
-        parentTableName == tableName relTable && -- projects
-        nodeName == tableName relFTable -- clients
+      -- /projects?select=projects_client_id_fkey(*)
+      (
+        source == tableName relTable && -- projects
+        Just target == relConstraint    -- projects_client_id_fkey
+      )
+    ) && (
+      isNothing fkHint || -- fkHint is optional
 
-      Just rd ->
+      -- /projects?select=clients!projects_client_id_fkey(*)
+      (
+      fkHint == relConstraint -- projects_client_id_fkey
+      ) ||
 
-        -- (request)        => clients { ..., projects!client_id{...} }
-        -- will match
-        -- (relation type)  => O2M
-        -- (entity)         => clients  {id}
-        -- (foriegn entity) => projects {client_id}
-        (
-          relType == O2M &&
-          parentTableName == tableName relTable && -- clients
-          nodeName == tableName relFTable && -- projects
-          length relFColumns == 1 &&
-          rd == colName (unsafeHead relFColumns) -- rd is client_id
-        ) ||
+      -- /tasks?select=users!tasks_users(*)
+      (
+        relType == M2M &&                      -- many-to-many between tasks and users
+        fkHint == (tableName <$> relLinkTable) -- tasks_users
+      )
+    ) && (
+      isNothing cardHint || -- cardHint is optional
 
-        -- (request)        => message { ..., person_detail!sender{...} }
-        -- will match
-        -- (relation type)  => M2O
-        -- (entity)         => message  {sender}
-        -- (foriegn entity) => person_detail {id}
-        (
-          relType == M2O &&
-          parentTableName == tableName relTable && -- message
-          nodeName == tableName relFTable && -- person_detail
-          length relColumns == 1 &&
-          rd == colName (unsafeHead relColumns) -- rd is sender
-        ) ||
-
-        -- (request)        => tasks { ..., users.tasks_users{...} }
-        -- will match
-        -- (relation type)  => M2M
-        -- (entity)         => users
-        -- (foriegn entity) => tasks
-        (
-          relType == M2M &&
-          parentTableName == tableName relTable && -- tasks
-          nodeName == tableName relFTable && -- users
-          rd == tableName (fromJust relLinkTable) -- rd is tasks_users
-        )
-  ) allRelations
+      -- /web_content?select=web_content!o2m(*)
+      (
+        cardHint == Just relType  -- o2m
+      )
+    )
+  ) allRels
 
 -- previousAlias is only used for the case of self joins
 addJoinConditions :: Maybe Alias -> ReadRequest -> Either ApiRequestError ReadRequest
-addJoinConditions previousAlias (Node node@(query@Select{from=tbl}, nodeProps@(_, relation, _, _, depth)) forest) =
-  case relation of
-    Just rel@Relation{relType=O2M} -> Node (augmentQuery rel, nodeProps) <$> updatedForest
-    Just rel@Relation{relType=M2O} -> Node (augmentQuery rel, nodeProps) <$> updatedForest
-    Just rel@Relation{relType=M2M, relLinkTable=lTable} ->
+addJoinConditions previousAlias (Node node@(query@Select{from=tbl}, nodeProps@(_, rel, _, _, depth)) forest) =
+  case rel of
+    Just r@Relation{relType=O2M} -> Node (augmentQuery r, nodeProps) <$> updatedForest
+    Just r@Relation{relType=M2O} -> Node (augmentQuery r, nodeProps) <$> updatedForest
+    Just r@Relation{relType=M2M, relLinkTable=lTable} ->
       case lTable of
         Just linkTable ->
-          let rq = augmentQuery rel in
+          let rq = augmentQuery r in
           Node (rq{implicitJoins=tableQi linkTable:implicitJoins rq}, nodeProps) <$> updatedForest
         Nothing ->
           Left UnknownRelation
     Nothing -> Node node <$> updatedForest
   where
-    newAlias = case isSelfReference <$> relation of
+    newAlias = case isSelfReference <$> rel of
       Just True
         | depth /= 0 -> Just (qiName tbl <> "_" <> show depth) -- root node doesn't get aliased
         | otherwise  -> Nothing
       _              -> Nothing
-    augmentQuery rel =
+    augmentQuery r =
       foldr
         (\jc rq@Select{joinConditions=jcs} -> rq{joinConditions=jc:jcs})
         query{fromAlias=newAlias}
-        (getJoinConditions previousAlias newAlias rel)
+        (getJoinConditions previousAlias newAlias r)
     updatedForest = mapM (addJoinConditions newAlias) forest
 
 -- previousAlias and newAlias are used in the case of self joins
 getJoinConditions :: Maybe Alias -> Maybe Alias -> Relation -> [JoinCondition]
-getJoinConditions previousAlias newAlias (Relation Table{tableSchema=tSchema, tableName=tN} cols Table{tableName=ftN} fCols typ lt lc1 lc2) =
+getJoinConditions previousAlias newAlias (Relation Table{tableSchema=tSchema, tableName=tN} cols _ Table{tableName=ftN} fCols typ lt lc1 lc2) =
   case typ of
     O2M ->
         zipWith (toJoinCondition tN ftN) cols fCols

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -95,8 +95,9 @@ decodeRels :: [Table] -> [Column] -> HD.Result [Relation]
 decodeRels tables cols =
   mapMaybe (relFromRow tables cols) <$> HD.rowList relRow
  where
-  relRow = (,,,,,)
+  relRow = (,,,,,,)
     <$> column HD.text
+    <*> column HD.text
     <*> column HD.text
     <*> column (HD.array (HD.dimension replicateM (element HD.text)))
     <*> column HD.text
@@ -290,7 +291,7 @@ The logic for composite pks is similar just need to make sure all the Relation c
 addViewM2ORels :: [SourceColumn] -> [Relation] -> [Relation]
 addViewM2ORels allSrcCols = concatMap (\rel ->
   rel : case rel of
-    Relation{relType=M2O, relTable, relColumns, relFTable, relFColumns} ->
+    Relation{relType=M2O, relTable, relColumns, relConstraint, relFTable, relFColumns} ->
 
       let srcColsGroupedByView :: [Column] -> [[SourceColumn]]
           srcColsGroupedByView relCols = L.groupBy (\(_, viewCol1) (_, viewCol2) -> colTable viewCol1 == colTable viewCol2) $
@@ -307,18 +308,20 @@ addViewM2ORels allSrcCols = concatMap (\rel ->
 
           viewTableM2O =
             [ Relation (getView srcCols) (snd <$> srcCols `sortAccordingTo` relColumns)
-                       relFTable relFColumns
+                       relConstraint relFTable relFColumns
                        M2O Nothing Nothing Nothing
             | srcCols <- relSrcCols, srcCols `allSrcColsOf` relColumns ]
 
           tableViewM2O =
             [ Relation relTable relColumns
+                       relConstraint
                        (getView fSrcCols) (snd <$> fSrcCols `sortAccordingTo` relFColumns)
                        M2O Nothing Nothing Nothing
             | fSrcCols <- relFSrcCols, fSrcCols `allSrcColsOf` relFColumns ]
 
           viewViewM2O =
             [ Relation (getView srcCols) (snd <$> srcCols `sortAccordingTo` relColumns)
+                       relConstraint
                        (getView fSrcCols) (snd <$> fSrcCols `sortAccordingTo` relFColumns)
                        M2O Nothing Nothing Nothing
             | srcCols  <- relSrcCols, srcCols `allSrcColsOf` relColumns
@@ -329,7 +332,7 @@ addViewM2ORels allSrcCols = concatMap (\rel ->
     _ -> [])
 
 addO2MRels :: [Relation] -> [Relation]
-addO2MRels = concatMap (\rel@(Relation t c ft fc _ _ _ _) -> [rel, Relation ft fc t c O2M Nothing Nothing Nothing])
+addO2MRels = concatMap (\rel@(Relation t c cn ft fc _ _ _ _) -> [rel, Relation ft fc cn t c O2M Nothing Nothing Nothing])
 
 addM2MRels :: [Relation] -> [Relation]
 addM2MRels rels = rels ++ addMirrorRelation (mapMaybe link2Relation links)
@@ -342,12 +345,12 @@ addM2MRels rels = rels ++ addMirrorRelation (mapMaybe link2Relation links)
     combinations 0 _  = [ [] ]
     combinations n xs = [ y:ys | y:xs' <- tails xs
                                , ys <- combinations (n-1) xs']
-    addMirrorRelation = concatMap (\rel@(Relation t c ft fc _ lt lc1 lc2) -> [rel, Relation ft fc t c M2M lt lc2 lc1])
+    addMirrorRelation = concatMap (\rel@(Relation t c _ ft fc _ lt lc1 lc2) -> [rel, Relation ft fc Nothing t c M2M lt lc2 lc1])
     link2Relation [
       Relation{relTable=lt, relColumns=lc1, relFTable=t,  relFColumns=c},
       Relation{             relColumns=lc2, relFTable=ft, relFColumns=fc}
       ]
-      | lc1 /= lc2 && length lc1 == 1 && length lc2 == 1 = Just $ Relation t c ft fc M2M (Just lt) (Just lc1) (Just lc2)
+      | lc1 /= lc2 && length lc1 == 1 && length lc2 == 1 = Just $ Relation t c Nothing ft fc M2M (Just lt) (Just lc1) (Just lc2)
       | otherwise = Nothing
     link2Relation _ = Nothing
 
@@ -574,32 +577,29 @@ allM2ORels tabs cols =
   sql = [q|
     SELECT ns1.nspname AS table_schema,
            tab.relname AS table_name,
+           conname     AS constraint_name,
            column_info.cols AS columns,
            ns2.nspname AS foreign_table_schema,
            other.relname AS foreign_table_name,
            column_info.refs AS foreign_columns
     FROM pg_constraint,
-       LATERAL (SELECT array_agg(cols.attname) AS cols,
-                       array_agg(cols.attnum)  AS nums,
-                       array_agg(refs.attname) AS refs
-                  FROM ( SELECT unnest(conkey) AS col, unnest(confkey) AS ref) k,
-                       LATERAL (SELECT * FROM pg_attribute
-                                 WHERE attrelid = conrelid AND attnum = col)
-                            AS cols,
-                       LATERAL (SELECT * FROM pg_attribute
-                                 WHERE attrelid = confrelid AND attnum = ref)
-                            AS refs)
-            AS column_info,
-       LATERAL (SELECT * FROM pg_namespace WHERE pg_namespace.oid = connamespace) AS ns1,
-       LATERAL (SELECT * FROM pg_class WHERE pg_class.oid = conrelid) AS tab,
-       LATERAL (SELECT * FROM pg_class WHERE pg_class.oid = confrelid) AS other,
-       LATERAL (SELECT * FROM pg_namespace WHERE pg_namespace.oid = other.relnamespace) AS ns2
+    LATERAL (
+      SELECT array_agg(cols.attname) AS cols,
+                    array_agg(cols.attnum)  AS nums,
+                    array_agg(refs.attname) AS refs
+      FROM ( SELECT unnest(conkey) AS col, unnest(confkey) AS ref) k,
+      LATERAL (SELECT * FROM pg_attribute WHERE attrelid = conrelid AND attnum = col) AS cols,
+      LATERAL (SELECT * FROM pg_attribute WHERE attrelid = confrelid AND attnum = ref) AS refs) AS column_info,
+    LATERAL (SELECT * FROM pg_namespace WHERE pg_namespace.oid = connamespace) AS ns1,
+    LATERAL (SELECT * FROM pg_class WHERE pg_class.oid = conrelid) AS tab,
+    LATERAL (SELECT * FROM pg_class WHERE pg_class.oid = confrelid) AS other,
+    LATERAL (SELECT * FROM pg_namespace WHERE pg_namespace.oid = other.relnamespace) AS ns2
     WHERE confrelid != 0
     ORDER BY (conrelid, column_info.nums) |]
 
-relFromRow :: [Table] -> [Column] -> (Text, Text, [Text], Text, Text, [Text]) -> Maybe Relation
-relFromRow allTabs allCols (rs, rt, rcs, frs, frt, frcs) =
-  Relation <$> table <*> cols <*> tableF <*> colsF <*> pure M2O <*> pure Nothing <*> pure Nothing <*> pure Nothing
+relFromRow :: [Table] -> [Column] -> (Text, Text, Text, [Text], Text, Text, [Text]) -> Maybe Relation
+relFromRow allTabs allCols (rs, rt, cn, rcs, frs, frt, frcs) =
+  Relation <$> table <*> cols <*> pure (Just cn) <*> tableF <*> colsF <*> pure M2O <*> pure Nothing <*> pure Nothing <*> pure Nothing
   where
     findTable s t = find (\tbl -> tableSchema tbl == s && tableName tbl == t) allTabs
     findCol s t c = find (\col -> tableSchema (colTable col) == s && tableName (colTable col) == t && colName col == c) allCols

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -80,7 +80,7 @@ instance JSON.ToJSON ApiRequestError where
   toJSON UnknownRelation = JSON.object [
     "message" .= ("Unknown relation" :: Text)]
   toJSON (NoRelBetween parent child) = JSON.object [
-    "message" .= ("Could not find foreign keys between these entities, No relation found between " <> parent <> " and " <> child :: Text)]
+    "message" .= ("Could not find foreign keys between these entities. No relationship found between " <> parent <> " and " <> child :: Text)]
   toJSON (AmbiguousRelBetween parent child rels) = JSON.object [
     "hint"    .= ("Disambiguate by choosing a relationship from the `details` key" :: Text),
     "message" .= ("More than one relationship was found for " <> parent <> " and " <> child :: Text),
@@ -93,27 +93,26 @@ instance JSON.ToJSON ApiRequestError where
 compressedRel :: Relation -> JSON.Value
 compressedRel rel =
   let
-    -- | Format like "test.orders[billing_address_id]". For easier debugging the format is compressed instead of structured.
-    fmt sch tbl cols = schTbl sch tbl <> joinCols cols
-    fmtMany sch tbl cols1 cols2 = schTbl sch tbl <> joinCols cols1 <> joinCols cols2
-    schTbl sch tbl = sch <> "." <> tbl
-    joinCols cols  = "[" <> T.intercalate ", " cols <> "]"
-
-    tab = relTable rel
-    fTab = relFTable rel
+    fmtTbl tbl = tableSchema tbl <> "." <> tableName tbl
+    -- | Format like "[id][client_id]". For easier debugging the format is compressed instead of structured.
+    fmtJoinCols cols1 cols2 =
+      let joinCols cols  = "[" <> T.intercalate ", " cols <> "]" in
+      joinCols cols1 <> joinCols cols2
   in
   JSON.object $ [
-    "source"      .= fmt (tableSchema tab) (tableName tab) (colName <$> relColumns rel)
-  , "target"      .= fmt (tableSchema fTab) (tableName fTab) (colName <$> relFColumns rel)
+    "source"      .= fmtTbl (relTable rel)
+  , "target"      .= fmtTbl (relFTable rel)
   , "cardinality" .= (show $ relType rel :: Text)
   ] ++
-  if relType rel == M2M
-    then [
-     "junction" .= case (relLinkTable rel, relLinkCols1 rel, relLinkCols2 rel) of
-        (Just lt, Just lc1, Just lc2) -> fmtMany (tableSchema lt) (tableName lt) (colName <$> lc1) (colName <$> lc2)
-        _                             -> toS $ JSON.encode JSON.Null
+  case (relType rel, (relLinkTable rel, relLinkCols1 rel, relLinkCols2 rel), relConstraint rel) of
+    (M2M, (Just lt, Just lc1, Just lc2), _) -> [
+      "junction" .= (fmtTbl lt <> fmtJoinCols (colName <$> lc1) (colName <$> lc2))
       ]
-    else mempty
+    (_, _, Just relCon) -> [
+      "foreignKey" .= (relCon <> fmtJoinCols (colName <$> relColumns rel) (colName <$> relFColumns rel))
+      ]
+    (_, _, _) ->
+      mempty
 
 data PgError = PgError Authenticated P.UsageError
 type Authenticated = Bool

--- a/src/PostgREST/Parsers.hs
+++ b/src/PostgREST/Parsers.hs
@@ -130,11 +130,7 @@ pRelationSelect :: Parser SelectItem
 pRelationSelect = lexeme $ try ( do
     alias <- optionMaybe ( try(pFieldName <* aliasSeparator) )
     fld <- pField
-    relationDetail <- optionMaybe (
-        try ( char '!' *> pFieldName ) <|>
-        try ( char '.' *> pFieldName ) -- TODO deprecated, remove in next major version
-      )
-
+    relationDetail <- optionMaybe $ try ( char '!' *> pFieldName )
     return (fld, Nothing, alias, relationDetail)
   )
 

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -409,11 +409,11 @@ toHeaders = map $ \(GucHeader (k, v)) -> (CI.mk $ toS k, toS v)
   This type will hold information about which particular 'Relation' between two tables to choose when there are multiple ones.
   Specifically, it will contain the name of the foreign key or the join table in many to many relations.
 -}
+type SelectItem = (Field, Maybe Cast, Maybe Alias, [EmbedHint])
 -- | Disambiguates an embedding operation when there's multiple relationships between two tables.
--- | Text can be the name of a foreign key column or the junction table in a many-to-many relationship.
--- | Cardinality is also useful for disambiguating. e.g. to choose a parent or child in a self reference case.
-type EmbedHint = (Maybe Text, Maybe Cardinality)
-type SelectItem = (Field, Maybe Cast, Maybe Alias, EmbedHint)
+data EmbedHint = FkOrJunctionHint Text -- ^ Can be the name of a foreign key constraint or the junction in an m2m relationship.
+               | CardHint Cardinality  -- ^ Cardinality is also useful for disambiguating. e.g. to choose a parent or child in a self reference case.
+               deriving (Show, Eq)
 -- | Path of the embedded levels, e.g "clients.projects.name=eq.." gives Path ["clients", "projects"]
 type EmbedPath = [Text]
 data Filter = Filter { field::Field, opExpr::OpExpr } deriving (Show, Eq)
@@ -456,7 +456,7 @@ data MutateQuery =
 type ReadRequest = Tree ReadNode
 type MutateRequest = MutateQuery
 
-type ReadNode = (ReadQuery, (NodeName, Maybe Relation, Maybe Alias, EmbedHint, Depth))
+type ReadNode = (ReadQuery, (NodeName, Maybe Relation, Maybe Alias, [EmbedHint], Depth))
 type Depth = Integer
 
 -- First level FieldNames(e.g get a,b from /table?select=a,b,other(c,d))

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -264,9 +264,9 @@ data Cardinality = O2M -- ^ one-to-many,  previously known as Parent
                  | M2M -- ^ many-to-many, previously known as Many
                  deriving Eq
 instance Show Cardinality where
-  show O2M = "o2m(one-to-many)"
-  show M2O = "m2o(many-to-one)"
-  show M2M = "m2m(many-to-many)"
+  show O2M = "o2m"
+  show M2O = "m2o"
+  show M2M = "m2m"
 
 type ConstraintName = Text
 

--- a/test/Feature/EmbedDisambiguationSpec.hs
+++ b/test/Feature/EmbedDisambiguationSpec.hs
@@ -349,6 +349,28 @@ spec =
           get "/tasks?id=eq.1&select=id,name,project:projects!project_id(id,name,client:client_id(id,name))" `shouldRespondWith`
             [str|[{"id":1,"name":"Design w7","project":{"id":1,"name":"Windows 7","client":{"id":1,"name":"Microsoft"}}}]|]
 
+        it "can embed by using a composite FK name" $
+          get "/unit_workdays?select=unit_id,day,fst_shift(car_id,schedule(name)),snd_shift(camera_id,schedule(name))" `shouldRespondWith`
+            [json| [
+              {
+                "day": "2019-12-02",
+                "fst_shift": {
+                    "car_id": "CAR-349",
+                    "schedule": {
+                        "name": "morning"
+                    }
+                },
+                "snd_shift": {
+                    "camera_id": "CAM-123",
+                    "schedule": {
+                        "name": "night"
+                    }
+                },
+                "unit_id": 1
+              }
+            ] |]
+            { matchHeaders = [matchContentTypeJson] }
+
     context "tables with self reference foreign keys" $ do
       context "one self reference foreign key" $ do
         it "embeds parents recursively" $

--- a/test/Feature/EmbedDisambiguationSpec.hs
+++ b/test/Feature/EmbedDisambiguationSpec.hs
@@ -294,13 +294,3 @@ spec =
                  "manager":{"name":"Umbrella Manager"},
                  "refereeds":[]}]
             }]|] { matchHeaders = [matchContentTypeJson] }
-
-    -- TODO Remove in next major version(7.0)
-    describe "old dot '.' symbol, deprecated" $
-      it "still works" $ do
-        get "/clients?id=eq.1&select=id,projects:projects.client_id(id,tasks(id))" `shouldRespondWith`
-          [json|[{"id":1,"projects":[{"id":1,"tasks":[{"id":1},{"id":2}]},{"id":2,"tasks":[{"id":3},{"id":4}]}]}]|]
-          { matchHeaders = [matchContentTypeJson] }
-        get "/tasks?select=id,users:users.users_tasks(id)" `shouldRespondWith`
-          [json|[{"id":1,"users":[{"id":1},{"id":3}]},{"id":2,"users":[{"id":1}]},{"id":3,"users":[{"id":1}]},{"id":4,"users":[{"id":1}]},{"id":5,"users":[{"id":2},{"id":3}]},{"id":6,"users":[{"id":2}]},{"id":7,"users":[{"id":2}]},{"id":8,"users":[]}]|]
-          { matchHeaders = [matchContentTypeJson] }

--- a/test/Feature/EmbedDisambiguationSpec.hs
+++ b/test/Feature/EmbedDisambiguationSpec.hs
@@ -15,6 +15,7 @@ spec =
   describe "resource embedding disambiguation" $ do
 
     it "gives a 300 Multiple Choices error when the request is ambiguous" $ do
+      pendingWith "duck typing removed: see what to do with single fk column embed"
       get "/message?select=id,body,sender(name,sent)" `shouldRespondWith`
         [json|
           {
@@ -163,24 +164,28 @@ spec =
         { matchHeaders = [matchContentTypeJson] }
 
     context "using FK col to specify the relationship" $ do
-      it "can embed by FK column name" $
-        get "/projects?id=in.(1,3)&select=id,name,client_id(id,name)" `shouldRespondWith`
-          [json|[{"id":1,"name":"Windows 7","client_id":{"id":1,"name":"Microsoft"}},{"id":3,"name":"IOS","client_id":{"id":2,"name":"Apple"}}]|]
-          { matchHeaders = [matchContentTypeJson] }
+        it "can embed by FK column name" $ do
+          pendingWith "duck typing removed: see what to do with single fk column embed"
+          get "/projects?id=in.(1,3)&select=id,name,client_id(id,name)" `shouldRespondWith`
+            [json|[{"id":1,"name":"Windows 7","client_id":{"id":1,"name":"Microsoft"}},{"id":3,"name":"IOS","client_id":{"id":2,"name":"Apple"}}]|]
+            { matchHeaders = [matchContentTypeJson] }
 
-      it "can embed by FK column name and select the FK value at the same time, if aliased" $
-        get "/projects?id=in.(1,3)&select=id,name,client_id,client:client_id(id,name)" `shouldRespondWith`
-          [json|[{"id":1,"name":"Windows 7","client_id":1,"client":{"id":1,"name":"Microsoft"}},{"id":3,"name":"IOS","client_id":2,"client":{"id":2,"name":"Apple"}}]|]
-          { matchHeaders = [matchContentTypeJson] }
+        it "can embed by FK column name and select the FK value at the same time, if aliased" $ do
+          pendingWith "duck typing removed: see what to do with single fk column embed"
+          get "/projects?id=in.(1,3)&select=id,name,client_id,client:client_id(id,name)" `shouldRespondWith`
+            [json|[{"id":1,"name":"Windows 7","client_id":1,"client":{"id":1,"name":"Microsoft"}},{"id":3,"name":"IOS","client_id":2,"client":{"id":2,"name":"Apple"}}]|]
+            { matchHeaders = [matchContentTypeJson] }
 
-      it "requests parents two levels up" $
-        get "/tasks?id=eq.1&select=id,name,project:projects!project_id(id,name,client:client_id(id,name))" `shouldRespondWith`
-          [str|[{"id":1,"name":"Design w7","project":{"id":1,"name":"Windows 7","client":{"id":1,"name":"Microsoft"}}}]|]
+        it "requests parents two levels up" $ do
+          pendingWith "duck typing removed: see what to do with single fk column embed"
+          get "/tasks?id=eq.1&select=id,name,project:projects!project_id(id,name,client:client_id(id,name))" `shouldRespondWith`
+            [str|[{"id":1,"name":"Design w7","project":{"id":1,"name":"Windows 7","client":{"id":1,"name":"Microsoft"}}}]|]
 
 
     context "tables with self reference foreign keys" $ do
       context "one self reference foreign key" $ do
-        it "embeds parents recursively" $
+        it "embeds parents recursively" $ do
+          pendingWith "duck typing removed: see what to do with single fk column embed"
           get "/family_tree?id=in.(3,4)&select=id,parent(id,name,parent(*))" `shouldRespondWith`
             [json|[
               { "id": "3", "parent": { "id": "1", "name": "Parental Unit", "parent": null } },
@@ -197,7 +202,8 @@ spec =
               ]
             }]|] { matchHeaders = [matchContentTypeJson] }
 
-        it "embeds parent and then embeds childs" $
+        it "embeds parent and then embeds childs" $ do
+          pendingWith "duck typing removed: see what to do with single fk column embed"
           get "/family_tree?id=eq.2&select=id,name,parent(id,name,childs:family_tree!parent(id,name))" `shouldRespondWith`
             [json|[{
               "id": "2", "name": "Kid One", "parent": {
@@ -206,7 +212,8 @@ spec =
             }]|] { matchHeaders = [matchContentTypeJson] }
 
       context "two self reference foreign keys" $ do
-        it "embeds parents" $
+        it "embeds parents" $ do
+          pendingWith "duck typing removed: see what to do with single fk column embed"
           get "/organizations?select=id,name,referee(id,name),auditor(id,name)&id=eq.3" `shouldRespondWith`
             [json|[{
               "id": 3, "name": "Acme",
@@ -221,6 +228,7 @@ spec =
             }]|] { matchHeaders = [matchContentTypeJson] }
 
         it "embeds childs" $ do
+          pendingWith "duck typing removed: see what to do with single fk column embed"
           get "/organizations?select=id,name,refereeds:organizations!referee(id,name)&id=eq.1" `shouldRespondWith`
             [json|[{
               "id": 1, "name": "Referee Org",
@@ -251,6 +259,7 @@ spec =
             }]|] { matchHeaders = [matchContentTypeJson] }
 
         it "embeds other relations(manager) besides the self reference" $ do
+          pendingWith "duck typing removed: see what to do with single fk column embed"
           get "/organizations?select=name,manager(name),referee(name,manager(name),auditor(name,manager(name))),auditor(name,manager(name),referee(name,manager(name)))&id=eq.5" `shouldRespondWith`
             [json|[{
               "name":"Cyberdyne",

--- a/test/Feature/EmbedDisambiguationSpec.hs
+++ b/test/Feature/EmbedDisambiguationSpec.hs
@@ -20,19 +20,19 @@ spec =
             {
               "details": [
                 {
-                    "cardinality": "m2o(many-to-one)",
-                    "foreignKey": "sender[sender][id]",
+                    "cardinality": "m2o",
+                    "relationship": "sender",
                     "source": "test.message",
                     "target": "test.person"
                 },
                 {
-                    "cardinality": "m2o(many-to-one)",
-                    "foreignKey": "sender[sender][id]",
+                    "cardinality": "m2o",
+                    "relationship": "sender",
                     "source": "test.message",
                     "target": "test.person_detail"
                 }
               ],
-              "hint": "Disambiguate by choosing a relationship from the `details` key",
+              "hint": "By following the 'details' key, disambiguate the request by changing the url to /source?select=relationship(*) or /source?select=target!<relationship|cardinality|junction>(*)",
               "message": "More than one relationship was found for message and sender"
             }
           |]
@@ -46,19 +46,19 @@ spec =
             {
               "details": [
                 {
-                    "cardinality": "m2o(many-to-one)",
-                    "foreignKey": "p_web_id[p_web_id][id]",
+                    "cardinality": "m2o",
+                    "relationship": "p_web_id",
                     "source": "test.web_content",
                     "target": "test.web_content"
                 },
                 {
-                    "cardinality": "o2m(one-to-many)",
-                    "foreignKey": "p_web_id[id][p_web_id]",
+                    "cardinality": "o2m",
+                    "relationship": "p_web_id",
                     "source": "test.web_content",
                     "target": "test.web_content"
                 }
               ],
-              "hint": "Disambiguate by choosing a relationship from the `details` key",
+              "hint": "By following the 'details' key, disambiguate the request by changing the url to /source?select=relationship(*) or /source?select=target!<relationship|cardinality|junction>(*)",
               "message": "More than one relationship was found for web_content and web_content"
             }
           |]
@@ -72,25 +72,25 @@ spec =
             {
               "details": [
                 {
-                    "cardinality": "m2o(many-to-one)",
-                    "foreignKey": "sites_main_project_id_fkey[main_project_id][big_project_id]",
+                    "cardinality": "m2o",
+                    "relationship": "sites_main_project_id_fkey",
                     "source": "test.sites",
                     "target": "test.big_projects"
                 },
                 {
-                    "cardinality": "m2m(many-to-many)",
-                    "junction": "test.jobs[site_id][big_project_id]",
+                    "cardinality": "m2m",
+                    "junction": "test.jobs",
                     "source": "test.sites",
                     "target": "test.big_projects"
                 },
                 {
-                    "cardinality": "m2m(many-to-many)",
-                    "junction": "test.main_jobs[site_id][big_project_id]",
+                    "cardinality": "m2m",
+                    "junction": "test.main_jobs",
                     "source": "test.sites",
                     "target": "test.big_projects"
                 }
               ],
-              "hint": "Disambiguate by choosing a relationship from the `details` key",
+              "hint": "By following the 'details' key, disambiguate the request by changing the url to /source?select=relationship(*) or /source?select=target!<relationship|cardinality|junction>(*)",
               "message": "More than one relationship was found for sites and big_projects"
             }
           |]
@@ -104,19 +104,19 @@ spec =
             {
               "details": [
                   {
-                      "cardinality": "m2m(many-to-many)",
-                      "junction": "test.jobs[site_id][big_project_id]",
+                      "cardinality": "m2m",
+                      "junction": "test.jobs",
                       "source": "test.sites",
                       "target": "test.big_projects"
                   },
                   {
-                      "cardinality": "m2m(many-to-many)",
-                      "junction": "test.main_jobs[site_id][big_project_id]",
+                      "cardinality": "m2m",
+                      "junction": "test.main_jobs",
                       "source": "test.sites",
                       "target": "test.big_projects"
                   }
               ],
-              "hint": "Disambiguate by choosing a relationship from the `details` key",
+              "hint": "By following the 'details' key, disambiguate the request by changing the url to /source?select=relationship(*) or /source?select=target!<relationship|cardinality|junction>(*)",
               "message": "More than one relationship was found for sites and big_projects"
             }
           |]
@@ -130,19 +130,19 @@ spec =
             {
               "details": [
                   {
-                      "cardinality": "m2m(many-to-many)",
-                      "junction": "test.jobs[site_id][big_project_id]",
+                      "cardinality": "m2m",
+                      "junction": "test.jobs",
                       "source": "test.sites",
                       "target": "test.big_projects"
                   },
                   {
-                      "cardinality": "m2m(many-to-many)",
-                      "junction": "test.main_jobs[site_id][big_project_id]",
+                      "cardinality": "m2m",
+                      "junction": "test.main_jobs",
                       "source": "test.sites",
                       "target": "test.big_projects"
                   }
               ],
-              "hint": "Disambiguate by choosing a relationship from the `details` key",
+              "hint": "By following the 'details' key, disambiguate the request by changing the url to /source?select=relationship(*) or /source?select=target!<relationship|cardinality|junction>(*)",
               "message": "More than one relationship was found for sites and big_projects"
             }
           |]
@@ -156,19 +156,19 @@ spec =
             {
               "details": [
                 {
-                  "cardinality": "m2o(many-to-one)",
-                  "foreignKey": "agents_department_id_fkey[department_id][id]",
+                  "cardinality": "m2o",
+                  "relationship": "agents_department_id_fkey",
                   "source": "test.agents",
                   "target": "test.departments"
                 },
                 {
-                  "cardinality": "o2m(one-to-many)",
-                  "foreignKey": "departments_head_id_fkey[id][head_id]",
+                  "cardinality": "o2m",
+                  "relationship": "departments_head_id_fkey",
                   "source": "test.agents",
                   "target": "test.departments"
                 }
               ],
-              "hint": "Disambiguate by choosing a relationship from the `details` key",
+              "hint": "By following the 'details' key, disambiguate the request by changing the url to /source?select=relationship(*) or /source?select=target!<relationship|cardinality|junction>(*)",
               "message": "More than one relationship was found for agents and departments"
             }
           |]
@@ -177,36 +177,41 @@ spec =
           }
 
       it "errs when there are more than two fks on a junction table(currently impossible to disambiguate, only choice is to split the table)" $
+        -- We have 4 possibilities for doing the junction JOIN here, using these columns:
+        -- [site_id_1][project_id_1]
+        -- [site_id_1][project_id_2]
+        -- [site_id_2][project_id_1]
+        -- [site_id_2][project_id_2]
         get "/whatev_sites?select=*,whatev_projects!m2m(*)" `shouldRespondWith`
           [json|
             {
               "details": [
                   {
-                    "cardinality": "m2m(many-to-many)",
-                    "junction": "test.whatev_jobs[site_id_1][project_id_1]",
+                    "cardinality": "m2m",
+                    "junction": "test.whatev_jobs",
                     "source": "test.whatev_sites",
                     "target": "test.whatev_projects"
                   },
                   {
-                    "cardinality": "m2m(many-to-many)",
-                    "junction": "test.whatev_jobs[site_id_1][project_id_2]",
+                    "cardinality": "m2m",
+                    "junction": "test.whatev_jobs",
                     "source": "test.whatev_sites",
                     "target": "test.whatev_projects"
                   },
                   {
-                    "cardinality": "m2m(many-to-many)",
-                    "junction": "test.whatev_jobs[site_id_2][project_id_1]",
+                    "cardinality": "m2m",
+                    "junction": "test.whatev_jobs",
                     "source": "test.whatev_sites",
                     "target": "test.whatev_projects"
                   },
                   {
-                    "cardinality": "m2m(many-to-many)",
-                    "junction": "test.whatev_jobs[site_id_2][project_id_2]",
+                    "cardinality": "m2m",
+                    "junction": "test.whatev_jobs",
                     "source": "test.whatev_sites",
                     "target": "test.whatev_projects"
                   }
               ],
-              "hint": "Disambiguate by choosing a relationship from the `details` key",
+              "hint": "By following the 'details' key, disambiguate the request by changing the url to /source?select=relationship(*) or /source?select=target!<relationship|cardinality|junction>(*)",
               "message": "More than one relationship was found for whatev_sites and whatev_projects"
             }
           |]

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -551,7 +551,8 @@ spec actualPgVersion = do
         simpleStatus p2 `shouldBe` created201
 
   context "tables with self reference foreign keys" $ do
-    it "embeds parent after insert" $
+    it "embeds parent after insert" $ do
+      pendingWith "Removing duck typing"
       request methodPost "/web_content?select=id,name,parent_content:p_web_id(name)"
               [("Prefer", "return=representation")]
         [json|{"id":6, "name":"wot", "p_web_id":4}|]
@@ -573,7 +574,8 @@ spec actualPgVersion = do
           matchHeaders = [matchContentTypeJson]
         }
 
-    it "embeds parent, childs and grandchilds after update" $
+    it "embeds parent, childs and grandchilds after update" $ do
+      pendingWith "Removing duck typing"
       request methodPatch "/web_content?id=eq.0&select=id,name,web_content(name,web_content(name)),parent_content:p_web_id(name)"
               [("Prefer", "return=representation")]
         [json|{"name": "tardis-patched-2"}|]

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -551,9 +551,8 @@ spec actualPgVersion = do
         simpleStatus p2 `shouldBe` created201
 
   context "tables with self reference foreign keys" $ do
-    it "embeds parent after insert" $ do
-      pendingWith "Removing duck typing"
-      request methodPost "/web_content?select=id,name,parent_content:p_web_id(name)"
+    it "embeds parent after insert" $
+      request methodPost "/web_content?select=id,name,parent_content:web_content!m2o(name)"
               [("Prefer", "return=representation")]
         [json|{"id":6, "name":"wot", "p_web_id":4}|]
         `shouldRespondWith`
@@ -563,7 +562,7 @@ spec actualPgVersion = do
         }
 
     it "embeds childs after update" $
-      request methodPatch "/web_content?id=eq.0&select=id,name,web_content(name)"
+      request methodPatch "/web_content?id=eq.0&select=id,name,web_content!o2m(name)"
               [("Prefer", "return=representation")]
         [json|{"name": "tardis-patched"}|]
         `shouldRespondWith`
@@ -574,9 +573,8 @@ spec actualPgVersion = do
           matchHeaders = [matchContentTypeJson]
         }
 
-    it "embeds parent, childs and grandchilds after update" $ do
-      pendingWith "Removing duck typing"
-      request methodPatch "/web_content?id=eq.0&select=id,name,web_content(name,web_content(name)),parent_content:p_web_id(name)"
+    it "embeds parent, childs and grandchilds after update" $
+      request methodPatch "/web_content?id=eq.0&select=id,name,web_content!o2m(name,web_content!o2m(name)),parent_content:web_content!m2o(name)"
               [("Prefer", "return=representation")]
         [json|{"name": "tardis-patched-2"}|]
         `shouldRespondWith`
@@ -597,7 +595,7 @@ spec actualPgVersion = do
         }
 
     it "embeds childs after update without explicitly including the id in the ?select" $
-      request methodPatch "/web_content?id=eq.0&select=name,web_content(name)"
+      request methodPatch "/web_content?id=eq.0&select=name,web_content!o2m(name)"
               [("Prefer", "return=representation")]
         [json|{"name": "tardis-patched"}|]
         `shouldRespondWith`

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -4,7 +4,7 @@ import Network.Wai      (Application)
 import Network.Wai.Test (SResponse (simpleHeaders))
 
 import Network.HTTP.Types
-import Test.Hspec
+import Test.Hspec          hiding (pendingWith)
 import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 
@@ -265,18 +265,8 @@ spec actualPgVersion = do
         [json|[{"id":1,"name":"Windows 7","clients":{"id":1,"name":"Microsoft"},"tasks":[{"id":1,"name":"Design w7"},{"id":2,"name":"Code w7"}]}]|]
         { matchHeaders = [matchContentTypeJson] }
 
-    it "requesting parent without specifying primary key" $
-      get "/projects?select=name,client(name)" `shouldRespondWith`
-        [json|[
-          {"name":"Windows 7","client":{"name": "Microsoft"}},
-          {"name":"Windows 10","client":{"name": "Microsoft"}},
-          {"name":"IOS","client":{"name": "Apple"}},
-          {"name":"OSX","client":{"name": "Apple"}},
-          {"name":"Orphan","client":null}
-        ]|]
-        { matchHeaders = [matchContentTypeJson] }
-
-    it "requesting parent and renaming primary key" $
+    it "requesting parent and renaming primary key" $ do
+      pendingWith "duck typing removed: see what to do with single fk column embed"
       get "/projects?select=name,client(clientId:id,name)" `shouldRespondWith`
         [json|[
           {"name":"Windows 7","client":{"name": "Microsoft", "clientId": 1}},
@@ -295,12 +285,14 @@ spec actualPgVersion = do
         [json|[{"id":1,"commenter_id":1,"user_id":2,"task_id":6,"content":"Needs to be delivered ASAP","users_tasks":{"taskId": 6}}]|]
         { matchHeaders = [matchContentTypeJson] }
 
-    it "embed data with two fk pointing to the same table" $
+    it "embed data with two fk pointing to the same table" $ do
+      pendingWith "duck typing removed: see what to do with single fk column embed"
       get "/orders?id=eq.1&select=id, name, billing_address_id(id), shipping_address_id(id)" `shouldRespondWith`
         [str|[{"id":1,"name":"order 1","billing_address_id":{"id":1},"shipping_address_id":{"id":2}}]|]
 
 
-    it "requesting parents and children while renaming them" $
+    it "requesting parents and children while renaming them" $ do
+      pendingWith "duck typing removed: see what to do with single fk column embed"
       get "/projects?id=eq.1&select=myId:id, name, project_client:client_id(*), project_tasks:tasks(id, name)" `shouldRespondWith`
         [json|[{"myId":1,"name":"Windows 7","project_client":{"id":1,"name":"Microsoft"},"project_tasks":[{"id":1,"name":"Design w7"},{"id":2,"name":"Code w7"}]}]|]
         { matchHeaders = [matchContentTypeJson] }
@@ -343,11 +335,6 @@ spec actualPgVersion = do
         [json|[{"user_id":2,"task_id":6,"comments":[{"content":"Needs to be delivered ASAP"}]}]|]
         { matchHeaders = [matchContentTypeJson] }
 
-    it "can select by column name sans id" $
-      get "/projects?id=in.(1,3)&select=id,name,client_id,client(id,name)" `shouldRespondWith`
-        [json|[{"id":1,"name":"Windows 7","client_id":1,"client":{"id":1,"name":"Microsoft"}},{"id":3,"name":"IOS","client_id":2,"client":{"id":2,"name":"Apple"}}]|]
-        { matchHeaders = [matchContentTypeJson] }
-
     describe "view embedding" $ do
       it "can detect fk relations through views to tables in the public schema" $
         get "/consumers_view?select=*,orders_view(*)" `shouldRespondWith` 200
@@ -355,7 +342,8 @@ spec actualPgVersion = do
       it "can detect fk relations through materialized views to tables in the public schema" $
         get "/materialized_projects?select=*,users(*)" `shouldRespondWith` 200
 
-      it "can request parent without specifying primary key" $
+      it "can request parent without specifying primary key" $ do
+        pendingWith "duck typing removed: see what to do with single fk column embed"
         get "/articleStars?select=createdAt,article(owner),user(name)&limit=1" `shouldRespondWith`
           [json|[{"createdAt":"2015-12-08T04:22:57.472738","article":{"owner": "postgrest_test_authenticator"},"user":{"name": "Angela Martin"}}]|]
           { matchHeaders = [matchContentTypeJson] }
@@ -447,7 +435,8 @@ spec actualPgVersion = do
              {"tournament":"tournament_3","player_view":{"first_name":"first_name_3"}}] |]
           { matchHeaders = [matchContentTypeJson] }
 
-      it "can embed a view that has group by" $
+      it "can embed a view that has group by" $ do
+        pendingWith "duck typing removed: see what to do with single fk column embed"
         get "/projects_count_grouped_by?select=number_of_projects,client(name)&order=number_of_projects" `shouldRespondWith`
           [json|
             [{"number_of_projects":1,"client":null},
@@ -612,10 +601,6 @@ spec actualPgVersion = do
       get "/projects?id=eq.1&select=id, name, clients(id, name)&clients.order=name.asc" `shouldRespondWith`
         [str|[{"id":1,"name":"Windows 7","clients":{"id":1,"name":"Microsoft"}}]|]
 
-    it "ordering embeded parents does not break things when using ducktape names" $
-      get "/projects?id=eq.1&select=id, name, client(id, name)&client.order=name.asc" `shouldRespondWith`
-        [str|[{"id":1,"name":"Windows 7","client":{"id":1,"name":"Microsoft"}}]|]
-
     context "order syntax errors" $ do
       it "gives meaningful error messages when asc/desc/nulls{first,last} are misspelled" $ do
         get "/items?order=id.ac" `shouldRespondWith`
@@ -745,7 +730,8 @@ spec actualPgVersion = do
         [json| [{"ghostBusters":[{"escapeId":1}]},{"ghostBusters":[]},{"ghostBusters":[{"escapeId":3}]},{"ghostBusters":[]},{"ghostBusters":[{"escapeId":5}]}] |]
         { matchHeaders = [matchContentTypeJson] }
 
-    it "will embed using a column" $
+    it "will embed using a column" $ do
+      pendingWith "duck typing removed: see what to do with single fk column embed"
       get "/ghostBusters?select=escapeId(*)" `shouldRespondWith`
         [json| [{"escapeId":{"so6meIdColumn":1}},{"escapeId":{"so6meIdColumn":3}},{"escapeId":{"so6meIdColumn":5}}] |]
         { matchHeaders = [matchContentTypeJson] }

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -198,7 +198,7 @@ spec actualPgVersion = do
 
     it "matches filtering nested items 2" $
       get "/clients?select=id,projects(id,tasks2(id,name))&projects.tasks.name=like.Design*"
-        `shouldRespondWith` [json| {"message":"Could not find foreign keys between these entities, No relation found between projects and tasks2"}|]
+        `shouldRespondWith` [json| {"message":"Could not find foreign keys between these entities. No relationship found between projects and tasks2"}|]
         { matchStatus  = 400
         , matchHeaders = [matchContentTypeJson]
         }
@@ -265,9 +265,8 @@ spec actualPgVersion = do
         [json|[{"id":1,"name":"Windows 7","clients":{"id":1,"name":"Microsoft"},"tasks":[{"id":1,"name":"Design w7"},{"id":2,"name":"Code w7"}]}]|]
         { matchHeaders = [matchContentTypeJson] }
 
-    it "requesting parent and renaming primary key" $ do
-      pendingWith "duck typing removed: see what to do with single fk column embed"
-      get "/projects?select=name,client(clientId:id,name)" `shouldRespondWith`
+    it "requesting parent and renaming primary key" $
+      get "/projects?select=name,client:clients(clientId:id,name)" `shouldRespondWith`
         [json|[
           {"name":"Windows 7","client":{"name": "Microsoft", "clientId": 1}},
           {"name":"Windows 10","client":{"name": "Microsoft", "clientId": 1}},
@@ -285,15 +284,8 @@ spec actualPgVersion = do
         [json|[{"id":1,"commenter_id":1,"user_id":2,"task_id":6,"content":"Needs to be delivered ASAP","users_tasks":{"taskId": 6}}]|]
         { matchHeaders = [matchContentTypeJson] }
 
-    it "embed data with two fk pointing to the same table" $ do
-      pendingWith "duck typing removed: see what to do with single fk column embed"
-      get "/orders?id=eq.1&select=id, name, billing_address_id(id), shipping_address_id(id)" `shouldRespondWith`
-        [str|[{"id":1,"name":"order 1","billing_address_id":{"id":1},"shipping_address_id":{"id":2}}]|]
-
-
-    it "requesting parents and children while renaming them" $ do
-      pendingWith "duck typing removed: see what to do with single fk column embed"
-      get "/projects?id=eq.1&select=myId:id, name, project_client:client_id(*), project_tasks:tasks(id, name)" `shouldRespondWith`
+    it "requesting parents and children while renaming them" $
+      get "/projects?id=eq.1&select=myId:id, name, project_client:clients(*), project_tasks:tasks(id, name)" `shouldRespondWith`
         [json|[{"myId":1,"name":"Windows 7","project_client":{"id":1,"name":"Microsoft"},"project_tasks":[{"id":1,"name":"Design w7"},{"id":2,"name":"Code w7"}]}]|]
         { matchHeaders = [matchContentTypeJson] }
 
@@ -342,9 +334,8 @@ spec actualPgVersion = do
       it "can detect fk relations through materialized views to tables in the public schema" $
         get "/materialized_projects?select=*,users(*)" `shouldRespondWith` 200
 
-      it "can request parent without specifying primary key" $ do
-        pendingWith "duck typing removed: see what to do with single fk column embed"
-        get "/articleStars?select=createdAt,article(owner),user(name)&limit=1" `shouldRespondWith`
+      it "can request two parents" $
+        get "/articleStars?select=createdAt,article:articles(owner),user:users(name)&limit=1" `shouldRespondWith`
           [json|[{"createdAt":"2015-12-08T04:22:57.472738","article":{"owner": "postgrest_test_authenticator"},"user":{"name": "Angela Martin"}}]|]
           { matchHeaders = [matchContentTypeJson] }
 
@@ -435,9 +426,8 @@ spec actualPgVersion = do
              {"tournament":"tournament_3","player_view":{"first_name":"first_name_3"}}] |]
           { matchHeaders = [matchContentTypeJson] }
 
-      it "can embed a view that has group by" $ do
-        pendingWith "duck typing removed: see what to do with single fk column embed"
-        get "/projects_count_grouped_by?select=number_of_projects,client(name)&order=number_of_projects" `shouldRespondWith`
+      it "can embed a view that has group by" $
+        get "/projects_count_grouped_by?select=number_of_projects,client:clients(name)&order=number_of_projects" `shouldRespondWith`
           [json|
             [{"number_of_projects":1,"client":null},
              {"number_of_projects":2,"client":{"name":"Microsoft"}},
@@ -728,12 +718,6 @@ spec actualPgVersion = do
     it "will embed a collection" $
       get "/Escap3e;?select=ghostBusters(*)" `shouldRespondWith`
         [json| [{"ghostBusters":[{"escapeId":1}]},{"ghostBusters":[]},{"ghostBusters":[{"escapeId":3}]},{"ghostBusters":[]},{"ghostBusters":[{"escapeId":5}]}] |]
-        { matchHeaders = [matchContentTypeJson] }
-
-    it "will embed using a column" $ do
-      pendingWith "duck typing removed: see what to do with single fk column embed"
-      get "/ghostBusters?select=escapeId(*)" `shouldRespondWith`
-        [json| [{"escapeId":{"so6meIdColumn":1}},{"escapeId":{"so6meIdColumn":3}},{"escapeId":{"so6meIdColumn":5}}] |]
         { matchHeaders = [matchContentTypeJson] }
 
     it "will select and filter a column that has spaces" $

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -158,10 +158,10 @@ spec actualPgVersion =
 
     context "foreign entities embedding" $ do
       it "can embed if related tables are in the exposed schema" $ do
-        post "/rpc/getproject?select=id,name,client(id),tasks(id)" [json| { "id": 1} |] `shouldRespondWith`
+        post "/rpc/getproject?select=id,name,client:clients(id),tasks(id)" [json| { "id": 1} |] `shouldRespondWith`
           [json|[{"id":1,"name":"Windows 7","client":{"id":1},"tasks":[{"id":1},{"id":2}]}]|]
           { matchHeaders = [matchContentTypeJson] }
-        get "/rpc/getproject?id=1&select=id,name,client(id),tasks(id)" `shouldRespondWith`
+        get "/rpc/getproject?id=1&select=id,name,client:clients(id),tasks(id)" `shouldRespondWith`
           [json|[{"id":1,"name":"Windows 7","client":{"id":1},"tasks":[{"id":1},{"id":2}]}]|]
           { matchHeaders = [matchContentTypeJson] }
 

--- a/test/fixtures/data.sql
+++ b/test/fixtures/data.sql
@@ -553,3 +553,16 @@ VALUES (1, 'dep 1', 1),
 
 UPDATE agents SET department_id = 1 WHERE id in (1, 2);
 UPDATE agents SET department_id = 2 WHERE id in (3, 4);
+
+TRUNCATE TABLE schedules CASCADE;
+INSERT INTO schedules VALUES(1, 'morning', '06:00:00', '11:59:00');
+INSERT INTO schedules VALUES(2, 'afternoon', '12:00:00', '17:59:00');
+INSERT INTO schedules VALUES(3, 'night', '18:00:00', '23:59:00');
+INSERT INTO schedules VALUES(4, 'early morning', '00:00:00', '05:59:00');
+
+TRUNCATE TABLE activities CASCADE;
+INSERT INTO activities(id, schedule_id, car_id)    VALUES(1, 1, 'CAR-349');
+INSERT INTO activities(id, schedule_id, camera_id) VALUES(2, 3, 'CAM-123');
+
+TRUNCATE TABLE unit_workdays CASCADE;
+INSERT INTO unit_workdays VALUES(1, '2019-12-02', 1, 1, 2, 3);

--- a/test/fixtures/data.sql
+++ b/test/fixtures/data.sql
@@ -520,3 +520,36 @@ INSERT INTO private.pages VALUES (2, 'http://postgrest.org/en/v6.0/admin.html');
 TRUNCATE TABLE private.referrals CASCADE;
 INSERT INTO private.referrals VALUES ('github.com', 1);
 INSERT INTO private.referrals VALUES ('hub.docker.com', 2);
+
+TRUNCATE TABLE big_projects CASCADE;
+INSERT INTO big_projects (big_project_id, name)
+VALUES (1, 'big project 1'),
+       (2, 'big project 2');
+
+TRUNCATE TABLE sites CASCADE;
+INSERT INTO sites (site_id, name, main_project_id)
+VALUES (1, 'site 1', 1),
+       (2, 'site 2', null),
+       (3, 'site 3', 2),
+       (4, 'site 4', null);
+
+TRUNCATE TABLE jobs CASCADE;
+INSERT INTO jobs (job_id, name, site_id, big_project_id)
+VALUES ('bc5d5362-b881-438f-b9f5-7417e08704ed', 'job 1-1', 1, 1),
+       ('3bd52697-033b-4edd-8a28-46a9c04b7c1e', 'job 2-1', 2, 1),
+       ('e6e67e4e-19b1-11e9-ab14-d663bd873d93', 'job 2-2', 2, 2);
+
+TRUNCATE TABLE departments CASCADE;
+TRUNCATE TABLE agents CASCADE;
+INSERT INTO agents (id, name)
+VALUES (1, 'agent 1'),
+       (2, 'agent 2'),
+       (3, 'agent 3'),
+       (4, 'agent 4');
+
+INSERT INTO departments (id, name, head_id)
+VALUES (1, 'dep 1', 1),
+       (2, 'dep 3', 3);
+
+UPDATE agents SET department_id = 1 WHERE id in (1, 2);
+UPDATE agents SET department_id = 2 WHERE id in (3, 4);

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -106,6 +106,15 @@ GRANT ALL ON TABLE
     , web_content
     , pages
     , referrals
+    , big_projects
+    , sites
+    , jobs
+    , main_jobs
+    , whatev_projects
+    , whatev_sites
+    , whatev_jobs
+    , agents
+    , departments
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -115,6 +115,9 @@ GRANT ALL ON TABLE
     , whatev_jobs
     , agents
     , departments
+    , schedules
+    , activities
+    , unit_workdays
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1686,6 +1686,11 @@ create view main_jobs as
 select * from jobs
 where site_id in (select site_id from sites where main_project_id is not null);
 
+-- junction in a private schema, just to make sure we don't leak it on resource embedding
+-- if it leaks it would show on the disambiguation error tests
+create view private.priv_jobs as
+  select * from jobs;
+
 -- tables to show our limitation when trying to do an m2m embed
 -- with a junction table that has more than two foreign keys
 create table whatev_projects (

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -463,10 +463,9 @@ ALTER SEQUENCE auto_incrementing_pk_id_seq OWNED BY auto_incrementing_pk.id;
 --
 
 CREATE TABLE clients (
-    id integer NOT NULL,
+    id integer primary key,
     name text NOT NULL
 );
-
 
 --
 -- Name: comments; Type: TABLE; Schema: test; Owner: -
@@ -663,11 +662,11 @@ CREATE TABLE insertonly (
 --
 
 CREATE TABLE projects (
-    id integer NOT NULL,
+    id integer primary key,
     name text NOT NULL,
-    client_id integer
+    client_id integer REFERENCES clients(id)
 );
-
+alter table projects rename constraint projects_client_id_fkey to client_id;
 
 --
 -- Name: projects_view; Type: VIEW; Schema: test; Owner: -
@@ -695,25 +694,24 @@ CREATE TABLE simple_pk (
     extra character varying NOT NULL
 );
 
---
--- Name: users_projects; Type: TABLE; Schema: test; Owner: -
---
+CREATE TABLE users (
+    id integer primary key,
+    name text NOT NULL
+);
 
 CREATE TABLE users_projects (
-    user_id integer NOT NULL,
-    project_id integer NOT NULL
+    user_id integer NOT NULL REFERENCES users(id),
+    project_id integer NOT NULL REFERENCES projects(id),
+    PRIMARY KEY (project_id, user_id)
 );
-
-
---
--- Name: tasks; Type: TABLE; Schema: test; Owner: -
---
 
 CREATE TABLE tasks (
-    id integer NOT NULL,
+    id integer primary key,
     name text NOT NULL,
-    project_id integer
+    project_id integer REFERENCES projects(id)
 );
+alter table tasks rename constraint tasks_project_id_fkey to project_id;
+
 
 CREATE OR REPLACE VIEW filtered_tasks AS
 SELECT id AS "myId", name, project_id AS "projectID"
@@ -725,6 +723,11 @@ project_id IN (
 	SELECT project_id FROM users_projects WHERE user_id = 1
 );
 
+CREATE TABLE users_tasks (
+  user_id integer NOT NULL REFERENCES users(id),
+  task_id integer NOT NULL REFERENCES tasks(id),
+  primary key (task_id, user_id)
+);
 
 --
 -- Name: tsearch; Type: TABLE; Schema: test; Owner: -
@@ -734,28 +737,6 @@ CREATE TABLE tsearch (
     text_search_vector tsvector
 );
 
-
---
--- Name: users; Type: TABLE; Schema: test; Owner: -
---
-
-CREATE TABLE users (
-    id integer NOT NULL,
-    name text NOT NULL
-);
-
-
-
---
--- Name: users_tasks; Type: TABLE; Schema: test; Owner: -
---
-
-CREATE TABLE users_tasks (
-    user_id integer NOT NULL,
-    task_id integer NOT NULL
-);
-
-
 CREATE TABLE "Escap3e;" (
 		"so6meIdColumn" integer primary key
 );
@@ -763,6 +744,7 @@ CREATE TABLE "Escap3e;" (
 CREATE TABLE "ghostBusters" (
 		"escapeId" integer not null references "Escap3e;"("so6meIdColumn")
 );
+alter table "ghostBusters" rename constraint "ghostBusters_escapeId_fkey" to "escapeId";
 
 CREATE TABLE "withUnique" (
     uni text UNIQUE,
@@ -772,7 +754,6 @@ CREATE TABLE "withUnique" (
 CREATE TABLE clashing_column (
     t text
 );
-
 
 --
 -- Name: id; Type: DEFAULT; Schema: test; Owner: -
@@ -842,14 +823,6 @@ ALTER TABLE ONLY auto_incrementing_pk
 
 
 --
--- Name: clients_pkey; Type: CONSTRAINT; Schema: test; Owner: -
---
-
-ALTER TABLE ONLY clients
-    ADD CONSTRAINT clients_pkey PRIMARY KEY (id);
-
-
---
 -- Name: comments_pkey; Type: CONSTRAINT; Schema: test; Owner: -
 --
 
@@ -903,46 +876,6 @@ ALTER TABLE ONLY items
 
 ALTER TABLE ONLY menagerie
     ADD CONSTRAINT menagerie_pkey PRIMARY KEY ("integer");
-
-
---
--- Name: project_user; Type: CONSTRAINT; Schema: test; Owner: -
---
-
-ALTER TABLE ONLY users_projects
-    ADD CONSTRAINT project_user PRIMARY KEY (project_id, user_id);
-
-
---
--- Name: projects_pkey; Type: CONSTRAINT; Schema: test; Owner: -
---
-
-ALTER TABLE ONLY projects
-    ADD CONSTRAINT projects_pkey PRIMARY KEY (id);
-
-
---
--- Name: task_user; Type: CONSTRAINT; Schema: test; Owner: -
---
-
-ALTER TABLE ONLY users_tasks
-    ADD CONSTRAINT task_user PRIMARY KEY (task_id, user_id);
-
-
---
--- Name: tasks_pkey; Type: CONSTRAINT; Schema: test; Owner: -
---
-
-ALTER TABLE ONLY tasks
-    ADD CONSTRAINT tasks_pkey PRIMARY KEY (id);
-
-
---
--- Name: users_pkey; Type: CONSTRAINT; Schema: test; Owner: -
---
-
-ALTER TABLE ONLY users
-    ADD CONSTRAINT users_pkey PRIMARY KEY (id);
 
 
 SET search_path = postgrest, pg_catalog;
@@ -1023,55 +956,6 @@ ALTER TABLE ONLY has_fk
 ALTER TABLE ONLY has_fk
     ADD CONSTRAINT has_fk_simple_fk_fkey FOREIGN KEY (simple_fk) REFERENCES simple_pk(k);
 
-
---
--- Name: projects_client_id_fkey; Type: FK CONSTRAINT; Schema: test; Owner: -
---
-
-ALTER TABLE ONLY projects
-    ADD CONSTRAINT projects_client_id_fkey FOREIGN KEY (client_id) REFERENCES clients(id);
-
-
---
--- Name: tasks_project_id_fkey; Type: FK CONSTRAINT; Schema: test; Owner: -
---
-
-ALTER TABLE ONLY tasks
-    ADD CONSTRAINT tasks_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects(id);
-
-
---
--- Name: users_projects_project_id_fkey; Type: FK CONSTRAINT; Schema: test; Owner: -
---
-
-ALTER TABLE ONLY users_projects
-    ADD CONSTRAINT users_projects_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects(id);
-
-
---
--- Name: users_projects_user_id_fkey; Type: FK CONSTRAINT; Schema: test; Owner: -
---
-
-ALTER TABLE ONLY users_projects
-    ADD CONSTRAINT users_projects_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id);
-
-
---
--- Name: users_tasks_task_id_fkey; Type: FK CONSTRAINT; Schema: test; Owner: -
---
-
-ALTER TABLE ONLY users_tasks
-    ADD CONSTRAINT users_tasks_task_id_fkey FOREIGN KEY (task_id) REFERENCES tasks(id);
-
-
---
--- Name: users_tasks_user_id_fkey; Type: FK CONSTRAINT; Schema: test; Owner: -
---
-
-ALTER TABLE ONLY users_tasks
-    ADD CONSTRAINT users_tasks_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id);
-
-
 create table addresses (
 	id                   int not null unique,
 	address              text not null
@@ -1083,6 +967,8 @@ create table orders (
 	billing_address_id   int references addresses(id),
 	shipping_address_id  int references addresses(id)
 );
+alter table orders rename constraint orders_billing_address_id_fkey to billing_address_id;
+alter table orders rename constraint orders_shipping_address_id_fkey to shipping_address_id;
 
 CREATE FUNCTION getproject(id int) RETURNS SETOF projects
     LANGUAGE sql
@@ -1398,8 +1284,9 @@ create table test.organizations (
   auditor integer,
   manager_id integer references managers(id)
 );
-alter table only test.organizations add constraint pptr1 foreign key (referee) references test.organizations(id);
-alter table only test.organizations add constraint pptr2 foreign key (auditor) references test.organizations(id);
+alter table only test.organizations add constraint referee foreign key (referee) references test.organizations(id);
+alter table only test.organizations add constraint auditor foreign key (auditor) references test.organizations(id);
+alter table only test.organizations rename constraint organizations_manager_id_fkey to manager;
 
 create table private.authors(
   id integer primary key,
@@ -1435,6 +1322,8 @@ create table message (
   body text not null default '',
   sender bigint not null references person(id),
   recipient bigint not null references person(id));
+alter table message rename constraint message_recipient_fkey to recipient;
+alter table message rename constraint message_sender_fkey    to sender;
 
 create view person_detail as
   select p.id, p.name, s.count as sent, r.count as received
@@ -1749,6 +1638,7 @@ CREATE TABLE web_content (
   p_web_id integer references web_content(id),
   primary key (id)
 );
+alter table web_content rename constraint web_content_p_web_id_fkey to p_web_id;
 
 CREATE FUNCTION getallusers() RETURNS SETOF users AS $$
   SELECT * FROM test.users;
@@ -1773,3 +1663,62 @@ create table private.referrals (
 create view test.pages as select * from private.pages;
 
 create view test.referrals as select * from private.referrals;
+
+create table big_projects (
+  big_project_id  serial  primary key,
+  name text
+);
+
+create table sites (
+  site_id         serial  primary key
+, name text
+, main_project_id int     null references big_projects (big_project_id)
+);
+
+create table jobs (
+  job_id          uuid    primary key
+, name text
+, site_id         int     not null references sites (site_id)
+, big_project_id  int     not null references big_projects (big_project_id)
+);
+
+create view main_jobs as
+select * from jobs
+where site_id in (select site_id from sites where main_project_id is not null);
+
+-- tables to show our limitation when trying to do an m2m embed
+-- with a junction table that has more than two foreign keys
+create table whatev_projects (
+  id  serial  primary key,
+  name text
+);
+
+create table whatev_sites (
+  id              serial  primary key
+, name text
+);
+
+create table whatev_jobs (
+  job_id        uuid    primary key
+, name text
+, site_id_1     int not null references whatev_sites (id)
+, project_id_1  int not null references whatev_projects (id)
+, site_id_2     int not null references whatev_sites (id)
+, project_id_2  int not null references whatev_projects (id)
+);
+
+-- circular reference
+create table agents (
+  id int primary key
+, name text
+, department_id int
+);
+
+create table departments (
+  id int primary key
+, name text
+, head_id int references agents(id)
+);
+
+ALTER TABLE agents
+    ADD CONSTRAINT agents_department_id_fkey foreign key (department_id) REFERENCES departments(id);

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1722,3 +1722,37 @@ create table departments (
 
 ALTER TABLE agents
     ADD CONSTRAINT agents_department_id_fkey foreign key (department_id) REFERENCES departments(id);
+
+-- composite key disambiguation
+create table schedules (
+  id        int primary key
+, name      text
+, start_at  timetz
+, end_at    timetz
+);
+
+create table activities (
+  id             int
+, schedule_id    int
+, car_id         text
+, camera_id      text
+, primary key (id, schedule_id)
+);
+alter table activities
+add constraint schedule foreign key          (schedule_id)
+                        references schedules (id);
+
+create table unit_workdays (
+  unit_id int
+, day date
+, fst_shift_activity_id int
+, fst_shift_schedule_id int
+, snd_shift_activity_id int
+, snd_shift_schedule_id int
+, primary key (unit_id, day)
+);
+alter table unit_workdays
+add constraint fst_shift foreign key           (fst_shift_activity_id, fst_shift_schedule_id)
+                         references activities (id, schedule_id),
+add constraint snd_shift foreign key           (snd_shift_activity_id, snd_shift_schedule_id)
+                         references activities (id, schedule_id);


### PR DESCRIPTION
Finishes the work started on #918. This should make resource embedding handle complex OLTP schemas in a non-ambiguous way.

The idea is to use the foreign key constraint name(as opposed to a column that it's part of the FK, previous discussion in https://github.com/PostgREST/postgrest/issues/1078#issuecomment-374325973)  and the [cardinality](https://en.wikipedia.org/wiki/Cardinality_(data_modeling)) to do the disambiguation.

(These ideas share some similarities with [Sybase's KEY JOIN](http://dcx.sybase.com/index.html#1201/en/dbusage/key-joins-aspen.html), which also does an `AUTO JOIN` based on a FK)

## Foreign key constraint name

With the fk name, the previous duck typing features are not necessary and "shorthands" can be defined in the schema. For example:
```sql
-- Having a m2o relationship on projects >- clients

-- We can define the FK constraint in this way
-- Note the "client" constraint
alter table projects add constraint client foreign key (client_id) references clients(id);

-- Or if the FK was already created we can rename it like
-- (this also provides a clear path for migration to our new version)
alter table projects rename constraint projects_client_id_fkey to client;
```

And the request with the embedding would be like:

```http
-- Note the singular "client"
GET /projects?select=id,client(*)

-- If the fk is not named it'll be like
GET /projects?select=id,projects_client_id_fkey(*)

-- If there's only one relationship the name of the table("clients") 
-- can be used as usual
GET /projects?select=id,clients(*)
```

Another advantage with this is that we handle composite keys disambiguations with a short url.

## Cardinality

In self reference cases the FK name is not enough to do the embedding since there's an m2o(many-to-one) and o2m(one-to-many) relationship with the same FK. So the cardinality can be specified to disambiguate:

```http
GET /family_tree?select=*,antecessor:family_tree!m2o(*)

GET /family_tree?select=*,successors:family_tree!o2m(*)
``` 
many-to-many would be `m2m`. In this case the ability to specify the junction table remains the same as in #918.
 
Also added some tests for circular references.

## Combined

These capabilities can be combined:
```http
GET /<view_or_table>?select=*,<view_or_table>!<cardinality>!<fk_name>(*)
```
Though in most cases just one hint will be enough to disambiguate. The error is also more clear(see the tests) and points what hint to use to disambiguate.

## Limitation

There's a limitation for junction tables that have more than one FK to the source and target. This is a rare case that cannot be disambiguated without complicating the syntax. In this case the table should be split(which I'd argue it's better design from a normalization standpoint). A clear error will be shown in this case(see the tests).

**Edit**:  this limitation can be lifted later if the need arises. The solution would be to allow to specify two more fks. Like `/users?select=tasks!m2m!fk1!fk2(*)`(long url, though there's no other choice). This could be added without causing a breaking change.