### PR TITLE
Allow base64-bytestring 1.2.

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -48,7 +48,7 @@ library
                     , Ranged-sets               >= 0.3 && < 0.5
                     , aeson                     >= 1.4.7 && < 1.5
                     , ansi-wl-pprint            >= 0.6.7 && < 0.7
-                    , base64-bytestring         >= 1 && < 1.1
+                    , base64-bytestring         >= 1 && < 1.2
                     , bytestring                >= 0.10.8 && < 0.11
                     , case-insensitive          >= 1.2 && < 1.3
                     , cassava                   >= 0.4.5 && < 0.6
@@ -101,7 +101,7 @@ executable postgrest
   hs-source-dirs:     main
   build-depends:      base              >= 4.9 && < 4.15
                     , auto-update       >= 0.1.4 && < 0.2
-                    , base64-bytestring >= 1 && < 1.1
+                    , base64-bytestring >= 1 && < 1.2
                     , bytestring        >= 0.10.8 && < 0.11
                     , directory         >= 1.2.6 && < 1.4
                     , either            >= 4.4.1 && < 5.1
@@ -168,7 +168,7 @@ test-suite spec
                     , aeson-qq          >= 0.8.1 && < 0.9
                     , async             >= 2.1.1 && < 2.3
                     , auto-update       >= 0.1.4 && < 0.2
-                    , base64-bytestring >= 1 && < 1.1
+                    , base64-bytestring >= 1 && < 1.2
                     , bytestring        >= 0.10.8 && < 0.11
                     , case-insensitive  >= 1.2 && < 1.3
                     , cassava           >= 0.4.5 && < 0.6
@@ -212,7 +212,7 @@ Test-Suite spec-querycost
                      , aeson-qq          >= 0.8.1 && < 0.9
                      , async             >= 2.1.1 && < 2.3
                      , auto-update       >= 0.1.4 && < 0.2
-                     , base64-bytestring >= 1 && < 1.1
+                     , base64-bytestring >= 1 && < 1.2
                      , bytestring        >= 0.10.8 && < 0.11
                      , case-insensitive  >= 1.2 && < 1.3
                      , cassava           >= 0.4.5 && < 0.6


### PR DESCRIPTION
Seems like a harmless change: http://hackage.haskell.org/package/base64-bytestring-1.1.0.0/changelog

Would a 7.0.1 release to hackage be feasible, since we've got the GHC 8.10 changes together now? (Actually this one isn't required, but we might as well include it.)