### PR TITLE
cabal: fix upload to hackage

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -52,7 +52,7 @@ let
 
   # Base dynamic derivation for the PostgREST package.
   drv =
-    pkgs.haskellPackages.callCabal2nix name src {};
+    lib.enableCabalFlag (pkgs.haskellPackages.callCabal2nix name src {}) "FailOnWarn";
 
   # Static derivation for the PostgREST executable.
   drvStatic =

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -19,7 +19,7 @@ source-repository head
   type:     git
   location: git://github.com/PostgREST/postgrest.git
 
-flag werror
+flag FailOnWarn
   default:     False
   manual:      True
   description: No warnings allowed
@@ -88,7 +88,7 @@ library
   default-extensions: OverloadedStrings
                       QuasiQuotes
                       NoImplicitPrelude
-  if flag(werror)
+  if flag(FailOnWarn)
     ghc-options: -O2 -Werror -Wall -fwarn-identities
                  -fno-spec-constr -optP-Wno-nonportable-include-path
   else
@@ -124,7 +124,7 @@ executable postgrest
   default-extensions: OverloadedStrings
                       QuasiQuotes
                       NoImplicitPrelude
-  if flag(werror)
+  if flag(FailOnWarn)
     ghc-options:      -threaded -rtsopts "-with-rtsopts=-N -I2"
                       -O2 -Werror -Wall -fwarn-identities
                       -fno-spec-constr -optP-Wno-nonportable-include-path

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -19,10 +19,10 @@ source-repository head
   type:     git
   location: git://github.com/PostgREST/postgrest.git
 
-flag ci
+flag werror
   default:     False
   manual:      True
-  description: No warnings allowed in continuous integration
+  description: No warnings allowed
 
 library
   exposed-modules:    PostgREST.ApiRequest
@@ -88,8 +88,12 @@ library
   default-extensions: OverloadedStrings
                       QuasiQuotes
                       NoImplicitPrelude
-  ghc-options:        -O2 -Werror -Wall -fwarn-identities
-                      -fno-spec-constr -optP-Wno-nonportable-include-path
+  if flag(werror)
+    ghc-options: -O2 -Werror -Wall -fwarn-identities
+                 -fno-spec-constr -optP-Wno-nonportable-include-path
+  else
+    ghc-options: -O2 -Wall -fwarn-identities
+                 -fno-spec-constr -optP-Wno-nonportable-include-path
           -- -fno-spec-constr may help keep compile time memory use in check,
           --   see https://gitlab.haskell.org/ghc/ghc/issues/16017#note_219304
           -- -optP-Wno-nonportable-include-path
@@ -120,8 +124,13 @@ executable postgrest
   default-extensions: OverloadedStrings
                       QuasiQuotes
                       NoImplicitPrelude
-  ghc-options:        -threaded -rtsopts "-with-rtsopts=-N -I2"
+  if flag(werror)
+    ghc-options:      -threaded -rtsopts "-with-rtsopts=-N -I2"
                       -O2 -Werror -Wall -fwarn-identities
+                      -fno-spec-constr -optP-Wno-nonportable-include-path
+  else
+    ghc-options:      -threaded -rtsopts "-with-rtsopts=-N -I2"
+                      -O2 -Wall -fwarn-identities
                       -fno-spec-constr -optP-Wno-nonportable-include-path
 
   if !os(windows)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,11 @@
 # stack is used for circleci and appveyor CI builds
 resolver: lts-15.8
+flags:
+    postgrest:
+        werror: true
 nix:
   packages: [pcre, pkgconfig, postgresql, zlib]
-  # disable pure by default so that the test enviroment can be passed 
+  # disable pure by default so that the test enviroment can be passed
   pure: false
 extra-deps:
 - configurator-pg-0.2.2@sha256:8f3f7c66dd4a53852283c70806ebc101a7219f8b01c3e80c5130e9749c998dc8,2987

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@
 resolver: lts-15.8
 flags:
     postgrest:
-        werror: true
+        FailOnWarn: true
 nix:
   packages: [pcre, pkgconfig, postgresql, zlib]
   # disable pure by default so that the test enviroment can be passed


### PR DESCRIPTION
When doing:

```
cabal upload dist-newstyle/sdist/postgrest-7.0.1.tar.gz
```

The following error is shown:

```
Error: Invalid package

'ghc-options: -Wall -Werror' makes the package very easy to break with
future GHC versions because new GHC versions often add new warnings.
Use just 'ghc-options: -Wall' instead. Alternatively, if you want to
use this, make it conditional based on a Cabal configuration flag
(with 'manual: True' and 'default: False') and enable that flag
during development.
```

Put -Werror in a cabal flag to work around this restriction.