### PR TITLE
Nixify io and memory tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,8 @@ jobs:
       - run:
           name: run io tests
           command: |
+            export PATH="~/.local/bin:$PATH"
+            stack install --fast -j1
             test/io-tests.sh
 
   # Run memory usage tests based on stack and docker.
@@ -111,12 +113,13 @@ jobs:
             - ".stack-work"
           key: v1-stack-prof-dependencies-{{ checksum "postgrest.cabal" }}-{{ checksum "stack.yaml" }}
       - run:
-          name: build with profiling enabled
+          name: install with profiling enabled
           command: |
-            stack build --profile -j1
+            stack install --profile -j1
       - run:
           name: run memory usage tests
           command: |
+            export PATH="~/.local/bin:$PATH"
             test/create_test_db "postgres://circleci@localhost" postgrest_test
             test/memory-tests.sh
 
@@ -196,6 +199,14 @@ jobs:
       # the libraries that are built with Nix. So this should only ever build
       # the PostgREST itself and be reasonably quick. We accelerate that part
       # further by caching `~/.cabal` and `dist-newstyle`.
+      #
+      # CircleCI looks for caches by prefix. When saving to the the cache
+      # below, we append the current time to the key ('-{{ epoch }}'), so a new
+      # cache will always be uploaded. If the `postgrest.cabal` and
+      # `nix/nixpkgs-version.nix` files are unchanged, the latest matching
+      # cache will be used. If there is no cache for those files, CircleCI will
+      # try the next, more general key and use the latest cache that matches
+      # it.
       - restore_cache:
           keys:
             - nix-test-{{ checksum "postgrest.cabal" }}-{{ checksum "nix/nixpkgs-version.nix" }}
@@ -219,6 +230,12 @@ jobs:
       - run:
           name: Run the spec tests against PostgreSQL 12
           command: postgrest-test-spec-postgresql-12
+      - run:
+          name: Run io tests
+          command: postgrest-test-io
+      - run:
+          name: Run memory tests
+          command: postgrest-test-memory
       - save_cache:
           paths:
             - "~/.cabal"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,8 +193,8 @@ jobs:
             nix-env -iA cachix -f https://cachix.org/api/v1/install
             cachix use postgrest
       - run:
-          name: Install testing scripts for all supported PostgreSQL versions
-          command: nix-env -f default.nix -iA tests
+          name: Install testing scripts
+          command: nix-env -f default.nix -iA tests tests.ioTests tests.memoryTests
       # Our utility scripts use cabal to run the tests, which will pick up all
       # the libraries that are built with Nix. So this should only ever build
       # the PostgREST itself and be reasonably quick. We accelerate that part

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ site
 *.swp
 result*
 dist-newstyle
+postgrest.hp
+postgrest.prof

--- a/nix/README.md
+++ b/nix/README.md
@@ -68,30 +68,36 @@ The PostgREST utilities available in `nix-shell` all have names that begin with
 ```
 # Note: The utilities listed here might not be up to date.
 [nix-shell]$ postgrest-<tab>
-postgrest-lint         postgrest-style        postgrest-style-check
+postgrest-lint                      postgrest-test-spec-postgresql-11
+postgrest-style                     postgrest-test-spec-postgresql-12
+postgrest-style-check               postgrest-test-spec-postgresql-9.4
+postgrest-test-spec                 postgrest-test-spec-postgresql-9.5
+postgrest-test-spec-all             postgrest-test-spec-postgresql-9.6
+postgrest-test-spec-postgresql-10
 
 [nix-shell]$
 
 ```
 
-Some additional modules like `tests`, `docker` and `release` have large
-dependencies that would need to be built before the shell becomes available,
-which could take an especially long time if the cachix binary cache is not used.
-You can activate those by passing a flag to `nix-shell`, which will make the respective
-utilites available:
+Some additional modules like `ioTests`, `memoryTests`, `docker` and `release`
+have large dependencies that would need to be built before the shell becomes
+available, which could take an especially long time if the cachix binary cache
+is not used. You can activate those by passing a flag to `nix-shell`, which
+will make the respective utilites available:
 
 ```
-$ nix-shell --arg tests true
+$ nix-shell --arg ioTests true
 [nix-shell]$ postgrest-<tab>
 postgrest-lint                      postgrest-test-spec-postgresql-10
 postgrest-style                     postgrest-test-spec-postgresql-11
 postgrest-style-check               postgrest-test-spec-postgresql-12
 postgrest-test-io                   postgrest-test-spec-postgresql-9.4
-postgrest-test-memory               postgrest-test-spec-postgresql-9.5
-postgrest-test-spec                 postgrest-test-spec-postgresql-9.6
-postgrest-test-spec-all
+postgrest-test-spec                 postgrest-test-spec-postgresql-9.5
+postgrest-test-spec-all             postgrest-test-spec-postgresql-9.6
 
 ```
