### PR TITLE
For discussion: Using a `lib.sql` to factor out many of the large hasql queries

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@ let
   src =
     pkgs.lib.sourceFilesBySuffices
       (pkgs.gitignoreSource ./.)
-      [ ".cabal" ".hs" ".lhs" "LICENSE" ];
+      [ ".cabal" ".hs" ".lhs" ".sql" "LICENSE" ];
 
   nixpkgsVersion =
     import nix/nixpkgs-version.nix;

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -58,6 +58,7 @@ library
                     , contravariant-extras      >= 0.3.3 && < 0.4
                     , cookie                    >= 0.4.2 && < 0.5
                     , either                    >= 4.4.1 && < 5.1
+                    , file-embed                >= 0.0.11.2 && < 0.0.12
                     , gitrev                    >= 1.2 && < 1.4
                     , hasql                     >= 1.4 && < 1.5
                     , hasql-pool                >= 0.5 && < 0.6

--- a/src/PostgREST/lib.sql
+++ b/src/PostgREST/lib.sql
@@ -1,0 +1,18 @@
+-- Make sure that we can create temporary functions if we are in a transaction.
+set transaction read write;
+
+
+-- Numeric precision
+
+-- Returns the numeric precision of the given column, if applicable.
+
+create or replace function pg_temp.postgrest_numeric_precision(a pg_attribute, t pg_type)
+  returns integer
+  language sql
+  as $$
+    select
+      information_schema._pg_char_max_length(
+        information_schema._pg_truetypid(a.*, t.*),
+        information_schema._pg_truetypmod(a.*, t.*)
+      )
+  $$;


### PR DESCRIPTION
This this not actually meant for merging, but I wanted to discuss with you if this could be a viable approach.

The large queries e.g. in `DbStructure.hs` are partly so convoluted because we cannot define our own functions. In PostgreSQL there is a sparsely documented feature `pg_temp`, a temporary per-session schema that tables, views and also functions can be defined on. `pg_temp` is an alias for a per-session schema named `pg_temp_nnn`, which is automatically created on first use. It's implemented in [`namespace.c`](https://github.com/postgres/postgres/blob/8f59f6b9c0376173a072e4fb7de1edd6a26e6b52/src/backend/catalog/namespace.c) and referenced in a few places in the Postgres [docs](https://www.postgresql.org/search/?u=%2Fdocs%2F12%2F&q=pg_temp).

The idea is to have a PostgREST `lib.sql` that is loaded in each new session that defines functions (and maybe views?) that are useful for the DbStructure queries and maybe also requests. This PR contains a small proof of concept where a part of the `allColumns` query is factored out into a function.

Benefits of the approach:
* Quick iteration - the SQL file can be checked with `test/with_tmp_db psql -f src/PostgREST/lib.sql` and it's easy to try out or `explain analyze` individual functions.
* Unit testing of queries/functions - we could set up a separate `libtests.sql` that tests all the functions using e.g. `pgtap`
* Maintainability, as the huge queries in e.g. DbStructure can be factored into smaller functions
* Potentially performance? The functions, possibly also prepared statements and views could be parsed once by PostgreSQL and then reused for subsequent requests. On the other hand, we need to load this lib.sql for each sql session (although that could maybe be split into libs for `dbstructure` and `requests`).

Issues that I think should be possible to fix:
* I'm not sure where the best point to hook the `lib.sql` in would be - as a quick hack I plugged it into `getDbStructure` and made the transactions writable (it's a bit scary that this works...). There should be a better way to do this! Is there a way to hook into the creation of new connections with `hasql-pool`?
* Cabal currently does not recompile when the SQL file is modified - maybe there is a cleaner way than the `embed-file` approach I picked?

Possibly more fundamental issues:
* Will we have write access to `pg_temp` in all use cases?
  * [`default_transaction_read_only`](https://www.postgresql.org/docs/11/runtime-config-client.html#GUC-DEFAULT-TRANSACTION-READ-ONLY) could be set to `on`, but `begin read write;` or `set transaction read write;` seems to override that in all cases
  * `temporary` is a default privilege on databases, see [here](https://www.postgresql.org/docs/9.4/sql-grant.html#SQL-GRANT-DESCRIPTION-OBJECTS). Users could have executed `revoke temporary on database [...] from [role];`. This could be fixed with `grant temporary ...`. Would the case for increased maintainability and performance be enough to risk blocking the (presumably few) users who revoked this?
  * Would not work [in recovery or with parallel workers](https://github.com/postgres/postgres/blob/8f59f6b9c0376173a072e4fb7de1edd6a26e6b52/src/backend/catalog/namespace.c#L3943), which should not be an issue
  * ...other ways that users might have blocked writing to pg_temp? 
* ... possibly others, to be discussed

I tested this with `postgrest-test-spec-all`, the proof of concept works for all PostgreSQL versions since 9.4.