### PR TITLE
Enable config file re-reading with SIGUSR2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
  - #1525, Allow http status override through response.status guc - @steve-chavez
  - #1512, Allow schema cache reloading with NOTIFY - @steve-chavez
+ - #1119, Allow config file reloading with SIGUSR2 - @steve-chavez
 
 ### Fixed
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -31,7 +31,7 @@ import System.IO                (BufferMode (..), hSetBuffering)
 
 import PostgREST.App         (postgrest)
 import PostgREST.Config      (AppConfig (..), configPoolTimeout',
-                              prettyVersion, readOptions)
+                              prettyVersion, readAppConfig, readPath)
 import PostgREST.DbStructure (getDbStructure, getPgVersion)
 import PostgREST.Error       (PgError (PgError), checkIsFatal,
                               errorPayload)
@@ -200,10 +200,13 @@ main = do
   hSetBuffering stdout LineBuffering
   hSetBuffering stdin LineBuffering
   hSetBuffering stderr NoBuffering
-  --
+
+  path <- readPath
+
   -- readOptions builds the 'AppConfig' from the config file specified on the
   -- command line
-  conf <- loadDbUriFile =<< loadSecretFile =<< readOptions
+  conf <- loadDbUriFile =<< loadSecretFile =<< readAppConfig path
+
   let schemas = toList $ configSchemas conf
       host = configHost conf
       port = configPort conf

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -30,13 +30,16 @@ import System.IO                (BufferMode (..), hSetBuffering)
 import PostgREST.App         (postgrest)
 import PostgREST.Auth        (parseSecret)
 import PostgREST.Config      (AppConfig (..), configPoolTimeout',
-                              prettyVersion, readAppConfig, readPathShowHelp, loadDbUriFile, loadSecretFile)
+                              loadDbUriFile, loadSecretFile,
+                              prettyVersion, readAppConfig,
+                              readPathShowHelp)
 import PostgREST.DbStructure (getDbStructure, getPgVersion)
 import PostgREST.Error       (PgError (PgError), checkIsFatal,
                               errorPayload)
 import PostgREST.OpenAPI     (isMalformedProxyUri)
 import PostgREST.Types       (ConnectionStatus (..), DbStructure,
-                              PgVersion (..), minimumPgVersion)
+                              LogSetup (..), PgVersion (..),
+                              minimumPgVersion)
 import Protolude             hiding (hPutStrLn, head, toS)
 import Protolude.Conv        (toS)
 
@@ -284,6 +287,7 @@ main = do
 
   let postgrestApplication =
         postgrest
