### PR TITLE
Allow http status override through response.status guc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+ - #1525, Allow http status override through response.status guc - @steve-chavez
+
 ### Fixed
 
  - #1530, Fix how the PostgREST version is shown in the help text when the `.git` directory is not available - @monacoremo

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -46,7 +46,7 @@ let
 
         EOF
 
-        ${withTmpDb postgresql} ${cabal-install}/bin/cabal v2-test \
+        ${withTmpDb postgresql} ${cabal-install}/bin/cabal v2-test -f FailOnWarn \
           --test-show-detail=direct
 
         cat << EOF

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -221,6 +221,7 @@ checkIsFatal _ = Nothing
 
 data SimpleError
   = GucHeadersError
+  | GucStatusError
   | BinaryFieldError ContentType
   | ConnectionLostError
   | PutMatchingPkError
@@ -233,6 +234,7 @@ data SimpleError
 
 instance PgrstError SimpleError where
   status GucHeadersError         = HT.status500
+  status GucStatusError          = HT.status500
   status (BinaryFieldError _)    = HT.status406
   status ConnectionLostError     = HT.status503
   status PutMatchingPkError      = HT.status400
@@ -249,6 +251,8 @@ instance PgrstError SimpleError where
 instance JSON.ToJSON SimpleError where
   toJSON GucHeadersError           = JSON.object [
     "message" .= ("response.headers guc must be a JSON array composed of objects with a single key and a string value" :: Text)]
+  toJSON GucStatusError           = JSON.object [
+    "message" .= ("response.status guc must be a valid status code" :: Text)]
   toJSON (BinaryFieldError ct)          = JSON.object [
     "message" .= ((toS (toMime ct) <> " requested but more than one column was selected") :: Text)]
   toJSON ConnectionLostError       = JSON.object [

--- a/src/PostgREST/Private/QueryFragment.hs
+++ b/src/PostgREST/Private/QueryFragment.hs
@@ -202,5 +202,16 @@ returningF qi returnings =
 responseHeadersF :: PgVersion -> SqlFragment
 responseHeadersF pgVer =
   if pgVer >= pgVersion96
-    then "coalesce(nullif(current_setting('response.headers', true), ''), '[]')" :: Text -- nullif is used because of https://gist.github.com/steve-chavez/8d7033ea5655096903f3b52f8ed09a15
-    else "'[]'" :: Text
+    then currentSettingF "response.headers"
+    else "null" :: Text
+
+responseStatusF :: PgVersion -> SqlFragment
+responseStatusF pgVer =
+  if pgVer >= pgVersion96
+    then currentSettingF "response.status"
+    else "null" :: Text
+
+currentSettingF :: SqlFragment -> SqlFragment
+currentSettingF setting =
+  -- nullif is used because of https://gist.github.com/steve-chavez/8d7033ea5655096903f3b52f8ed09a15
+  "nullif(current_setting(" <> pgFmtLit setting <> ", true), '')"

--- a/test/Feature/PgVersion96Spec.hs
+++ b/test/Feature/PgVersion96Spec.hs
@@ -161,6 +161,27 @@ spec =
           let respHeaders = simpleHeaders r
           respHeaders `shouldSatisfy` noBlankHeader
 
+    context "GUC status override" $ do
+      it "can override the status on RPC" $
+        get "/rpc/send_body_status_403"
+          `shouldRespondWith`
+          [json|{"message" : "invalid user or password"}|]
+          { matchStatus  = 403
+          , matchHeaders = [ matchContentTypeJson ]
+          }
+
+      it "can override the status through trigger" $
+        request methodPatch "/stuff?id=eq.1" [] [json|[{"name": "updated stuff 1"}]|]
+          `shouldRespondWith` 205
+
+      it "fails when setting invalid status guc" $
+        get "/rpc/send_bad_status"
+          `shouldRespondWith`
+          [json|{"message":"response.status guc must be a valid status code"}|]
+          { matchStatus  = 500
+          , matchHeaders = [ matchContentTypeJson ]
+          }
+
     context "Use of the phraseto_tsquery function" $ do
       it "finds matches" $
         get "/tsearch?text_search_vector=phfts.The%20Fat%20Cats" `shouldRespondWith`

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1086,6 +1086,20 @@ begin
 end;
 $$ language plpgsql;
 
+create or replace function test.send_body_status_403() returns pg_catalog.json as $$
+begin
+  perform set_config('response.status', '403', true);
+  return json_build_object('message', 'invalid user or password');
+end;
+$$ language plpgsql;
+
+create or replace function test.send_bad_status() returns pg_catalog.json as $$
+begin
+  perform set_config('response.status', 'bad', true);
+  return null;
+end;
+$$ language plpgsql;
+
 create or replace function test.get_projects_and_guc_headers() returns setof test.projects as $$
   set local "response.headers" = '[{"X-Test": "key1=val1; someValue; key2=val2"}, {"X-Test-2": "key1=val1"}]';
   select * from test.projects;
@@ -1692,8 +1706,7 @@ create table private.stuff(
 
 create view test.stuff as select * from private.stuff;
 
-create or replace function location_for_stuff() returns trigger
-    as $$
+create or replace function location_for_stuff() returns trigger as $$
 begin
     insert into private.stuff values (new.id, new.name);
     if new.id is not null
@@ -1708,6 +1721,15 @@ begin
 end
 $$ language plpgsql security definer;
 create trigger location_for_stuff instead of insert on test.stuff for each row execute procedure test.location_for_stuff();
+
+create or replace function status_205_for_updated_stuff() returns trigger as $$
+begin
+    update private.stuff set id = new.id, name = new.name;
+    perform set_config('response.status' , '205' , true);
+    return new;
+end
+$$ language plpgsql security definer;
+create trigger status_205_for_updated_stuff instead of update on test.stuff for each row execute procedure test.status_205_for_updated_stuff();
 
 create table loc_test (
   id int primary key


### PR DESCRIPTION
Fixes https://github.com/PostgREST/postgrest/issues/1525.

A quick feature for this new batch of enhancements!

I think this should finish the [HTTP Logic](http://postgrest.org/en/v7.0.0/api.html#http-logic) features. I should turn that on its own page, the API reference is getting big.