### PR TITLE
Return 405 Method not Allowed for GET of volatile RPC instead of 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
  - #1522, #1528, #1535, Docker images are now built from scratch based on a the static PostgREST executable (#1494) and with Nix instead of a `Dockerfile`. This reduces the compressed image size from over 30mb to about 4mb - @monacoremo
  - #1475, Location header for POST request is only included when PK is available on the table (#1461) - @wolfgangwalther
+ - #1560, Volatile RPC called with GET now returns 405 Method not Allowed instead of 500 - @wolfgangwalther
 
 ## [7.0.1] - 2020-05-18
 

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -185,6 +185,7 @@ pgErrorStatus authed (P.SessionError (H.QueryError _ _ (H.ResultError rError))) 
         '0':'P':_ -> HT.status403 -- invalid role specification
         "23503"   -> HT.status409 -- foreign_key_violation
         "23505"   -> HT.status409 -- unique_violation
+        "25006"   -> HT.status405 -- read_only_sql_transaction
         '2':'5':_ -> HT.status500 -- invalid tx state
         '2':'8':_ -> HT.status403 -- invalid auth specification
         '2':'D':_ -> HT.status500 -- invalid tx termination

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -616,8 +616,8 @@ spec actualPgVersion =
 
     context "only for GET rpc" $ do
       it "should fail on mutating procs" $ do
-        get "/rpc/callcounter" `shouldRespondWith` 500
-        get "/rpc/setprojects?id_l=1&id_h=5&name=FreeBSD" `shouldRespondWith` 500
+        get "/rpc/callcounter" `shouldRespondWith` 405
+        get "/rpc/setprojects?id_l=1&id_h=5&name=FreeBSD" `shouldRespondWith` 405
 
       it "should filter a proc that has arg name = filter name" $
         get "/rpc/get_projects_below?id=5&id=gt.2&select=id" `shouldRespondWith`


### PR DESCRIPTION
As discussed in https://github.com/PostgREST/postgrest/pull/1552#issuecomment-657863333

I changed the CHANGELOG to include this changed behaviour, but still need to change the docs, I guess ;)