### PR TITLE
Change docker image to support scram-sha-256 auth

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,7 @@
-FROM debian:stretch-slim
+# To build use:
+# docker build --build-arg POSTGREST_VERSION=<v5.2.0 or another version> -t postgrest ./docker/
+
+FROM debian:buster-slim
 
 ARG POSTGREST_VERSION
 


### PR DESCRIPTION
Debian stretch has a libpq < 10: https://packages.debian.org/stretch/libpq5.
But buster has libpq >= 10 https://packages.debian.org/buster/libpq5.

Fixes https://github.com/PostgREST/postgrest/issues/1443.

Better to do this now before v7.0.0 so the automatic release can upload the right docker image.