### PR TITLE
Allow schema cache reloading with NOTIFY

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,6 +267,8 @@ workflows:
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
+          requires:
+            - nix-build
       - release:
           requires:
             - style-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
  - #1525, Allow http status override through response.status guc - @steve-chavez
+ - #1512, Allow schema cache reloading with NOTIFY - @steve-chavez
 
 ### Fixed
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -234,7 +234,7 @@ main = do
   -- a 'Connection' or a 'ConnectionError'. Does not throw.
   pool <- P.acquire (configPool conf, configPoolTimeout' conf, dbUri)
 
-  -- No connection to the db at first. This is only used if the dbChannelEnabled is true(listener enabled).
+  -- Used to sync the listener with the connectionWorker. No connection for the listener at first. Only used if dbChannelEnabled=true.
   mvarConnectionStatus <- newEmptyMVar
 
   -- To be filled in by connectionWorker
@@ -271,7 +271,7 @@ main = do
     ) Nothing
 #endif
 
-  -- run connectionWorker on NOTIFY, in addition to SIGUSR1
+  -- reload schema cache on NOTIFY
   when dbChannelEnabled $
     listener dbUri dbChannel pool schemas refDbStructure mvarConnectionStatus connWorker
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -181,7 +181,7 @@ main = do
       maybeSocketAddr = configSocket conf
       socketFileMode = configSocketMode conf
       dbUri = toS (configDbUri conf)
-      dbChannel = toS (configDbChannel conf)
+      (dbChannelEnabled, dbChannel) = (configDbChannelEnabled conf, toS $ configDbChannel conf)
       roleClaimKey = configRoleClaimKey conf
       appSettings =
         setHost ((fromString . toS) host) -- Warp settings
@@ -239,7 +239,8 @@ main = do
 #endif
 
   -- run connectionWorker on NOTIFY, in addition to SIGUSR1
-  listener dbUri dbChannel worker
+  when dbChannelEnabled $
+    listener dbUri dbChannel worker
 
   -- ask for the OS time at most once per second
   getTime <- mkAutoUpdate defaultUpdateSettings {updateAction = getCurrentTime}

--- a/nix/docker/default.nix
+++ b/nix/docker/default.nix
@@ -30,7 +30,7 @@ let
           "PGRST_DB_POOL_TIMEOUT=10"
           "PGRST_DB_EXTRA_SEARCH_PATH=public"
           "PGRST_DB_CHANNEL=pgrst"
-          "PGRST_DB_CHANNEL_ENABLED=true"
+          "PGRST_DB_CHANNEL_ENABLED=false"
           "PGRST_SERVER_HOST=*4"
           "PGRST_SERVER_PORT=3000"
           "PGRST_OPENAPI_SERVER_PROXY_URI="

--- a/nix/docker/default.nix
+++ b/nix/docker/default.nix
@@ -29,6 +29,8 @@ let
           "PGRST_DB_POOL=100"
           "PGRST_DB_POOL_TIMEOUT=10"
           "PGRST_DB_EXTRA_SEARCH_PATH=public"
+          "PGRST_DB_CHANNEL=pgrst"
+          "PGRST_DB_CHANNEL_ENABLED=true"
           "PGRST_SERVER_HOST=*4"
           "PGRST_SERVER_PORT=3000"
           "PGRST_OPENAPI_SERVER_PROXY_URI="

--- a/nix/docker/postgrest.conf
+++ b/nix/docker/postgrest.conf
@@ -12,6 +12,9 @@ db-pool = "$(PGRST_DB_POOL)"
 db-pool-timeout = "$(PGRST_DB_POOL_TIMEOUT)"
 db-extra-search-path = "$(PGRST_DB_EXTRA_SEARCH_PATH)"
 
+db-channel = "$(PGRST_DB_CHANNEL)"
+db-channel-enabled = "$(PGRST_DB_CHANNEL_ENABLED)"
+
 server-host = "$(PGRST_SERVER_HOST)"
 server-port = "$(PGRST_SERVER_PORT)"
 

--- a/nix/overlays/haskell-packages/default.nix
+++ b/nix/overlays/haskell-packages/default.nix
@@ -12,6 +12,19 @@ let
             ver = "0.3.0";
             sha256 = "0iwh4wsjhb7pms88lw1afhdal9f86nrrkkvv65f9wxbd1b159n72";
           } { };