+
+Note that `postgrest-tests-io` is now also available.
 
 To run one-off commands, you can also use `nix-shell --run <command>`, which
 will lauch the Nix shell, run that one command and exit. Note that the tab

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -116,7 +116,16 @@ buildEnv {
     [
       (testSpec "postgrest-test-spec" postgresql)
       testSpecAllVersions
-      (testIO "postgrest-test-io" postgresql)
-      (testMemory "postgrest-test-memory" postgresql)
     ] ++ testSpecVersions;
+}
+  # The IO an memory tests have large dependencies (a static and a profiled
+  # build of PostgREST respectively) and are run less often than the spec
+  # tests, so we don't include them in the default test environment. We make
+  # them available through separate attributes:
+  // {
+  ioTests =
+    (testIO "postgrest-test-io" postgresql);
+
+  memoryTests =
+    (testMemory "postgrest-test-memory" postgresql);
 }

--- a/shell.nix
+++ b/shell.nix
@@ -9,7 +9,7 @@
 #
 # We highly recommend that use the PostgREST binary cache by installing cachix
 # (https://app.cachix.org/) and running `cachix use postgrest`.
-{ tests ? false, docker ? false, release ? false }:
+{ ioTests ? false, memoryTests ? false, docker ? false, release ? false }:
 let
   postgrest =
     import ./default.nix;
@@ -29,8 +29,10 @@ lib.overrideDerivation postgrest.env (
         pkgs.postgresql
         postgrest.nixpkgsUpgrade
         postgrest.devtools
+        postgrest.tests
       ]
-      ++ lib.optional tests postgrest.tests
+      ++ lib.optional ioTests postgrest.tests.ioTests
+      ++ lib.optional memoryTests postgrest.tests.memoryTests
       ++ lib.optional docker postgrest.docker
       ++ lib.optional release postgrest.release;
   }

--- a/shell.nix
+++ b/shell.nix
@@ -1,26 +1,37 @@
-with (import ./default.nix);
-pkgs.lib.overrideDerivation env (
+# The additional modules below have large dependencies and are therefore
+# disabled by default. You can activate them by passing arguments to nix-shell,
+# e.g.:
+#
+#    nix-shell --arg release true
+#
+# This will provide you with a shell where the `postgrest-release-*` scripts
+# are available.
+#
+# We highly recommend that use the PostgREST binary cache by installing cachix
+# (https://app.cachix.org/) and running `cachix use postgrest`.
+{ tests ? false, docker ? false, release ? false }:
+let
+  postgrest =
+    import ./default.nix;
+
+  pkgs =
+    postgrest.pkgs;
+
+  lib =
+    pkgs.lib;
+in
+lib.overrideDerivation postgrest.env (
   base: {
     buildInputs =
       base.buildInputs ++ [
         pkgs.cabal-install
-        pkgs.stack
         pkgs.cabal2nix
         pkgs.postgresql
-        nixpkgsUpgrade
-        tests
-        devtools
-        # We don't include the `postgrest-docker-load` here, as that would
-        # cause the shell to depend on building the Docker images and in turn
-        # on the static executable. Use `nix-shell default.nix -A dockerLoad`
-        # to get a shell with that script on the PATH.
-      ];
-
-    shellHook =
-      ''
-        # Set our pinned version of Nixpkgs in the NIX_PATH so that
-        # `stack --nix` also uses that version.
-        NIX_PATH="nixpkgs=${nixpkgs}"
-      '';
+        postgrest.nixpkgsUpgrade
+        postgrest.devtools
+      ]
+      ++ lib.optional tests postgrest.tests
+      ++ lib.optional docker postgrest.docker
+      ++ lib.optional release postgrest.release;
   }
 )

--- a/test/QueryCost.hs
+++ b/test/QueryCost.hs
@@ -50,6 +50,7 @@ main = do
           cost <- exec pool [str| [{"id": 1}, {"id": 4}] |] $
             requestToCallProcQuery (QualifiedIdentifier "test" "get_projects_below") [PgArg "id" "int" True] False (Just MultipleObjects) []
           liftIO $ do
