### PR TITLE
Schema cache reload with zero downtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #1525, Allow http status override through response.status guc - @steve-chavez
  - #1512, Allow schema cache reloading with NOTIFY - @steve-chavez
  - #1119, Allow config file reloading with SIGUSR2 - @steve-chavez
+ - #1559, No downtime when reloading the schema cache with SIGUSR1 - @steve-chavez
 
 ### Fixed
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -45,153 +45,6 @@ import System.Posix.Signals
 import UnixSocket
 #endif
 
--- Time constants
-_32s :: Int
-_32s = 32000000 :: Int -- 32 seconds
-
-_1s :: Int
-_1s  = 1000000  :: Int -- 1 second
-
-{-|
-  The purpose of this worker is to obtain a healthy connection to pg and an up-to-date schema cache(DbStructure).
-  This method is meant to be called by multiple times by the same thread, but does nothing if
-  the previous invocation has not terminated. In all cases this method does not
-  halt the calling thread, the work is preformed in a separate thread.
-
-  Note: 'atomicWriteIORef' is essentially a lazy semaphore that prevents two
-  threads from running 'connectionWorker' at the same time.
-
-  Background thread that does the following :
-  1. Tries to connect to pg server and will keep trying until success.
-  2. Checks if the pg version is supported and if it's not it kills the main
-     program.
-  3. Obtains the dbStructure.
--}
-connectionWorker
-  :: ThreadId                      -- ^ Main thread id. Killed if pg version is unsupported
-  -> P.Pool                        -- ^ The pg connection pool
-  -> IORef AppConfig               -- ^ mutable reference to AppConfig
-  -> IORef (Maybe DbStructure)     -- ^ mutable reference to 'DbStructure'
-  -> IORef Bool                    -- ^ Used as a binary Semaphore
-  -> (Bool, MVar ConnectionStatus) -- ^ For interacting with the LISTEN channel
-  -> IO ()
-connectionWorker mainTid pool refConf refDbStructure refIsWorkerOn (dbChannelEnabled, mvarConnectionStatus) = do
-  isWorkerOn <- readIORef refIsWorkerOn
-  unless isWorkerOn $ do -- Prevents multiple workers to be running at the same time. Could happen on too many SIGUSR1s.
-    atomicWriteIORef refIsWorkerOn True
-    void $ forkIO work
-  where
-    work = do
-      putStrLn ("Attempting to connect to the database..." :: Text)
-      connected <- connectionStatus pool
-      when dbChannelEnabled $
-        void $ tryPutMVar mvarConnectionStatus connected -- tryPutMVar doesn't lock the thread. It should always succeed since the worker is the only mvar producer.
-      case connected of
-        FatalConnectionError reason -> hPutStrLn stderr reason >> killThread mainTid -- Fatal error when connecting
-        NotConnected                -> return ()                                     -- Unreachable because connectionStatus will keep trying to connect
-        Connected actualPgVersion   -> do                                            -- Procede with initialization
-          putStrLn ("Connection successful" :: Text)
-          fillSchemaCache pool actualPgVersion refConf refDbStructure
-          liftIO $ atomicWriteIORef refIsWorkerOn False
-
-fillSchemaCache :: P.Pool -> PgVersion -> IORef AppConfig -> IORef (Maybe DbStructure) -> IO ()
-fillSchemaCache pool actualPgVersion refConf refDbStructure = do
-  conf <- readIORef refConf
-  result <- P.use pool $ HT.transaction HT.ReadCommitted HT.Read $ getDbStructure (toList $ configSchemas conf) actualPgVersion
-  case result of
-    Left e -> do
-      -- If this error happens it would mean the connection is down again. Improbable because connectionStatus ensured the connection.
-      -- It's not a problem though, because App.postgrest would retry the connectionWorker or the user can do a SIGSUR1 again.
-      hPutStrLn stderr . toS . errorPayload $ PgError False e
-      putStrLn ("Failed to load the schema cache" :: Text)
-
-    Right dbStructure -> do
-      atomicWriteIORef refDbStructure $ Just dbStructure
-      putStrLn ("Schema cache loaded" :: Text)
-
-{-|
-  Check if a connection from the pool allows access to the PostgreSQL database.
-  If not, the pool connections are released and a new connection is tried.
-  Releasing the pool is key for rapid recovery. Otherwise, the pool timeout would have to be reached for new healthy connections to be acquired.
-  Which might not happen if the server is busy with requests. No idle connection, no pool timeout.
-
-  The connection tries are capped, but if the connection times out no error is thrown, just 'False' is returned.
--}
-connectionStatus :: P.Pool -> IO ConnectionStatus
-connectionStatus pool =
-  retrying (capDelay _32s $ exponentialBackoff _1s)
-           shouldRetry
-           (const $ P.release pool >> getConnectionStatus)
-  where
-    getConnectionStatus :: IO ConnectionStatus
-    getConnectionStatus = do
-      pgVersion <- P.use pool getPgVersion
-      case pgVersion of
-        Left e -> do
-          let err = PgError False e
-          hPutStrLn stderr . toS $ errorPayload err
-          case checkIsFatal err of
-            Just reason -> return $ FatalConnectionError reason
-            Nothing     -> return NotConnected
-
-        Right version ->
-          if version < minimumPgVersion
-             then return . FatalConnectionError $ "Cannot run in this PostgreSQL version, PostgREST needs at least " <> pgvName minimumPgVersion
-             else return . Connected  $ version
-
-    shouldRetry :: RetryStatus -> ConnectionStatus -> IO Bool
-    shouldRetry rs isConnSucc = do
-      let delay    = fromMaybe 0 (rsPreviousDelay rs) `div` _1s
-          itShould = NotConnected == isConnSucc
-      when itShould $
-        putStrLn $ "Attempting to reconnect to the database in " <> (show delay::Text) <> " seconds..."
-      return itShould
-
-{-|
-  Starts a dedicated pg connection to LISTEN for notifications.
-  When a NOTIFY channel(with an empty payload) is done, it refills the schema cache.
-  It uses the connectionWorker in case the LISTEN connection dies.
--}
-listener :: ByteString -> Text -> P.Pool -> IORef AppConfig -> IORef (Maybe DbStructure) -> MVar ConnectionStatus -> IO () -> IO ()
-listener dbUri dbChannel pool refConf refDbStructure mvarConnectionStatus connWorker = start
-  where
-    start = do
-      connStatus <- takeMVar mvarConnectionStatus -- takeMVar makes the thread wait if the MVar is empty(until there's a connection).
-      case connStatus of
-        Connected actualPgVersion -> void $ forkFinally (do -- forkFinally allows to detect if the thread dies
-          dbOrError <- C.acquire dbUri
-          -- Debounce in case too many NOTIFYs arrive. Could happen on a migration(assuming a pg EVENT TRIGGER is set up).
-          scFiller <- mkDebounce (defaultDebounceSettings {
-                        debounceAction = fillSchemaCache pool actualPgVersion refConf refDbStructure,
-                        debounceEdge = trailingEdge, -- wait until the function hasn’t been called in _1s
-                        debounceFreq = _1s })
-          case dbOrError of
-            Right db -> do
-              putStrLn $ "Listening for notifications on the " <> dbChannel <> " channel"
-              let channelToListen = N.toPgIdentifier dbChannel
-              N.listen db channelToListen
-              N.waitForNotifications (\_ msg ->
-                if BS.null msg
-                  then scFiller    -- reload the schema cache
-                  else pure ()) db -- Do nothing if anything else than an empty message is sent
-            _ -> die errorMessage)
-          (\_ -> do -- if the thread dies, we try to recover
-            putStrLn retryMessage
-            connWorker -- assume the pool connection was also lost, call the connection worker
-            start)     -- retry the listener
-        _ ->
-          putStrLn errorMessage -- Should be unreachable. connectionStatus will retry until there's a connection.
-    errorMessage = "Could not listen for notifications on the " <> dbChannel <> " channel" :: Text
-    retryMessage = "Retrying listening for notifications on the " <> dbChannel <> " channel.." :: Text
-
--- | Re-reads the config at runtime. Invoked on SIGUSR2.
--- | If it panics(config path was changed, invalid setting), it'll show an error but won't kill the main thread.
-reReadConfig :: FilePath -> IORef AppConfig -> IO ()
-reReadConfig path refConf = do
-  conf <- readValidateConfig path
-  atomicWriteIORef refConf conf
-  putStrLn ("Config file reloaded" :: Text)
-
 -- | This is where everything starts.
 main :: IO ()
 main = do
@@ -229,7 +82,7 @@ main = do
   -- create connection pool with the provided settings, returns either a 'Connection' or a 'ConnectionError'. Does not throw.
   pool <- P.acquire (poolSize, poolTimeout, dbUri)
 
-  -- Used to sync the listener with the connectionWorker. No connection for the listener at first. Only used if dbChannelEnabled=true.
+  -- Used to sync the listener(NOTIFY reload) with the connectionWorker. No connection for the listener at first. Only used if dbChannelEnabled=true.
   mvarConnectionStatus <- newEmptyMVar
 
   -- No schema cache at the start. Will be filled in by the connectionWorker
@@ -297,6 +150,154 @@ main = do
   whenNothing maybeSocketAddr $ do
     putStrLn $ ("Listening on port " :: Text) <> show port
     runSettings serverSettings postgrestApplication
+
+-- Time constants
+_32s :: Int
+_32s = 32000000 :: Int -- 32 seconds
+
+_1s :: Int
+_1s  = 1000000  :: Int -- 1 second
+
+{-|
+  The purpose of this worker is to obtain a healthy connection to pg and an up-to-date schema cache(DbStructure).
+  This method is meant to be called by multiple times by the same thread, but does nothing if
+  the previous invocation has not terminated. In all cases this method does not
+  halt the calling thread, the work is preformed in a separate thread.
+
+  Note: 'atomicWriteIORef' is essentially a lazy semaphore that prevents two
+  threads from running 'connectionWorker' at the same time.
+
+  Background thread that does the following :
+  1. Tries to connect to pg server and will keep trying until success.
+  2. Checks if the pg version is supported and if it's not it kills the main
+     program.
+  3. Obtains the dbStructure.
+-}
+connectionWorker
+  :: ThreadId                      -- ^ Main thread id. Killed if pg version is unsupported
+  -> P.Pool                        -- ^ The pg connection pool
+  -> IORef AppConfig               -- ^ mutable reference to AppConfig
+  -> IORef (Maybe DbStructure)     -- ^ mutable reference to 'DbStructure'
+  -> IORef Bool                    -- ^ Used as a binary Semaphore
+  -> (Bool, MVar ConnectionStatus) -- ^ For interacting with the LISTEN channel
+  -> IO ()
+connectionWorker mainTid pool refConf refDbStructure refIsWorkerOn (dbChannelEnabled, mvarConnectionStatus) = do
+  isWorkerOn <- readIORef refIsWorkerOn
+  unless isWorkerOn $ do -- Prevents multiple workers to be running at the same time. Could happen on too many SIGUSR1s.
+    atomicWriteIORef refIsWorkerOn True
+    void $ forkIO work
+  where
+    work = do
+      putStrLn ("Attempting to connect to the database..." :: Text)
+      connected <- connectionStatus pool
+      when dbChannelEnabled $
+        void $ tryPutMVar mvarConnectionStatus connected -- tryPutMVar doesn't lock the thread. It should always succeed since the worker is the only mvar producer.
+      case connected of
+        FatalConnectionError reason -> hPutStrLn stderr reason >> killThread mainTid -- Fatal error when connecting
+        NotConnected                -> return ()                                     -- Unreachable because connectionStatus will keep trying to connect
+        Connected actualPgVersion   -> do                                            -- Procede with initialization
+          putStrLn ("Connection successful" :: Text)
+          fillSchemaCache pool actualPgVersion refConf refDbStructure
+          liftIO $ atomicWriteIORef refIsWorkerOn False
+
+{-|
+  Check if a connection from the pool allows access to the PostgreSQL database.
+  If not, the pool connections are released and a new connection is tried.
+  Releasing the pool is key for rapid recovery. Otherwise, the pool timeout would have to be reached for new healthy connections to be acquired.
+  Which might not happen if the server is busy with requests. No idle connection, no pool timeout.
+
+  The connection tries are capped, but if the connection times out no error is thrown, just 'False' is returned.
+-}
+connectionStatus :: P.Pool -> IO ConnectionStatus
+connectionStatus pool =
+  retrying (capDelay _32s $ exponentialBackoff _1s)
+           shouldRetry
+           (const $ P.release pool >> getConnectionStatus)
+  where
+    getConnectionStatus :: IO ConnectionStatus
+    getConnectionStatus = do
+      pgVersion <- P.use pool getPgVersion
+      case pgVersion of
+        Left e -> do
+          let err = PgError False e
+          hPutStrLn stderr . toS $ errorPayload err
+          case checkIsFatal err of
+            Just reason -> return $ FatalConnectionError reason
+            Nothing     -> return NotConnected
+
+        Right version ->
+          if version < minimumPgVersion
+             then return . FatalConnectionError $ "Cannot run in this PostgreSQL version, PostgREST needs at least " <> pgvName minimumPgVersion
+             else return . Connected  $ version
+
+    shouldRetry :: RetryStatus -> ConnectionStatus -> IO Bool
+    shouldRetry rs isConnSucc = do
+      let delay    = fromMaybe 0 (rsPreviousDelay rs) `div` _1s
+          itShould = NotConnected == isConnSucc
+      when itShould $
+        putStrLn $ "Attempting to reconnect to the database in " <> (show delay::Text) <> " seconds..."
+      return itShould
+
+-- | Fill the DbStructure by using a connection from the pool
+fillSchemaCache :: P.Pool -> PgVersion -> IORef AppConfig -> IORef (Maybe DbStructure) -> IO ()
+fillSchemaCache pool actualPgVersion refConf refDbStructure = do
+  conf <- readIORef refConf
+  result <- P.use pool $ HT.transaction HT.ReadCommitted HT.Read $ getDbStructure (toList $ configSchemas conf) actualPgVersion
+  case result of
+    Left e -> do
+      -- If this error happens it would mean the connection is down again. Improbable because connectionStatus ensured the connection.
+      -- It's not a problem though, because App.postgrest would retry the connectionWorker or the user can do a SIGSUR1 again.
+      hPutStrLn stderr . toS . errorPayload $ PgError False e
+      putStrLn ("Failed to load the schema cache" :: Text)
+
+    Right dbStructure -> do
+      atomicWriteIORef refDbStructure $ Just dbStructure
+      putStrLn ("Schema cache loaded" :: Text)
+
+{-|
+  Starts a dedicated pg connection to LISTEN for notifications.
+  When a NOTIFY <db-channel> - with an empty payload - is done, it refills the schema cache.
+  It uses the connectionWorker in case the LISTEN connection dies.
+-}
+listener :: ByteString -> Text -> P.Pool -> IORef AppConfig -> IORef (Maybe DbStructure) -> MVar ConnectionStatus -> IO () -> IO ()
+listener dbUri dbChannel pool refConf refDbStructure mvarConnectionStatus connWorker = start
+  where
+    start = do
+      connStatus <- takeMVar mvarConnectionStatus -- takeMVar makes the thread wait if the MVar is empty(until there's a connection).
+      case connStatus of
+        Connected actualPgVersion -> void $ forkFinally (do -- forkFinally allows to detect if the thread dies
+          dbOrError <- C.acquire dbUri
+          -- Debounce in case too many NOTIFYs arrive. Could happen on a migration(assuming a pg EVENT TRIGGER is set up).
+          scFiller <- mkDebounce (defaultDebounceSettings {
+                        debounceAction = fillSchemaCache pool actualPgVersion refConf refDbStructure,
+                        debounceEdge = trailingEdge, -- wait until the function hasn’t been called in _1s
+                        debounceFreq = _1s })
+          case dbOrError of
+            Right db -> do
+              putStrLn $ "Listening for notifications on the " <> dbChannel <> " channel"
+              let channelToListen = N.toPgIdentifier dbChannel
+              N.listen db channelToListen
+              N.waitForNotifications (\_ msg ->
+                if BS.null msg
+                  then scFiller    -- reload the schema cache
+                  else pure ()) db -- Do nothing if anything else than an empty message is sent
+            _ -> die errorMessage)
+          (\_ -> do -- if the thread dies, we try to recover
+            putStrLn retryMessage
+            connWorker -- assume the pool connection was also lost, call the connection worker
+            start)     -- retry the listener
+        _ ->
+          putStrLn errorMessage -- Should be unreachable. connectionStatus will retry until there's a connection.
+    errorMessage = "Could not listen for notifications on the " <> dbChannel <> " channel" :: Text
+    retryMessage = "Retrying listening for notifications on the " <> dbChannel <> " channel.." :: Text
+
+-- | Re-reads the config at runtime. Invoked on SIGUSR2.
+-- | If it panics(config path was changed, invalid setting), it'll show an error but won't kill the main thread.
+reReadConfig :: FilePath -> IORef AppConfig -> IO ()
+reReadConfig path refConf = do
+  conf <- readValidateConfig path
+  atomicWriteIORef refConf conf
+  putStrLn ("Config file reloaded" :: Text)
 
 -- Utilitarian functions.
 whenJust :: Applicative f => Maybe a -> (a -> f ()) -> f ()

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -83,7 +83,6 @@ connectionWorker mainTid pool refConf refDbStructure refIsWorkerOn (dbChannelEna
     void $ forkIO work
   where
     work = do
-      atomicWriteIORef refDbStructure Nothing
       putStrLn ("Attempting to connect to the database..." :: Text)
       connected <- connectionStatus pool
       when dbChannelEnabled $
@@ -236,7 +235,7 @@ main = do
   -- Used to sync the listener with the connectionWorker. No connection for the listener at first. Only used if dbChannelEnabled=true.
   mvarConnectionStatus <- newEmptyMVar
 
-  -- To be filled in by connectionWorker
+  -- No schema cache at the start. Will be filled in by the connectionWorker
   refDbStructure <- newIORef Nothing
 
   -- Helper ref to make sure just one connectionWorker can run at a time

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -132,7 +132,7 @@ instance JSON.ToJSON PgError where
 instance JSON.ToJSON P.UsageError where
   toJSON (P.ConnectionError e) = JSON.object [
     "code"    .= ("" :: Text),
-    "message" .= ("Database connection error" :: Text),
+    "message" .= ("Database connection error. Retrying the connection." :: Text),
     "details" .= (toS $ fromMaybe "" e :: Text)]
   toJSON (P.SessionError e) = JSON.toJSON e -- H.Error
 
@@ -169,7 +169,7 @@ instance JSON.ToJSON H.CommandError where
     "message" .= ("Unexpected amount of rows" :: Text),
     "details" .= i]
   toJSON (H.ClientError d) = JSON.object [
-    "message" .= ("Database client error" :: Text),
+    "message" .= ("Database client error. Retrying the connection." :: Text),
     "details" .= (fmap toS d :: Maybe Text)]
 
 pgErrorStatus :: Bool -> P.UsageError -> HT.Status
@@ -256,7 +256,7 @@ instance JSON.ToJSON SimpleError where
   toJSON (BinaryFieldError ct)          = JSON.object [
     "message" .= ((toS (toMime ct) <> " requested but more than one column was selected") :: Text)]
   toJSON ConnectionLostError       = JSON.object [
-    "message" .= ("Database connection lost, retrying the connection." :: Text)]
+    "message" .= ("Database connection lost. Retrying the connection." :: Text)]
 
   toJSON PutRangeNotAllowedError   = JSON.object [
     "message" .= ("Range header and limit/offset querystring parameters are not allowed for PUT" :: Text)]

--- a/test/io-tests.sh
+++ b/test/io-tests.sh
@@ -251,11 +251,11 @@ checkDbSchemaReload(){
     sleep 0.1 \
     || sleep 1 # fallback: subsecond sleep is not standard and may fail
   done
-  secret="reallyreallyreallyreallyverysafe"
   # add v1 schema to db-schema
   replaceConfigValue "db-schema" "test, v1" ./configs/sigusr2-settings.config
   # reload
   kill -s SIGUSR2 $pgrPID
+  kill -s SIGUSR1 $pgrPID
   httpStatus="$(v1SchemaParentsStatus)"
   if test "$httpStatus" -eq 200
   then


### PR DESCRIPTION
The current SIGUSR1 schema cache reload causes downtime for some milliseconds(depending on schema size). To test this:

```bash
# Start
postgrest conf
# Reload
killall -SIGUSR1 postgrest & curl localhost:3000/projects
{"message":"Database connection lost, retrying the connection."}
```

This is because the current reload(implemented in https://github.com/PostgREST/postgrest/pull/869) was meant for a single schema and the error message prevented getting a response from a stale schema cache.

(The error message is inaccurate when the db connection is actually up and a reload is done).

But now that we support multiple schemas in `db-schema`, is not appropriate to err a response on an up-to-date schema just because a newly added one can be stale.

So with this PR, responses can come from a stale cache. Embedding and rpc can be innacurate for a short time, but pgrst will be available on this lapse.