+      # To get the sha256
+      # nix-prefetch-url --unpack https://hackage.haskell.org/package/hasql-notifications-0.1.0.0/hasql-notifications-0.1.0.0.tar.gz
+      hasql-notifications =
+        self.haskell.lib.overrideCabal
+          (
+            prev.callHackageDirect
+              {
+                pkg = "hasql-notifications";
+                ver = "0.1.0.0";
+                sha256 = "1z17gsqvvzzi0yipc3qy3jz8vzpww4vsc4vaj2kbzr2mfliq6fx3";
+              } { }
+          )
+          (old: { doCheck = false; });
     } // extraOverrides final prev;
 in
 {

--- a/nix/patches/default.nix
+++ b/nix/patches/default.nix
@@ -31,4 +31,7 @@
   # https://github.com/nh2/static-haskell-nix/pull/91
   static-haskell-nix-postgrest-openssl-linking-fix =
     ./static-haskell-nix-postgrest-openssl-linking-fix.patch;
+
+  static-haskell-nix-hasql-notifications-openssl-linking-fix =
+    ./static-haskell-nix-hasql-notifications-openssl-linking-fix.patch;
 }

--- a/nix/patches/static-haskell-nix-hasql-notifications-openssl-linking-fix.patch
+++ b/nix/patches/static-haskell-nix-hasql-notifications-openssl-linking-fix.patch
@@ -1,0 +1,28 @@
+From 49ecb703d9d0bfd38eb69ba5cb63a8262bd03f96 Mon Sep 17 00:00:00 2001
+From: steve-chavez <stevechavezast@gmail.com>
+Date: Thu, 11 Jun 2020 13:18:07 -0500
+Subject: [PATCH] Add hasql-notifications openssl linking fix
+
+---
+ survey/default.nix | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/survey/default.nix b/survey/default.nix
+index 828beaa..9c2d5f6 100644
+--- a/survey/default.nix
++++ b/survey/default.nix
+@@ -1054,6 +1054,11 @@ let
+                   super.squeal-postgresql
+                   [ final.openssl ]
+                   "--libs openssl";
++              hasql-notifications =
++                addStaticLinkerFlagsWithPkgconfig
++                  super.hasql-notifications
++                  [ final.openssl ]
++                  "--libs openssl";
+
+               xml-to-json =
+                 addStaticLinkerFlagsWithPkgconfig
+--
+2.19.3
+

--- a/nix/static-haskell-package.nix
+++ b/nix/static-haskell-package.nix
@@ -18,6 +18,7 @@ let
       static-haskell-nix
       [
         patches.static-haskell-nix-postgrest-openssl-linking-fix
+        patches.static-haskell-nix-hasql-notifications-openssl-linking-fix
       ];
 
   patchedNixpkgs =

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -112,6 +112,7 @@ executable postgrest
                     , hasql             >= 1.4 && < 1.5
                     , hasql-pool        >= 0.5 && < 0.6
                     , hasql-transaction >= 0.7.2 && < 1.1
+                    , hasql-notifications == 0.1.0.0
                     , network           < 3.2
                     , postgrest
                     , protolude         >= 0.3 && < 0.4

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -166,7 +166,7 @@ readOptions = do
         <*> (fmap unpack <$> optString "server-unix-socket")
         <*> parseSocketFileMode "server-unix-socket-mode"
         <*> (fromMaybe "pgrst" <$> optString "db-channel")
