### PR TITLE
Allow specifying the constraint name to disambiguate an embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #1383, Add support for HEAD request - @steve-chavez
 - #1378, Add support for `Prefer: count=planned` and `Prefer: count=estimated` on GET /table - @steve-chavez
 - #1327, Add support for optional query parameter `on_conflict` to upsert with specified keys for POST - @ykst
+- #1430, Allow specifying the constraint name(`/source?select=constraint`) to disambiguate an embedding - @steve-chavez
 
 ### Fixed
 
@@ -25,7 +26,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #1385, bulk RPC call now should be done by specifying a `Prefer: params=multiple-objects` header - @steve-chavez
 - #1401, resource embedding now outputs an error when multiple relationships between two tables are found - @steve-chavez
 - #1423, default Unix Socket file mode from 755 to 660 - @dwagin
-- Remove embedding with duck typed column names `GET /projects?select=client(*)`- @steve-chavez
+- #1430, Remove embedding with duck typed column names `GET /projects?select=client(*)`- @steve-chavez
+  + You can rename the foreign key to `client` to make this request work in the new version: `alter table projects rename constraint projects_client_id_fkey to client`
 
 ## [6.0.2] - 2019-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #1383, Add support for HEAD request - @steve-chavez
 - #1378, Add support for `Prefer: count=planned` and `Prefer: count=estimated` on GET /table - @steve-chavez
 - #1327, Add support for optional query parameter `on_conflict` to upsert with specified keys for POST - @ykst
-- #1430, Allow specifying the constraint name(`/source?select=constraint`) to disambiguate an embedding - @steve-chavez
+- #1430, Allow specifying the foreign key constraint name(`/source?select=fk_constraint(*)`) to disambiguate an embedding - @steve-chavez
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #1385, bulk RPC call now should be done by specifying a `Prefer: params=multiple-objects` header - @steve-chavez
 - #1401, resource embedding now outputs an error when multiple relationships between two tables are found - @steve-chavez
 - #1423, default Unix Socket file mode from 755 to 660 - @dwagin
+- Remove embedding with duck typed column names `GET /projects?select=client(*)`- @steve-chavez
 
 ## [6.0.2] - 2019-08-22
 

--- a/src/PostgREST/DbRequestBuilder.hs
+++ b/src/PostgREST/DbRequestBuilder.hs
@@ -16,9 +16,8 @@ module PostgREST.DbRequestBuilder (
 , mutateRequest
 ) where
 
-import qualified Data.ByteString.Char8 as BS
-import qualified Data.HashMap.Strict   as M
-import qualified Data.Set              as S
+import qualified Data.HashMap.Strict as M
+import qualified Data.Set            as S
 
 import Control.Arrow           ((***))
 import Data.Either.Combinators (mapLeft)
@@ -26,7 +25,6 @@ import Data.Foldable           (foldr1)
 import Data.List               (delete, head, (!!))
 import Data.Maybe              (fromJust)
 import Data.Text               (isInfixOf)
-import Text.Regex.TDFA         ((=~))
 import Unsafe                  (unsafeHead)
 
 import Control.Applicative
@@ -141,31 +139,8 @@ findRelation schema allRelations parentTableName nodeName relationDetail =
         -- (relation type)  => M2O
         -- (entity)         => clients  {id}
         -- (foriegn entity) => projects {client_id}
-        (
-          parentTableName == tableName relTable && -- projects
-          nodeName == tableName relFTable -- clients
-        ) ||
-
-        -- (request)        => projects { ..., client_id{...} }
-        -- will match
-        -- (relation type)  => M2O
-        -- (entity)         => clients  {id}
-        -- (foriegn entity) => projects {client_id}
-        (
-          parentTableName == tableName relTable && -- projects
-          length relColumns == 1 &&
-          -- match common foreign key names(table_name_id, table_name_fk) to table_name
-          (toS ("^" <> colName (unsafeHead relColumns) <> "_?(?:|[iI][dD]|[fF][kK])$") :: BS.ByteString) =~
-          (toS nodeName :: BS.ByteString) -- client_id
-        )
-
-        -- (request)        => project_id { ..., client_id{...} }
-        -- will match
-        -- (relation type)  => M2O
-        -- (entity)         => clients  {id}
-        -- (foriegn entity) => projects {client_id}
-        -- this case works becasue before reaching this place
-        -- addRelation will turn project_id to project so the above condition will match
+        parentTableName == tableName relTable && -- projects
+        nodeName == tableName relFTable -- clients
 
       Just rd ->
 

--- a/src/PostgREST/DbRequestBuilder.hs
+++ b/src/PostgREST/DbRequestBuilder.hs
@@ -22,10 +22,8 @@ import qualified Data.Set            as S
 import Control.Arrow           ((***))
 import Data.Either.Combinators (mapLeft)
 import Data.Foldable           (foldr1)
-import Data.List               (delete, head, (!!))
-import Data.Maybe              (fromJust)
+import Data.List               (delete)
 import Data.Text               (isInfixOf)
-import Unsafe                  (unsafeHead)
 
 import Control.Applicative
 import Data.Tree
@@ -36,7 +34,7 @@ import PostgREST.Error      (ApiRequestError (..), errorResponseFor)
 import PostgREST.Parsers
 import PostgREST.RangeQuery (NonnegRange, allRange, restrictRange)
 import PostgREST.Types
-import Protolude            hiding (from, head)
+import Protolude            hiding (from)
 
 readRequest :: Schema -> TableName -> Maybe Integer -> [Relation] -> ApiRequest -> Either Response ReadRequest
 readRequest schema rootTableName maxRows allRels apiRequest  =
@@ -47,20 +45,20 @@ readRequest schema rootTableName maxRows allRels apiRequest  =
   (initReadRequest rootName <$> pRequestSelect sel)
   where
     sel = fromMaybe "*" $ iSelect apiRequest -- default to all columns requested (SELECT *) for a non existent ?select querystring param
-    (rootName, rootRels) = rootWithRelations schema rootTableName allRels (iAction apiRequest)
+    (rootName, rootRels) = rootWithRels schema rootTableName allRels (iAction apiRequest)
 
--- Get the root table name with its relations according to the Action type.
+-- Get the root table name with its relationships according to the Action type.
 -- This is done because of the shape of the final SQL Query. The mutation cases are wrapped in a WITH {sourceCTEName}(see Statements.hs).
 -- So we need a FROM {sourceCTEName} instead of FROM {tableName}.
-rootWithRelations :: Schema -> TableName -> [Relation] -> Action -> (QualifiedIdentifier, [Relation])
-rootWithRelations schema rootTableName allRels action = case action of
+rootWithRels :: Schema -> TableName -> [Relation] -> Action -> (QualifiedIdentifier, [Relation])
+rootWithRels schema rootTableName allRels action = case action of
   ActionRead _ -> (QualifiedIdentifier schema rootTableName, allRels) -- normal read case
-  _            -> (QualifiedIdentifier mempty sourceCTEName, mapMaybe toSourceRelation allRels ++ allRels) -- mutation cases and calling proc
+  _            -> (QualifiedIdentifier mempty sourceCTEName, mapMaybe toSourceRel allRels ++ allRels) -- mutation cases and calling proc
   where
     -- To enable embedding in the sourceCTEName cases we need to replace the foreign key tableName in the Relation
-    -- with {sourceCTEName}. This way findRelation can find Relations with sourceCTEName.
-    toSourceRelation :: Relation -> Maybe Relation
-    toSourceRelation r@Relation{relTable=t}
+    -- with {sourceCTEName}. This way findRel can find relationships with sourceCTEName.
+    toSourceRel :: Relation -> Maybe Relation
+    toSourceRel r@Relation{relTable=t}
       | rootTableName == tableName t = Just $ r {relTable=t {tableName=sourceCTEName}}
       | otherwise                    = Nothing
 
@@ -75,14 +73,14 @@ initReadRequest rootQi =
     rootName = qiName rootQi
     initial = Node (Select [] rootQi Nothing [] [] [] [] allRange, (rootName, Nothing, Nothing, Nothing, rootDepth)) []
     treeEntry :: Depth -> Tree SelectItem -> ReadRequest -> ReadRequest
-    treeEntry depth (Node fld@((fn, _),_,alias,relationDetail) fldForest) (Node (q, i) rForest) =
+    treeEntry depth (Node fld@((fn, _),_,alias, embedHint) fldForest) (Node (q, i) rForest) =
       let nxtDepth = succ depth in
       case fldForest of
         [] -> Node (q {select=fld:select q}, i) rForest
         _  -> Node (q, i) $
               foldr (treeEntry nxtDepth)
               (Node (Select [] (QualifiedIdentifier rootSchema fn) Nothing [] [] [] [] allRange,
-                (fn, Nothing, alias, relationDetail, nxtDepth)) [])
+                (fn, Nothing, alias, embedHint, nxtDepth)) [])
               fldForest:rForest
 
 treeRestrictRange :: Maybe Integer -> ReadRequest -> Either ApiRequestError ReadRequest
@@ -93,30 +91,16 @@ treeRestrictRange maxRows request = pure $ nodeRestrictRange maxRows <$> request
 
 augumentRequestWithJoin :: Schema -> [Relation] -> ReadRequest -> Either ApiRequestError ReadRequest
 augumentRequestWithJoin schema allRels request =
