### PR TITLE
Nix development and build environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,38 +88,18 @@ jobs:
 
   style:
     docker:
-      - image: circleci/buildpack-deps:trusty
+      - image: nixos/nix:2.3
     steps:
       - checkout
-      - restore_cache:
-          keys:
-          - v1-stack-style-dependencies-{{ checksum "stack.yaml" }}
       - run:
-          name: install stack
-          command: |
-            curl -L https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz | tar zx -C /tmp
-            sudo mv /tmp/stack-2.1.3-linux-x86_64/stack /usr/bin
-            stack setup
+          name: Install linters
+          command: nix-env -iA lint style -f default.nix
       - run:
-          name: install linters
-          command: |
-            rm -rf $(stack path --dist-dir) $(stack path --local-install-root)
-            stack install hlint stylish-haskell
-      - save_cache:
-          paths:
-            - "~/.stack"
-            - ".stack-work"
-          key: v1-stack-style-dependencies-{{ checksum "stack.yaml" }}
+          name: Run linter
+          command: postgrest-lint
       - run:
-          name: Add stack tools to $PATH
-          command: |
-            echo "export PATH=/home/circleci/.local/bin:$PATH" >> $BASH_ENV
-      - run:
-          name: run linter
-          command: make lint
-      - run:
-          name: run styler
-          command: make style
+          name: Run styler
+          command: postgrest-style-check
 
   build-test-9.4:
     docker:

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ site
 *~
 *#*
 .#*
+*.swp
+result*
+dist-newstyle

--- a/default.nix
+++ b/default.nix
@@ -26,22 +26,27 @@ let
     import pinnedPkgs { inherit overlays; };
 
   postgresqlVersions =