+            -- lower bound needed for now to make sure that cost is not Nothing
             cost `shouldSatisfy` (> Just 2000)
             cost `shouldSatisfy` (< Just 2100)
 

--- a/test/io-tests.sh
+++ b/test/io-tests.sh
@@ -1,6 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Run unit tests for Input/Ouput of PostgREST seen as a black box
 # with test output in Test Anything Protocol format.
+#
+# These tests expect that `postgrest` is on the PATH, as well as `curl` and
+# `ncat` (from the nmap package in some distribution).
 #
 # References:
 #   [1] Test Anything Protocol
@@ -12,8 +15,14 @@
 #   [3] List of TCP and UDP port numbers
 #   https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers
 #
+set -eu
+
+export POSTGREST_TEST_CONNECTION=${POSTGREST_TEST_CONNECTION:-"postgres:///postgrest_test"}
+
 cd "$(dirname "$0")"
 cd io-tests
+
+trap "kill 0" int term exit
 
 # Port for Test PostgREST Server (must match config)
 pgrPort=49421 # in range 49152–65535: for private or temporary use
@@ -30,11 +39,11 @@ ko(){ result 'not ok' "- $1"; failedTests=$(( $failedTests + 1 )); }
 comment(){ echo "# $1"; }
 
 # Utilities to start/stop test PostgREST server running in the background
-pgrStart(){ stack exec -- postgrest "$1" >/dev/null & pgrPID="$!"; }
-pgrStartRead(){ stack exec -- postgrest "$1" >/dev/null < "$2" & pgrPID="$!"; }
+pgrStart(){ postgrest $1 >/dev/null 2>/dev/null & pgrPID="$!"; }
+pgrStartRead(){ postgrest $1 <$2 >/dev/null & pgrPID="$!"; }
+pgrStartStdin(){ postgrest $1 >/dev/null <<< "$2" & pgrPID="$!"; }
 pgrStarted(){ kill -0 "$pgrPID" 2>/dev/null; }
