### PR TITLE
Upsert with "Prefer: resolution=merge-duplicates" on specified columns (#1327)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #1415, Add support for user defined socket permission via `server-unix-socket-mode` config option - @Dansvidania
 - #1383, Add support for HEAD request - @steve-chavez
 - #1378, Add support for `Prefer: count=planned` and `Prefer: count=estimated` on GET /table - @steve-chavez
+- #1327, Add support for optional query parameter `on_conflict` to upsert with specified keys for POST - @ykst
 
 ### Fixed
 

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -87,6 +87,7 @@ data ApiRequest = ApiRequest {
   , iFilters              :: [(Text, Text)]                   -- ^ Filters on the result ("id", "eq.10")
   , iLogic                :: [(Text, Text)]                   -- ^ &and and &or parameters used for complex boolean logic
   , iSelect               :: Maybe Text                       -- ^ &select parameter used to shape the response
+  , iOnConflict           :: Maybe Text                       -- ^ &on_conflict parameter used to upsert on specific unique keys
   , iColumns              :: Maybe Text                       -- ^ &columns parameter used to shape the payload
   , iOrder                :: [(Text, Text)]                   -- ^ &order parameters for each level
   , iCanonicalQS          :: ByteString                       -- ^ Alphabetized (canonical) request query string for response URLs
@@ -122,6 +123,7 @@ userApiRequest schema rootSpec req reqBody
       , iFilters = filters
       , iLogic = [(toS k, toS $ fromJust v) | (k,v) <- qParams, isJust v, endingIn ["and", "or"] k ]
       , iSelect = toS <$> join (lookup "select" qParams)
+      , iOnConflict = toS <$> join (lookup "on_conflict" qParams)
       , iColumns = columns
       , iOrder = [(toS k, toS $ fromJust v) | (k,v) <- qParams, isJust v, endingIn ["order"] k ]
       , iCanonicalQS = toS $ urlEncodeVars

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -169,7 +169,7 @@ app dbStructure proc cols conf apiRequest =
                         else Nothing
                     , Just $ contentRangeH 1 0 $
                         if shouldCount then Just queryTotal else Nothing
-                    , if null pkCols
+                    , if null pkCols && isNothing (iOnConflict apiRequest)
                         then Nothing
                         else (\x -> ("Preference-Applied", show x)) <$> iPreferResolution apiRequest
                     ]

--- a/src/PostgREST/DbRequestBuilder.hs
+++ b/src/PostgREST/DbRequestBuilder.hs
@@ -326,7 +326,7 @@ mutateRequest schema tName apiRequest cols pkCols readReq = mapLeft errorRespons
   case action of
     ActionCreate -> do
         confCols <- case iOnConflict apiRequest of
-            Nothing -> pure pkCols
+            Nothing    -> pure pkCols
             Just param -> pRequestOnConflict param
         pure $ Insert qi cols ((,) <$> iPreferResolution apiRequest <*> Just confCols) [] returnings
     ActionUpdate -> Update qi cols <$> combinedLogic <*> pure returnings

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -133,6 +133,13 @@ makeParamDefs ti =
       & schema .~ ParamOther ((mempty :: ParamOtherSchema)
         & in_ .~ ParamQuery
         & type_ ?~ SwaggerString))
+  , ("on_conflict", (mempty :: Param)
+      & name        .~ "on_conflict"
+      & description ?~ "On Conflict"
+      & required    ?~ False
+      & schema .~ ParamOther ((mempty :: ParamOtherSchema)
+        & in_ .~ ParamQuery
+        & type_ ?~ SwaggerString))
   , ("order", (mempty :: Param)
       & name        .~ "order"
       & description ?~ "Ordering"

--- a/src/PostgREST/Parsers.hs
+++ b/src/PostgREST/Parsers.hs
@@ -32,9 +32,7 @@ pRequestSelect selStr =
 
 pRequestOnConflict :: Text -> Either ApiRequestError  [FieldName]
 pRequestOnConflict oncStr =
-  mapError $ parse columns ("failed to parse on_conflict parameter (" <> toS oncStr <> ")") (toS oncStr)
-  where
-    columns = pFieldName `sepBy1` char ','
+  mapError $ parse pColumns ("failed to parse on_conflict parameter (" <> toS oncStr <> ")") (toS oncStr)
 
 pRequestFilter :: (Text, Text) -> Either ApiRequestError (EmbedPath, Filter)
 pRequestFilter (k, v) = mapError $ (,) <$> path <*> (Filter <$> fld <*> oper)

--- a/src/PostgREST/Parsers.hs
+++ b/src/PostgREST/Parsers.hs
@@ -30,6 +30,12 @@ pRequestSelect :: Text -> Either ApiRequestError [Tree SelectItem]
 pRequestSelect selStr =
   mapError $ parse pFieldForest ("failed to parse select parameter (" <> toS selStr <> ")") (toS selStr)
 
+pRequestOnConflict :: Text -> Either ApiRequestError  [FieldName]
+pRequestOnConflict oncStr =
+  mapError $ parse columns ("failed to parse on_conflict parameter (" <> toS oncStr <> ")") (toS oncStr)
+  where
+    columns = pFieldName `sepBy1` char ','
+
 pRequestFilter :: (Text, Text) -> Either ApiRequestError (EmbedPath, Filter)
 pRequestFilter (k, v) = mapError $ (,) <$> path <*> (Filter <$> fld <*> oper)
   where

--- a/test/fixtures/data.sql
+++ b/test/fixtures/data.sql
@@ -344,6 +344,12 @@ INSERT INTO employees VALUES
 TRUNCATE TABLE tiobe_pls CASCADE;
 INSERT INTO tiobe_pls VALUES ('Java', 1), ('C', 2), ('Python', 4);
 
+TRUNCATE TABLE single_unique CASCADE;
+INSERT INTO single_unique (unique_key, value) VALUES (1, 'A');
+
+TRUNCATE TABLE compound_unique CASCADE;
+INSERT INTO compound_unique (key1, key2, value) VALUES (1, 1, 'A');
+
 TRUNCATE TABLE only_pk CASCADE;
 INSERT INTO only_pk VALUES (1), (2);
 

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -66,6 +66,8 @@ GRANT ALL ON TABLE
     , perf_articles
     , employees
     , tiobe_pls
+    , single_unique
+    , compound_unique
     , only_pk
     , family_tree
     , managers

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1379,6 +1379,18 @@ create table test.tiobe_pls(
   rank smallint
 );
 
+create table test.single_unique(
+  unique_key integer unique not null,
+  value text
+);
+
+create table test.compound_unique(
+  key1 integer not null,
+  key2 integer not null,
+  value text,
+  unique(key1, key2)
+);
+
 create table test.family_tree (
   id text not null primary key,
   name text not null,


### PR DESCRIPTION
This introduces new optional query syntax  `on_conflict=key1,key2,...` for POST, as discussed on #1327.  It enables upsert on keys with unique constraint other than primary keys. 

## Usage

Given unique constraint on `unique_key`;

```
POST /employees?on_conflict=unique_key HTTP/1.1
Prefer: resolution=merge-duplicates
[
  { "unique_key": 1, "value": "A" }
]
```

performs upsert with `unique_key` instead of primary keys.

For compound unique keys, comma-separated list of column names should be given.

When multiple `on_conflict` terms are given, only the first one is used (like `select`).

## Compatibility

Comply with the semantics of `merge-duplicates/ignore-duplicates` in request headers, and `Preference-Applied` in response headers as with upsert on primary keys. 