-    [
-      pkgs.postgresql_9_5
-      pkgs.postgresql_9_6
-      pkgs.postgresql_10
-      pkgs.postgresql_11
-      pkgs.postgresql_12
-    ];
+    map postgresqlWithPackages
+      [
+        pkgs.postgresql_12
+        pkgs.postgresql_11
+        pkgs.postgresql_10
+        pkgs.postgresql_9_6
+        pkgs.postgresql_9_5
+      ];
+
+  postgresqlWithPackages =
+    postgresql:
+      postgresql.withPackages (p: [ p.pgjwt ]);
 in
 rec {
-  inherit pkgs;
+  inherit pkgs pinnedPkgs;
 
   postgrest =
     pkgs.haskellPackages.callCabal2nixWithOptions name src "--no-check" {};
 
   tests =
-    pkgs.callPackage nix/tests.nix { inherit postgresqlVersions; };
+    pkgs.callPackage nix/tests.nix { inherit postgresqlVersions pinnedPkgs; };
 
   style =
     pkgs.callPackage nix/style.nix {};

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,54 @@
+# The compiler version is set to be identical to the one from the stack
+# resolver by default.
+{ compiler ? "ghc883" }:
+let
+  name =
+    "postgrest";
+
+  src =
+    pkgs.gitignoreSource ./.;
+
+  nixpkgsVersion =
+    import nix/nixpkgs-version.nix;
+
+  pinnedPkgs =
+    builtins.fetchTarball {
+      url = "https://github.com/nixos/nixpkgs/archive/${nixpkgsVersion.rev}.tar.gz";
+      sha256 = nixpkgsVersion.tarballHash;
+    };
+
+  overlays = [
+    (import nix/overlays/gitignore.nix)
+    (import nix/overlays/haskell-packages { inherit compiler; })
+  ];
+
+  pkgs =
+    import pinnedPkgs { inherit overlays; };
+
+  postgresqlVersions =
+    [
+      pkgs.postgresql_9_5
+      pkgs.postgresql_9_6
+      pkgs.postgresql_10
+      pkgs.postgresql_11
+      pkgs.postgresql_12
+    ];
+in
+rec {
+  inherit pkgs;
+
+  postgrest =
+    pkgs.haskellPackages.callCabal2nixWithOptions name src "--no-check" {};
+
+  tests =
+    pkgs.callPackage nix/tests.nix { inherit postgresqlVersions; };
+
+  style =
+    pkgs.callPackage nix/style.nix {};
+
+  lint =
+    pkgs.callPackage nix/lint.nix {};
+
+  nixpkgsUpdate =
+    pkgs.callPackage nix/nixpkgs-update.nix {};
+}

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,109 @@
+# Nix development and build environment
+
+Nix helps us to quickly and reliably recreate the full environments for
+developing, testing and building PostgREST.
+
+## Getting started with Nix
+
+You'll need to [get Nix](https://nixos.org/download.html). The installer will
+create your Nix store in the `/nix/` directory, where all build artifacts and
+their dependencies will be stored. It will also link the Nix executables like
+`nix-env` and `nix-shell` into your PATH. Nix will manage all other PostgREST
+dependencies from here on out. To clean up older build artifacts from the
+`/nix/store`, you can run `nix-collect-garbage`.
+
+## Building PostgREST
+
+To build PostgREST from your local checkout of the repository, run:
+
+```bash
+nix-build --attr postgrest
+
+```
+
+This will create a `result` directory that contains the PostgREST binary at
+`result/bin/postgrest`. The `--attr` parameter (or short: `-A`) tells Nix to
+build the `postgrest` attribute from the Nix expression it finds in our
+`default.nix` (see below for details). Nix will take care of getting the right
+GHC version and all the build dependencies.
+
+## Developing
+
+A full development environment for PostgREST is available with `nix-shell`. The
+following command will put you into a new shell that has Cabal, stack and all
+the PostgREST linting and testing tools on the PATH:
+
+```bash
+nix-shell
+
+```
+
+Within `nix-shell`, you can run cabal commands as usual. You can also use
+some utility scripts that are specific to PostgREST:
+
+```bash
+postgrest-test-spec # Run the Haskell test suite
+postgrest-test-spec-all # Run the Haskell test suite for all PostgreSQL versions
+postgrest-test-spec-postgresql-and-plugins-12.12 # Test a specific version
+
+postgrest-test-io # Run end-to-end tests
+postgrest-test-memory # Run memory usage tests
+
+postgrest-lint # Run all linters like hlint
+postgrest-style # Auto-format code, including Haskell and Nix files
+
+```
+
+All the dependencies of those utility scripts, like several different PostgreSQL
+versions, hlint and stylish-haskell, are automatically handled by Nix.
+`nix-shell` will add items to your `/nix/store` (which can be cleaned up with
+`nix-collect-garbage`), but it will not make any other permanent changes to
+your machine or environment.
+
+Running `nix-shell --pure` will put you into a temporary enviroment that
+is as independent as possible from you local machine. For example, it will
+only have binaries on the PATH that were defined through Nix. If the test
+suite passes in `--pure`, you can be pretty sure that all dependencies are
+fully defined and that it will pass on any other machine.
+
+To run commands directly, you can also use `--run`:
+
+```bash
+nix-shell --pure --run postgrest-test-spec
+nix-shell --run "cabal v2-build"
+
+```
+
+## Tour
+
+The following is not required for working on PostgREST with Nix, but it will
+give you some more background and details on how it works.
+
+### `default.nix`
+
+[`default.nix`](../default.nix) is our 'respository expression' that pulls all
+the pieces that we define with Nix together. It returns a set (like a dict in
+other programming languages), where each attribute is a derivation that Nix
+knows how to build.  We saw the `postgrest` attribute earlier, but there are
+also `tests`, `style`, `lint` etc.
+
+Internally, our `default.nix` uses the `pkgs.callPackage` function to import
+the modules that we defined in the `nix` directory. It automatically passes the
+arguments those modules require if they are available in `pkgs` (that means
+that `pkgs` is defined in terms of itself, better not to think too much about
+that... :-) ).
+
+We also use `default.nix` to load our pinned version of the `nixpkgs`
+repository. This set of packages will always be the same, independently from
+where or when you use it.
+
+### `shell.nix`
+
+[`shell.nix`](../shell.nix) defines an environment in which PostgREST can be
+built and developed. It extends the build enviroment from our `postgrest`
+attribute with useful utilities that will be put on the PATH in `nix-shell`.
+
+### `nix/overlays`
+
+Our overlays to the Nix package set are defined here. They allow us to tweak our
+`pkgs` in `default.nix` by adding new packages or overriding existing ones.

--- a/nix/lint.nix
+++ b/nix/lint.nix
@@ -1,0 +1,12 @@
+{ writeShellScriptBin, git, silver-searcher, hlint }:
+
+writeShellScriptBin "postgrest-lint"
+  ''
+    set -euo pipefail
+
+    rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
+
+    # Lint Haskell files
+    ${silver-searcher}/bin/ag -l -g '\.l?hs$' "$rootdir" \
+      | xargs ${hlint}/bin/hlint -X QuasiQuotes -X NoPatternSynonyms
+  ''

