### PR TITLE
circleci: Build linters with memory-saving ghc-options.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,9 @@ jobs:
           name: install linters
           command: |
             rm -rf $(stack path --dist-dir) $(stack path --local-install-root)
-            stack install hlint stylish-haskell
+            # -fno-spec-constr may help with out-of-memory issues compiling
+            # haskell-src-exts. Compare stack.yaml.
+            stack install --ghc-options=-fno-spec-constr hlint stylish-haskell
       - save_cache:
           paths:
             - "~/.stack"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,6 @@ jobs:
       - run:
           name: install linters
           command: |
-            rm -rf $(stack path --dist-dir) $(stack path --local-install-root)
             # -fno-spec-constr may help with out-of-memory issues compiling
             # haskell-src-exts. Compare stack.yaml.
             stack install --ghc-options=-fno-spec-constr hlint stylish-haskell


### PR DESCRIPTION
Previously, the linters would use the cached build artefacts from
building postgrest with -fno-spec-constr via stack.yaml. Potentially
passing it to the linter build explicitly will fix recent out-of-memory
issues.