### PR TITLE
Simplify the DbStructure queries

### DIFF
--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -596,14 +596,7 @@ allPrimaryKeys tabs =
         SELECT
             c.conname::name AS constraint_name,
             nr.nspname::name AS table_schema,
-            r.relname::name AS table_name,
-                CASE c.contype
-                    WHEN 'c' THEN 'CHECK'
-                    WHEN 'f' THEN 'FOREIGN KEY'
-                    WHEN 'p' THEN 'PRIMARY KEY'
-                    WHEN 'u' THEN 'UNIQUE'
-                    ELSE NULL
-                END::text AS constraint_type
+            r.relname::name AS table_name
         FROM pg_namespace nc,
             pg_namespace nr,
             pg_constraint c,
@@ -611,9 +604,10 @@ allPrimaryKeys tabs =
         WHERE
             nc.oid = c.connamespace
             AND nr.oid = r.relnamespace
-            AND c.conrelid = r.oid AND (c.contype <> ALL (ARRAY['t', 'x']))
+            AND c.conrelid = r.oid
             AND r.relkind = 'r'
             AND NOT pg_is_other_temp_schema(nr.oid)
+            AND c.contype = 'p'
     ),
     -- CTE to replace information_schema.key_column_usage to remove owner limit
     kc AS (
@@ -663,7 +657,6 @@ allPrimaryKeys tabs =
     FROM
         tc, kc
     WHERE
-        tc.constraint_type = 'PRIMARY KEY' AND
         kc.table_name = tc.table_name AND
         kc.table_schema = tc.table_schema AND
         kc.constraint_name = tc.constraint_name AND

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -462,52 +462,8 @@ allColumns tabs =
                         END
                     END::information_schema.character_data AS data_type,
                 information_schema._pg_char_max_length(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS character_maximum_length,
-                information_schema._pg_char_octet_length(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS character_octet_length,
                 information_schema._pg_numeric_precision(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS numeric_precision,
-                information_schema._pg_numeric_precision_radix(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS numeric_precision_radix,
-                information_schema._pg_numeric_scale(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS numeric_scale,
-                information_schema._pg_datetime_precision(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS datetime_precision,
-                information_schema._pg_interval_type(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.character_data AS interval_type,
-                NULL::integer::information_schema.cardinal_number AS interval_precision,
-                NULL::character varying::information_schema.sql_identifier AS character_set_catalog,
-                NULL::character varying::information_schema.sql_identifier AS character_set_schema,
-                NULL::character varying::information_schema.sql_identifier AS character_set_name,
-                    CASE
-                        WHEN nco.nspname IS NOT NULL THEN current_database()
-                        ELSE NULL::name
-                    END::information_schema.sql_identifier AS collation_catalog,
-                nco.nspname::information_schema.sql_identifier AS collation_schema,
-                co.collname::information_schema.sql_identifier AS collation_name,
-                    CASE
-                        WHEN t.typtype = 'd'::"char" THEN current_database()
-                        ELSE NULL::name
-                    END::information_schema.sql_identifier AS domain_catalog,
-                    CASE
-                        WHEN t.typtype = 'd'::"char" THEN nt.nspname
-                        ELSE NULL::name
-                    END::information_schema.sql_identifier AS domain_schema,
-                    CASE
-                        WHEN t.typtype = 'd'::"char" THEN t.typname
-                        ELSE NULL::name
-                    END::information_schema.sql_identifier AS domain_name,
-                current_database()::information_schema.sql_identifier AS udt_catalog,
-                COALESCE(nbt.nspname, nt.nspname)::information_schema.sql_identifier AS udt_schema,
                 COALESCE(bt.typname, t.typname)::information_schema.sql_identifier AS udt_name,
-                NULL::character varying::information_schema.sql_identifier AS scope_catalog,
-                NULL::character varying::information_schema.sql_identifier AS scope_schema,
-                NULL::character varying::information_schema.sql_identifier AS scope_name,
-                NULL::integer::information_schema.cardinal_number AS maximum_cardinality,
-                a.attnum::information_schema.sql_identifier AS dtd_identifier,
-                'NO'::character varying::information_schema.yes_or_no AS is_self_referencing,
-                'NO'::character varying::information_schema.yes_or_no AS is_identity,
-                NULL::character varying::information_schema.character_data AS identity_generation,
-                NULL::character varying::information_schema.character_data AS identity_start,
-                NULL::character varying::information_schema.character_data AS identity_increment,
-                NULL::character varying::information_schema.character_data AS identity_maximum,
-                NULL::character varying::information_schema.character_data AS identity_minimum,
-                NULL::character varying::information_schema.yes_or_no AS identity_cycle,
-                'NEVER'::character varying::information_schema.character_data AS is_generated,
-                NULL::character varying::information_schema.character_data AS generation_expression,
                 CASE
                     WHEN c.relkind = 'r'::"char" OR (c.relkind = ANY (ARRAY['v'::"char", 'f'::"char"])) AND pg_column_is_updatable(c.oid::regclass, a.attnum, false) THEN 'YES'::text
                     ELSE 'NO'::text

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -392,7 +392,7 @@ allTables =
           FROM pg_trigger
           WHERE
             pg_trigger.tgrelid = c.oid
-            AND (pg_trigger.tgtype::integer & 69) = 69 
+            AND (pg_trigger.tgtype::integer & 69) = 69
         )
       ) AS insertable
     FROM pg_class c

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -189,14 +189,14 @@ accessibleProcs = H.Statement (toS sql) (param HE.text) decodeProcs True
 procsSqlQuery :: SqlQuery
 procsSqlQuery = [q|
   SELECT
-    pn.nspname as "proc_schema",
-    p.proname as "proc_name",
-    d.description as "proc_description",
-    pg_get_function_arguments(p.oid) as "args",
-    tn.nspname as "rettype_schema",
-    coalesce(comp.relname, t.typname) as "rettype_name",
-    p.proretset as "rettype_is_setof",
-    t.typtype as "rettype_typ",
+    pn.nspname as proc_schema,
+    p.proname as proc_name,
+    d.description as proc_description,
+    pg_get_function_arguments(p.oid) as args,
+    tn.nspname as rettype_schema,
+    coalesce(comp.relname, t.typname) as rettype_name,
+    p.proretset as rettype_is_setof,
+    t.typtype as rettype_typ,
     p.provolatile
   FROM pg_proc p
     JOIN pg_namespace pn ON pn.oid = p.pronamespace
@@ -229,7 +229,7 @@ accessibleTables =
       relname as table_name,
       d.description as table_description,
       (
-        c.relkind IN ('r', 'v', 'f')
+        c.relkind in ('r', 'v', 'f')
         and (pg_relation_is_updatable(c.oid::regclass, false) & 8) = 8
         -- The function `pg_relation_is_updateable` returns a bitmask where 8
         -- corresponds to `1 << CMD_INSERT` in the PostgreSQL source code, i.e.
@@ -384,13 +384,17 @@ allTables =
       n.nspname AS table_schema,
       c.relname AS table_name,
       NULL AS table_description,
-      c.relkind = 'r' OR (c.relkind IN ('v','f'))
-      AND (pg_relation_is_updatable(c.oid::regclass, FALSE) & 8) = 8
-      OR (EXISTS
-        ( SELECT 1
+      (
+        c.relkind IN ('r', 'v','f')
+        AND (pg_relation_is_updatable(c.oid::regclass, FALSE) & 8) = 8
+        OR EXISTS (
+          SELECT 1
           FROM pg_trigger
-          WHERE pg_trigger.tgrelid = c.oid
-          AND (pg_trigger.tgtype::integer & 69) = 69) ) AS insertable
+          WHERE
+            pg_trigger.tgrelid = c.oid
+            AND (pg_trigger.tgtype::integer & 69) = 69 
+        )
+      ) AS insertable
     FROM pg_class c
     JOIN pg_namespace n ON n.oid = c.relnamespace
     WHERE c.relkind IN ('v','r','m','f')
@@ -417,9 +421,7 @@ allColumns tabs =
         info.column_default AS default_value,
         array_to_string(enum_info.vals, ',') AS enum
     FROM (
-        /*
         -- CTE based on pg_catalog to get PRIMARY/FOREIGN key and UNIQUE columns outside api schema
-        */
         WITH key_columns AS (
              SELECT
                r.oid AS r_oid,
@@ -447,14 +449,14 @@ allColumns tabs =
         -- limit columns to the ones in the api schema or PK/FK columns
         */
         columns AS (
-            SELECT current_database()::name AS table_catalog,
+            SELECT
                 nc.nspname::name AS table_schema,
                 c.relname::name AS table_name,
                 a.attname::name AS column_name,
                 d.description AS description,
-                a.attnum::information_schema.cardinal_number AS ordinal_position,
+                a.attnum::integer AS ordinal_position,
                 pg_get_expr(ad.adbin, ad.adrelid)::text AS column_default,
-                    not (a.attnotnull OR t.typtype = 'd' AND t.typnotnull) AS is_nullable,
+                not (a.attnotnull OR t.typtype = 'd' AND t.typnotnull) AS is_nullable,
                     CASE
                         WHEN t.typtype = 'd' THEN
                         CASE
@@ -472,35 +474,38 @@ allColumns tabs =
                 information_schema._pg_char_max_length(
                     information_schema._pg_truetypid(a.*, t.*),
                     information_schema._pg_truetypmod(a.*, t.*)
-                )::information_schema.cardinal_number AS character_maximum_length,
+                )::integer AS character_maximum_length,
                 information_schema._pg_numeric_precision(
                     information_schema._pg_truetypid(a.*, t.*),
                     information_schema._pg_truetypmod(a.*, t.*)
-                )::information_schema.cardinal_number AS numeric_precision,
+                )::integer AS numeric_precision,
                 COALESCE(bt.typname, t.typname)::name AS udt_name,
                 (
-                    c.relkind = 'r'
-                    OR (c.relkind = ANY (ARRAY['v', 'f']))
+                    c.relkind in ('r', 'v', 'f')
                     AND pg_column_is_updatable(c.oid::regclass, a.attnum, false)
                 )::bool is_updatable
             FROM pg_attribute a
-               LEFT JOIN key_columns kc ON kc.conkey = a.attnum AND kc.c_oid = a.attrelid
-               LEFT JOIN pg_catalog.pg_description AS d ON d.objoid = a.attrelid and d.objsubid = a.attnum
-               LEFT JOIN pg_attrdef ad ON a.attrelid = ad.adrelid AND a.attnum = ad.adnum
-               JOIN (pg_class c
-               JOIN pg_namespace nc ON c.relnamespace = nc.oid) ON a.attrelid = c.oid
-               JOIN (pg_type t
-               JOIN pg_namespace nt ON t.typnamespace = nt.oid) ON a.atttypid = t.oid
-               LEFT JOIN (pg_type bt
-               JOIN pg_namespace nbt ON bt.typnamespace = nbt.oid) ON t.typtype = 'd' AND t.typbasetype = bt.oid
-               LEFT JOIN (pg_collation co
-               JOIN pg_namespace nco ON co.collnamespace = nco.oid) ON a.attcollation = co.oid AND (nco.nspname <> 'pg_catalog'::name OR co.collname <> 'default'::name)
+                LEFT JOIN key_columns kc
+                    ON kc.conkey = a.attnum AND kc.c_oid = a.attrelid
+                LEFT JOIN pg_catalog.pg_description AS d
+                    ON d.objoid = a.attrelid and d.objsubid = a.attnum
+                LEFT JOIN pg_attrdef ad
+                    ON a.attrelid = ad.adrelid AND a.attnum = ad.adnum
+                JOIN (pg_class c JOIN pg_namespace nc ON c.relnamespace = nc.oid)
+                    ON a.attrelid = c.oid
+                JOIN (pg_type t JOIN pg_namespace nt ON t.typnamespace = nt.oid)
+                    ON a.atttypid = t.oid
+                LEFT JOIN (pg_type bt JOIN pg_namespace nbt ON bt.typnamespace = nbt.oid)
+                    ON t.typtype = 'd' AND t.typbasetype = bt.oid
+                LEFT JOIN (pg_collation co JOIN pg_namespace nco ON co.collnamespace = nco.oid)
+                    ON a.attcollation = co.oid AND (nco.nspname <> 'pg_catalog'::name OR co.collname <> 'default'::name)
             WHERE
                 NOT pg_is_other_temp_schema(nc.oid)
                 AND a.attnum > 0
                 AND NOT a.attisdropped
-                AND (c.relkind = ANY (ARRAY['r', 'v', 'f', 'm']))
-                AND (nc.nspname = ANY ($1) OR kc.r_oid IS NOT NULL) /*--filter only columns that are FK/PK or in the api schema */
+                AND c.relkind in ('r', 'v', 'f', 'm')
+                -- Filter only columns that are FK/PK or in the api schema:
+                AND (nc.nspname = ANY ($1) OR kc.r_oid IS NOT NULL)
         )
         SELECT
             table_schema,
@@ -586,14 +591,10 @@ allPrimaryKeys tabs =
   H.Statement sql HE.noParams (decodePks tabs) True
  where
   sql = [q|
-    /*
     -- CTE to replace information_schema.table_constraints to remove owner limit
-    */
     WITH tc AS (
-        SELECT current_database()::name AS constraint_catalog,
-            nc.nspname::name AS constraint_schema,
+        SELECT
             c.conname::name AS constraint_name,
-            current_database()::name AS table_catalog,
             nr.nspname::name AS table_schema,
             r.relname::name AS table_name,
                 CASE c.contype
@@ -614,22 +615,18 @@ allPrimaryKeys tabs =
             AND r.relkind = 'r'
             AND NOT pg_is_other_temp_schema(nr.oid)
     ),
-    /*
     -- CTE to replace information_schema.key_column_usage to remove owner limit
-    */
     kc AS (
-        SELECT current_database()::name AS constraint_catalog,
-            ss.nc_nspname::name AS constraint_schema,
+        SELECT
             ss.conname::name AS constraint_name,
-            current_database()::name AS table_catalog,
             ss.nr_nspname::name AS table_schema,
             ss.relname::name AS table_name,
             a.attname::name AS column_name,
-            (ss.x).n::information_schema.cardinal_number AS ordinal_position,
-                CASE
-                    WHEN ss.contype = 'f' THEN information_schema._pg_index_position(ss.conindid, ss.confkey[(ss.x).n])
-                    ELSE NULL::integer
-                END::information_schema.cardinal_number AS position_in_unique_constraint
+            (ss.x).n::integer AS ordinal_position,
+            CASE
+                WHEN ss.contype = 'f' THEN information_schema._pg_index_position(ss.conindid, ss.confkey[(ss.x).n])
+                ELSE NULL::integer
+            END::integer AS position_in_unique_constraint
         FROM pg_attribute a,
             ( SELECT r.oid AS roid,
                 r.relname,
@@ -641,7 +638,6 @@ allPrimaryKeys tabs =
                 c.contype,
                 c.conindid,
                 c.confkey,
-                c.confrelid,
                 information_schema._pg_expandarray(c.conkey) AS x
                FROM pg_namespace nr,
                 pg_class r,
@@ -651,9 +647,14 @@ allPrimaryKeys tabs =
                 nr.oid = r.relnamespace
                 AND r.oid = c.conrelid
                 AND nc.oid = c.connamespace
-                AND (c.contype = ANY (ARRAY['p', 'u', 'f']))
-                AND r.relkind = 'r' AND NOT pg_is_other_temp_schema(nr.oid)) ss
-        WHERE ss.roid = a.attrelid AND a.attnum = (ss.x).x AND NOT a.attisdropped
+                AND c.contype in ('p', 'u', 'f')
+                AND r.relkind = 'r'
+                AND NOT pg_is_other_temp_schema(nr.oid)
+            ) ss
+        WHERE
+          ss.roid = a.attrelid
+          AND a.attnum = (ss.x).x
+          AND NOT a.attisdropped
     )
     SELECT
         kc.table_schema,
@@ -693,7 +694,7 @@ allSourceColumns cols pgVer =
         from pg_class c
         join pg_namespace n on n.oid = c.relnamespace
         join pg_rewrite r on r.ev_class = c.oid
-        where (c.relkind in ('v', 'm')) and n.nspname = ANY ($1)
+        where c.relkind in ('v', 'm') and n.nspname = ANY ($1)
       ),
       removed_subselects as(
         select


### PR DESCRIPTION
First suggestion for some cleanup in the DbStructure queries:

* [x] removed no-op lines
* [x] renamed `information_schema.sql_identifier` type to name, and similar cases
* [x] replaced uses of the `information_schema.yes_or_no` (quite archaic! :-) ) with bool 
* [x] broke long lines with many conditions
* [x] removed redundant type casts
* [x] added explanations on some magic numbers
* [x] removed unnecessary quotes

Overall, this should hopefully make the queries easier to read and understand.

I did not change the case or indentation of most of the queries in order to keep the diff a bit smaller.  

--
Before edit:

While working on a PostgREST bindings generator I noticed that the `DbStructure` type contains a lot of redundant info and that the queries for reading the DbStructure from the database are probably more complex than they need to be. This might negatively impact performance and maintainability, but of course changing this part of the project is highly sensitive - so it might not be worth it to change anything here, to be discussed.

An approach to simplifying the structure could be:
1. Simplify the queries in DbStructure.hs as much as possible (should become much shorter, e.g. see the first commit here)
2. Internally to the DbStructure module: Switch to getting the columns directly with the table query, but still return the current DbStructure type for compatibility with the rest of the library
3. Switch the DbStructure type to a less redundant definition - As noted in https://github.com/PostgREST/postgrest/blob/c5245317845d8c0524800b08b3aded150b8eb6a0/src/PostgREST/Types.hs#L113 the `Table` type could hold it's own columns, for example. This would, of course, impact many other modules.

What do you think? Is this a refactor worth pursuing?