--- a/nix/nixpkgs-update.nix
+++ b/nix/nixpkgs-update.nix
@@ -1,0 +1,36 @@
+# Pin the current unstable version of Nixpkgs, based on the more efficient
+# tarball instead of the huge Git repository
+{ curl
+, jq
+, writeShellScriptBin
+, nix
+}:
+let
+  name =
+    "nixpkgs-update";
+
+  refUrl =
+    https://api.github.com/repos/nixos/nixpkgs/git/ref/heads/nixpkgs-unstable;
+
+  githubV3Header =
+    "Accept: application/vnd.github.v3+json";
+
+  tarballUrlBase =
+    https://github.com/nixos/nixpkgs/archive/;
+in
+writeShellScriptBin name
+  ''
+    commitHash="$(${curl}/bin/curl "${refUrl}" -H "${githubV3Header}" | ${jq}/bin/jq -r .object.sha)"
+    tarballUrl="${tarballUrlBase}$commitHash.tar.gz"
+    tarballHash="$(${nix}/bin/nix-prefetch-url --unpack "$tarballUrl")"
+    currentDate="$(date --iso)"
+
+    cat << EOF
+    # Pinned version of Nixpkgs, generated with ${name}.
+    {
+      date = "$currentDate";
+      rev = "$commitHash";
+      tarballHash = "$tarballHash";
+    }
+    EOF
+  ''

--- a/nix/nixpkgs-version.nix
+++ b/nix/nixpkgs-version.nix
@@ -1,0 +1,6 @@
+# Pinned version of Nixpkgs, generated with nixpkgs-update.
+{
+  date = "2020-04-15";
+  rev = "7e07846d99bed4bd7272b1626038e77a78aa36f6";
+  tarballHash = "1dx82cj4pyjv1fdxbfqp0j7bpm869hyjyvnz57zi9pbp20awjzjr";
+}

--- a/nix/overlays/gitignore.nix
+++ b/nix/overlays/gitignore.nix
@@ -1,0 +1,13 @@
+self: super:
+
+{
+  gitignoreSource =
+    let
+      gitignoreSrc = super.fetchFromGitHub {
+        owner = "hercules-ci";
+        repo = "gitignore";
+        rev = "2ced4519f865341adcb143c5d668f955a2cb997f";
+        sha256 = "sha256:0fc5bgv9syfcblp23y05kkfnpgh3gssz6vn24frs8dzw39algk2z";
+      };
+    in (super.callPackage gitignoreSrc {}).gitignoreSource;
+}

--- a/nix/overlays/haskell-packages/README.md
+++ b/nix/overlays/haskell-packages/README.md
@@ -1,0 +1,11 @@
+
+The `.nix` files for individual Haskell packages  were generated with
+`cabal2nix`, e.g.:
+
+```bash
+cabal2nix --no-check cabal://hasql-pool > hasql-pool.nix
+
+```
+
+Those overrides might become obsolete as the builds of the packages are fixed
+on nixpkgs.

--- a/nix/overlays/haskell-packages/default.nix
+++ b/nix/overlays/haskell-packages/default.nix
@@ -1,0 +1,14 @@
+{ compiler }:
+
+self: super:
+
+{
+  haskellPackages =
+    super.haskell.packages."${compiler}".override {
+      overrides =
+        newPkgs: oldPkgs: rec {
+          hasql-pool =
+            newPkgs.callPackage ../haskell-packages/hasql-pool.nix {};
+        };
+    };
+}

--- a/nix/overlays/haskell-packages/hasql-pool.nix
+++ b/nix/overlays/haskell-packages/hasql-pool.nix
@@ -1,0 +1,19 @@
+{ mkDerivation
+, base-prelude
+, hasql
+, hspec
+, resource-pool
+, stdenv
+, time
+}:
+mkDerivation {
+  pname = "hasql-pool";
+  version = "0.5.1";
+  sha256 = "739860f61589261b120368c113fbe88360e5db8eafc2166fbaba2a70692cf429";
+  libraryHaskellDepends = [ base-prelude hasql resource-pool time ];
+  testHaskellDepends = [ base-prelude hasql hspec ];
+  homepage = "https://github.com/nikita-volkov/hasql-pool";
+  description = "A pool of connections for Hasql";
+  license = stdenv.lib.licenses.mit;
+  doCheck = false;
+}