-pgrStop(){ kill "$pgrPID" 2>/dev/null; }
-pgrStopAll(){ pkill -f "$(stack path --local-install-root)/bin/postgrest"; }
+pgrStop(){ kill "$pgrPID" 2>/dev/null; pgrPID=""; }
 
 # Utilities to send HTTP requests to the PostgREST server
 rootStatus(){
@@ -46,10 +55,6 @@ authorsStatus(){
     -H "Authorization: Bearer $1" \
     "http://localhost:$pgrPort/authors_only"
 }
-
-# Start and End of Unit Tests
-setUp(){ pgrStopAll; }
-cleanUp(){ pgrStopAll; }
 
 # Unit Test Templates
 readSecretFromFile(){
@@ -82,9 +87,9 @@ readSecretFromFile(){
   pgrStop
 }
 
-readDbUriFromFile(){
+readDbUriFromStdin(){
   pgrConfig="dburi-from-file.config"
-  pgrStartRead "./configs/$pgrConfig" "./dburis/$1"
+  pgrStartStdin "./configs/$pgrConfig" "$1"
   while pgrStarted && test "$( rootStatus )" -ne 200
   do
     # wait for the server to start
@@ -93,9 +98,9 @@ readDbUriFromFile(){
   done
   if pgrStarted
   then
-    ok "connection with $2 dburi read from a file"
+    ok "connection with $2 dburi read from stdin / a file"
   else
-    ko "connection with $2 dburi read from a file"
+    ko "connection with $2 dburi read from stdin / a file"
   fi
   pgrStop
 }
@@ -109,7 +114,7 @@ reqWithRoleClaimKey(){
     sleep 0.1 \
     || sleep 1 # fallback: subsecond sleep is not standard and may fail
   done
-  authorsJwt=$(psql -qtAX postgrest_test -c "select jwt.sign('$2', 'reallyreallyreallyreallyverysafe');")
+  authorsJwt=$(psql -qtAX "$POSTGREST_TEST_CONNECTION" -c "select jwt.sign('$2', 'reallyreallyreallyreallyverysafe');")
   httpStatus="$( authorsStatus "$authorsJwt" )"
   if test "$httpStatus" -eq $3
   then
@@ -132,10 +137,10 @@ invalidRoleClaimKey(){
   if pgrStarted
   then
     ko "invalid jspath \"$1\": accepted"
+    pgrStop
   else
     ok "invalid jspath \"$1\": rejected"
   fi
-  pgrStop
 }
 
 # ensure iat claim is successful in the presence of pgrst time cache, see https://github.com/PostgREST/postgrest/issues/1139
@@ -148,7 +153,7 @@ ensureIatClaimWorks(){
     || sleep 1 # fallback: subsecond sleep is not standard and may fail
   done
   for i in {1..10}; do \
-    iatJwt=$(psql -qtAX postgrest_test -c "select jwt.sign(row_to_json(r), 'reallyreallyreallyreallyverysafe') from ( select 'postgrest_test_author' as role, extract(epoch from now()) as iat) r")
+    iatJwt=$(psql -qtAX "$POSTGREST_TEST_CONNECTION" -c "select jwt.sign(row_to_json(r), 'reallyreallyreallyreallyverysafe') from ( select 'postgrest_test_author' as role, extract(epoch from now()) as iat) r")
     httpStatus="$( authorsStatus $iatJwt )"
     if test "$httpStatus" -ne 200
     then
@@ -209,9 +214,7 @@ socketConnection(){
 test -n "$(command -v curl)" || bailOut 'curl is not available'
 
 # PRE: postgres must be running
-psql -l 1>/dev/null 2>/dev/null || bailOut 'postgres is not running'
-
-setUp
+psql -l "$POSTGREST_TEST_CONNECTION" 1>/dev/null 2>/dev/null || bailOut 'postgres is not running'
 
 echo "Running IO tests.."
 
@@ -231,8 +234,10 @@ readSecretFromFile ascii.b64 'Base64 (ASCII)'
 readSecretFromFile utf8.b64 'Base64 (UTF-8)'
 readSecretFromFile binary.b64 'Base64 (binary)'
 
-readDbUriFromFile uri.noeol "(no EOL)"
-readDbUriFromFile uri.txt "(EOL)"
+eol=$'\x0a'
+
+readDbUriFromStdin "$POSTGREST_TEST_CONNECTION" "(no EOL)"
+readDbUriFromStdin "$POSTGREST_TEST_CONNECTION$eol" "(EOL)"
 
 reqWithRoleClaimKey '.postgrest.a_role' '{"postgrest":{"a_role":"postgrest_test_author"}}' 200
 reqWithRoleClaimKey '.customObject.manyRoles[1]' '{"customObject":{"manyRoles": ["other", "postgrest_test_author"]}}' 200
@@ -250,7 +255,6 @@ invalidRoleClaimKey 1234
 ensureIatClaimWorks
 ensureAppSettings
 
-
-cleanUp
+trap - int term exit
 
 exit $failedTests

--- a/test/io-tests/configs/app-settings.config
+++ b/test/io-tests/configs/app-settings.config
@@ -1,4 +1,4 @@
-db-uri = "postgres:///postgrest_test"
+db-uri = "$(POSTGREST_TEST_CONNECTION)"
 db-schema = "test"
 db-anon-role = "postgrest_test_anonymous"
 db-pool = 1

--- a/test/io-tests/configs/base64-secret-from-file.config
+++ b/test/io-tests/configs/base64-secret-from-file.config
@@ -1,4 +1,4 @@
-db-uri = "postgres:///postgrest_test"
+db-uri = "$(POSTGREST_TEST_CONNECTION)"
 db-schema = "test"
 db-anon-role = "postgrest_test_anonymous"
 db-pool = 1

--- a/test/io-tests/configs/role-claim-key.config
+++ b/test/io-tests/configs/role-claim-key.config
@@ -1,4 +1,4 @@
-db-uri = "postgres:///postgrest_test"
+db-uri = "$(POSTGREST_TEST_CONNECTION)"
 db-schema = "test"
 db-anon-role = "postgrest_test_anonymous"
 db-pool = 1

--- a/test/io-tests/configs/secret-from-file.config
+++ b/test/io-tests/configs/secret-from-file.config
@@ -1,4 +1,4 @@
-db-uri = "postgres:///postgrest_test"
+db-uri = "$(POSTGREST_TEST_CONNECTION)"
 db-schema = "test"
 db-anon-role = "postgrest_test_anonymous"
 db-pool = 1

--- a/test/io-tests/configs/simple.config
+++ b/test/io-tests/configs/simple.config
@@ -1,4 +1,4 @@
-db-uri = "postgres:///postgrest_test"
+db-uri = "$(POSTGREST_TEST_CONNECTION)"
 db-schema = "test"
 db-anon-role = "postgrest_test_anonymous"
 db-pool = 1

--- a/test/io-tests/configs/unix-socket.config
+++ b/test/io-tests/configs/unix-socket.config
@@ -1,4 +1,4 @@
-db-uri = "postgres:///postgrest_test"
+db-uri = "$(POSTGREST_TEST_CONNECTION)"
 db-schema = "test"
 db-anon-role = "postgrest_test_anonymous"
 db-pool = 1

--- a/test/io-tests/dburis/uri.noeol
+++ b/test/io-tests/dburis/uri.noeol
@@ -1,1 +1,0 @@
-postgres:///postgrest_test

--- a/test/io-tests/dburis/uri.txt
+++ b/test/io-tests/dburis/uri.txt
@@ -1,1 +1,0 @@
-postgres:///postgrest_test

--- a/test/memory-tests.sh
+++ b/test/memory-tests.sh
@@ -1,4 +1,15 @@
 #! /usr/bin/env bash
+
+# This test script expects that a `postgrest` executable with profiling enabled
+# is on the PATH. With stack, for example, you can run `stack install --profile
+# postgrest`.
+
+set -eu
+
+export POSTGREST_TEST_CONNECTION=${POSTGREST_TEST_CONNECTION:-"postgres:///postgrest_test"}
+
+trap "kill 0" int term exit
+
 currentTest=1
 failedTests=0
 result(){ echo "$1 $currentTest $2"; currentTest=$(( $currentTest + 1 )); }
@@ -7,13 +18,8 @@ ko(){ result 'not ok' "- $1"; failedTests=$(( $failedTests + 1 )); }
 
 pgrPort=49421
 
-pgrStopAll(){ pkill -f "$(stack path --profile --local-install-root)/bin/postgrest"; }
-
-pgrStart(){ stack exec --profile -- postgrest test/memory-tests/config +RTS -p -h >/dev/null & pgrPID="$!"; }
+pgrStart(){ postgrest test/memory-tests/config +RTS -p -h > /dev/null & pgrPID="$!"; }
 pgrStop(){ kill "$pgrPID" 2>/dev/null; }
-
-setUp(){ pgrStopAll; }
-cleanUp(){ pgrStopAll; }
 
 checkPgrStarted(){
   while pgrStarted && test $(rootStatus) -ne 200
@@ -90,8 +96,6 @@ postJsonArrayTest(){
   fi
 }
 
-setUp
-
 echo "Running memory usage tests.."
 
 jsonKeyTest "1M" "POST" "/rpc/leak?columns=blob" "13M"
@@ -110,6 +114,6 @@ postJsonArrayTest "1000" "/perf_articles?columns=id,body" "11M"
 postJsonArrayTest "10000" "/perf_articles?columns=id,body" "11M"
 postJsonArrayTest "100000" "/perf_articles?columns=id,body" "21M"
 
-cleanUp
+trap - int term exit
 
 exit $failedTests

--- a/test/memory-tests/config
+++ b/test/memory-tests/config
@@ -1,4 +1,4 @@
-db-uri = "postgres:///postgrest_test"
+db-uri = "$(POSTGREST_TEST_CONNECTION)"
 db-schema = "test"
 db-anon-role = "postgrest_test_anonymous"
 db-pool = 1


### PR DESCRIPTION
As discussed in #1535, this integrates the io and memory tests with the Nix setup.

A few notes:
* The io and memory scripts are now independent from stack and take the postgrest executable from the PATH (also reflected in the stack CI jobs)
* This PR touches quite a few files because the db URI needed to be parameterized (the `with_tmp_db` will never be in the same location) - otherwise I tried to keep the changes minimal
* The tests still feels a bit hacky/brittle - the nmap dependency could probably be removed (its process not being properly terminated currently), as could the dependency on a hardcoded port. Shellcheck throws many warnings on the two scripts, but I left as much as possible as it was for this PR :-)
* The Nix test scripts now depend on the final executables (both a static and profiled build). This is good on the one hand, as that makes the tests truly end-to-end. On the other hand, it would make the nix-shell startup times very large if we included the tests by default. So I implemented flags to enable the more 'expensive' modules and also reflected that in the README