### PR TITLE
Fix error messages on connection failure for postgres on localized Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #1530, Fix how the PostgREST version is shown in the help text when the `.git` directory is not available - @monacoremo
  - #1094, Fix expired JWTs starting an empty transaction on the db - @steve-chavez
  - #1475, Fix location header for POST request with select= without PK (#1162) - @wolfgangwalther
+ - #1599, Fix error messages on connection failure for localized postgres on Windows (#1585) - @wolfgangwalther
 
 ### Changed
 

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -28,7 +28,7 @@ import Network.HTTP.Types.Header
 
 import PostgREST.Types
 import Protolude       hiding (toS)
-import Protolude.Conv  (toS)
+import Protolude.Conv  (toS, toSL)
 
 
 class (JSON.ToJSON a) => PgrstError a where
@@ -133,7 +133,7 @@ instance JSON.ToJSON P.UsageError where
   toJSON (P.ConnectionError e) = JSON.object [
     "code"    .= ("" :: Text),
     "message" .= ("Database connection error. Retrying the connection." :: Text),
-    "details" .= (toS $ fromMaybe "" e :: Text)]
+    "details" .= (toSL $ fromMaybe "" e :: Text)]
   toJSON (P.SessionError e) = JSON.toJSON e -- H.Error
 
 instance JSON.ToJSON H.QueryError where


### PR DESCRIPTION
Resolves #1585. TLDR: When postgres returns localized error messages on Windows, those are returned with a Windows codepage encoding (here `German_Germany.1252`) instead of UTF8 - independent of `client_encoding` (which defaults to UTF8 for Hasql). Converting this error message to JSON fails because strict conversion to UTF8 is used and some of the special characters fall out of this range.

This seems to be only an issue before the connection is established. Once it is, postgres sends UTF8 according to `client_encoding`. Therefore, I think, the "Database Connection Error" should be the only one that needs this change.

Not sure if/where/how to add tests for this. This is what was happening on my local test-setup before:

```
Attempting to connect to the database...
Listening on port 3000
postgrest: Cannot decode byte '\xfc': Data.Text.Internal.Encoding.decodeUtf8: Invalid UTF-8 stream
```

This is happening after:

```
Attempting to connect to the database...
Listening on port 3000
{"details":"FATAL:  kein pg_hba.conf-Eintrag f�r Host �192.168.0.2�, Benutzer �authenticator�, Datenbank �postgres�, SSL aus\n","code":"","message":"Database connection error. Retrying the connection."}
```

While this is not converted perfectly, I think this is the best we can do here.

Definitely one of the hardest to debug issues in relation to the length of the fix so far. If it wasn't for the additional import, it would be a 1 character difference... ;)