--- a/nix/style.nix
+++ b/nix/style.nix
@@ -3,18 +3,35 @@
 , nixpkgs-fmt
 , silver-searcher
 , stylish-haskell
+, buildEnv
 }:
+let
+  style =
+    writeShellScriptBin "postgrest-style"
+      ''
+        set -euo pipefail
 
-writeShellScriptBin "postgrest-style"
-  ''
-    set -euo pipefail
+        rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
 
-    rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
+        # Format Nix files
+        ${nixpkgs-fmt}/bin/nixpkgs-fmt "$rootdir" > /dev/null 2> /dev/null
 
-    # Format Nix files
-    ${nixpkgs-fmt}/bin/nixpkgs-fmt "$rootdir" > /dev/null 2> /dev/null
+        # Format Haskell files
+        ${silver-searcher}/bin/ag -l -g '\.l?hs$' "$rootdir" \
+          | xargs ${stylish-haskell}/bin/stylish-haskell -i
+      '';
 
-    # Format Haskell files
-    ${silver-searcher}/bin/ag -l -g '\.l?hs$' "$rootdir" \
-      | xargs ${stylish-haskell}/bin/stylish-haskell -i
-  ''
+  check =
+    writeShellScriptBin "postgrest-style-check"
+      ''
+        set -euo pipefail
+
+        ${style}/bin/${style.name}
+
+        ${git}/bin/git diff-index --exit-code HEAD -- '*.hs' '*.lhs' '*.nix'
+      '';
+in
+buildEnv {
+  name = "postgrest-style";
+  paths = [ style check ];
+}

