### PR TITLE
fix UNKNOWN being shown as git commit hash (fixes #1530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+ - #1530, Fix how the PostgREST version is shown in the help text when the `.git` directory is not available - @monacoremo
+
 ## [7.0.1] - 2020-05-18
 
 ### Fixed

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -127,10 +127,9 @@ prettyVersion =
   intercalate "." (map show $ versionBranch version) <> gitRev
   where
     gitRev =
-      if $(gitHash) == "UNKNOWN" then
-        ""
-      else
-        " (" <> take 7 $(gitHash) <> ")"
+      if $(gitHash) == "UNKNOWN"
+        then mempty
+        else " (" <> take 7 $(gitHash) <> ")"
 
 -- | Version number used in docs
 docsVersion :: Text

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -124,8 +124,13 @@ corsPolicy req = case lookup "origin" headers of
 -- | User friendly version number
 prettyVersion :: Text
 prettyVersion =
-  intercalate "." (map show $ versionBranch version)
-  <> " (" <> take 7 $(gitHash) <> ")"
+  intercalate "." (map show $ versionBranch version) <> gitRev
+  where
+    gitRev =
+      if $(gitHash) == "UNKNOWN" then
+        ""
+      else
+        " (" <> take 7 $(gitHash) <> ")"
 
 -- | Version number used in docs
 docsVersion :: Text


### PR DESCRIPTION
Fix for #1530 

This might be a good compromise - it will show the commit hash in the help text if `.git` is available (e.g. when someone built PostgREST from source), but it will not show `UNKNOWN` if it's not.

There are some cases where `.git` simply can't be available (e.g. when cabal or nix build the package from a sdist tarball from Hackage), so this would give us the best of both worlds I think.

Example when built with nix:
```
Usage: postgrest FILENAME
  PostgREST 7.0.1 / create a REST API to an existing Postgres database
```

Example when built with stack:
```
Usage: postgrest FILENAME
  PostgREST 7.0.1 (69516b9) / create a REST API to an existing Postgres database
```