-  addRelations schema allRels Nothing request
+  addRels schema allRels Nothing request
   >>= addJoinConditions Nothing
 
-addRelations :: Schema -> [Relation] -> Maybe ReadRequest -> ReadRequest -> Either ApiRequestError ReadRequest
-addRelations schema allRelations parentNode (Node (query@Select{from=tbl}, (nodeName, _, alias, relationDetail, depth)) forest) =
+addRels :: Schema -> [Relation] -> Maybe ReadRequest -> ReadRequest -> Either ApiRequestError ReadRequest
+addRels schema allRels parentNode (Node (query@Select{from=tbl}, (nodeName, _, alias, hint, depth)) forest) =
   case parentNode of
     Just (Node (Select{from=parentNodeQi}, _) _) ->
       let newFrom r = if qiName tbl == nodeName then tableQi (relFTable r) else tbl
           newReadNode = (\r -> (query{from=newFrom r}, (nodeName, Just r, alias, Nothing, depth))) <$> rel
-          parentNodeTable = qiName parentNodeQi
-          results = findRelation schema allRelations parentNodeTable nodeName relationDetail
-          rel :: Either ApiRequestError Relation
-          rel = case results of
-            []  -> Left $ NoRelBetween parentNodeTable nodeName
-            [r] -> Right r
-            rs  ->
-              -- Hack for handling a self reference relationship.
-              -- In this case we get an O2M and M2O rels with the same relTable and relFtable.
-              -- We output the O2M rel, the M2O rel can be obtained by using the fk column as an embed hint in findRelation.
-              let rel0 = head rs
-                  rel1 = rs !! 1 in
-              if length rs == 2 && relTable rel0 == relTable rel1 && relFTable rel0 == relFTable rel1
-                then note (NoRelBetween parentNodeTable nodeName) (find (\r -> relType r == O2M) rs)
-                else Left $ AmbiguousRelBetween parentNodeTable nodeName rs
+          rel = findRel schema allRels (qiName parentNodeQi) nodeName hint
       in
       Node <$> newReadNode <*> (updateForest . hush $ Node <$> newReadNode <*> pure forest)
     _ ->
