### PR TITLE
Change SET LOCAL gucs to set_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #504, Add `log-level` config option. The admitted levels are: crit, error, warn and info - @steve-chavez
  - #1607, Enable embedding through multiple views recursively - @wolfgangwalther
  - #1598, Allow rollback of the transaction with Prefer tx=rollback - @wolfgangwalther
- - #1633, Enable prepared statements for filters. When behind a connection pooler, you can disable preparing with `db-prepared-statements=false` - @steve-chavez
+ - #1633, #1600, Enable prepared statements for filters. When behind a connection pooler, you can disable preparing with `db-prepared-statements=false` - @steve-chavez
 
 ### Fixed
 

--- a/src/PostgREST/Private/Common.hs
+++ b/src/PostgREST/Private/Common.hs
@@ -5,9 +5,12 @@ Description : Common helper functions.
 module PostgREST.Private.Common where
 
 import           Data.Maybe
-import qualified Hasql.Decoders as HD
-import qualified Hasql.Encoders as HE
+import qualified Hasql.Decoders                  as HD
+import qualified Hasql.DynamicStatements.Snippet as H
+import qualified Hasql.Encoders                  as HE
 import           Protolude
+
+import Data.Foldable (foldr1)
 
 column :: HD.Value a -> HD.Row a
 column = HD.column . HD.nonNullable
@@ -23,3 +26,10 @@ param = HE.param . HE.nonNullable
 
 arrayParam :: HE.Value a -> HE.Params [a]
 arrayParam = param . HE.array . HE.dimension foldl' . HE.element . HE.nonNullable
+
+emptySnippetOnFalse :: H.Snippet -> Bool -> H.Snippet
+emptySnippetOnFalse val cond = if cond then mempty else val
+
+intercalateSnippet :: ByteString -> [H.Snippet] -> H.Snippet
+intercalateSnippet _ [] = mempty
+intercalateSnippet frag snippets = foldr1 (\a b -> a <> H.sql frag <> b) snippets

