### PR TITLE
circleci: Split out dedicated style check and build caching jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,9 @@ jobs:
       - image: circleci/buildpack-deps:trusty
     steps:
       - checkout
+      - restore_cache:
+          keys:
+          - v1-stack-style-dependencies-{{ checksum "stack.yaml" }}
       - run:
           name: install stack
           command: |
@@ -68,6 +71,11 @@ jobs:
           command: |
             rm -rf $(stack path --dist-dir) $(stack path --local-install-root)
             stack install hlint stylish-haskell
+      - save_cache:
+          paths:
+            - "~/.stack"
+            - ".stack-work"
+          key: v1-stack-style-dependencies-{{ checksum "stack.yaml" }}
       - run:
           name: Add stack tools to $PATH
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,33 @@ build-distro-bin: &build-distro-bin
         key: v1-{{ .Environment.CIRCLE_JOB }}-dependencies-{{ checksum "postgrest.cabal" }}-{{ checksum "stack.yaml" }}
 
 jobs:
+  style:
+    docker:
+      - image: circleci/buildpack-deps:trusty
+    steps:
+      - checkout
+      - run:
+          name: install stack
+          command: |
+            curl -L https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz | tar zx -C /tmp
+            sudo mv /tmp/stack-2.1.3-linux-x86_64/stack /usr/bin
+            stack setup
+      - run:
+          name: install linters
+          command: |
+            rm -rf $(stack path --dist-dir) $(stack path --local-install-root)
+            stack install hlint stylish-haskell
+      - run:
+          name: Add stack tools to $PATH
+          command: |
+            echo "export PATH=/home/circleci/.local/bin:$PATH" >> $BASH_ENV
+      - run:
+          name: run linter
+          command: make lint
+      - run:
+          name: run styler
+          command: make style
+
   build-test-9.4:
     docker:
       - image: circleci/buildpack-deps:trusty
@@ -102,21 +129,6 @@ jobs:
           command: |
             POSTGREST_TEST_CONNECTION=$(test/create_test_db "postgres://circleci@localhost" postgrest_test) stack test
             test/io-tests.sh
-      - run:
-          name: install dependencies
-          command: |
-            rm -rf $(stack path --dist-dir) $(stack path --local-install-root)
-            stack install hlint stylish-haskell
-      - run:
-          name: Add stack tools to $PATH
-          command: |
-            echo "export PATH=/home/circleci/.local/bin:$PATH" >> $BASH_ENV
-      - run:
-          name: run linter
-          command: make lint
-      - run:
-          name: run styler
-          command: make style
 
   build-test-9.6:
     docker:
@@ -339,6 +351,10 @@ workflows:
   version: 2
   build-test-release:
     jobs:
+      - style:
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
       - build-test-9.4:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,40 @@ build-distro-bin: &build-distro-bin
         key: v1-{{ .Environment.CIRCLE_JOB }}-dependencies-{{ checksum "postgrest.cabal" }}-{{ checksum "stack.yaml" }}
 
 jobs:
+  build-cache:
+    docker:
+      - image: circleci/buildpack-deps:trusty
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-stack-dependencies-{{ checksum "postgrest.cabal" }}-{{ checksum "stack.yaml" }}
+      - run:
+          name: install stack & dependencies
+          command: |
+            curl -L https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz | tar zx -C /tmp
+            sudo mv /tmp/stack-2.1.3-linux-x86_64/stack /usr/bin
+            sudo apt-get update
+            sudo apt-get install -y libgmp-dev
+            sudo apt-get install -y --only-upgrade binutils
+            sudo apt-get install -y postgresql-client
+            stack setup
+      - run:
+          name: build src and tests dependencies
+          command: |
+            stack build --fast -j1 --only-dependencies
+            stack build --fast --test --no-run-tests --only-dependencies
+      - save_cache:
+          paths:
+            - "~/.stack"
+            - ".stack-work"
+          key: v1-stack-dependencies-{{ checksum "postgrest.cabal" }}-{{ checksum "stack.yaml" }}
+      - run:
+          name: build src and tests
+          command: |
+            stack build --fast -j1
+            stack build --fast --test --no-run-tests
+
   style:
     docker:
       - image: circleci/buildpack-deps:trusty
@@ -122,11 +156,6 @@ jobs:
           command: |
             stack build --fast -j1 --only-dependencies
             stack build --fast --test --no-run-tests --only-dependencies
-      - save_cache:
-          paths:
-            - "~/.stack"
-            - ".stack-work"
-          key: v1-stack-dependencies-{{ checksum "postgrest.cabal" }}-{{ checksum "stack.yaml" }}
       - run:
           name: build src and tests
           command: |
@@ -359,6 +388,10 @@ workflows:
   version: 2
   build-test-release:
     jobs:
+      - build-cache:
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
       - style:
           filters:
             tags:
@@ -367,22 +400,32 @@ workflows:
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
+          requires:
+            - build-cache
       - build-test-9.6:
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
+          requires:
+            - build-cache
       - build-test-10:
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
+          requires:
+            - build-cache
       - build-test-11:
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
+          requires:
+            - build-cache
       - build-test-12:
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
+          requires:
+            - build-cache
       - build-prof-test:
           filters:
             tags:


### PR DESCRIPTION
Currently, the postgres 9.4 job is also responsible for

- running style checks
- caching the dependencies

This has a couple downsides. E.g. it's not apparent at a glance that your PR tests failed due to linter issues, and you need to wait quite a while for these. Secondly, on a dependency update, most of the test jobs do the full compile work in parallel because the cache doesn't exists, and again it's hard to distinguish between postgres version specific failures and a general postgrest build failure.

This PR aims to address those by

- splitting out a style checking target that doesn't even build
- splitting out a dedicated build and cache target, and having the various postgres-version-specific jobs depend on this
