### PR TITLE
Build Docker image from Nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -83,7 +83,7 @@ rec {
 
   # Docker image and loading script.
   docker =
-    pkgs.callPackage nix/docker.nix { postgrest = postgrestStatic; };
+    pkgs.callPackage nix/docker { postgrest = postgrestStatic; };
 
   # Environment in which PostgREST can be built with cabal, useful e.g. for
   # defining a shell for nix-shell.

--- a/default.nix
+++ b/default.nix
@@ -81,6 +81,10 @@ rec {
   postgrestStatic =
     lib.justStaticExecutables (lib.dontCheck drvStatic);
 
+  # Docker image and loading script.
+  docker =
+    pkgs.callPackage nix/docker.nix { postgrest = postgrestStatic; };
+
   # Environment in which PostgREST can be built with cabal, useful e.g. for
   # defining a shell for nix-shell.
   env =

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -1,0 +1,45 @@
+{ postgrest, dockerTools, writeShellScriptBin }:
+
+rec {
+  image =
+    dockerTools.buildImage {
+      name = "postgrest";
+      tag = "latest";
+      contents = postgrest;
+      extraCommands = ''
+        mkdir etc
+        cp ${../docker/postgrest.conf} etc/postgrest.conf
+      '';
+      config = {
+        Cmd = [ "/bin/postgrest" "/etc/postgrest.conf" ];
+        Env = [
+          "PGRST_DB_URI=postgresql://?user=postgres"
+          "PGRST_DB_SCHEMA=public"
+          "PGRST_DB_ANON_ROLE="
+          "PGRST_DB_POOL=100"
+          "PGRST_DB_EXTRA_SEARCH_PATH=public"
+          "PGRST_SERVER_HOST=*4"
+          "PGRST_SERVER_PORT=3000"
+          "PGRST_OPENAPI_SERVER_PROXY_URI="
+          "PGRST_JWT_SECRET="
+          "PGRST_SECRET_IS_BASE64=false"
+          "PGRST_JWT_AUD="
+          "PGRST_MAX_ROWS="
+          "PGRST_PRE_REQUEST="
+          "PGRST_ROLE_CLAIM_KEY=.role"
+          "PGRST_ROOT_SPEC="
+          "PGRST_RAW_MEDIA_TYPES="
+        ];
+        User = "1000";
+        ExposedPorts = {
+          "3000/tcp" = {};
+        };
+      };
+    };
+
+  load =
+    writeShellScriptBin "postgrest-docker-load"
+      ''
+        docker load -i ${image}
+      '';
+}

--- a/nix/docker/default.nix
+++ b/nix/docker/default.nix
@@ -8,6 +8,10 @@ let
         name = "postgrest/postgrest";
         contents = postgrest;
 
+        # Set the current time as the image creation date. This makes the build
+        # non-reproducible, but that should not be an issue for us.
+        created = "now";
+
         extraCommands =
           ''
             mkdir etc

--- a/nix/docker/default.nix
+++ b/nix/docker/default.nix
@@ -8,7 +8,7 @@ rec {
       contents = postgrest;
       extraCommands = ''
         mkdir etc
-        cp ${../docker/postgrest.conf} etc/postgrest.conf
+        cp ${./postgrest.conf} etc/postgrest.conf
       '';
       config = {
         Cmd = [ "/bin/postgrest" "/etc/postgrest.conf" ];

--- a/nix/docker/default.nix
+++ b/nix/docker/default.nix
@@ -5,7 +5,7 @@ let
       dockerTools.buildImage {
         inherit tag;
 
-        name = "postgrest";
+        name = "postgrest/postgrest";
         contents = postgrest;
 
         extraCommands =

--- a/nix/docker/default.nix
+++ b/nix/docker/default.nix
@@ -1,45 +1,59 @@
 { postgrest, dockerTools, writeShellScriptBin }:
-
-rec {
+let
   image =
-    dockerTools.buildImage {
-      name = "postgrest";
-      tag = "latest";
-      contents = postgrest;
-      extraCommands = ''
-        mkdir etc
-        cp ${./postgrest.conf} etc/postgrest.conf
-      '';
-      config = {
-        Cmd = [ "/bin/postgrest" "/etc/postgrest.conf" ];
-        Env = [
-          "PGRST_DB_URI=postgresql://?user=postgres"
-          "PGRST_DB_SCHEMA=public"
-          "PGRST_DB_ANON_ROLE="
-          "PGRST_DB_POOL=100"
-          "PGRST_DB_EXTRA_SEARCH_PATH=public"
-          "PGRST_SERVER_HOST=*4"
-          "PGRST_SERVER_PORT=3000"
-          "PGRST_OPENAPI_SERVER_PROXY_URI="
-          "PGRST_JWT_SECRET="
-          "PGRST_SECRET_IS_BASE64=false"
-          "PGRST_JWT_AUD="
-          "PGRST_MAX_ROWS="
-          "PGRST_PRE_REQUEST="
-          "PGRST_ROLE_CLAIM_KEY=.role"
-          "PGRST_ROOT_SPEC="
-          "PGRST_RAW_MEDIA_TYPES="
-        ];
-        User = "1000";
-        ExposedPorts = {
-          "3000/tcp" = {};
+    tag:
+      dockerTools.buildImage {
+        inherit tag;
+
+        name = "postgrest";
+        contents = postgrest;
+
+        extraCommands =
+          ''
+            mkdir etc
+            cp ${./postgrest.conf} etc/postgrest.conf
+          '';
+
+        config = {
+          Cmd = [ "/bin/postgrest" "/etc/postgrest.conf" ];
+          Env = [
+            "PGRST_DB_URI=postgresql://?user=postgres"
+            "PGRST_DB_SCHEMA=public"
+            "PGRST_DB_ANON_ROLE="
+            "PGRST_DB_POOL=100"
+            "PGRST_DB_EXTRA_SEARCH_PATH=public"
+            "PGRST_SERVER_HOST=*4"
+            "PGRST_SERVER_PORT=3000"
+            "PGRST_OPENAPI_SERVER_PROXY_URI="
+            "PGRST_JWT_SECRET="
+            "PGRST_SECRET_IS_BASE64=false"
+            "PGRST_JWT_AUD="
+            "PGRST_MAX_ROWS="
+            "PGRST_PRE_REQUEST="
+            "PGRST_ROLE_CLAIM_KEY=.role"
+            "PGRST_ROOT_SPEC="
+            "PGRST_RAW_MEDIA_TYPES="
+          ];
+          User = "1000";
+          ExposedPorts = {
+            "3000/tcp" = {};
+          };
         };
       };
-    };
+in
+rec {
+  imageLatest =
+    image "latest";
+
+  imageWithVersion =
+    image "v${postgrest.version}";
 
   load =
     writeShellScriptBin "postgrest-docker-load"
       ''
-        docker load -i ${image}
+        set -euo pipefail
+
+        docker load -i ${imageLatest}
+        docker load -i ${imageWithVersion}
       '';
 }

--- a/nix/docker/postgrest.conf
+++ b/nix/docker/postgrest.conf
@@ -1,0 +1,19 @@
+db-uri = "$(PGRST_DB_URI)"
+db-schema = "$(PGRST_DB_SCHEMA)"
+db-anon-role = "$(PGRST_DB_ANON_ROLE)"
+db-pool = "$(PGRST_DB_POOL)"
+db-extra-search-path = "$(PGRST_DB_EXTRA_SEARCH_PATH)"
+
+server-host = "$(PGRST_SERVER_HOST)"
+server-port = "$(PGRST_SERVER_PORT)"
+
+openapi-server-proxy-uri = "$(PGRST_OPENAPI_SERVER_PROXY_URI)"
+jwt-secret = "$(PGRST_JWT_SECRET)"
+secret-is-base64 = "$(PGRST_SECRET_IS_BASE64)"
+jwt-aud = "$(PGRST_JWT_AUD)"
+role-claim-key = "$(PGRST_ROLE_CLAIM_KEY)"
+
+max-rows = "$(PGRST_MAX_ROWS)"
+pre-request = "$(PGRST_PRE_REQUEST)"
+root-spec = "$(PGRST_ROOT_SPEC)"
+raw-media-types = "$(PGRST_RAW_MEDIA_TYPES)"


### PR DESCRIPTION
This builds a PostgREST Docker image directly from Nix using the static executable. Usage would look something like this:

```bash
$ nix-build -A docker.load
...

$ result/bin/postgrest-docker-load
Loaded image: postgrest/postgrest:latest
Loaded image: postgrest/postgrest:v7.0.0

$ docker push postgrest/postgrest:latest
The push refers to repository [docker.io/postgrest/postgrest]
9c714c7702db: Pushed                                 
latest: digest: sha256:5dba29a5d2c8c257307378da428e46c7d2096d369c717a05a0056596eea2d291 size: 529
```

I re-tagged the built image a pushed it here for testing: [monacoremo/postgrest:latest](
https://hub.docker.com/layers/monacoremo/postgrest/latest/images/sha256-5dba29a5d2c8c257307378da428e46c7d2096d369c717a05a0056596eea2d291)

Benefits:
* Building the image from Nix does not actually require Docker or root privileges, so it might easier to build it locally or in CI.
* The result is significantly smaller than the current images (13mb vs. 38mb compressed).

Possible issues:
* The resulting image is absolutely bare bones, so it does not include bash or anything else. Those could be added if needed, e.g. to help users to introspect the image with `docker run`. 
* The creation date is set to 1970-01-01, as that keeps the build repeatable. We could specify `created = "now";` in the `dockerTools.buildImage` call to get the current time. 