### PR TITLE
Improve command line help

### DIFF
--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -275,7 +275,7 @@ readOptions = do
           |
           |## choose a secret, JSON Web Key (or set) to enable JWT auth
           |## (use "@filename" to load from separate file)
-          |# jwt-secret = "foo"
+          |# jwt-secret = "secret_with_at_least_32_characters"
           |# secret-is-base64 = false
           |# jwt-aud = "your_audience_claim"
           |


### PR DESCRIPTION
After searching for a while I found that there is a hidden requirement of at least being 32 characters in the `jwt-secret`.

It would be best to fail on config parsing if this requirement is not satisfied, but my Haskell is not good enough, so hopefully this documentation update will prevent people from making the same mistake in the future.

https://github.com/PostgREST/postgrest/issues/977