--- a/src/PostgREST/Private/QueryFragment.hs
+++ b/src/PostgREST/Private/QueryFragment.hs
@@ -30,9 +30,8 @@ import           Protolude                       hiding (cast,
 import           Protolude.Conv                  (toS)
 import           Text.InterpolatedString.Perl6   (qc)
 
-import qualified Hasql.Encoders as HE
-
-import Data.Foldable (foldr1)
+import qualified Hasql.Encoders           as HE
+import           PostgREST.Private.Common
 
 noLocationF :: SqlFragment
 noLocationF = "array[]::text[]"
@@ -250,10 +249,3 @@ unknownEncoder = H.encoderAndParam (HE.nonNullable HE.unknown)
 
 unknownLiteral :: Text -> H.Snippet
 unknownLiteral = unknownEncoder . encodeUtf8
-
-emptySnippetOnFalse :: H.Snippet -> Bool -> H.Snippet
-emptySnippetOnFalse val cond = if cond then mempty else val
-
-intercalateSnippet :: SqlFragment -> [H.Snippet] -> H.Snippet
-intercalateSnippet _ [] = mempty
-intercalateSnippet frag snippets = foldr1 (\a b -> a <> H.sql frag <> b) snippets

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -16,8 +16,7 @@ module PostgREST.QueryBuilder (
   , readRequestToCountQuery
   , requestToCallProcQuery
   , limitedQuery
-  , setLocalQuery
-  , setLocalSearchPathQuery
+  , setConfigLocal
   ) where
 
 import qualified Data.ByteString.Char8           as BS
@@ -173,10 +172,7 @@ readRequestToCountQuery (Node (Select{from=qi, where_=logicForest}, _) _) =
 limitedQuery :: H.Snippet -> Maybe Integer -> H.Snippet
 limitedQuery query maxRows = query <> H.sql (maybe mempty (\x -> " LIMIT " <> BS.pack (show x)) maxRows)
 
-setLocalQuery :: Text -> (Text, Text) -> SqlQuery
-setLocalQuery prefix (k, v) =
-  "SET LOCAL " <> pgFmtIdent (prefix <> k) <> " = " <> pgFmtLit v <> ";"
-
-setLocalSearchPathQuery :: [Text] -> SqlQuery
-setLocalSearchPathQuery vals =
-  "SET LOCAL search_path = " <> BS.intercalate ", " (pgFmtLit <$> vals) <> ";"
+-- | Do a pg set_config(setting, value, true) call. This is equivalent to a SET LOCAL.
+setConfigLocal :: Text -> (Text, Text) -> Text
+setConfigLocal prefix (k, v) =
+  "set_config(" <> decodeUtf8 (pgFmtLit (prefix <> k)) <> ", " <> decodeUtf8 (pgFmtLit v) <> ", true)"

--- a/src/PostgREST/QueryBuilder.hs
+++ b/src/PostgREST/QueryBuilder.hs
@@ -26,6 +26,7 @@ import qualified Hasql.DynamicStatements.Snippet as H
 import Data.Tree (Tree (..))
 
 import Data.Maybe
+import PostgREST.Private.Common
 import PostgREST.Private.QueryFragment
 import PostgREST.Types
 import Protolude                       hiding (cast, intercalate,
@@ -173,6 +174,6 @@ limitedQuery :: H.Snippet -> Maybe Integer -> H.Snippet
 limitedQuery query maxRows = query <> H.sql (maybe mempty (\x -> " LIMIT " <> BS.pack (show x)) maxRows)
 
 -- | Do a pg set_config(setting, value, true) call. This is equivalent to a SET LOCAL.
-setConfigLocal :: Text -> (Text, Text) -> Text
+setConfigLocal :: Text -> (Text, Text) -> H.Snippet
 setConfigLocal prefix (k, v) =
-  "set_config(" <> decodeUtf8 (pgFmtLit (prefix <> k)) <> ", " <> decodeUtf8 (pgFmtLit v) <> ", true)"
+  "set_config(" <> unknownLiteral (prefix <> k) <> ", " <> unknownLiteral v <> ", true)"


### PR DESCRIPTION
Changes how we set the GUCs from using SET LOCALs to using [set_config](https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADMIN-SET-TABLE).

We go from this:
```sql
SET LOCAL search_path = 'test', 'public';SET LOCAL "role" = 'postgres';SET LOCAL "request.jwt.claim.role" = 'postgres';
SET LOCAL "request.method" = 'GET';SET LOCAL "request.path" = '/projects';SET LOCAL "request.header.host" = 'localhost:3000';
SET LOCAL "request.header.connection" = 'keep-alive';SET LOCAL "request.header.upgrade-insecure-requests" = '1';
SET LOCAL "request.header.user-agent" = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.87 Safari/537.36';
SET LOCAL "request.header.sec-fetch-user" = '?1';SET LOCAL "request.header.accept" = 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3';
SET LOCAL "request.header.sec-fetch-site" = 'none';SET LOCAL "request.header.sec-fetch-mode" = 'navigate';
SET LOCAL "request.header.accept-encoding" = 'gzip, deflate, br';SET LOCAL "request.header.accept-language" = 'en-US,en;q=0.9,es;q=0.8';
SET LOCAL "app.settings.jwt-secret" = 'a_test';
SET LOCAL "app.settings.other" = 'another';
SET LOCAL "app.settings.test" = 'a_test';

-- Time: 0.265 ms
-- Time: 0.231 ms
-- Time: 0.249 ms
-- Time: 0.300 ms
-- Time: 0.213 ms
-- Time: 0.283 ms
-- Time: 0.351 ms
-- Time: 0.196 ms
-- Time: 0.230 ms
-- Time: 0.338 ms
-- Time: 0.251 ms
-- Time: 0.236 ms
-- Time: 0.208 ms
-- Time: 0.333 ms
-- Time: 0.265 ms
-- Time: 0.359 ms
-- Time: 0.263 ms
-- Time: 0.305 ms
-- Time: 0.273 ms
-- Time: 0.451 ms
-- Time: 0.350 ms
-- Time: 0.359 ms

-- Total: 6.309 ms
```
To this:
```sql
select
  set_config('search_path', 'test', true)
, set_config('role', 'postgres', true)
, set_config('request.jwt.claim.role', 'postgres', true)
, set_config('request.jwt.claim.role', 'postgres', true)
, set_config('request.method', 'GET', true)
, set_config('request.path', '/projects', true)
, set_config('request.header.host', 'localhost:3000', true)
, set_config('request.header.user-agent', 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.87 Safari/537.36', true)
, set_config('request.header.sec-fetch-user', '?1', true)
, set_config('request.header.accept', 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3', true)
, set_config('request.header.sec-fetch-site', 'none', true)
, set_config('request.header.sec-fetch-mode', 'navigate', true)
, set_config('request.header.accept-encoding', 'navigate', true)
, set_config('request.header.accept-language', 'en-US,en;q=0.9,es;q=0.8', true)
, set_config('app.settings.jwt-secret', 'a_test', true)
, set_config('app.settings.other', 'another', true)
, set_config('app.settings.test', 'a_test', true);

--   Time: 1.841 ms
```

Note that it saves around ~5ms.

I'm working on an updated benchmark and this might get us a few more requests per second.