### PR TITLE
Add a script for running the test suite in a local temporary database.

### DIFF
--- a/test/with_tmp_db
+++ b/test/with_tmp_db
@@ -54,7 +54,8 @@ trap stop exit
 # Prepare the database for running the tests.
 psql <<EOF
     create extension pgcrypto;
-    alter database $PGDATABASE set request.jwt.claim.id = '-1';
+    alter database $PGDATABASE set request.jwt.claim.id = '-1';# 
+    alter role $PGUSER set default_text_search_config to english;
 EOF
 
 export POSTGREST_TEST_CONNECTION="postgresql://$PGDATABASE?host=$PGDATA&user=$PGUSER"

--- a/test/with_tmp_db
+++ b/test/with_tmp_db
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat << EOF
+
+USAGE: $0 <command>
+
+Runs the given command with the POSTGREST_TEST_CONNECTION environment variable
+set to a temporary database that is ready for running the PostgREST test suite.
+
+You'll need to have the Postgres binaries 'initdb' and 'pg_ctl' on your PATH.
+
+Example:
+
+    $0 stack test
+
+EOF
+    exit -1
+}
+
+if [ "$#" -lt 1 ]; then
+    echo "Please provide a command to be run with the temporary database."
+    usage
+fi
+
+# All data will be stored in a temporary directory.
+tmpdir="$(mktemp -d)"
+
+trap "rm -rf tmpdir" exit
+
+export PGDATA="$tmpdir"
+export PGHOST="$tmpdir"
+export PGUSER=postgrest_test_authenticator
+export PGDATABASE=postgres
+
+# Initialize a database cluster. We try to make it as independent as possible
+# from the host by specifying the timezone, locale and encoding.
+TZ=UTC initdb --no-locale --encoding=UTF8 --nosync -U "$PGUSER"
+
+# Start the database cluster. Instead of listening on a local port, we will
+# listen on a unix domain socket. We will reuse the $PGDATA directory for that
+# socket.
+pg_ctl start -o "-F -c listen_addresses=\"\" -k $PGDATA"
+
+stop() {
+    pg_ctl stop -m i
+    rm -rf "$tmpdir"
+}
+
+trap stop exit
+
+# Prepare the database for running the tests.
+psql <<EOF
+    create extension pgcrypto;
+    alter database $PGDATABASE set request.jwt.claim.id = '-1';
+EOF
+
+export POSTGREST_TEST_CONNECTION="postgresql://$PGDATABASE?host=$PGDATA&user=$PGUSER"
+
+# Run the command that was given as an argument. The `exit` trap above will
+# make sure that the database is shut down and the temporary directory is
+# deleted when the command is done. This is also why we don't `exec` the
+# command - our trap would be lost if we did that.
+$@


### PR DESCRIPTION
This utility script makes it much simpler to run the tests locally - just run:

```bash
test/with_tmp_db stack test
```

No Docker or a host Postgres cluster needed, and you can always be sure that the tests are run on a fresh database. The only dependencies are the Postgres binaries 'initdb' and 'pg_ctl'.

Happy to provide matching testing docs to postgrest-docs if there is interest! This might also make some CI tasks faster/simpler.