### PR TITLE
Fix empty headers being added on POST/PATCH/DELETE

### DIFF
--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -178,6 +178,9 @@ matchHeader :: CI BS.ByteString -> BS.ByteString -> [Header] -> Bool
 matchHeader name valRegex headers =
   maybe False (=~ valRegex) $ lookup name headers
 
+noBlankHeader :: [Header] -> Bool
+noBlankHeader = notElem mempty
+
 authHeaderBasic :: BS.ByteString -> BS.ByteString -> Header
 authHeaderBasic u p =
   (hAuthorization, "Basic " <> (toS . B64.encode . toS $ u <> ":" <> p))

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -121,6 +121,7 @@ GRANT ALL ON TABLE
     , activities
     , unit_workdays
     , stuff
+    , loc_test
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1681,10 +1681,15 @@ begin
       perform set_config(
         'response.headers'
       , format('[{"Location": "/%s?id=eq.%s&overriden=true"}]', tg_table_name, new.id)
-      , false
+      , true
       );
     end if;
     return new;
 end
 $$ language plpgsql security definer;
 create trigger location_for_stuff instead of insert on test.stuff for each row execute procedure test.location_for_stuff();
+
+create table loc_test (
+  id int primary key
+, c text
+);


### PR DESCRIPTION
Should fix a side-effect of implementing #1427. There were empty headers(see https://github.com/PostgREST/postgrest/issues/1427#issuecomment-595907535) being added in POST/PATCH/DELETE(added a test for GET, just in case). This caused proxies to fail the response coming from postgrest.