@@ -124,95 +108,99 @@ addRelations schema allRelations parentNode (Node (query@Select{from=tbl}, (node
       Node rn <$> updateForest (Just $ Node rn forest)
   where
     updateForest :: Maybe ReadRequest -> Either ApiRequestError [ReadRequest]
-    updateForest rq = mapM (addRelations schema allRelations rq) forest
+    updateForest rq = mapM (addRels schema allRels rq) forest
 
-findRelation :: Schema -> [Relation] -> TableName -> NodeName -> Maybe RelationDetail -> [Relation]
-findRelation schema allRelations parentTableName nodeName relationDetail =
-  filter (\Relation{relTable, relColumns, relFTable, relFColumns, relType, relLinkTable} ->
-    -- Both relation ends need to be on the exposed schema
-    schema == tableSchema relTable && schema == tableSchema relFTable &&
-    case relationDetail of
-      Nothing ->
-
-        -- (request)        => projects { ..., clients{...} }
-        -- will match
-        -- (relation type)  => M2O
-        -- (entity)         => clients  {id}
-        -- (foriegn entity) => projects {client_id}
-        parentTableName == tableName relTable && -- projects
-        nodeName == tableName relFTable -- clients
-
-      Just rd ->
-
-        -- (request)        => clients { ..., projects!client_id{...} }
-        -- will match
-        -- (relation type)  => O2M
-        -- (entity)         => clients  {id}
-        -- (foriegn entity) => projects {client_id}
+-- Finds a relationship between a source and target in the request: /source?select=target(*)
+-- If more than one relationship is found then the request is ambiguous and we return an error.
+-- In that case the request can be disambiguated by adding precision to the target or by using a hint: /source?select=target!hint(*)
+-- The elements will be matched according to these rules:
+-- source = table / view
+-- target = table / view / constraint / column-from-source
+-- hint   = constraint / column-from-source / column-from-target / junction
+findRel :: Schema -> [Relation] -> NodeName -> NodeName -> Maybe EmbedHint -> Either ApiRequestError Relation
+findRel schema allRels source target hint =
+  case rel of
+    []  -> Left $ NoRelBetween source target
+    [r] -> Right r
+    rs  ->
+      -- Return error if more than one relationship is found, unless we're in a self reference case.
+      --
+      -- Here we handle a self reference relationship to not cause a breaking change:
+      -- In a self reference we get two relationships with the same foreign key and relTable/relFtable but with different cardinalities(m2o/o2m)
+      -- We output the O2M rel, the M2O rel can be obtained by using the source column as an embed hint.
+      let [rel0, rel1] = take 2 rs in
+      if length rs == 2 && relConstraint rel0 == relConstraint rel1 && relTable rel0 == relTable rel1 && relFTable rel0 == relFTable rel1
+        then note (NoRelBetween source target) (find (\r -> relType r == O2M) rs)
+        else Left $ AmbiguousRelBetween source target rs
+  where
+    matchFKSingleCol hint_ cols = length cols == 1 && hint_ == (colName <$> head cols)
+    rel = filter (
+      \Relation{relTable, relColumns, relConstraint, relFTable, relFColumns, relType, relLinkTable} ->
+        -- Both relationship ends need to be on the exposed schema
+        schema == tableSchema relTable && schema == tableSchema relFTable &&
         (
-          relType == O2M &&
-          parentTableName == tableName relTable && -- clients
-          nodeName == tableName relFTable && -- projects
-          length relFColumns == 1 &&
-          rd == colName (unsafeHead relFColumns) -- rd is client_id
-        ) ||
+          -- /projects?select=clients(*)
+          source == tableName relTable  &&  -- projects
+          target == tableName relFTable ||  -- clients
 
-        -- (request)        => message { ..., person_detail!sender{...} }
-        -- will match
-        -- (relation type)  => M2O
-        -- (entity)         => message  {sender}
-        -- (foriegn entity) => person_detail {id}
-        (
-          relType == M2O &&
-          parentTableName == tableName relTable && -- message
-          nodeName == tableName relFTable && -- person_detail
-          length relColumns == 1 &&
-          rd == colName (unsafeHead relColumns) -- rd is sender
-        ) ||
+          -- /projects?select=projects_client_id_fkey(*)
+          (
+            source == tableName relTable && -- projects
+            Just target == relConstraint    -- projects_client_id_fkey
+          ) ||
+          -- /projects?select=client_id(*)
+          (
+            source == tableName relTable &&           -- projects
+            matchFKSingleCol (Just target) relColumns -- client_id
+          )
+        ) && (
+          isNothing hint || -- hint is optional
 
-        -- (request)        => tasks { ..., users.tasks_users{...} }
-        -- will match
-        -- (relation type)  => M2M
-        -- (entity)         => users
-        -- (foriegn entity) => tasks
-        (
-          relType == M2M &&
-          parentTableName == tableName relTable && -- tasks
-          nodeName == tableName relFTable && -- users
-          rd == tableName (fromJust relLinkTable) -- rd is tasks_users
+          -- /projects?select=clients!projects_client_id_fkey(*)
+          hint == relConstraint             || -- projects_client_id_fkey
+
+          -- /projects?select=clients!client_id(*) or /projects?select=clients!id(*)
+          matchFKSingleCol hint relColumns  || -- client_id
+          matchFKSingleCol hint relFColumns || -- id
+
+          -- /tasks?select=users!tasks_users(*)
+          (
+            relType == M2M &&                    -- many-to-many between tasks and users
+            hint == (tableName <$> relLinkTable) -- tasks_users
+          )
         )
-  ) allRelations
+      ) allRels
 
 -- previousAlias is only used for the case of self joins
 addJoinConditions :: Maybe Alias -> ReadRequest -> Either ApiRequestError ReadRequest
-addJoinConditions previousAlias (Node node@(query@Select{from=tbl}, nodeProps@(_, relation, _, _, depth)) forest) =
-  case relation of
-    Just rel@Relation{relType=O2M} -> Node (augmentQuery rel, nodeProps) <$> updatedForest
-    Just rel@Relation{relType=M2O} -> Node (augmentQuery rel, nodeProps) <$> updatedForest
-    Just rel@Relation{relType=M2M, relLinkTable=lTable} ->
+addJoinConditions previousAlias (Node node@(query@Select{from=tbl}, nodeProps@(_, rel, _, _, depth)) forest) =
+  case rel of
+    Just r@Relation{relType=O2M} -> Node (augmentQuery r, nodeProps) <$> updatedForest
+    Just r@Relation{relType=M2O} -> Node (augmentQuery r, nodeProps) <$> updatedForest
+    Just r@Relation{relType=M2M, relLinkTable=lTable} ->
       case lTable of
         Just linkTable ->
-          let rq = augmentQuery rel in
+          let rq = augmentQuery r in
           Node (rq{implicitJoins=tableQi linkTable:implicitJoins rq}, nodeProps) <$> updatedForest
         Nothing ->
           Left UnknownRelation
     Nothing -> Node node <$> updatedForest
   where
-    newAlias = case isSelfReference <$> relation of
+    newAlias = case isSelfReference <$> rel of
       Just True
         | depth /= 0 -> Just (qiName tbl <> "_" <> show depth) -- root node doesn't get aliased
         | otherwise  -> Nothing
       _              -> Nothing
-    augmentQuery rel =
+    augmentQuery r =
       foldr
         (\jc rq@Select{joinConditions=jcs} -> rq{joinConditions=jc:jcs})
         query{fromAlias=newAlias}
-        (getJoinConditions previousAlias newAlias rel)
+        (getJoinConditions previousAlias newAlias r)
     updatedForest = mapM (addJoinConditions newAlias) forest
 
 -- previousAlias and newAlias are used in the case of self joins
 getJoinConditions :: Maybe Alias -> Maybe Alias -> Relation -> [JoinCondition]
-getJoinConditions previousAlias newAlias (Relation Table{tableSchema=tSchema, tableName=tN} cols Table{tableName=ftN} fCols typ lt lc1 lc2) =
+getJoinConditions previousAlias newAlias (Relation Table{tableSchema=tSchema, tableName=tN} cols _ Table{tableName=ftN} fCols typ lt lc1 lc2) =
   case typ of
     O2M ->
         zipWith (toJoinCondition tN ftN) cols fCols

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -309,21 +309,21 @@ addViewM2ORels allSrcCols = concatMap (\rel ->
           viewTableM2O =
             [ Relation (getView srcCols) (snd <$> srcCols `sortAccordingTo` relColumns)
                        relConstraint relFTable relFColumns
-                       M2O Nothing Nothing Nothing
+                       M2O Nothing
             | srcCols <- relSrcCols, srcCols `allSrcColsOf` relColumns ]
 
           tableViewM2O =
             [ Relation relTable relColumns
                        relConstraint
                        (getView fSrcCols) (snd <$> fSrcCols `sortAccordingTo` relFColumns)
-                       M2O Nothing Nothing Nothing
+                       M2O Nothing
             | fSrcCols <- relFSrcCols, fSrcCols `allSrcColsOf` relFColumns ]
 
           viewViewM2O =
             [ Relation (getView srcCols) (snd <$> srcCols `sortAccordingTo` relColumns)
                        relConstraint
                        (getView fSrcCols) (snd <$> fSrcCols `sortAccordingTo` relFColumns)
-                       M2O Nothing Nothing Nothing
+                       M2O Nothing
             | srcCols  <- relSrcCols, srcCols `allSrcColsOf` relColumns
             , fSrcCols <- relFSrcCols, fSrcCols `allSrcColsOf` relFColumns ]
 
@@ -332,12 +332,12 @@ addViewM2ORels allSrcCols = concatMap (\rel ->
     _ -> [])
 
 addO2MRels :: [Relation] -> [Relation]
-addO2MRels = concatMap (\rel@(Relation t c cn ft fc _ _ _ _) -> [rel, Relation ft fc cn t c O2M Nothing Nothing Nothing])
+addO2MRels = concatMap (\rel@(Relation t c cn ft fc _ _) -> [rel, Relation ft fc cn t c O2M Nothing])
 
 addM2MRels :: [Relation] -> [Relation]
-addM2MRels rels = rels ++ addMirrorRelation (mapMaybe link2Relation links)
+addM2MRels rels = rels ++ addMirrorRel (mapMaybe junction2Rel junctions)
   where
-    links = join $ map (combinations 2) $ filter (not . null) $ groupWith groupFn $ filter ( (==M2O). relType) rels
+    junctions = join $ map (combinations 2) $ filter (not . null) $ groupWith groupFn $ filter ( (==M2O). relType) rels
     groupFn :: Relation -> Text
     groupFn Relation{relTable=Table{tableSchema=s, tableName=t}} = s <> "_" <> t
     -- Reference : https://wiki.haskell.org/99_questions/Solutions/26
@@ -345,14 +345,15 @@ addM2MRels rels = rels ++ addMirrorRelation (mapMaybe link2Relation links)
     combinations 0 _  = [ [] ]
     combinations n xs = [ y:ys | y:xs' <- tails xs
                                , ys <- combinations (n-1) xs']
-    addMirrorRelation = concatMap (\rel@(Relation t c _ ft fc _ lt lc1 lc2) -> [rel, Relation ft fc Nothing t c M2M lt lc2 lc1])
-    link2Relation [
-      Relation{relTable=lt, relColumns=lc1, relFTable=t,  relFColumns=c},
-      Relation{             relColumns=lc2, relFTable=ft, relFColumns=fc}
+    junction2Rel [
+      Relation{relTable=jt, relColumns=jc1, relConstraint=const1, relFTable=t,  relFColumns=c},
+      Relation{             relColumns=jc2, relConstraint=const2, relFTable=ft, relFColumns=fc}
       ]
-      | lc1 /= lc2 && length lc1 == 1 && length lc2 == 1 = Just $ Relation t c Nothing ft fc M2M (Just lt) (Just lc1) (Just lc2)
+      | jc1 /= jc2 && length jc1 == 1 && length jc2 == 1 = Just $ Relation t c Nothing ft fc M2M (Just $ Junction jt const1 jc1 const2 jc2)
       | otherwise = Nothing
-    link2Relation _ = Nothing
+    junction2Rel _ = Nothing
+    addMirrorRel = concatMap (\rel@(Relation t c _ ft fc _ (Just (Junction jt const1 jc1 const2 jc2))) ->
+      [rel, Relation ft fc Nothing t c M2M (Just (Junction jt const2 jc2 const1 jc1))])
 
 addViewPrimaryKeys :: [SourceColumn] -> [PrimaryKey] -> [PrimaryKey]
 addViewPrimaryKeys srcCols = concatMap (\pk ->
@@ -599,7 +600,7 @@ allM2ORels tabs cols =
 
 relFromRow :: [Table] -> [Column] -> (Text, Text, Text, [Text], Text, Text, [Text]) -> Maybe Relation
 relFromRow allTabs allCols (rs, rt, cn, rcs, frs, frt, frcs) =
-  Relation <$> table <*> cols <*> pure (Just cn) <*> tableF <*> colsF <*> pure M2O <*> pure Nothing <*> pure Nothing <*> pure Nothing
+  Relation <$> table <*> cols <*> pure (Just cn) <*> tableF <*> colsF <*> pure M2O <*> pure Nothing
   where
     findTable s t = find (\tbl -> tableSchema tbl == s && tableName tbl == t) allTabs
     findCol s t c = find (\col -> tableSchema (colTable col) == s && tableName (colTable col) == t && colName col == c) allCols

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -95,8 +95,9 @@ decodeRels :: [Table] -> [Column] -> HD.Result [Relation]
 decodeRels tables cols =
   mapMaybe (relFromRow tables cols) <$> HD.rowList relRow
  where
-  relRow = (,,,,,)
+  relRow = (,,,,,,)
     <$> column HD.text
+    <*> column HD.text
     <*> column HD.text
     <*> column (HD.array (HD.dimension replicateM (element HD.text)))
     <*> column HD.text
@@ -290,7 +291,7 @@ The logic for composite pks is similar just need to make sure all the Relation c
 addViewM2ORels :: [SourceColumn] -> [Relation] -> [Relation]
 addViewM2ORels allSrcCols = concatMap (\rel ->
   rel : case rel of
-    Relation{relType=M2O, relTable, relColumns, relFTable, relFColumns} ->
+    Relation{relType=M2O, relTable, relColumns, relConstraint, relFTable, relFColumns} ->
 
       let srcColsGroupedByView :: [Column] -> [[SourceColumn]]
           srcColsGroupedByView relCols = L.groupBy (\(_, viewCol1) (_, viewCol2) -> colTable viewCol1 == colTable viewCol2) $
@@ -307,18 +308,20 @@ addViewM2ORels allSrcCols = concatMap (\rel ->
 
           viewTableM2O =
             [ Relation (getView srcCols) (snd <$> srcCols `sortAccordingTo` relColumns)
-                       relFTable relFColumns
+                       relConstraint relFTable relFColumns
                        M2O Nothing Nothing Nothing
             | srcCols <- relSrcCols, srcCols `allSrcColsOf` relColumns ]
 
           tableViewM2O =
             [ Relation relTable relColumns
+                       relConstraint
                        (getView fSrcCols) (snd <$> fSrcCols `sortAccordingTo` relFColumns)
                        M2O Nothing Nothing Nothing
             | fSrcCols <- relFSrcCols, fSrcCols `allSrcColsOf` relFColumns ]
 
           viewViewM2O =
             [ Relation (getView srcCols) (snd <$> srcCols `sortAccordingTo` relColumns)
+                       relConstraint
                        (getView fSrcCols) (snd <$> fSrcCols `sortAccordingTo` relFColumns)
                        M2O Nothing Nothing Nothing
             | srcCols  <- relSrcCols, srcCols `allSrcColsOf` relColumns
@@ -329,7 +332,7 @@ addViewM2ORels allSrcCols = concatMap (\rel ->
     _ -> [])
 
 addO2MRels :: [Relation] -> [Relation]
-addO2MRels = concatMap (\rel@(Relation t c ft fc _ _ _ _) -> [rel, Relation ft fc t c O2M Nothing Nothing Nothing])
+addO2MRels = concatMap (\rel@(Relation t c cn ft fc _ _ _ _) -> [rel, Relation ft fc cn t c O2M Nothing Nothing Nothing])
 
 addM2MRels :: [Relation] -> [Relation]
 addM2MRels rels = rels ++ addMirrorRelation (mapMaybe link2Relation links)
@@ -342,12 +345,12 @@ addM2MRels rels = rels ++ addMirrorRelation (mapMaybe link2Relation links)
     combinations 0 _  = [ [] ]
     combinations n xs = [ y:ys | y:xs' <- tails xs
                                , ys <- combinations (n-1) xs']
-    addMirrorRelation = concatMap (\rel@(Relation t c ft fc _ lt lc1 lc2) -> [rel, Relation ft fc t c M2M lt lc2 lc1])
+    addMirrorRelation = concatMap (\rel@(Relation t c _ ft fc _ lt lc1 lc2) -> [rel, Relation ft fc Nothing t c M2M lt lc2 lc1])
     link2Relation [
       Relation{relTable=lt, relColumns=lc1, relFTable=t,  relFColumns=c},
       Relation{             relColumns=lc2, relFTable=ft, relFColumns=fc}
       ]
-      | lc1 /= lc2 && length lc1 == 1 && length lc2 == 1 = Just $ Relation t c ft fc M2M (Just lt) (Just lc1) (Just lc2)
+      | lc1 /= lc2 && length lc1 == 1 && length lc2 == 1 = Just $ Relation t c Nothing ft fc M2M (Just lt) (Just lc1) (Just lc2)
       | otherwise = Nothing
     link2Relation _ = Nothing
 
@@ -574,32 +577,29 @@ allM2ORels tabs cols =
   sql = [q|
     SELECT ns1.nspname AS table_schema,
            tab.relname AS table_name,
+           conname     AS constraint_name,
            column_info.cols AS columns,
            ns2.nspname AS foreign_table_schema,
            other.relname AS foreign_table_name,
            column_info.refs AS foreign_columns
     FROM pg_constraint,
-       LATERAL (SELECT array_agg(cols.attname) AS cols,
-                       array_agg(cols.attnum)  AS nums,
-                       array_agg(refs.attname) AS refs
-                  FROM ( SELECT unnest(conkey) AS col, unnest(confkey) AS ref) k,
-                       LATERAL (SELECT * FROM pg_attribute
-                                 WHERE attrelid = conrelid AND attnum = col)
-                            AS cols,
-                       LATERAL (SELECT * FROM pg_attribute
-                                 WHERE attrelid = confrelid AND attnum = ref)
-                            AS refs)
-            AS column_info,
-       LATERAL (SELECT * FROM pg_namespace WHERE pg_namespace.oid = connamespace) AS ns1,
-       LATERAL (SELECT * FROM pg_class WHERE pg_class.oid = conrelid) AS tab,
-       LATERAL (SELECT * FROM pg_class WHERE pg_class.oid = confrelid) AS other,
-       LATERAL (SELECT * FROM pg_namespace WHERE pg_namespace.oid = other.relnamespace) AS ns2
+    LATERAL (
+      SELECT array_agg(cols.attname) AS cols,
+                    array_agg(cols.attnum)  AS nums,
+                    array_agg(refs.attname) AS refs
+      FROM ( SELECT unnest(conkey) AS col, unnest(confkey) AS ref) k,
+      LATERAL (SELECT * FROM pg_attribute WHERE attrelid = conrelid AND attnum = col) AS cols,
+      LATERAL (SELECT * FROM pg_attribute WHERE attrelid = confrelid AND attnum = ref) AS refs) AS column_info,
+    LATERAL (SELECT * FROM pg_namespace WHERE pg_namespace.oid = connamespace) AS ns1,
+    LATERAL (SELECT * FROM pg_class WHERE pg_class.oid = conrelid) AS tab,
+    LATERAL (SELECT * FROM pg_class WHERE pg_class.oid = confrelid) AS other,
+    LATERAL (SELECT * FROM pg_namespace WHERE pg_namespace.oid = other.relnamespace) AS ns2
     WHERE confrelid != 0
     ORDER BY (conrelid, column_info.nums) |]
 
-relFromRow :: [Table] -> [Column] -> (Text, Text, [Text], Text, Text, [Text]) -> Maybe Relation
-relFromRow allTabs allCols (rs, rt, rcs, frs, frt, frcs) =
-  Relation <$> table <*> cols <*> tableF <*> colsF <*> pure M2O <*> pure Nothing <*> pure Nothing <*> pure Nothing
+relFromRow :: [Table] -> [Column] -> (Text, Text, Text, [Text], Text, Text, [Text]) -> Maybe Relation
+relFromRow allTabs allCols (rs, rt, cn, rcs, frs, frt, frcs) =
+  Relation <$> table <*> cols <*> pure (Just cn) <*> tableF <*> colsF <*> pure M2O <*> pure Nothing <*> pure Nothing <*> pure Nothing
   where
     findTable s t = find (\tbl -> tableSchema tbl == s && tableName tbl == t) allTabs
     findCol s t c = find (\col -> tableSchema (colTable col) == s && tableName (colTable col) == t && colName col == c) allCols

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -82,7 +82,7 @@ instance JSON.ToJSON ApiRequestError where
   toJSON (NoRelBetween parent child) = JSON.object [
     "message" .= ("Could not find foreign keys between these entities. No relationship found between " <> parent <> " and " <> child :: Text)]
   toJSON (AmbiguousRelBetween parent child rels) = JSON.object [
-    "hint"    .= ("By following the 'details' key, disambiguate the request by changing the url to /source?select=relationship(*) or /source?select=target!relationship(*)" :: Text),
+    "hint"    .= ("By following the 'details' key, disambiguate the request by changing the url to /origin?select=relationship(*) or /origin?select=target!relationship(*)" :: Text),
     "message" .= ("More than one relationship was found for " <> parent <> " and " <> child :: Text),
     "details" .= (compressedRel <$> rels) ]
   toJSON UnsupportedVerb = JSON.object [
@@ -97,7 +97,7 @@ compressedRel rel =
     fmtEls els = "[" <> T.intercalate ", " els <> "]"
   in
   JSON.object $ [
-    "source"      .= fmtTbl (relTable rel)
+    "origin"      .= fmtTbl (relTable rel)
   , "target"      .= fmtTbl (relFTable rel)
   , "cardinality" .= (show $ relType rel :: Text)
   ] ++

--- a/src/PostgREST/Parsers.hs
+++ b/src/PostgREST/Parsers.hs
@@ -134,12 +134,12 @@ pRelationSelect :: Parser SelectItem
 pRelationSelect = lexeme $ try ( do
     alias <- optionMaybe ( try(pFieldName <* aliasSeparator) )
     fld <- pField
-    relationDetail <- optionMaybe (
-        try ( char '!' *> pFieldName ) <|>
-        try ( char '.' *> pFieldName ) -- TODO deprecated, remove in next major version
+    hint <- optionMaybe (
+        try ( char '!' *> pFieldName) <|>
+        -- deprecated, remove in next major version
+        try ( char '.' *> pFieldName)
       )
-
-    return (fld, Nothing, alias, relationDetail)
+    return (fld, Nothing, alias, hint)
   )
 
 pFieldSelect :: Parser SelectItem

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -264,28 +264,28 @@ data Cardinality = O2M -- ^ one-to-many,  previously known as Parent
                  | M2M -- ^ many-to-many, previously known as Many
                  deriving Eq
 instance Show Cardinality where
-  show O2M = "one-to-many"
-  show M2O = "many-to-one"
-  show M2M = "many-to-many"
+  show O2M = "o2m"
+  show M2O = "m2o"
+  show M2M = "m2m"
+
+type ConstraintName = Text
 
 {-|
-  The name 'Relation' here is used with the meaning
-  "What is the relation between the current node and the parent node".
-  It has nothing to do with PostgreSQL referring to tables/views as relations.
-  The order of the relColumns and relFColumns should be maintained to get
-  the join conditions right.
+  "Relation"ship between two tables.
+  The order of the relColumns and relFColumns should be maintained to get the join conditions right.
   TODO merge relColumns and relFColumns to a tuple or Data.Bimap
 -}
 data Relation = Relation {
-  relTable     :: Table
-, relColumns   :: [Column]
-, relFTable    :: Table
-, relFColumns  :: [Column]
-, relType      :: Cardinality
--- The Link attrs are used when Cardinality == Many
-, relLinkTable :: Maybe Table
-, relLinkCols1 :: Maybe [Column]
-, relLinkCols2 :: Maybe [Column]
+  relTable      :: Table
+, relColumns    :: [Column]
+, relConstraint :: Maybe ConstraintName -- ^ Just on O2M/M2O, Nothing on M2M
+, relFTable     :: Table
+, relFColumns   :: [Column]
+, relType       :: Cardinality
+-- The Link attrs are used when Cardinality == M2M
+, relLinkTable  :: Maybe Table
+, relLinkCols1  :: Maybe [Column]
+, relLinkCols2  :: Maybe [Column]
 } deriving (Show, Eq)
 
 isSelfReference :: Relation -> Bool
@@ -409,8 +409,10 @@ toHeaders = map $ \(GucHeader (k, v)) -> (CI.mk $ toS k, toS v)
   This type will hold information about which particular 'Relation' between two tables to choose when there are multiple ones.
   Specifically, it will contain the name of the foreign key or the join table in many to many relations.
 -}
-type RelationDetail = Text
-type SelectItem = (Field, Maybe Cast, Maybe Alias, Maybe RelationDetail)
+type SelectItem = (Field, Maybe Cast, Maybe Alias, Maybe EmbedHint)
+-- | Disambiguates an embedding operation when there's multiple relationships between two tables.
+-- | Can be the name of a foreign key constraint, column name or the junction in an m2m relationship.
+type EmbedHint = Text
 -- | Path of the embedded levels, e.g "clients.projects.name=eq.." gives Path ["clients", "projects"]
 type EmbedPath = [Text]
 data Filter = Filter { field::Field, opExpr::OpExpr } deriving (Show, Eq)
@@ -453,7 +455,7 @@ data MutateQuery =
 type ReadRequest = Tree ReadNode
 type MutateRequest = MutateQuery
 
-type ReadNode = (ReadQuery, (NodeName, Maybe Relation, Maybe Alias, Maybe RelationDetail, Depth))
+type ReadNode = (ReadQuery, (NodeName, Maybe Relation, Maybe Alias, Maybe EmbedHint, Depth))
 type Depth = Integer
 
 -- First level FieldNames(e.g get a,b from /table?select=a,b,other(c,d))

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -282,10 +282,16 @@ data Relation = Relation {
 , relFTable     :: Table
 , relFColumns   :: [Column]
 , relType       :: Cardinality
--- The Link attrs are used when Cardinality == M2M
-, relLinkTable  :: Maybe Table
-, relLinkCols1  :: Maybe [Column]
-, relLinkCols2  :: Maybe [Column]
+, relJunction   :: Maybe Junction -- ^ Junction for M2M Cardinality
+} deriving (Show, Eq)
+
+-- | Junction table on an M2M relationship
+data Junction = Junction {
+  junTable       :: Table
+, junConstraint1 :: Maybe ConstraintName
+, junCols1       :: [Column]
+, junConstraint2 :: Maybe ConstraintName
+, junCols2       :: [Column]
 } deriving (Show, Eq)
 
 isSelfReference :: Relation -> Bool

--- a/test/Feature/EmbedDisambiguationSpec.hs
+++ b/test/Feature/EmbedDisambiguationSpec.hs
@@ -22,17 +22,17 @@ spec =
                 {
                     "cardinality": "m2o",
                     "relationship": "message_sender_fkey[sender][id]",
-                    "source": "test.message",
+                    "origin": "test.message",
                     "target": "test.person"
                 },
                 {
                     "cardinality": "m2o",
                     "relationship": "message_sender_fkey[sender][id]",
-                    "source": "test.message",
+                    "origin": "test.message",
                     "target": "test.person_detail"
                 }
               ],
-              "hint": "By following the 'details' key, disambiguate the request by changing the url to /source?select=relationship(*) or /source?select=target!relationship(*)",
+              "hint": "By following the 'details' key, disambiguate the request by changing the url to /origin?select=relationship(*) or /origin?select=target!relationship(*)",
               "message": "More than one relationship was found for message and sender"
             }
           |]
@@ -48,23 +48,23 @@ spec =
                 {
                   "cardinality": "m2o",
                   "relationship": "main_project[main_project_id][big_project_id]",
-                  "source": "test.sites",
+                  "origin": "test.sites",
                   "target": "test.big_projects"
                 },
                 {
                   "cardinality": "m2m",
                   "relationship": "test.jobs[jobs_site_id_fkey][jobs_big_project_id_fkey]",
-                  "source": "test.sites",
+                  "origin": "test.sites",
                   "target": "test.big_projects"
                 },
                 {
                   "cardinality": "m2m",
                   "relationship": "test.main_jobs[jobs_site_id_fkey][jobs_big_project_id_fkey]",
-                  "source": "test.sites",
+                  "origin": "test.sites",
                   "target": "test.big_projects"
                 }
               ],
-              "hint": "By following the 'details' key, disambiguate the request by changing the url to /source?select=relationship(*) or /source?select=target!relationship(*)",
+              "hint": "By following the 'details' key, disambiguate the request by changing the url to /origin?select=relationship(*) or /origin?select=target!relationship(*)",
               "message": "More than one relationship was found for sites and big_projects"
             }
           |]
@@ -80,17 +80,17 @@ spec =
                 {
                     "cardinality": "m2o",
                     "relationship": "agents_department_id_fkey[department_id][id]",
-                    "source": "test.agents",
+                    "origin": "test.agents",
                     "target": "test.departments"
                 },
                 {
                     "cardinality": "o2m",
                     "relationship": "departments_head_id_fkey[id][head_id]",
-                    "source": "test.agents",
+                    "origin": "test.agents",
                     "target": "test.departments"
                 }
               ],
-              "hint": "By following the 'details' key, disambiguate the request by changing the url to /source?select=relationship(*) or /source?select=target!relationship(*)",
+              "hint": "By following the 'details' key, disambiguate the request by changing the url to /origin?select=relationship(*) or /origin?select=target!relationship(*)",
               "message": "More than one relationship was found for agents and departments"
             }
            |]
@@ -109,29 +109,29 @@ spec =
                 {
                   "cardinality": "m2m",
                   "relationship": "test.whatev_jobs[whatev_jobs_site_id_1_fkey][whatev_jobs_project_id_1_fkey]",
-                  "source": "test.whatev_sites",
+                  "origin": "test.whatev_sites",
                   "target": "test.whatev_projects"
                 },
                 {
                   "cardinality": "m2m",
                   "relationship": "test.whatev_jobs[whatev_jobs_site_id_1_fkey][whatev_jobs_project_id_2_fkey]",
-                  "source": "test.whatev_sites",
+                  "origin": "test.whatev_sites",
                   "target": "test.whatev_projects"
                 },
                 {
                   "cardinality": "m2m",
                   "relationship": "test.whatev_jobs[whatev_jobs_site_id_2_fkey][whatev_jobs_project_id_1_fkey]",
-                  "source": "test.whatev_sites",
+                  "origin": "test.whatev_sites",
                   "target": "test.whatev_projects"
                 },
                 {
                   "cardinality": "m2m",
                   "relationship": "test.whatev_jobs[whatev_jobs_site_id_2_fkey][whatev_jobs_project_id_2_fkey]",
-                  "source": "test.whatev_sites",
+                  "origin": "test.whatev_sites",
                   "target": "test.whatev_projects"
                 }
               ],
-              "hint": "By following the 'details' key, disambiguate the request by changing the url to /source?select=relationship(*) or /source?select=target!relationship(*)",
+              "hint": "By following the 'details' key, disambiguate the request by changing the url to /origin?select=relationship(*) or /origin?select=target!relationship(*)",
               "message": "More than one relationship was found for whatev_sites and whatev_projects"
             }
           |]