+          LogStdout
           conf
           refDbStructure
           pool

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -28,6 +28,7 @@ import Network.Wai.Handler.Warp (defaultSettings, runSettings,
 import System.IO                (BufferMode (..), hSetBuffering)
 
 import PostgREST.App         (postgrest)
+import PostgREST.Auth        (parseSecret)
 import PostgREST.Config      (AppConfig (..), configPoolTimeout',
                               prettyVersion, readAppConfig, readPathShowHelp, loadDbUriFile, loadSecretFile)
 import PostgREST.DbStructure (getDbStructure, getPgVersion)
@@ -203,7 +204,9 @@ main = do
   path <- readPathShowHelp
 
   -- build the 'AppConfig' from the config file path
-  conf <- loadDbUriFile =<< loadSecretFile =<< readAppConfig path
+  conf <- do
+    cnf <- loadDbUriFile =<< loadSecretFile =<< readAppConfig path
+    pure cnf { configJWKS = parseSecret <$> configJwtSecret cnf}
 
   -- Checks that the provided proxy uri is formated correctly
   when (isMalformedProxyUri $ toS <$> configOpenAPIProxyUri conf) $

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -41,6 +41,7 @@ library
                       PostgREST.Types
   other-modules:      Paths_postgrest
                       PostgREST.Private.Common
+                      PostgREST.Private.ProxyUri
                       PostgREST.Private.QueryFragment
   hs-source-dirs:     src
   build-depends:      base                      >= 4.9 && < 4.15

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -65,12 +65,13 @@ import PostgREST.Types
 import Protolude                  hiding (Proxy, intercalate, toS)
 import Protolude.Conv             (toS)
 
-postgrest :: LogSetup -> AppConfig -> IORef (Maybe DbStructure) -> P.Pool -> IO UTCTime -> IO () -> Application
-postgrest logs conf refDbStructure pool getTime worker =
-  pgrstMiddleware logs $ \ req respond -> do
+postgrest :: LogSetup -> IORef AppConfig -> IORef (Maybe DbStructure) -> P.Pool -> IO UTCTime -> IO () -> Application
+postgrest logS refConf refDbStructure pool getTime worker =
+  pgrstMiddleware logS $ \ req respond -> do
     time <- getTime
     body <- strictRequestBody req
     maybeDbStructure <- readIORef refDbStructure
+    conf <- readIORef refConf
     case maybeDbStructure of
       Nothing -> respond . errorResponseFor $ ConnectionLostError
       Just dbStructure -> do

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -27,11 +27,9 @@ import qualified Hasql.Transaction          as H
 import qualified Hasql.Transaction          as HT
 import qualified Hasql.Transaction.Sessions as HT
 
-import Data.Function                        (id)
-import Data.IORef                           (IORef, readIORef)
-import Data.Time.Clock                      (UTCTime)
-import Network.HTTP.Types.URI               (renderSimpleQuery)
-import Network.Wai.Middleware.RequestLogger (logStdout)
+import Data.IORef             (IORef, readIORef)
+import Data.Time.Clock        (UTCTime)
+import Network.HTTP.Types.URI (renderSimpleQuery)
 
 import Control.Applicative
 import Data.Maybe
@@ -67,10 +65,9 @@ import PostgREST.Types
 import Protolude                  hiding (Proxy, intercalate, toS)
 import Protolude.Conv             (toS)
 
-postgrest :: AppConfig -> IORef (Maybe DbStructure) -> P.Pool -> IO UTCTime -> IO () -> Application
-postgrest conf refDbStructure pool getTime worker =
-  let middle = (if configQuiet conf then id else logStdout) . defaultMiddle in
-  middle $ \ req respond -> do
+postgrest :: LogSetup -> AppConfig -> IORef (Maybe DbStructure) -> P.Pool -> IO UTCTime -> IO () -> Application
+postgrest logs conf refDbStructure pool getTime worker =
+  pgrstMiddleware logs $ \ req respond -> do
     time <- getTime
     body <- strictRequestBody req
     maybeDbStructure <- readIORef refDbStructure

--- a/src/PostgREST/Auth.hs
+++ b/src/PostgREST/Auth.hs
@@ -58,14 +58,14 @@ jwtClaims attempt =
 -}
 attemptJwtClaims :: Maybe JWKSet -> Maybe StringOrURI -> LByteString -> UTCTime -> Maybe JSPath -> IO JWTAttempt
 attemptJwtClaims _ _ "" _ _ = return $ JWTClaims M.empty
-attemptJwtClaims secret audience payload time jspath =
-  case secret of
+attemptJwtClaims maybeSecret audience payload time jspath =
+  case maybeSecret of
     Nothing -> return JWTMissingSecret
-    Just s -> do
+    Just secret -> do
       let validation = set allowedSkew 1 $ defaultJWTValidationSettings (maybe (const True) (==) audience)
       eJwt <- runExceptT $ do
         jwt <- decodeCompact payload
-        verifyClaimsAt validation s time jwt
+        verifyClaimsAt validation secret time jwt
       return $ case eJwt of
         Left e    -> JWTInvalid e
         Right jwt -> JWTClaims $ claims2map jwt jspath

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -7,7 +7,6 @@ Description : Generates the OpenAPI output
 module PostgREST.OpenAPI (
   encodeOpenAPI
 , pickProxy
-, isMalformedProxyUri
 ) where
 
 import qualified Data.HashSet.InsOrd as Set

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -6,8 +6,8 @@ Description : Generates the OpenAPI output
 
 module PostgREST.OpenAPI (
   encodeOpenAPI
-, isMalformedProxyUri
 , pickProxy
+, isMalformedProxyUri
 ) where
 
 import qualified Data.HashSet.InsOrd as Set