-        <*> ((Just False /=) <$> optBool "db-channel-enabled")
+        <*> ((Just True ==) <$> optBool "db-channel-enabled")
         <*> (fmap encodeUtf8 <$> optString "jwt-secret")
         <*> ((Just True ==) <$> optBool "secret-is-base64")
         <*> parseJwtAudience "jwt-aud"

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -67,7 +67,7 @@ import Protolude.Conv    (toS)
 
 -- | Config file settings for the server
 data AppConfig = AppConfig {
-    configDatabase          :: Text
+    configDbUri             :: Text
   , configAnonRole          :: Text
   , configOpenAPIProxyUri   :: Maybe Text
   , configSchemas           :: NonEmpty Text
@@ -75,6 +75,7 @@ data AppConfig = AppConfig {
   , configPort              :: Int
   , configSocket            :: Maybe FilePath
   , configSocketMode        :: Either Text FileMode
+  , configDbChannel         :: Text
 
   , configJwtSecret         :: Maybe B.ByteString
   , configJwtSecretIsBase64 :: Bool
@@ -163,6 +164,7 @@ readOptions = do
         <*> (fromMaybe 3000 <$> optInt "server-port")
         <*> (fmap unpack <$> optString "server-unix-socket")
         <*> parseSocketFileMode "server-unix-socket-mode"
+        <*> (fromMaybe "pgrst" <$> optString "db-channel")
         <*> (fmap encodeUtf8 <$> optString "jwt-secret")
         <*> ((Just True ==) <$> optBool "secret-is-base64")
         <*> parseJwtAudience "jwt-aud"
@@ -275,6 +277,9 @@ readOptions = do
           |## unix socket file mode
           |## when none is provided, 660 is applied by default
           |# server-unix-socket-mode = "660"
+          |
+          |## Notification channel for reloading the schema cache
+          |# db-channel = "pgrst"
           |
           |## base url for swagger output
           |# openapi-server-proxy-uri = ""

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -283,7 +283,7 @@ readOptions = do
           |## Notification channel for reloading the schema cache
           |# db-channel = "pgrst"
           |## Enable or disable the notification channel
-          |# db-channel-enabled = true
+          |# db-channel-enabled = false
           |
           |## base url for swagger output
           |# openapi-server-proxy-uri = ""

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -76,6 +76,7 @@ data AppConfig = AppConfig {
   , configSocket            :: Maybe FilePath
   , configSocketMode        :: Either Text FileMode
   , configDbChannel         :: Text
+  , configDbChannelEnabled  :: Bool
 
   , configJwtSecret         :: Maybe B.ByteString
   , configJwtSecretIsBase64 :: Bool
@@ -165,6 +166,7 @@ readOptions = do
         <*> (fmap unpack <$> optString "server-unix-socket")
         <*> parseSocketFileMode "server-unix-socket-mode"
         <*> (fromMaybe "pgrst" <$> optString "db-channel")
+        <*> ((Just False /=) <$> optBool "db-channel-enabled")
         <*> (fmap encodeUtf8 <$> optString "jwt-secret")
         <*> ((Just True ==) <$> optBool "secret-is-base64")
         <*> parseJwtAudience "jwt-aud"
@@ -280,6 +282,8 @@ readOptions = do
           |
           |## Notification channel for reloading the schema cache
           |# db-channel = "pgrst"
+          |## Enable or disable the notification channel
+          |# db-channel-enabled = true
           |
           |## base url for swagger output
           |# openapi-server-proxy-uri = ""

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,3 +12,4 @@ extra-deps:
 - hspec-wai-json-0.10.1@sha256:67b405c38f0a9e2771480c8d3ecd8aeb8d8776a35d3b2906cb1b76c9538617e4,1629
 - interpolatedstring-perl6-1.0.2@sha256:7ce49c8a69a2a1b89c001ed79db2aab656ffd0faf2a7a701a553b6deb5c8ba7f,1073
 - protolude-0.3.0@sha256:8361b811b420585b122a7ba715aa5923834db6e8c36309bf267df2dbf66b95ef,2693
+- hasql-notifications-0.1.0.0@sha256:9ab112d2bb5da0d55abd65f0d27a7bb1dc4aeb792518d9a2ea8a16e243e19985,2156

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -69,6 +69,8 @@ _baseCfg =  -- Connection Settings
             Nothing
             -- No user configured Unix Socket file mode (defaults to 660)
             (Right 432)
+            -- db-channel
+            "pgrst"
             -- Jwt settings
             (Just $ encodeUtf8 "reallyreallyreallyreallyverysafe") False Nothing
             -- Connection Modifiers
@@ -88,7 +90,7 @@ _baseCfg =  -- Connection Settings
             []
 
 testCfg :: Text -> AppConfig
-testCfg testDbConn = _baseCfg { configDatabase = testDbConn }
+testCfg testDbConn = _baseCfg { configDbUri = testDbConn }
 
 testCfgNoJWT :: Text -> AppConfig
 testCfgNoJWT testDbConn = (testCfg testDbConn) { configJwtSecret = Nothing }

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -71,6 +71,8 @@ _baseCfg =  -- Connection Settings
             (Right 432)
             -- db-channel
             "pgrst"
+            -- db-channel-enabled
+            False
             -- Jwt settings
             (Just $ encodeUtf8 "reallyreallyreallyreallyverysafe") False Nothing
             -- Connection Modifiers


### PR DESCRIPTION
Fixes #1512

Helps on environments where you can't send unix signals(Windows, managed
containers). Also provides better UX for schema reloads - NOTIFY
can be send from pg clients(psql, pgadmin).

By default, `NOTIFY pgrst` - with no payload - should be done to reload
the schema cache. Notifications with a payload will be ignored.
The channel name can be configured with `db-channel`.

~~There's limitation for now, if the LISTEN connection is lost the
connection won't be retried.~~

**Edit**: The LISTEN connection is retried if lost now. With exponential backoff, same way as the pool.