### PR TITLE
Allow wai-extra 3.1

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -83,7 +83,7 @@ library
                     , vector                    >= 0.11 && < 0.13
                     , wai                       >= 3.2.1 && < 3.3
                     , wai-cors                  >= 0.2.5 && < 0.3
-                    , wai-extra                 >= 3.0.19 && < 3.1
+                    , wai-extra                 >= 3.0.19 && < 3.2
                     , wai-middleware-static     >= 0.8.1 && < 0.9
   default-language:   Haskell2010
   default-extensions: OverloadedStrings
@@ -204,7 +204,7 @@ test-suite spec
                     , time              >= 1.6 && < 1.11
                     , transformers-base >= 0.4.4 && < 0.5
                     , wai               >= 3.2.1 && < 3.3
-                    , wai-extra         >= 3.0.19 && < 3.1
+                    , wai-extra         >= 3.0.19 && < 3.2
   default-language:   Haskell2010
   default-extensions: OverloadedStrings
                       QuasiQuotes
@@ -248,4 +248,4 @@ Test-Suite spec-querycost
                      , time              >= 1.6 && < 1.11
                      , transformers-base >= 0.4.4 && < 0.5
                      , wai               >= 3.2.1 && < 3.3
-                     , wai-extra         >= 3.0.19 && < 3.1
+                     , wai-extra         >= 3.0.19 && < 3.2


### PR DESCRIPTION
See https://github.com/commercialhaskell/stackage/issues/5655.

If this passes CI without changes to source code, would be nice to add to add to hackage as a revision.