### PR TITLE
Make tests pass for Postgres 12.2

### DIFF
--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -497,6 +497,9 @@ pgVersion112 = PgVersion 110002 "11.2"
 pgVersion114 :: PgVersion
 pgVersion114 = PgVersion 110004 "11.4"
 
+pgVersion122 :: PgVersion
+pgVersion122 = PgVersion 120002 "12.2"
+
 sourceCTEName :: SqlFragment
 sourceCTEName = "pg_source"
 

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -10,7 +10,7 @@ import Test.Hspec.Wai.JSON
 
 import Text.Heredoc
 
-import PostgREST.Types (PgVersion, pgVersion112)
+import PostgREST.Types (PgVersion, pgVersion112, pgVersion122)
 import Protolude       hiding (get)
 import SpecHelper
 
@@ -914,9 +914,16 @@ spec actualPgVersion = do
         [json| [] |] { matchHeaders = [matchContentTypeJson] }
 
     it "only returns an empty result set if the in value is empty" $
+      let
+        responseBody =
+          if actualPgVersion >= pgVersion122
+          then
+            [json| {"hint":null,"details":null,"code":"22P02","message":"invalid input syntax for type integer: \"\""} |]
+          else
+            [json| {"hint":null,"details":null,"code":"22P02","message":"invalid input syntax for integer: \"\""} |]
+      in
       get "/items_with_different_col_types?int_data=in.( ,3,4)"
-        `shouldRespondWith`
-        [json| {"hint":null,"details":null,"code":"22P02","message":"invalid input syntax for integer: \"\""} |]
+        `shouldRespondWith` responseBody
         { matchStatus = 400
         , matchHeaders = [matchContentTypeJson]
         }


### PR DESCRIPTION
When running the test suite against a 12.2 Postgres database, all but two tests passed. The two failures were due to a changed error message. The new error message is added for the newer versions.