@@ -20,20 +20,21 @@ import Data.String                (IsString (..))
 import Data.Text                  (append, breakOn, dropWhile, init,
                                    intercalate, pack, tail, toLower,
                                    unpack)
-import Network.URI                (URI (..), URIAuth (..),
-                                   isAbsoluteURI, parseURI)
+import Network.URI                (URI (..), URIAuth (..))
 
 import Control.Lens
 import Data.Swagger
 
-import PostgREST.ApiRequest (ContentType (..))
-import PostgREST.Config     (docsVersion, prettyVersion)
-import PostgREST.Types      (Column (..), ForeignKey (..), PgArg (..),
-                             PrimaryKey (..), ProcDescription (..),
-                             Proxy (..), Table (..), toMime)
-import Protolude            hiding (Proxy, dropWhile, get,
-                             intercalate, toLower, toS, (&))
-import Protolude.Conv       (toS)
+import PostgREST.ApiRequest       (ContentType (..))
+import PostgREST.Config           (docsVersion, prettyVersion)
+import PostgREST.Private.ProxyUri (isMalformedProxyUri, toURI)
+import PostgREST.Types            (Column (..), ForeignKey (..),
+                                   PgArg (..), PrimaryKey (..),
+                                   ProcDescription (..), Proxy (..),
+                                   Table (..), toMime)
+import Protolude                  hiding (Proxy, dropWhile, get,
+                                   intercalate, toLower, toS, (&))
+import Protolude.Conv             (toS)
 
 makeMimeList :: [ContentType] -> MimeList
 makeMimeList cs = MimeList $ map (fromString . toS . toMime) cs
@@ -306,24 +307,6 @@ postgrestSpec pds ti (s, h, p, b) sd pks = (mempty :: Swagger)
 encodeOpenAPI :: [ProcDescription] -> [(Table, [Column], [Text])] -> (Text, Text, Integer, Text) -> Maybe Text -> [PrimaryKey] ->  LByteString
 encodeOpenAPI pds ti uri sd pks = encode $ postgrestSpec pds ti uri sd pks
 
-{-|
-  Test whether a proxy uri is malformed or not.
-  A valid proxy uri should be an absolute uri without query and user info,
-  only http(s) schemes are valid, port number range is 1-65535.
-
-  For example
-  http://postgrest.com/openapi.json
-  https://postgrest.com:8080/openapi.json
--}
-isMalformedProxyUri :: Maybe Text -> Bool
-isMalformedProxyUri Nothing =  False
-isMalformedProxyUri (Just uri)
-  | isAbsoluteURI (toS uri) = not $ isUriValid $ toURI uri
-  | otherwise = True
-
-toURI :: Text -> URI
-toURI uri = fromJust $ parseURI (toS uri)
-
 pickProxy :: Maybe Text -> Maybe Proxy
 pickProxy proxy
   | isNothing proxy = Nothing
@@ -352,40 +335,3 @@ pickProxy proxy
              ("", "http")  -> 80
              ("", "https") -> 443
              _             -> readPort $ unpack $ tail $ pack port'
-
-isUriValid:: URI -> Bool
-isUriValid = fAnd [isSchemeValid, isQueryValid, isAuthorityValid]
-
-fAnd :: [a -> Bool] -> a -> Bool
-fAnd fs x = all ($ x) fs
-
-isSchemeValid :: URI -> Bool
-isSchemeValid URI {uriScheme = s}
-  | toLower (pack s) == "https:" = True
-  | toLower (pack s) == "http:" = True
-  | otherwise = False
-
-isQueryValid :: URI -> Bool
-isQueryValid URI {uriQuery = ""} = True
-isQueryValid _                   = False
-
-isAuthorityValid :: URI -> Bool
-isAuthorityValid URI {uriAuthority = a}
-  | isJust a = fAnd [isUserInfoValid, isHostValid, isPortValid] $ fromJust a
-  | otherwise = False
-
-isUserInfoValid :: URIAuth -> Bool
-isUserInfoValid URIAuth {uriUserInfo = ""} = True
-isUserInfoValid _                          = False
-
-isHostValid :: URIAuth -> Bool
-isHostValid URIAuth {uriRegName = ""} = False
-isHostValid _                         = True
-
-isPortValid :: URIAuth -> Bool
-isPortValid URIAuth {uriPort = ""} = True
-isPortValid URIAuth {uriPort = (':':p)} =
-  case readMaybe p of
-    Just i  -> i > (0 :: Integer) && i < 65536
-    Nothing -> False
-isPortValid _ = False