--- a/test/Feature/EmbedDisambiguationSpec.hs
+++ b/test/Feature/EmbedDisambiguationSpec.hs
@@ -15,6 +15,7 @@ spec =
   describe "resource embedding disambiguation" $ do
 
     it "gives a 300 Multiple Choices error when the request is ambiguous" $ do
+      pendingWith "duck typing removed: see what to do with single fk column embed"
       get "/message?select=id,body,sender(name,sent)" `shouldRespondWith`
         [json|
           {
@@ -163,24 +164,28 @@ spec =
         { matchHeaders = [matchContentTypeJson] }
 
     context "using FK col to specify the relationship" $ do
-      it "can embed by FK column name" $
-        get "/projects?id=in.(1,3)&select=id,name,client_id(id,name)" `shouldRespondWith`
-          [json|[{"id":1,"name":"Windows 7","client_id":{"id":1,"name":"Microsoft"}},{"id":3,"name":"IOS","client_id":{"id":2,"name":"Apple"}}]|]
-          { matchHeaders = [matchContentTypeJson] }
+        it "can embed by FK column name" $ do
+          pendingWith "duck typing removed: see what to do with single fk column embed"
+          get "/projects?id=in.(1,3)&select=id,name,client_id(id,name)" `shouldRespondWith`
+            [json|[{"id":1,"name":"Windows 7","client_id":{"id":1,"name":"Microsoft"}},{"id":3,"name":"IOS","client_id":{"id":2,"name":"Apple"}}]|]
+            { matchHeaders = [matchContentTypeJson] }
 
-      it "can embed by FK column name and select the FK value at the same time, if aliased" $
-        get "/projects?id=in.(1,3)&select=id,name,client_id,client:client_id(id,name)" `shouldRespondWith`
-          [json|[{"id":1,"name":"Windows 7","client_id":1,"client":{"id":1,"name":"Microsoft"}},{"id":3,"name":"IOS","client_id":2,"client":{"id":2,"name":"Apple"}}]|]
-          { matchHeaders = [matchContentTypeJson] }
+        it "can embed by FK column name and select the FK value at the same time, if aliased" $ do
+          pendingWith "duck typing removed: see what to do with single fk column embed"
+          get "/projects?id=in.(1,3)&select=id,name,client_id,client:client_id(id,name)" `shouldRespondWith`
+            [json|[{"id":1,"name":"Windows 7","client_id":1,"client":{"id":1,"name":"Microsoft"}},{"id":3,"name":"IOS","client_id":2,"client":{"id":2,"name":"Apple"}}]|]
+            { matchHeaders = [matchContentTypeJson] }
 
-      it "requests parents two levels up" $
-        get "/tasks?id=eq.1&select=id,name,project:projects!project_id(id,name,client:client_id(id,name))" `shouldRespondWith`
-          [str|[{"id":1,"name":"Design w7","project":{"id":1,"name":"Windows 7","client":{"id":1,"name":"Microsoft"}}}]|]
+        it "requests parents two levels up" $ do
+          pendingWith "duck typing removed: see what to do with single fk column embed"
+          get "/tasks?id=eq.1&select=id,name,project:projects!project_id(id,name,client:client_id(id,name))" `shouldRespondWith`
+            [str|[{"id":1,"name":"Design w7","project":{"id":1,"name":"Windows 7","client":{"id":1,"name":"Microsoft"}}}]|]
 
 
     context "tables with self reference foreign keys" $ do
       context "one self reference foreign key" $ do
-        it "embeds parents recursively" $
+        it "embeds parents recursively" $ do
+          pendingWith "duck typing removed: see what to do with single fk column embed"
           get "/family_tree?id=in.(3,4)&select=id,parent(id,name,parent(*))" `shouldRespondWith`
             [json|[
               { "id": "3", "parent": { "id": "1", "name": "Parental Unit", "parent": null } },
@@ -197,7 +202,8 @@ spec =
               ]
             }]|] { matchHeaders = [matchContentTypeJson] }
 
