### PR TITLE
Pin version 0.3 of protolude in nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -23,6 +23,7 @@ let
   overlays =
     [
       (import nix/overlays/gitignore.nix)
+      (import nix/overlays/haskell-packages)
     ];
 
   pkgs =

--- a/nix/overlays/haskell-packages/README.md
+++ b/nix/overlays/haskell-packages/README.md
@@ -1,0 +1,10 @@
+The `.nix` files in this directory pin specific versions of Haskell packages
+from Hackage. They were generated with `cabal2nix`, e.g.:
+
+```bash
+cabal2nix cabal://protolude > protolude.nix
+
+```
+
+Those overrides might become obsolete as the pinned versions are adopted into
+our pinned version of nixpkgs.

--- a/nix/overlays/haskell-packages/default.nix
+++ b/nix/overlays/haskell-packages/default.nix
@@ -1,0 +1,11 @@
+self: super:
+
+{
+  haskellPackages =
+    super.haskellPackages.override {
+      overrides =
+        final: prev: rec {
+          protolude = prev.callPackage ./protolude.nix {};
+        };
+    };
+}

--- a/nix/overlays/haskell-packages/protolude.nix
+++ b/nix/overlays/haskell-packages/protolude.nix
@@ -1,0 +1,18 @@
+{ mkDerivation, array, async, base, bytestring, containers, deepseq
+, ghc-prim, hashable, mtl, mtl-compat, stdenv, stm, text
+, transformers, transformers-compat
+}:
+mkDerivation {
+  pname = "protolude";
+  version = "0.3.0";
+  sha256 = "4083385a9e03fab9201f63ce198b9ced3fbc1c50d6d42574db5e36c757bedcac";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    array async base bytestring containers deepseq ghc-prim hashable
+    mtl mtl-compat stm text transformers transformers-compat
+  ];
+  homepage = "https://github.com/sdiehl/protolude";
+  description = "A small prelude";
+  license = stdenv.lib.licenses.mit;
+}


### PR DESCRIPTION
Protolude 0.3, which was added as a dependency with #1496, is not yet available in our pinned version of nixpkgs. This pins the protolude package to fix the issue.

This is a great example I think for how to solve this kind of issues if they should crop up. In the future, this incompatibility would have been automatically flagged to us by the failing Nix build in CI. 