--- a/src/PostgREST/Parsers.hs
+++ b/src/PostgREST/Parsers.hs
@@ -252,9 +252,9 @@ mapError = mapLeft translateError
            $ showErrorMessages "or" "unknown parse error" "expecting" "unexpected" "end of input" (errorMessages e)
 
 -- Used for the config value "role-claim-key"
-pRoleClaimKey :: Text -> Either ApiRequestError JSPath
+pRoleClaimKey :: Text -> Either Text JSPath
 pRoleClaimKey selStr =
-  mapError $ parse pJSPath ("failed to parse role-claim-key value (" <> toS selStr <> ")") (toS selStr)
+  mapLeft show $ parse pJSPath ("failed to parse role-claim-key value (" <> toS selStr <> ")") (toS selStr)
 
 pJSPath :: Parser JSPath
 pJSPath = toJSPath <$> (period *> pPath `sepBy` period <* eof)

--- a/src/PostgREST/Private/ProxyUri.hs
+++ b/src/PostgREST/Private/ProxyUri.hs
@@ -1,0 +1,72 @@
+
+{-|
+Module      : PostgREST.Private.ProxyUri
+Description : Proxy Uri validator
+-}
+module PostgREST.Private.ProxyUri (
+  isMalformedProxyUri
+, toURI
+) where
+
+import Data.Maybe  (fromJust)
+import Data.Text   (pack, toLower)
+import Network.URI (URI (..), URIAuth (..), isAbsoluteURI, parseURI)
+
+import Protolude      hiding (Proxy, dropWhile, get, intercalate,
+                       toLower, toS, (&))
+import Protolude.Conv (toS)
+
+{-|
+  Test whether a proxy uri is malformed or not.
+  A valid proxy uri should be an absolute uri without query and user info,
+  only http(s) schemes are valid, port number range is 1-65535.
+
+  For example
+  http://postgrest.com/openapi.json
+  https://postgrest.com:8080/openapi.json
+-}
+isMalformedProxyUri :: Maybe Text -> Bool
+isMalformedProxyUri Nothing =  False
+isMalformedProxyUri (Just uri)
+  | isAbsoluteURI (toS uri) = not $ isUriValid $ toURI uri
+  | otherwise = True
+
+toURI :: Text -> URI
+toURI uri = fromJust $ parseURI (toS uri)
+
+isUriValid:: URI -> Bool
+isUriValid = fAnd [isSchemeValid, isQueryValid, isAuthorityValid]
+
+fAnd :: [a -> Bool] -> a -> Bool
+fAnd fs x = all ($ x) fs
+
+isSchemeValid :: URI -> Bool
+isSchemeValid URI {uriScheme = s}
+  | toLower (pack s) == "https:" = True
+  | toLower (pack s) == "http:" = True
+  | otherwise = False
+
+isQueryValid :: URI -> Bool
+isQueryValid URI {uriQuery = ""} = True
+isQueryValid _                   = False
+
+isAuthorityValid :: URI -> Bool
+isAuthorityValid URI {uriAuthority = a}
+  | isJust a = fAnd [isUserInfoValid, isHostValid, isPortValid] $ fromJust a
+  | otherwise = False
+
+isUserInfoValid :: URIAuth -> Bool
+isUserInfoValid URIAuth {uriUserInfo = ""} = True
+isUserInfoValid _                          = False
+
+isHostValid :: URIAuth -> Bool
+isHostValid URIAuth {uriRegName = ""} = False
+isHostValid _                         = True
+
+isPortValid :: URIAuth -> Bool
+isPortValid URIAuth {uriPort = ""} = True
+isPortValid URIAuth {uriPort = (':':p)} =
+  case readMaybe p of
+    Just i  -> i > (0 :: Integer) && i < 65536
+    Nothing -> False
+isPortValid _ = False

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -535,3 +535,6 @@ data ConnectionStatus
   | Connected PgVersion
   | FatalConnectionError Text
   deriving (Eq, Show)