-        it "embeds parent and then embeds childs" $
+        it "embeds parent and then embeds childs" $ do
+          pendingWith "duck typing removed: see what to do with single fk column embed"
           get "/family_tree?id=eq.2&select=id,name,parent(id,name,childs:family_tree!parent(id,name))" `shouldRespondWith`
             [json|[{
               "id": "2", "name": "Kid One", "parent": {
@@ -206,7 +212,8 @@ spec =
             }]|] { matchHeaders = [matchContentTypeJson] }
 
       context "two self reference foreign keys" $ do
-        it "embeds parents" $
+        it "embeds parents" $ do
+          pendingWith "duck typing removed: see what to do with single fk column embed"
           get "/organizations?select=id,name,referee(id,name),auditor(id,name)&id=eq.3" `shouldRespondWith`
             [json|[{
               "id": 3, "name": "Acme",
@@ -221,6 +228,7 @@ spec =
             }]|] { matchHeaders = [matchContentTypeJson] }
 
         it "embeds childs" $ do
+          pendingWith "duck typing removed: see what to do with single fk column embed"
           get "/organizations?select=id,name,refereeds:organizations!referee(id,name)&id=eq.1" `shouldRespondWith`
             [json|[{
               "id": 1, "name": "Referee Org",
@@ -251,6 +259,7 @@ spec =
             }]|] { matchHeaders = [matchContentTypeJson] }
 
         it "embeds other relations(manager) besides the self reference" $ do
+          pendingWith "duck typing removed: see what to do with single fk column embed"
           get "/organizations?select=name,manager(name),referee(name,manager(name),auditor(name,manager(name))),auditor(name,manager(name),referee(name,manager(name)))&id=eq.5" `shouldRespondWith`
             [json|[{
               "name":"Cyberdyne",

--- a/test/Feature/EmbedDisambiguationSpec.hs
+++ b/test/Feature/EmbedDisambiguationSpec.hs
@@ -32,7 +32,7 @@ spec =
                     "target": "test.person_detail"
                 }
               ],
-              "hint": "By following the 'details' key, disambiguate the request by changing the url to /source?select=relationship(*) or /source?select=target!<relationship|junction>(*)",
+              "hint": "By following the 'details' key, disambiguate the request by changing the url to /source?select=relationship(*) or /source?select=target!relationship(*)",
               "message": "More than one relationship was found for message and sender"
             }
           |]
