### PR TITLE
Add docker-compose file to run tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.6"
+
+services:
+  test:
+    build:
+      context: .
+      dockerfile: test/Dockerfile.test
+    depends_on:
+      - postgres
+    working_dir: /root/postgrest
+    volumes:
+      - ./:/root/postgrest
+      - stack-linux:/root/.stack
+      - stack-work:/root/postgrest/.stack-work
+    command: bash -c "POSTGREST_TEST_CONNECTION=$$(test/create_test_db 'postgres://postgres:postgres@postgres' test_db) stack test"
+
+  postgres:
+    image: postgres:11
+    environment:
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - postgres:/var/lib/postgresql/data
+
+volumes:
+  postgres:
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+  stack-linux:
+  stack-work:

--- a/test/Dockerfile.test
+++ b/test/Dockerfile.test
@@ -4,7 +4,7 @@ ENV PATH /root/.local/bin:$PATH
 
 RUN apt-get update \
     && apt-get install -y wget libpq-dev pkg-config libpcre3 libpcre3-dev \
-       postgresql-client debconf locales \
+       postgresql-client debconf locales build-essential libffi-dev libgmp-dev git \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen \
     && locale-gen \

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -160,7 +160,7 @@ analyzeTable dbConn tableName =
 
 loadFixture :: Text -> FilePath -> IO()
 loadFixture dbConn name =
-  void $ readProcess "psql" ["--set", "ON_ERROR_STOP=1", toS dbConn, "-a", "-f", "test/fixtures/" ++ name ++ ".sql"] []
+  void $ readProcess "psql" ["--set", "ON_ERROR_STOP=1", toS dbConn, "-q", "-f", "test/fixtures/" ++ name ++ ".sql"] []
 
 rangeHdrs :: ByteRange -> [Header]
 rangeHdrs r = [rangeUnit, (hRange, renderByteRange r)]

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -4,12 +4,12 @@ services:
   test:
     build:
       context: .
-      dockerfile: test/Dockerfile.test
+      dockerfile: Dockerfile.test
     depends_on:
       - postgres
     working_dir: /root/postgrest
     volumes:
-      - ./:/root/postgrest
+      - ../:/root/postgrest
       - stack-linux:/root/.stack
       - stack-work:/root/postgrest/.stack-work
     command: bash -c "POSTGREST_TEST_CONNECTION=$$(test/create_test_db 'postgres://postgres:postgres@postgres' test_db) stack test"


### PR DESCRIPTION
Tried to run the tests with docker according to the docs and came up with this docker-compose file.

Tests can be run with:
`docker-compose up test`

Although the first run will fail, while the database container is still created and not accepting connections, yet - calling it again works. Calling `docker-compose up postgres` separately before would as well.

Some notes regarding the other changes:
- Had to add a couple of missing dependencies to `test/Dockerfile.test`, otherwise it wouldn't build for me.
- Changing `-a` to `-q` for the psql command was needed to stop psql from printing non-ascii characters to stdout, which readProcess would fail to read correctly. It would just throw with `spec: fd:14: hGetContents: invalid argument (invalid byte sequence)`.