### PR TITLE
Additionally allow "bearer" instead of only "Bearer" in Authorization…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #1525, Allow http status override through response.status guc - @steve-chavez
  - #1512, Allow schema cache reloading with NOTIFY - @steve-chavez
  - #1119, Allow config file reloading with SIGUSR2 - @steve-chavez
+ - #1558, Allow 'Bearer' with and without capitalization as authentication schema - @wolfgangwalther
 
 ### Fixed
 

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -263,6 +263,7 @@ userApiRequest confSchemas rootSpec req reqBody
   auth = fromMaybe "" $ lookupHeader hAuthorization
   tokenStr = case T.split (== ' ') (toS auth) of
     ("Bearer" : t : _) -> t
+    ("bearer" : t : _) -> t
     _                  -> ""
   endingIn:: [Text] -> Text -> Bool
   endingIn xx key = lastWord `elem` xx

--- a/test/Feature/AuthSpec.hs
+++ b/test/Feature/AuthSpec.hs
@@ -170,3 +170,10 @@ spec actualPgVersion = describe "authorization" $ do
           { matchStatus = 400
           , matchHeaders = []
           }
+
+  it "allows 'Bearer' and 'bearer' as authentication schemes" $ do
+    let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoicG9zdGdyZXN0X3Rlc3RfYXV0aG9yIiwiaWQiOiJqZG9lIn0.B-lReuGNDwAlU1GOC476MlO0vAt9JNoHIlxg2vwMaO0"
+    request methodGet "/authors_only" [authHeader "Bearer" token] ""
+      `shouldRespondWith` 200
+    request methodGet "/authors_only" [authHeader "bearer" token] ""
+      `shouldRespondWith` 200

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -199,8 +199,7 @@ authHeaderBasic u p =
   authHeader "Basic" $ toS . B64.encode . toS $ u <> ":" <> p
 
 authHeaderJWT :: BS.ByteString -> Header
-authHeaderJWT token =
-  authHeader "Bearer" token
+authHeaderJWT = authHeader "Bearer"
 
 -- | Tests whether the text can be parsed as a json object comtaining
 -- the key "message", and optional keys "details", "hint", "code",

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -201,7 +201,7 @@ authHeaderBasic u p =
 authHeaderJWT :: BS.ByteString -> Header
 authHeaderJWT = authHeader "Bearer"
 
--- | Tests whether the text can be parsed as a json object comtaining
+-- | Tests whether the text can be parsed as a json object containing
 -- the key "message", and optional keys "details", "hint", "code",
 -- and no extraneous keys
 isErrorFormat :: BL.ByteString -> Bool

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -190,13 +190,17 @@ noBlankHeader = notElem mempty
 noProfileHeader :: [Header] -> Bool
 noProfileHeader headers = isNothing $ find ((== "Content-Profile") . fst) headers
 
+authHeader :: BS.ByteString -> BS.ByteString -> Header
+authHeader typ creds =
+  (hAuthorization, typ <> " " <> creds)
+
 authHeaderBasic :: BS.ByteString -> BS.ByteString -> Header
 authHeaderBasic u p =
-  (hAuthorization, "Basic " <> (toS . B64.encode . toS $ u <> ":" <> p))
+  authHeader "Basic" $ toS . B64.encode . toS $ u <> ":" <> p
 
 authHeaderJWT :: BS.ByteString -> Header
 authHeaderJWT token =
-  (hAuthorization, "Bearer " <> token)
+  authHeader "Bearer" token
 
 -- | Tests whether the text can be parsed as a json object comtaining
 -- the key "message", and optional keys "details", "hint", "code",


### PR DESCRIPTION
Related to #1554 

While technically using `Bearer` seems to be correct (https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml), I think it should be no problem to allow `bearer` as well.