+
+-- | Logging setup
+data LogSetup = LogQuiet | LogStdout deriving (Eq, Show)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -15,7 +15,7 @@ import Test.Hspec
 import PostgREST.App         (postgrest)
 import PostgREST.Config      (AppConfig (..))
 import PostgREST.DbStructure (getDbStructure, getPgVersion)
-import PostgREST.Types       (pgVersion95, pgVersion96)
+import PostgREST.Types       (LogSetup (..), pgVersion95, pgVersion96)
 import Protolude             hiding (toList, toS)
 import Protolude.Conv        (toS)
 import SpecHelper
@@ -65,12 +65,12 @@ main = do
 
   let
     -- For tests that run with the same refDbStructure
-    app cfg = return ((), postgrest (cfg testDbConn) refDbStructure pool getTime $ pure ())
+    app cfg = return ((), postgrest LogQuiet (cfg testDbConn) refDbStructure pool getTime $ pure ())
 
     -- For tests that run with a different DbStructure(depends on configSchemas)
     appDbs cfg = do
       dbs <- (newIORef . Just) =<< setupDbStructure pool (configSchemas $ cfg testDbConn) actualPgVersion
-      return ((), postgrest (cfg testDbConn) dbs pool getTime $ pure ())
+      return ((), postgrest LogQuiet (cfg testDbConn) dbs pool getTime $ pure ())
 
   let withApp              = app testCfg
       maxRowsApp           = app testMaxRowsCfg

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -65,12 +65,15 @@ main = do
 
   let
     -- For tests that run with the same refDbStructure
-    app cfg = return ((), postgrest LogQuiet (cfg testDbConn) refDbStructure pool getTime $ pure ())
+    app cfg = do
+      refConf <- newIORef $ cfg testDbConn
+      return ((), postgrest LogQuiet refConf refDbStructure pool getTime $ pure ())
 
     -- For tests that run with a different DbStructure(depends on configSchemas)
     appDbs cfg = do
       dbs <- (newIORef . Just) =<< setupDbStructure pool (configSchemas $ cfg testDbConn) actualPgVersion
-      return ((), postgrest LogQuiet (cfg testDbConn) dbs pool getTime $ pure ())
+      refConf <- newIORef $ cfg testDbConn
+      return ((), postgrest LogQuiet refConf dbs pool getTime $ pure ())
 
   let withApp              = app testCfg
       maxRowsApp           = app testMaxRowsCfg

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -90,6 +90,8 @@ _baseCfg =  -- Connection Settings
             Nothing
             -- Raw output media types
             []
+            -- Config path
+            Nothing
 
 testCfg :: Text -> AppConfig
 testCfg testDbConn = _baseCfg { configDbUri = testDbConn }

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -64,36 +64,32 @@ getEnvVarWithDefault var def = toS <$>
   getEnv (toS var) `E.catchIOError` const (return $ toS def)
 
 _baseCfg :: AppConfig
