### PR TITLE
Allow base64-bytestring 1.2 and optparse-applicative 0.16

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -104,24 +104,24 @@ library
 executable postgrest
   main-is:            Main.hs
   hs-source-dirs:     main
-  build-depends:      base              >= 4.9 && < 4.15
-                    , auto-update       >= 0.1.4 && < 0.2
-                    , base64-bytestring >= 1 && < 1.3
-                    , bytestring        >= 0.10.8 && < 0.11
-                    , directory         >= 1.2.6 && < 1.4
-                    , either            >= 4.4.1 && < 5.1
-                    , hasql             >= 1.4 && < 1.5
-                    , hasql-pool        >= 0.5 && < 0.6
-                    , hasql-transaction >= 0.7.2 && < 1.1
-                    , hasql-notifications == 0.1.0.0
-                    , network           < 3.2
+  build-depends:      base                >= 4.9 && < 4.15
+                    , auto-update         >= 0.1.4 && < 0.2
+                    , base64-bytestring   >= 1 && < 1.3
+                    , bytestring          >= 0.10.8 && < 0.11
+                    , directory           >= 1.2.6 && < 1.4
+                    , either              >= 4.4.1 && < 5.1
+                    , hasql               >= 1.4 && < 1.5
+                    , hasql-pool          >= 0.5 && < 0.6
+                    , hasql-transaction   >= 0.7.2 && < 1.1
+                    , hasql-notifications >= 0.1 && < 0.2
+                    , network             >= 2.6 && < 3.2
                     , postgrest
-                    , protolude         >= 0.3 && < 0.4
-                    , retry             >= 0.7.4 && < 0.9
-                    , text              >= 1.2.2 && < 1.3
-                    , time              >= 1.6 && < 1.11
-                    , wai               >= 3.2.1 && < 3.3
-                    , warp              >= 3.2.12 && < 3.4
+                    , protolude           >= 0.3 && < 0.4
+                    , retry               >= 0.7.4 && < 0.9
+                    , text                >= 1.2.2 && < 1.3
+                    , time                >= 1.6 && < 1.11
+                    , wai                 >= 3.2.1 && < 3.3
+                    , warp                >= 3.2.12 && < 3.4
   default-language:   Haskell2010
   default-extensions: OverloadedStrings
                       QuasiQuotes

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -49,7 +49,7 @@ library
                     , Ranged-sets               >= 0.3 && < 0.5
                     , aeson                     >= 1.4.7 && < 1.6
                     , ansi-wl-pprint            >= 0.6.7 && < 0.7
-                    , base64-bytestring         >= 1 && < 1.2
+                    , base64-bytestring         >= 1 && < 1.3
                     , bytestring                >= 0.10.8 && < 0.11
                     , case-insensitive          >= 1.2 && < 1.3
                     , cassava                   >= 0.4.5 && < 0.6
@@ -71,7 +71,7 @@ library
                     , lens                      >= 4.14 && < 4.20
                     , lens-aeson                >= 1.0.1 && < 1.2
                     , network-uri               >= 2.6.1 && < 2.8
-                    , optparse-applicative      >= 0.13 && < 0.16
+                    , optparse-applicative      >= 0.13 && < 0.17
                     , parsec                    >= 3.1.11 && < 3.2
                     , protolude                 >= 0.3 && < 0.4
                     , regex-tdfa                >= 1.2.2 && < 1.4
@@ -106,7 +106,7 @@ executable postgrest
   hs-source-dirs:     main
   build-depends:      base              >= 4.9 && < 4.15
                     , auto-update       >= 0.1.4 && < 0.2
-                    , base64-bytestring >= 1 && < 1.2
+                    , base64-bytestring >= 1 && < 1.3
                     , bytestring        >= 0.10.8 && < 0.11
                     , directory         >= 1.2.6 && < 1.4
                     , either            >= 4.4.1 && < 5.1
@@ -179,7 +179,7 @@ test-suite spec
                     , aeson-qq          >= 0.8.1 && < 0.9
                     , async             >= 2.1.1 && < 2.3
                     , auto-update       >= 0.1.4 && < 0.2
-                    , base64-bytestring >= 1 && < 1.2
+                    , base64-bytestring >= 1 && < 1.3
                     , bytestring        >= 0.10.8 && < 0.11
                     , case-insensitive  >= 1.2 && < 1.3
                     , cassava           >= 0.4.5 && < 0.6
@@ -223,7 +223,7 @@ Test-Suite spec-querycost
                      , aeson-qq          >= 0.8.1 && < 0.9
                      , async             >= 2.1.1 && < 2.3
                      , auto-update       >= 0.1.4 && < 0.2
-                     , base64-bytestring >= 1 && < 1.2
+                     , base64-bytestring >= 1 && < 1.3
                      , bytestring        >= 0.10.8 && < 0.11
                      , case-insensitive  >= 1.2 && < 1.3
                      , cassava           >= 0.4.5 && < 0.6


### PR DESCRIPTION
Relax some bounds for stackage, compare https://github.com/commercialhaskell/stackage/issues/5598 and https://github.com/commercialhaskell/stackage/issues/5597