@@ -53,18 +53,18 @@ spec =
                 },
                 {
                   "cardinality": "m2m",
-                  "junction": "test.jobs[site_id][site_id][big_project_id][big_project_id]",
+                  "relationship": "test.jobs[jobs_site_id_fkey][jobs_big_project_id_fkey]",
                   "source": "test.sites",
                   "target": "test.big_projects"
                 },
                 {
                   "cardinality": "m2m",
-                  "junction": "test.main_jobs[site_id][site_id][big_project_id][big_project_id]",
+                  "relationship": "test.main_jobs[jobs_site_id_fkey][jobs_big_project_id_fkey]",
                   "source": "test.sites",
                   "target": "test.big_projects"
                 }
               ],
-              "hint": "By following the 'details' key, disambiguate the request by changing the url to /source?select=relationship(*) or /source?select=target!<relationship|junction>(*)",
+              "hint": "By following the 'details' key, disambiguate the request by changing the url to /source?select=relationship(*) or /source?select=target!relationship(*)",
               "message": "More than one relationship was found for sites and big_projects"
             }
           |]
@@ -90,7 +90,7 @@ spec =
                     "target": "test.departments"
                 }
               ],
-              "hint": "By following the 'details' key, disambiguate the request by changing the url to /source?select=relationship(*) or /source?select=target!<relationship|junction>(*)",
+              "hint": "By following the 'details' key, disambiguate the request by changing the url to /source?select=relationship(*) or /source?select=target!relationship(*)",
               "message": "More than one relationship was found for agents and departments"
             }
            |]
@@ -100,7 +100,7 @@ spec =
 
       it "errs when there are more than two fks on a junction table(currently impossible to disambiguate, only choice is to split the table)" $
         -- We have 4 possibilities for doing the junction JOIN here.
-        -- This could be solved by specifying two additional fks, like whatev_projects!m2m!fk1!fk2(*) but the url would be too complex
+        -- This could be solved by specifying two additional fks, like whatev_projects!fk1!fk2(*)
         -- If the need arises this capability can be added later without causing a breaking change
         get "/whatev_sites?select=*,whatev_projects(*)" `shouldRespondWith`
           [json|
@@ -108,30 +108,30 @@ spec =
               "details": [
                 {
                   "cardinality": "m2m",
-                  "junction": "test.whatev_jobs[id][site_id_1][id][project_id_1]",
+                  "relationship": "test.whatev_jobs[whatev_jobs_site_id_1_fkey][whatev_jobs_project_id_1_fkey]",
                   "source": "test.whatev_sites",
                   "target": "test.whatev_projects"
                 },
                 {
                   "cardinality": "m2m",
-                  "junction": "test.whatev_jobs[id][site_id_1][id][project_id_2]",
+                  "relationship": "test.whatev_jobs[whatev_jobs_site_id_1_fkey][whatev_jobs_project_id_2_fkey]",
                   "source": "test.whatev_sites",
                   "target": "test.whatev_projects"
                 },
                 {
                   "cardinality": "m2m",
-                  "junction": "test.whatev_jobs[id][site_id_2][id][project_id_1]",
+                  "relationship": "test.whatev_jobs[whatev_jobs_site_id_2_fkey][whatev_jobs_project_id_1_fkey]",
                   "source": "test.whatev_sites",
                   "target": "test.whatev_projects"
                 },
                 {
                   "cardinality": "m2m",
-                  "junction": "test.whatev_jobs[id][site_id_2][id][project_id_2]",
+                  "relationship": "test.whatev_jobs[whatev_jobs_site_id_2_fkey][whatev_jobs_project_id_2_fkey]",
                   "source": "test.whatev_sites",
                   "target": "test.whatev_projects"
                 }
               ],
-              "hint": "By following the 'details' key, disambiguate the request by changing the url to /source?select=relationship(*) or /source?select=target!<relationship|junction>(*)",
+              "hint": "By following the 'details' key, disambiguate the request by changing the url to /source?select=relationship(*) or /source?select=target!relationship(*)",
               "message": "More than one relationship was found for whatev_sites and whatev_projects"
             }
           |]

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -551,7 +551,8 @@ spec actualPgVersion = do
         simpleStatus p2 `shouldBe` created201
 
   context "tables with self reference foreign keys" $ do
-    it "embeds parent after insert" $
+    it "embeds parent after insert" $ do
+      pendingWith "Removing duck typing"
       request methodPost "/web_content?select=id,name,parent_content:p_web_id(name)"
               [("Prefer", "return=representation")]
         [json|{"id":6, "name":"wot", "p_web_id":4}|]
@@ -573,7 +574,8 @@ spec actualPgVersion = do
           matchHeaders = [matchContentTypeJson]
         }
 
-    it "embeds parent, childs and grandchilds after update" $
+    it "embeds parent, childs and grandchilds after update" $ do
+      pendingWith "Removing duck typing"
       request methodPatch "/web_content?id=eq.0&select=id,name,web_content(name,web_content(name)),parent_content:p_web_id(name)"
               [("Prefer", "return=representation")]
         [json|{"name": "tardis-patched-2"}|]

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -551,8 +551,7 @@ spec actualPgVersion = do
         simpleStatus p2 `shouldBe` created201
 
   context "tables with self reference foreign keys" $ do
-    it "embeds parent after insert" $ do
-      pendingWith "Removing duck typing"
+    it "embeds parent after insert" $
       request methodPost "/web_content?select=id,name,parent_content:p_web_id(name)"
               [("Prefer", "return=representation")]
         [json|{"id":6, "name":"wot", "p_web_id":4}|]
