### PR TITLE
Relax upper bounds for lens, network-uri, time.

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -67,9 +67,9 @@ library
                     , insert-ordered-containers >= 0.2.2 && < 0.3
                     , interpolatedstring-perl6  >= 1 && < 1.1
                     , jose                      >= 0.8.1 && < 0.9
-                    , lens                      >= 4.14 && < 4.19
+                    , lens                      >= 4.14 && < 4.20
                     , lens-aeson                >= 1.0.1 && < 1.2
-                    , network-uri               >= 2.6.1 && < 2.7
+                    , network-uri               >= 2.6.1 && < 2.8
                     , optparse-applicative      >= 0.13 && < 0.16
                     , parsec                    >= 3.1.11 && < 3.2
                     , protolude                 >= 0.2.2 && < 0.3
@@ -77,7 +77,7 @@ library
                     , scientific                >= 0.3.4 && < 0.4
                     , swagger2                  >= 2.4 && < 2.6
                     , text                      >= 1.2.2 && < 1.3
-                    , time                      >= 1.6 && < 1.10
+                    , time                      >= 1.6 && < 1.11
                     , unordered-containers      >= 0.2.8 && < 0.3
                     , vector                    >= 0.11 && < 0.13
                     , wai                       >= 3.2.1 && < 3.3
@@ -106,7 +106,7 @@ executable postgrest
                     , protolude         >= 0.2.2 && < 0.3
                     , retry             >= 0.7.4 && < 0.9
                     , text              >= 1.2.2 && < 1.3
-                    , time              >= 1.6 && < 1.10
+                    , time              >= 1.6 && < 1.11
                     , wai               >= 3.2.1 && < 3.3
                     , warp              >= 3.2.12 && < 3.4
   default-language:   Haskell2010
@@ -173,7 +173,7 @@ test-suite spec
                     , hspec-wai         >= 0.10 && < 0.11
                     , hspec-wai-json    >= 0.10 && < 0.11
                     , http-types        >= 0.12.3 && < 0.13
-                    , lens              >= 4.14 && < 4.19
+                    , lens              >= 4.14 && < 4.20
                     , lens-aeson        >= 1.0.1 && < 1.2
                     , monad-control     >= 1.0.1 && < 1.1
                     , postgrest
@@ -181,7 +181,7 @@ test-suite spec
                     , protolude         >= 0.2.2 && < 0.3
                     , regex-tdfa        >= 1.2.2 && < 1.4
                     , text              >= 1.2.2 && < 1.3
-                    , time              >= 1.6 && < 1.10
+                    , time              >= 1.6 && < 1.11
                     , transformers-base >= 0.4.4 && < 0.5
                     , wai               >= 3.2.1 && < 3.3
                     , wai-extra         >= 3.0.19 && < 3.1
@@ -217,7 +217,7 @@ Test-Suite spec-querycost
                      , hspec-wai         >= 0.10 && < 0.11
                      , hspec-wai-json    >= 0.10 && < 0.11
                      , http-types        >= 0.12.3 && < 0.13
-                     , lens              >= 4.14 && < 4.19
+                     , lens              >= 4.14 && < 4.20
                      , lens-aeson        >= 1.0.1 && < 1.2
                      , monad-control     >= 1.0.1 && < 1.1
                      , postgrest
@@ -225,7 +225,7 @@ Test-Suite spec-querycost
                      , protolude         >= 0.2.2 && < 0.3
                      , regex-tdfa        >= 1.2.2 && < 1.4
                      , text              >= 1.2.2 && < 1.3
-                     , time              >= 1.6 && < 1.10
+                     , time              >= 1.6 && < 1.11
                      , transformers-base >= 0.4.4 && < 0.5
                      , wai               >= 3.2.1 && < 3.3
                      , wai-extra         >= 3.0.19 && < 3.1


### PR DESCRIPTION
This allows lens-4.19, network-uri-2.7 and time-0.10. According to
the respective changelogs, none of these should cause trouble.

lens-4.19 is required to build with GHC 8.10.