--- a/nix/style.nix
+++ b/nix/style.nix
@@ -1,0 +1,20 @@
+{ writeShellScriptBin
+, git
+, nixpkgs-fmt
+, silver-searcher
+, stylish-haskell
+}:
+
+writeShellScriptBin "postgrest-style"
+  ''
+    set -euo pipefail
+
+    rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
+
+    # Format Nix files
+    ${nixpkgs-fmt}/bin/nixpkgs-fmt "$rootdir" > /dev/null 2> /dev/null
+
+    # Format Haskell files
+    ${silver-searcher}/bin/ag -l -g '\.l?hs$' "$rootdir" \
+      | xargs ${stylish-haskell}/bin/stylish-haskell -i
+  ''

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -1,10 +1,15 @@
-{ postgresql
-, postgresqlVersions
+{ postgresqlVersions
 , runtimeShell
 , writeShellScript
 , writeShellScriptBin
 , cabal-install
 , buildEnv
+, git
+, ncat
+, stack
+, curl
+, lib
+, pinnedPkgs
 }:
 let
   withTestEnv =
@@ -13,61 +18,146 @@ let
         ''
           set -euo pipefail
 
+          rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
+
           # All data will be stored in a temporary directory.
           tmpdir="$(mktemp -d)"
 
           trap "rm -rf tmpdir" exit
 
-          export PGDATA="$tmpdir"
-          export PGHOST="$tmpdir"
+          mkdir -p "$tmpdir"/{db,socket}
+
+          export PGDATA="$tmpdir/db"
+          export PGHOST="$tmpdir/socket"
           export PGUSER=postgrest_test_authenticator
           export PGDATABASE=postgres
-          export DB_URI="postgresql://$PGDATABASE?host=$PGDATA&user=$PGUSER"
+          export DB_URI="postgresql://$PGDATABASE?host=$PGHOST&user=$PGUSER"
           export POSTGREST_TEST_CONNECTION="$DB_URI"
 
           # Initialize a database cluster. We try to make it as independent as possible
           # from the host by specifying the timezone, locale and encoding.
           TZ=UTC ${postgresql}/bin/initdb --no-locale --encoding=UTF8 \
-            --nosync -U "$PGUSER" --auth=trust > /dev/null
+            --nosync -U "$PGUSER" --auth=trust > "$tmpdir/initdb.log"
 
           # Start the database cluster. Instead of listening on a local port, we will
-          # listen on a unix domain socket. We will reuse the $PGDATA directory for that
-          # socket.
-          ${postgresql}/bin/pg_ctl start \
-            -o "-F -c listen_addresses=\"\" -k $PGDATA" > /dev/null
+          # listen on a unix domain socket.
+          ${postgresql}/bin/pg_ctl -l "$tmpdir/db.log" start \
+            -o "-F -c listen_addresses=\"\" -k $PGHOST"
 
           # We need to wait for the cluster to be ready on older versions of
           # Postgres (< 10)
-          until ${postgresql}/bin/pg_isready > /dev/null; do
+          until ${postgresql}/bin/pg_isready > "$tmpdir/wait.log"; do
             sleep 0.1
           done
 
           stop() {
-              ${postgresql}/bin/pg_ctl stop -m i > /dev/null
+              ${postgresql}/bin/pg_ctl stop -m i > "$tmpdir/stop.log"
               rm -rf "$tmpdir"
           }
 
           trap stop exit
 
           # Prepare the database for running the tests.
-          ${postgresql}/bin/psql > /dev/null << EOF
+          ${postgresql}/bin/psql -v ON_ERROR_STOP=1 > "$tmpdir/fixtures.log" <<EOF
               create extension pgcrypto;
               alter database $PGDATABASE set request.jwt.claim.id = '-1';
               alter role $PGUSER set default_text_search_config to english;
           EOF
+
+          loadfixture() {
+            ${postgresql}/bin/psql -q -v ON_ERROR_STOP=1 \
+              -f "$rootdir/test/fixtures/$1.sql" \
+              > "$tmpdir/fixtures.log"
+          }
+
+          loadfixture database
+          loadfixture roles
+          loadfixture schema
+          loadfixture jwt
+          loadfixture jsonschema
+          loadfixture privileges
 
           export PATH="${postgresql}/bin:$PATH"
 
           ${runtimeShell} -c "$@"
         '';
 
-  test =
-    writeShellScriptBin "postgrest-test"
+  testSpec =
+    name: postgresql:
+      writeShellScriptBin name
+        ''
+          set -euo pipefail
+
+          ${withTestEnv postgresql} "${cabal-install}/bin/cabal v2-test"
+        '';
+
+  testIO =
+    name: postgresql:
+      writeShellScriptBin name
+        ''
+          set -euo pipefail
+
+          rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
+          cd "$rootdir"
+
+          tmpdir="$(mktemp -d)"
+          trap "rm -rf $tmpdir" exit
+          ${cabal-install}/bin/cabal v2-install --installdir="$tmpdir"
+
+          echo $(find $tmpdir)
+
+          export PATH="${curl}/bin:${ncat}/bin:$PATH"
+          export POSTGREST_TEST_POSTGREST_CMD="$tmpdir/postgrest"
+
+          ${withTestEnv postgresql} "$rootdir"/test/io-tests.sh
+        '';
+
+  testMemory =
+    name: postgresql:
+      writeShellScriptBin name
+        ''
+          set -euo pipefail
+
+          rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
+          cd "$rootdir"
+
+          echo $(find $tmpdir)
+
+          export PATH="${curl}/bin:${stack}/bin:$PATH"
+
+          # need to set the Nix path for stack Nix integration
+          export NIX_PATH="nixpath=${pinnedPkgs}"
+          export POSTGREST_TEST_STACK_CMD="stack --nix"
+
+          ${withTestEnv postgresql} "$rootdir/test/memory-tests.sh"
+        '';
+
+  defaultPostgresql =
+    builtins.head postgresqlVersions;
+
+  testSpecVersions =
+    map
+      (postgresql: testSpec "postgrest-test-spec-${postgresql.name}" postgresql)
+      postgresqlVersions;
+
+  testSpecAllVersions =
+    writeShellScriptBin "postgrest-test-spec-all"
       ''
-        ${withTestEnv postgresql} "${cabal-install}/bin/cabal v2-test"
+        set -euo pipefail
+
+        ${lib.concatStringsSep "\n" (
+        map
+          (test: "${test}/bin/${test.name}")
+          testSpecVersions
+      )}
       '';
 in
 buildEnv {
   name = "postgrest-tests";
-  paths = [ test ];
+  paths = [
+    (testSpec "postgrest-test-spec" defaultPostgresql)
+    testSpecAllVersions
+    (testIO "postgrest-test-io" defaultPostgresql)
+    (testMemory "postgrest-test-memory" defaultPostgresql)
+  ] ++ testSpecVersions;
 }

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -1,0 +1,73 @@
+{ postgresql
+, postgresqlVersions
+, runtimeShell
+, writeShellScript
+, writeShellScriptBin
+, cabal-install
+, buildEnv
+}:
+let
+  withTestEnv =
+    postgresql:
+      writeShellScript "postgrest-test-${postgresql.name}"
+        ''
+          set -euo pipefail
+
+          # All data will be stored in a temporary directory.
+          tmpdir="$(mktemp -d)"
+
+          trap "rm -rf tmpdir" exit
+
+          export PGDATA="$tmpdir"
+          export PGHOST="$tmpdir"
+          export PGUSER=postgrest_test_authenticator
+          export PGDATABASE=postgres
+          export DB_URI="postgresql://$PGDATABASE?host=$PGDATA&user=$PGUSER"
+          export POSTGREST_TEST_CONNECTION="$DB_URI"
+
+          # Initialize a database cluster. We try to make it as independent as possible
+          # from the host by specifying the timezone, locale and encoding.
+          TZ=UTC ${postgresql}/bin/initdb --no-locale --encoding=UTF8 \
+            --nosync -U "$PGUSER" --auth=trust > /dev/null
+
+          # Start the database cluster. Instead of listening on a local port, we will
+          # listen on a unix domain socket. We will reuse the $PGDATA directory for that
+          # socket.
+          ${postgresql}/bin/pg_ctl start \
+            -o "-F -c listen_addresses=\"\" -k $PGDATA" > /dev/null
+
+          # We need to wait for the cluster to be ready on older versions of
+          # Postgres (< 10)
+          until ${postgresql}/bin/pg_isready > /dev/null; do
+            sleep 0.1
+          done
+
+          stop() {
+              ${postgresql}/bin/pg_ctl stop -m i > /dev/null
+              rm -rf "$tmpdir"
+          }
+
+          trap stop exit
+
+          # Prepare the database for running the tests.
+          ${postgresql}/bin/psql > /dev/null << EOF
+              create extension pgcrypto;
+              alter database $PGDATABASE set request.jwt.claim.id = '-1';
+              alter role $PGUSER set default_text_search_config to english;
+          EOF
+
+          export PATH="${postgresql}/bin:$PATH"
+
+          ${runtimeShell} -c "$@"
+        '';
+
+  test =
+    writeShellScriptBin "postgrest-test"
+      ''
+        ${withTestEnv postgresql} "${cabal-install}/bin/cabal v2-test"
+      '';
+in
+buildEnv {
+  name = "postgrest-tests";
+  paths = [ test ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -5,14 +5,18 @@ pkgs.lib.overrideDerivation postgrest.env (
       base.buildInputs ++ [
         pkgs.cabal-install
         pkgs.cabal2nix
-        pkgs.nixpkgs-fmt
+        pkgs.stack
         pkgs.postgresql
         pkgs.silver-searcher
-        pkgs.stylish-haskell
         tests
         style
         lint
         nixpkgsUpdate
       ];
+
+    shellHook = ''
+      # Set the Nix path to our pinned packages, e.g. for the stack integration
+      export NIX_PATH="nixpkgs=${pinnedPkgs}"
+    '';
   }
 )

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,18 @@
+with (import ./default.nix {});
+pkgs.lib.overrideDerivation postgrest.env (
+  base: {
+    buildInputs =
+      base.buildInputs ++ [
+        pkgs.cabal-install
+        pkgs.cabal2nix
+        pkgs.nixpkgs-fmt
+        pkgs.postgresql
+        pkgs.silver-searcher
+        pkgs.stylish-haskell
+        tests
+        style
+        lint
+        nixpkgsUpdate
+      ];
+  }
+)

--- a/test/QueryCost.hs
+++ b/test/QueryCost.hs
@@ -50,6 +50,7 @@ main = do
           cost <- exec pool [str| [{"id": 1}, {"id": 4}] |] $
             requestToCallProcQuery (QualifiedIdentifier "test" "get_projects_below") [PgArg "id" "int" True] False (Just MultipleObjects) []
           liftIO $ do
+            -- lower bound needed for now to make sure that cost is not Nothing
             cost `shouldSatisfy` (> Just 2000)
             cost `shouldSatisfy` (< Just 2100)
 

--- a/test/io-tests/configs/app-settings.config
+++ b/test/io-tests/configs/app-settings.config
@@ -1,4 +1,4 @@
-db-uri = "postgres:///postgrest_test"
+db-uri = "$(POSTGREST_TEST_CONNECTION)"
 db-schema = "test"
 db-anon-role = "postgrest_test_anonymous"
 db-pool = 1

--- a/test/io-tests/configs/base64-secret-from-file.config
+++ b/test/io-tests/configs/base64-secret-from-file.config
@@ -1,4 +1,4 @@
-db-uri = "postgres:///postgrest_test"
+db-uri = "$(POSTGREST_TEST_CONNECTION)"
 db-schema = "test"
 db-anon-role = "postgrest_test_anonymous"
 db-pool = 1

--- a/test/io-tests/configs/role-claim-key.config
+++ b/test/io-tests/configs/role-claim-key.config
@@ -1,4 +1,4 @@
-db-uri = "postgres:///postgrest_test"
+db-uri = "$(POSTGREST_TEST_CONNECTION)"
 db-schema = "test"
 db-anon-role = "postgrest_test_anonymous"
 db-pool = 1

--- a/test/io-tests/configs/secret-from-file.config
+++ b/test/io-tests/configs/secret-from-file.config
@@ -1,4 +1,4 @@
-db-uri = "postgres:///postgrest_test"
+db-uri = "$(POSTGREST_TEST_CONNECTION)"
 db-schema = "test"
 db-anon-role = "postgrest_test_anonymous"
 db-pool = 1

--- a/test/io-tests/configs/simple.config
+++ b/test/io-tests/configs/simple.config
@@ -1,4 +1,4 @@
-db-uri = "postgres:///postgrest_test"
+db-uri = "$(POSTGREST_TEST_CONNECTION)"
 db-schema = "test"
 db-anon-role = "postgrest_test_anonymous"
 db-pool = 1

--- a/test/io-tests/configs/unix-socket.config
+++ b/test/io-tests/configs/unix-socket.config
@@ -1,4 +1,4 @@
-db-uri = "postgres:///postgrest_test"
+db-uri = "$(POSTGREST_TEST_CONNECTION)"
 db-schema = "test"
 db-anon-role = "postgrest_test_anonymous"
 db-pool = 1

--- a/test/io-tests/dburis/uri.noeol
+++ b/test/io-tests/dburis/uri.noeol
@@ -1,1 +1,0 @@
-postgres:///postgrest_test

--- a/test/io-tests/dburis/uri.txt
+++ b/test/io-tests/dburis/uri.txt
@@ -1,1 +1,0 @@
-postgres:///postgrest_test

--- a/test/memory-tests/config
+++ b/test/memory-tests/config
@@ -1,4 +1,4 @@
-db-uri = "postgres:///postgrest_test"
+db-uri = "$(POSTGREST_TEST_CONNECTION)"
 db-schema = "test"
 db-anon-role = "postgrest_test_anonymous"
 db-pool = 1


### PR DESCRIPTION
Work in progress towards #756 

## Tasks

* [x] `nix-build` works, building PostgREST with Nix
* [x] `nix-shell` development environment
  * [x] includes a Nix development environment for PostgREST (`ghc` etc.) 
  * [x] `cabal` integrated with ghc (build, test etc.)
  * [x] `cabal build` works
  * [x] Testing
    * [x] `postgrest-test-spec` implemented, runs the test suite against a temporary db
    * [x] Pass all tests
    * [x] `postgrest-test-spec-all`: implement a script for running the tests against all Postgres versions
    * [x] integrate other test scripts
      * [x] `io-tests.sh`
      * [x] `memory-tests.sh`
  * [x] Styling: implemented `postgrest-style`, automatically formats Haskell and Nix code so far
  * [x] Linting: implemented `postgrest-lint`, uses `hlint` so far
  * [x] Pinned nixpkgs: implemented `nixpkgs-upgrade`, a script for upgrading the pinned version of nixpkgs to the current nixpkgs-unstable
  
## Possibly for later, tdb

* Docs on postgrest-docs
* CI integration
  * [x] Preferences regarding CircleCI, Github Actions, etc.? --> CircleCI
  * Caching with Cachix (tdb if required, as we track nixpkgs-unstable and most packages have cached builds)
* Static: building static binaries directly from Nix  
* Docker: generate Docker images directly from Nix
* Cleanup of older setup?
  * determine how much should be possible to do without Nix (build, run test suite, lint, ...)
  * `test/`: create_test_db, destroy_test_db etc.
  * Makefile
  * CI
  * `docker/`