@@ -574,8 +573,7 @@ spec actualPgVersion = do
           matchHeaders = [matchContentTypeJson]
         }
 
-    it "embeds parent, childs and grandchilds after update" $ do
-      pendingWith "Removing duck typing"
+    it "embeds parent, childs and grandchilds after update" $
       request methodPatch "/web_content?id=eq.0&select=id,name,web_content(name,web_content(name)),parent_content:p_web_id(name)"
               [("Prefer", "return=representation")]
         [json|{"name": "tardis-patched-2"}|]

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -4,7 +4,7 @@ import Network.Wai      (Application)
 import Network.Wai.Test (SResponse (simpleHeaders))
 
 import Network.HTTP.Types
-import Test.Hspec
+import Test.Hspec          hiding (pendingWith)
 import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 
@@ -265,18 +265,8 @@ spec actualPgVersion = do
         [json|[{"id":1,"name":"Windows 7","clients":{"id":1,"name":"Microsoft"},"tasks":[{"id":1,"name":"Design w7"},{"id":2,"name":"Code w7"}]}]|]
         { matchHeaders = [matchContentTypeJson] }
 
-    it "requesting parent without specifying primary key" $
-      get "/projects?select=name,client(name)" `shouldRespondWith`
-        [json|[
-          {"name":"Windows 7","client":{"name": "Microsoft"}},
-          {"name":"Windows 10","client":{"name": "Microsoft"}},
-          {"name":"IOS","client":{"name": "Apple"}},
-          {"name":"OSX","client":{"name": "Apple"}},
-          {"name":"Orphan","client":null}
-        ]|]
-        { matchHeaders = [matchContentTypeJson] }
-
-    it "requesting parent and renaming primary key" $
+    it "requesting parent and renaming primary key" $ do
+      pendingWith "duck typing removed: see what to do with single fk column embed"
       get "/projects?select=name,client(clientId:id,name)" `shouldRespondWith`
         [json|[
           {"name":"Windows 7","client":{"name": "Microsoft", "clientId": 1}},
@@ -295,12 +285,14 @@ spec actualPgVersion = do
         [json|[{"id":1,"commenter_id":1,"user_id":2,"task_id":6,"content":"Needs to be delivered ASAP","users_tasks":{"taskId": 6}}]|]
         { matchHeaders = [matchContentTypeJson] }
 
-    it "embed data with two fk pointing to the same table" $
+    it "embed data with two fk pointing to the same table" $ do
+      pendingWith "duck typing removed: see what to do with single fk column embed"
       get "/orders?id=eq.1&select=id, name, billing_address_id(id), shipping_address_id(id)" `shouldRespondWith`
         [str|[{"id":1,"name":"order 1","billing_address_id":{"id":1},"shipping_address_id":{"id":2}}]|]
 
 
-    it "requesting parents and children while renaming them" $
+    it "requesting parents and children while renaming them" $ do
+      pendingWith "duck typing removed: see what to do with single fk column embed"
       get "/projects?id=eq.1&select=myId:id, name, project_client:client_id(*), project_tasks:tasks(id, name)" `shouldRespondWith`
         [json|[{"myId":1,"name":"Windows 7","project_client":{"id":1,"name":"Microsoft"},"project_tasks":[{"id":1,"name":"Design w7"},{"id":2,"name":"Code w7"}]}]|]
         { matchHeaders = [matchContentTypeJson] }
@@ -343,11 +335,6 @@ spec actualPgVersion = do
         [json|[{"user_id":2,"task_id":6,"comments":[{"content":"Needs to be delivered ASAP"}]}]|]
         { matchHeaders = [matchContentTypeJson] }
 
-    it "can select by column name sans id" $
-      get "/projects?id=in.(1,3)&select=id,name,client_id,client(id,name)" `shouldRespondWith`
-        [json|[{"id":1,"name":"Windows 7","client_id":1,"client":{"id":1,"name":"Microsoft"}},{"id":3,"name":"IOS","client_id":2,"client":{"id":2,"name":"Apple"}}]|]
-        { matchHeaders = [matchContentTypeJson] }
-
     describe "view embedding" $ do
       it "can detect fk relations through views to tables in the public schema" $
         get "/consumers_view?select=*,orders_view(*)" `shouldRespondWith` 200
@@ -355,7 +342,8 @@ spec actualPgVersion = do
       it "can detect fk relations through materialized views to tables in the public schema" $
         get "/materialized_projects?select=*,users(*)" `shouldRespondWith` 200
 
-      it "can request parent without specifying primary key" $
+      it "can request parent without specifying primary key" $ do
+        pendingWith "duck typing removed: see what to do with single fk column embed"
         get "/articleStars?select=createdAt,article(owner),user(name)&limit=1" `shouldRespondWith`
           [json|[{"createdAt":"2015-12-08T04:22:57.472738","article":{"owner": "postgrest_test_authenticator"},"user":{"name": "Angela Martin"}}]|]
           { matchHeaders = [matchContentTypeJson] }
@@ -447,7 +435,8 @@ spec actualPgVersion = do
              {"tournament":"tournament_3","player_view":{"first_name":"first_name_3"}}] |]
           { matchHeaders = [matchContentTypeJson] }
 
