### PR TITLE
Fix expired JWTs starting an empty transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
  - #1530, Fix how the PostgREST version is shown in the help text when the `.git` directory is not available - @monacoremo
+ - #1094, Fix expired JWTs starting an empty transaction on the db - @steve-chavez
 
 ### Changed
 

--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -19,43 +19,34 @@ import Network.Wai.Middleware.Cors   (cors)
 import Network.Wai.Middleware.Gzip   (def, gzip)
 import Network.Wai.Middleware.Static (only, staticPolicy)
 
-import Crypto.JWT
-
 import PostgREST.ApiRequest   (ApiRequest (..))
-import PostgREST.Auth         (JWTAttempt (..))
 import PostgREST.Config       (AppConfig (..), corsPolicy)
-import PostgREST.Error        (SimpleError (JwtTokenInvalid, JwtTokenMissing),
-                               errorResponseFor)
 import PostgREST.QueryBuilder (setLocalQuery, setLocalSearchPathQuery)
 import Protolude              hiding (head, toS)
 import Protolude.Conv         (toS)
 
-runWithClaims :: AppConfig -> JWTAttempt ->
-                 (ApiRequest -> H.Transaction Response) ->
-                 ApiRequest -> H.Transaction Response
-runWithClaims conf eClaims app req =
-  case eClaims of
-    JWTMissingSecret      -> return . errorResponseFor $ JwtTokenMissing
-    JWTInvalid JWTExpired -> return . errorResponseFor . JwtTokenInvalid $ "JWT expired"
-    JWTInvalid e          -> return . errorResponseFor . JwtTokenInvalid . show $ e
-    JWTClaims claims      -> do
-      H.sql $ toS . mconcat $ setSearchPathSql : setRoleSql ++ claimsSql ++ [methodSql, pathSql] ++ headersSql ++ cookiesSql ++ appSettingsSql
-      mapM_ H.sql customReqCheck
-      app req
-      where
-        methodSql = setLocalQuery mempty ("request.method", toS $ iMethod req)
-        pathSql = setLocalQuery mempty ("request.path", toS $ iPath req)
-        headersSql = setLocalQuery "request.header." <$> iHeaders req
-        cookiesSql = setLocalQuery "request.cookie." <$> iCookies req
-        claimsSql = setLocalQuery "request.jwt.claim." <$> [(c,unquoted v) | (c,v) <- M.toList claimsWithRole]
-        appSettingsSql = setLocalQuery mempty <$> configSettings conf
-        setRoleSql = maybeToList $ (\x ->
-          setLocalQuery mempty ("role", unquoted x)) <$> M.lookup "role" claimsWithRole
-        setSearchPathSql = setLocalSearchPathQuery (iSchema req : configExtraSearchPath conf)
-        -- role claim defaults to anon if not specified in jwt
-        claimsWithRole = M.union claims (M.singleton "role" anon)
-        anon = JSON.String . toS $ configAnonRole conf
-        customReqCheck = (\f -> "select " <> toS f <> "();") <$> configReqCheck conf
+-- | Runs local(transaction scoped) GUCs for every request, plus the pre-request function
+runPgLocals :: AppConfig   -> M.HashMap Text JSON.Value ->
+               (ApiRequest -> H.Transaction Response) ->
+               ApiRequest  -> H.Transaction Response
+runPgLocals conf claims app req = do
+  H.sql $ toS . mconcat $ setSearchPathSql : setRoleSql ++ claimsSql ++ [methodSql, pathSql] ++ headersSql ++ cookiesSql ++ appSettingsSql
+  traverse_ H.sql customReqCheck
+  app req
+  where
+    methodSql = setLocalQuery mempty ("request.method", toS $ iMethod req)
+    pathSql = setLocalQuery mempty ("request.path", toS $ iPath req)
+    headersSql = setLocalQuery "request.header." <$> iHeaders req
+    cookiesSql = setLocalQuery "request.cookie." <$> iCookies req
+    claimsSql = setLocalQuery "request.jwt.claim." <$> [(c,unquoted v) | (c,v) <- M.toList claimsWithRole]
+    appSettingsSql = setLocalQuery mempty <$> configSettings conf
+    setRoleSql = maybeToList $ (\x ->
+      setLocalQuery mempty ("role", unquoted x)) <$> M.lookup "role" claimsWithRole
+    setSearchPathSql = setLocalSearchPathQuery (iSchema req : configExtraSearchPath conf)
+    -- role claim defaults to anon if not specified in jwt
+    claimsWithRole = M.union claims (M.singleton "role" anon)
+    anon = JSON.String . toS $ configAnonRole conf
+    customReqCheck = (\f -> "select " <> toS f <> "();") <$> configReqCheck conf
 
 defaultMiddle :: Application -> Application
 defaultMiddle =


### PR DESCRIPTION
Fixes https://github.com/PostgREST/postgrest/issues/1094.

Expired JWTs were doing an empty BEGIN/COMMIT in the db.

For testing this manually, do the following request on the master branch:

```bash
curl -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIiA6ICJ3ZWJ1c2VyIiwgImV4cCIgOiAxNTkzNjQ0MTc3fQ.p0M9dhxX9RMkq7ZwTdWpjWQHLuSH-0zEudZ2vm01tNo" localhost:3000/authors_only

{"message":"JWT expired"}
```

The `postgrest.conf` should have `jwt-secret=reallyreallyreallyreallyverysafe`.

And the empty BEGIN/COMMIT should show in the [db logs](http://postgrest.org/en/v7.0.0/admin.html#database-logs):

```
2020-07-01 23:00:37.171 GMT [25897] LOG:  00000: execute 0: BEGIN ISOLATION LEVEL READ COMMITTED READ ONLY
2020-07-01 23:00:37.171 GMT [25897] LOCATION:  exec_execute_message, postgres.c:2011
2020-07-01 23:00:37.171 GMT [25897] LOG:  00000: execute 7: COMMIT
2020-07-01 23:00:37.171 GMT [25897] LOCATION:  exec_execute_message, postgres.c:2011
```

With this PR, the empty transaction doesn't happen anymore.

(Also, just noticed that the empty transaction happened with invalid signatures too, PR also fixes this).