-_baseCfg =  -- Connection Settings
-  let secret = Just $ encodeUtf8 "reallyreallyreallyreallyverysafe" in
-  AppConfig mempty "postgrest_test_anonymous" Nothing (fromList ["test"]) "localhost" 3000
-            -- No user configured Unix Socket
-            Nothing
-            -- No user configured Unix Socket file mode (defaults to 660)
-            (Right 432)
-            -- db-channel
-            "pgrst"
-            -- db-channel-enabled
-            False
-            -- Jwt settings
-            secret False Nothing
-            -- Connection Modifiers
-            10 10 Nothing (Just "test.switch_role")
-            -- Debug Settings
-            True
-            [ ("app.settings.app_host", "localhost")
-            , ("app.settings.external_api_secret", "0123456789abcdef")
-            ]
-            -- Default role claim key
-            (Right [JSPKey "role"])
-            -- Empty db-extra-search-path
-            []
-            -- No root spec override
-            Nothing
-            -- Raw output media types
-            []
-            -- Config JWK
-            (parseSecret <$> secret)
+_baseCfg = let secret = Just $ encodeUtf8 "reallyreallyreallyreallyverysafe" in
+  AppConfig {
+    configDbUri             = mempty
+  , configAnonRole          = "postgrest_test_anonymous"
+  , configOpenAPIProxyUri   = Nothing
+  , configSchemas           = fromList ["test"]
+  , configHost              = "localhost"
+  , configPort              = 3000
+  , configSocket            = Nothing
+  , configSocketMode        = Right 432
+  , configDbChannel         = mempty
+  , configDbChannelEnabled  = False
+  , configJwtSecret         = secret
+  , configJwtSecretIsBase64 = False
+  , configJwtAudience       = Nothing
+  , configPoolSize          = 10
+  , configPoolTimeout       = 10
+  , configMaxRows           = Nothing
+  , configPreReq            = Just "test.switch_role"
+  , configSettings          = [ ("app.settings.app_host", "localhost") , ("app.settings.external_api_secret", "0123456789abcdef") ]
+  , configRoleClaimKey      = Right [JSPKey "role"]
+  , configExtraSearchPath   = []
+  , configRootSpec          = Nothing
+  , configRawMediaTypes     = []
+  , configJWKS              = parseSecret <$> secret
+  }
 
 testCfg :: Text -> AppConfig
 testCfg testDbConn = _baseCfg { configDbUri = testDbConn }
@@ -156,7 +152,7 @@ testCfgHtmlRawOutput :: Text -> AppConfig
 testCfgHtmlRawOutput testDbConn = (testCfg testDbConn) { configRawMediaTypes = ["text/html"] }
 
 testCfgResponseHeaders :: Text -> AppConfig
-testCfgResponseHeaders testDbConn = (testCfg testDbConn) { configReqCheck = Just "custom_headers" }
+testCfgResponseHeaders testDbConn = (testCfg testDbConn) { configPreReq = Just "custom_headers" }
 
 testMultipleSchemaCfg :: Text -> AppConfig
 testMultipleSchemaCfg testDbConn = (testCfg testDbConn) { configSchemas = fromList ["v1", "v2"] }

--- a/test/io-tests/configs/sigusr2-settings.config
+++ b/test/io-tests/configs/sigusr2-settings.config
@@ -1,0 +1,9 @@
+db-uri = "$(POSTGREST_TEST_CONNECTION)"
+db-schema = "test"
+db-anon-role = "postgrest_test_anonymous"
+db-pool = 1
+server-host = "127.0.0.1"
+server-port = 49421
+
+app.settings.name_var = "John"
+jwt-secret = "invalidinvalidinvalidinvalidinvalid"


### PR DESCRIPTION
Continuing the work on https://github.com/PostgREST/postgrest/pull/1289. Should also fix https://github.com/PostgREST/postgrest/issues/1119.

Considerations:
- SIGUSR2 only re-reads the config, but doesn't reload the schema cache. This is because `jwt-secret` and other settings don't deal with the db. Reloading the cache on a `jwt-secret` update would be wasteful.
- From the above, if a `db-schema` changes, a SIGUSR2 + SIGUSR1 would be needed for a correct schema cache reload.
- If the config file path has changed, the reload will fail(and show an error) but postgrest will continue to work. The reloading will be done in a different thread. This is probably not an issue in production since services have an absolute path defined for the config.
- If the config file has an invalid config option(like invalid roleClaimKey) the reload will also fail and pgrst will continue to work. In this case the user would have to fix the config for the reload to be successful.

Only these settings will be re-read:

- db-schema
- db-anon-role
- server-proxy-uri
- jwt-secret
- secret-is-base64
- jwt-aud
- max-rows
- pre-request
- role-claim-key
- db-extra-search-path
- app.settings.*

These setting won't be re-read(would require a `restart`):

- db-uri
- db-pool
- db-pool-timeout
- server-host
- server-port
- server-unix-socket
- server-unix-socket-mode