-      it "can embed a view that has group by" $
+      it "can embed a view that has group by" $ do
+        pendingWith "duck typing removed: see what to do with single fk column embed"
         get "/projects_count_grouped_by?select=number_of_projects,client(name)&order=number_of_projects" `shouldRespondWith`
           [json|
             [{"number_of_projects":1,"client":null},
@@ -612,10 +601,6 @@ spec actualPgVersion = do
       get "/projects?id=eq.1&select=id, name, clients(id, name)&clients.order=name.asc" `shouldRespondWith`
         [str|[{"id":1,"name":"Windows 7","clients":{"id":1,"name":"Microsoft"}}]|]
 
-    it "ordering embeded parents does not break things when using ducktape names" $
-      get "/projects?id=eq.1&select=id, name, client(id, name)&client.order=name.asc" `shouldRespondWith`
-        [str|[{"id":1,"name":"Windows 7","client":{"id":1,"name":"Microsoft"}}]|]
-
     context "order syntax errors" $ do
       it "gives meaningful error messages when asc/desc/nulls{first,last} are misspelled" $ do
         get "/items?order=id.ac" `shouldRespondWith`
@@ -745,7 +730,8 @@ spec actualPgVersion = do
         [json| [{"ghostBusters":[{"escapeId":1}]},{"ghostBusters":[]},{"ghostBusters":[{"escapeId":3}]},{"ghostBusters":[]},{"ghostBusters":[{"escapeId":5}]}] |]
         { matchHeaders = [matchContentTypeJson] }
 
-    it "will embed using a column" $
+    it "will embed using a column" $ do
+      pendingWith "duck typing removed: see what to do with single fk column embed"
       get "/ghostBusters?select=escapeId(*)" `shouldRespondWith`
         [json| [{"escapeId":{"so6meIdColumn":1}},{"escapeId":{"so6meIdColumn":3}},{"escapeId":{"so6meIdColumn":5}}] |]
         { matchHeaders = [matchContentTypeJson] }

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -198,7 +198,7 @@ spec actualPgVersion = do
 
     it "matches filtering nested items 2" $
       get "/clients?select=id,projects(id,tasks2(id,name))&projects.tasks.name=like.Design*"
-        `shouldRespondWith` [json| {"message":"Could not find foreign keys between these entities, No relation found between projects and tasks2"}|]
+        `shouldRespondWith` [json| {"message":"Could not find foreign keys between these entities. No relationship found between projects and tasks2"}|]
         { matchStatus  = 400
         , matchHeaders = [matchContentTypeJson]
         }
@@ -265,9 +265,8 @@ spec actualPgVersion = do
         [json|[{"id":1,"name":"Windows 7","clients":{"id":1,"name":"Microsoft"},"tasks":[{"id":1,"name":"Design w7"},{"id":2,"name":"Code w7"}]}]|]
         { matchHeaders = [matchContentTypeJson] }
 
-    it "requesting parent and renaming primary key" $ do
-      pendingWith "duck typing removed: see what to do with single fk column embed"
-      get "/projects?select=name,client(clientId:id,name)" `shouldRespondWith`
+    it "requesting parent and renaming primary key" $
+      get "/projects?select=name,client:clients(clientId:id,name)" `shouldRespondWith`
         [json|[
           {"name":"Windows 7","client":{"name": "Microsoft", "clientId": 1}},
           {"name":"Windows 10","client":{"name": "Microsoft", "clientId": 1}},
@@ -285,15 +284,8 @@ spec actualPgVersion = do
         [json|[{"id":1,"commenter_id":1,"user_id":2,"task_id":6,"content":"Needs to be delivered ASAP","users_tasks":{"taskId": 6}}]|]
         { matchHeaders = [matchContentTypeJson] }
 
-    it "embed data with two fk pointing to the same table" $ do
-      pendingWith "duck typing removed: see what to do with single fk column embed"
-      get "/orders?id=eq.1&select=id, name, billing_address_id(id), shipping_address_id(id)" `shouldRespondWith`
-        [str|[{"id":1,"name":"order 1","billing_address_id":{"id":1},"shipping_address_id":{"id":2}}]|]
-
-
-    it "requesting parents and children while renaming them" $ do
-      pendingWith "duck typing removed: see what to do with single fk column embed"
-      get "/projects?id=eq.1&select=myId:id, name, project_client:client_id(*), project_tasks:tasks(id, name)" `shouldRespondWith`
+    it "requesting parents and children while renaming them" $
+      get "/projects?id=eq.1&select=myId:id, name, project_client:clients(*), project_tasks:tasks(id, name)" `shouldRespondWith`
         [json|[{"myId":1,"name":"Windows 7","project_client":{"id":1,"name":"Microsoft"},"project_tasks":[{"id":1,"name":"Design w7"},{"id":2,"name":"Code w7"}]}]|]
         { matchHeaders = [matchContentTypeJson] }
 
@@ -342,9 +334,8 @@ spec actualPgVersion = do
       it "can detect fk relations through materialized views to tables in the public schema" $
         get "/materialized_projects?select=*,users(*)" `shouldRespondWith` 200
 
-      it "can request parent without specifying primary key" $ do
-        pendingWith "duck typing removed: see what to do with single fk column embed"
-        get "/articleStars?select=createdAt,article(owner),user(name)&limit=1" `shouldRespondWith`
+      it "can request two parents" $
+        get "/articleStars?select=createdAt,article:articles(owner),user:users(name)&limit=1" `shouldRespondWith`
           [json|[{"createdAt":"2015-12-08T04:22:57.472738","article":{"owner": "postgrest_test_authenticator"},"user":{"name": "Angela Martin"}}]|]
           { matchHeaders = [matchContentTypeJson] }
 
@@ -435,9 +426,8 @@ spec actualPgVersion = do
              {"tournament":"tournament_3","player_view":{"first_name":"first_name_3"}}] |]
           { matchHeaders = [matchContentTypeJson] }
 
-      it "can embed a view that has group by" $ do
-        pendingWith "duck typing removed: see what to do with single fk column embed"
-        get "/projects_count_grouped_by?select=number_of_projects,client(name)&order=number_of_projects" `shouldRespondWith`
+      it "can embed a view that has group by" $
+        get "/projects_count_grouped_by?select=number_of_projects,client:clients(name)&order=number_of_projects" `shouldRespondWith`
           [json|
             [{"number_of_projects":1,"client":null},
              {"number_of_projects":2,"client":{"name":"Microsoft"}},
@@ -728,12 +718,6 @@ spec actualPgVersion = do
     it "will embed a collection" $
       get "/Escap3e;?select=ghostBusters(*)" `shouldRespondWith`
         [json| [{"ghostBusters":[{"escapeId":1}]},{"ghostBusters":[]},{"ghostBusters":[{"escapeId":3}]},{"ghostBusters":[]},{"ghostBusters":[{"escapeId":5}]}] |]
-        { matchHeaders = [matchContentTypeJson] }
-
-    it "will embed using a column" $ do
-      pendingWith "duck typing removed: see what to do with single fk column embed"
-      get "/ghostBusters?select=escapeId(*)" `shouldRespondWith`
-        [json| [{"escapeId":{"so6meIdColumn":1}},{"escapeId":{"so6meIdColumn":3}},{"escapeId":{"so6meIdColumn":5}}] |]
         { matchHeaders = [matchContentTypeJson] }
 
     it "will select and filter a column that has spaces" $

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -158,10 +158,10 @@ spec actualPgVersion =
 
     context "foreign entities embedding" $ do
       it "can embed if related tables are in the exposed schema" $ do
-        post "/rpc/getproject?select=id,name,client(id),tasks(id)" [json| { "id": 1} |] `shouldRespondWith`
+        post "/rpc/getproject?select=id,name,client:clients(id),tasks(id)" [json| { "id": 1} |] `shouldRespondWith`
           [json|[{"id":1,"name":"Windows 7","client":{"id":1},"tasks":[{"id":1},{"id":2}]}]|]
           { matchHeaders = [matchContentTypeJson] }
-        get "/rpc/getproject?id=1&select=id,name,client(id),tasks(id)" `shouldRespondWith`
+        get "/rpc/getproject?id=1&select=id,name,client:clients(id),tasks(id)" `shouldRespondWith`
           [json|[{"id":1,"name":"Windows 7","client":{"id":1},"tasks":[{"id":1},{"id":2}]}]|]
           { matchHeaders = [matchContentTypeJson] }
 

--- a/test/fixtures/data.sql
+++ b/test/fixtures/data.sql
@@ -526,3 +526,49 @@ INSERT INTO private.pages VALUES (2, 'http://postgrest.org/en/v6.0/admin.html');
 TRUNCATE TABLE private.referrals CASCADE;
 INSERT INTO private.referrals VALUES ('github.com', 1);
 INSERT INTO private.referrals VALUES ('hub.docker.com', 2);
+
+TRUNCATE TABLE big_projects CASCADE;
+INSERT INTO big_projects (big_project_id, name)
+VALUES (1, 'big project 1'),
+       (2, 'big project 2');
+
+TRUNCATE TABLE sites CASCADE;
+INSERT INTO sites (site_id, name, main_project_id)
+VALUES (1, 'site 1', 1),
+       (2, 'site 2', null),
+       (3, 'site 3', 2),
+       (4, 'site 4', null);
+
+TRUNCATE TABLE jobs CASCADE;
+INSERT INTO jobs (job_id, name, site_id, big_project_id)
+VALUES ('bc5d5362-b881-438f-b9f5-7417e08704ed', 'job 1-1', 1, 1),
+       ('3bd52697-033b-4edd-8a28-46a9c04b7c1e', 'job 2-1', 2, 1),
+       ('e6e67e4e-19b1-11e9-ab14-d663bd873d93', 'job 2-2', 2, 2);
+
+TRUNCATE TABLE departments CASCADE;
+TRUNCATE TABLE agents CASCADE;
+INSERT INTO agents (id, name)
+VALUES (1, 'agent 1'),
+       (2, 'agent 2'),
+       (3, 'agent 3'),
+       (4, 'agent 4');
+
+INSERT INTO departments (id, name, head_id)
+VALUES (1, 'dep 1', 1),
+       (2, 'dep 3', 3);
+
+UPDATE agents SET department_id = 1 WHERE id in (1, 2);
+UPDATE agents SET department_id = 2 WHERE id in (3, 4);
+
+TRUNCATE TABLE schedules CASCADE;
+INSERT INTO schedules VALUES(1, 'morning', '06:00:00', '11:59:00');
+INSERT INTO schedules VALUES(2, 'afternoon', '12:00:00', '17:59:00');
+INSERT INTO schedules VALUES(3, 'night', '18:00:00', '23:59:00');
+INSERT INTO schedules VALUES(4, 'early morning', '00:00:00', '05:59:00');
+
+TRUNCATE TABLE activities CASCADE;
+INSERT INTO activities(id, schedule_id, car_id)    VALUES(1, 1, 'CAR-349');
+INSERT INTO activities(id, schedule_id, camera_id) VALUES(2, 3, 'CAM-123');
+
+TRUNCATE TABLE unit_workdays CASCADE;
+INSERT INTO unit_workdays VALUES(1, '2019-12-02', 1, 1, 2, 3);

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -108,6 +108,18 @@ GRANT ALL ON TABLE
     , web_content
     , pages
     , referrals
+    , big_projects
+    , sites
+    , jobs
+    , main_jobs
+    , whatev_projects
+    , whatev_sites
+    , whatev_jobs
+    , agents
+    , departments
+    , schedules
+    , activities
+    , unit_workdays
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1554,6 +1554,7 @@ create table sites (
 , name text
 , main_project_id int     null references big_projects (big_project_id)
 );
+alter table sites rename constraint sites_main_project_id_fkey to main_project;
 
 create table jobs (
   job_id          uuid    primary key


### PR DESCRIPTION
This makes the previous duck typing rules(undocumented) unnecessary, allows composite FK disambiguation and supports a more flexible naming scheme. 

The previous duck typing can give unexpected matches: see https://github.com/PostgREST/postgrest/issues/1406#issue-520233773 (how it allows embedding `smallmolec`) and this [previous test](https://github.com/PostgREST/postgrest/blob/2e6c78d72349cc5fd6214ee08c4f5f5daf19fac2/test/Feature/EmbedDisambiguationSpec.hs#L41-L131)(which shows how long the error message can get). These make the disambiguation error less helpful.

A migration path(without changing the clients/frontends) for deployments that used the duck typing feature would be renaming the foreign key:
```sql
alter table projects rename constraint projects_client_id_fkey to client;
```
Then this request can be done as before:
```http
GET /projects?select=*,client(*)
```
This is also more flexible since you can rename the fk as `project_client` or any other format that makes the embedding more clear(also FK renaming is easy compared to renaming columns since they're not used in queries). FK names are also namespaced by table, which makes this mechanism convenient since two different tables can have an FK named `client`.

This would leave the disambiguation options like:
```abnf
; GET /origin?select=target(*)
request = "/" origin "?select=" target "(*)"
; GET /origin?select=target!hint(*)
request-with-hint = "/" origin "?select=" target "!" hint "(*)"
origin = table / view
target = table / view / constraint / column-from-origin
hint = constraint / column-from-origin / column-from-target / junction
```

(no breaking changes to column name disambiguation, self reference embeds are also handled in a special way as before)

I'll start working on docs for disambiguation to see how clear it can be explained.