### PR TITLE
Allow calling variadic functions with repeated parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #1512, Allow schema cache reloading with NOTIFY - @steve-chavez
  - #1119, Allow config file reloading with SIGUSR2 - @steve-chavez
  - #1558, Allow 'Bearer' with and without capitalization as authentication schema - @wolfgangwalther
+ - #1470, Allow calling RPC with variadic argument by passing repeated params - @wolfgangwalther
  - #1559, No downtime when reloading the schema cache with SIGUSR1 - @steve-chavez
  - #504, Add `log-level` config option. The admitted levels are: crit, error, warn and info - @steve-chavez
 

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -149,14 +149,16 @@ decodeProcs =
     parseArgs = mapMaybe parseArg . filter (not . isPrefixOf "OUT" . toS) . map strip . split (==',')
 
     parseArg :: Text -> Maybe PgArg
-    parseArg a =
-      let arg = lastDef "" $ splitOn "INOUT " a
-          (body, def) = breakOn " DEFAULT " arg
+    parseArg arg =
+      let isVariadic = isPrefixOf "VARIADIC " $ toS arg
+          -- argmode can be IN, OUT, INOUT, or VARIADIC
+          argNoMode = lastDef "" $ splitOn (if isVariadic then "VARIADIC " else "INOUT ") arg
+          (body, def) = breakOn " DEFAULT " argNoMode
           (name, typ) = breakOn " " body in
       if T.null typ
          then Nothing
          else Just $
-           PgArg (dropAround (== '"') name) (strip typ) (T.null def)
+           PgArg (dropAround (== '"') name) (strip typ) (T.null def) isVariadic
 
     parseRetType :: Text -> Text -> Bool -> Char -> RetType
     parseRetType schema name isSetOf typ

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -96,7 +96,7 @@ makeProcSchema pd =
   & required .~ map pgaName (filter pgaReq (pdArgs pd))
 
 makeProcProperty :: PgArg -> (Text, Referenced Schema)
-makeProcProperty (PgArg n t _) = (n, Inline s)
+makeProcProperty (PgArg n t _ _) = (n, Inline s)
   where
     s = (mempty :: Schema)
           & type_ ?~ toSwaggerType t

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -511,19 +511,26 @@ spec actualPgVersion =
           `shouldRespondWith` [json|{ "p1": "1", "p2": "text"}|]
           { matchHeaders = [matchContentTypeJson] }
 
-    it "should work with an overloaded function" $ do
-      get "/rpc/overloaded" `shouldRespondWith`
-        [json|[{ "overloaded": 1 },
-               { "overloaded": 2 },
-               { "overloaded": 3 }]|]
-        { matchHeaders = [matchContentTypeJson] }
-      request methodPost "/rpc/overloaded" [("Prefer","params=single-object")]
-        [json|[{"x": 1, "y": "first"}, {"x": 2, "y": "second"}]|]
-       `shouldRespondWith`
-        [json|[{"x": 1, "y": "first"}, {"x": 2, "y": "second"}]|]
-        { matchHeaders = [matchContentTypeJson] }
-      get "/rpc/overloaded?a=1&b=2" `shouldRespondWith` [str|3|]
-      get "/rpc/overloaded?a=1&b=2&c=3" `shouldRespondWith` [str|"123"|]
+    context "should work with an overloaded function" $ do
+      it "overloaded()" $
+        get "/rpc/overloaded" `shouldRespondWith`
+          [json|[{ "overloaded": 1 },
+                 { "overloaded": 2 },
+                 { "overloaded": 3 }]|]
+          { matchHeaders = [matchContentTypeJson] }
+
+      it "overloaded(json) single-object" $
+        request methodPost "/rpc/overloaded" [("Prefer","params=single-object")]
+          [json|[{"x": 1, "y": "first"}, {"x": 2, "y": "second"}]|]
+         `shouldRespondWith`
+          [json|[{"x": 1, "y": "first"}, {"x": 2, "y": "second"}]|]
+          { matchHeaders = [matchContentTypeJson] }
+
+      it "overloaded(int, int)" $
+        get "/rpc/overloaded?a=1&b=2" `shouldRespondWith` [str|3|]
+
+      it "overloaded(text, text, text)" $
+        get "/rpc/overloaded?a=1&b=2&c=3" `shouldRespondWith` [str|"123"|]
 
     context "only for POST rpc" $ do
       it "gives a parse filter error if GET style proc args are specified" $

--- a/test/Feature/StructureSpec.hs
+++ b/test/Feature/StructureSpec.hs
@@ -425,7 +425,8 @@ spec = do
                   "boolean",
                   "date",
                   "money",
-                  "enum"
+                  "enum",
+                  "arr"
                 ],
                 "properties": {
                   "double": {
@@ -450,6 +451,10 @@ spec = do
                   },
                   "enum": {
                     "format": "enum_menagerie_type",
+                    "type": "string"
+                  },
+                  "arr": {
+                    "format": "text[]",
                     "type": "string"
                   },
                   "integer": {

--- a/test/QueryCost.hs
+++ b/test/QueryCost.hs
@@ -29,7 +29,7 @@ main = do
     context "call proc query" $ do
       it "should not exceed cost when calling setof composite proc" $ do
         cost <- exec pool [str| {"id": 3} |] $
-          requestToCallProcQuery (QualifiedIdentifier "test" "get_projects_below") [PgArg "id" "int" True] False Nothing []
+          requestToCallProcQuery (QualifiedIdentifier "test" "get_projects_below") [PgArg "id" "int" True False] False Nothing []
         liftIO $
           cost `shouldSatisfy` (< Just 40)
 
@@ -41,14 +41,14 @@ main = do
 
       it "should not exceed cost when calling scalar proc" $ do
         cost <- exec pool [str| {"a": 3, "b": 4} |] $
-          requestToCallProcQuery (QualifiedIdentifier "test" "add_them") [PgArg "a" "int" True, PgArg "b" "int" True] True Nothing []
+          requestToCallProcQuery (QualifiedIdentifier "test" "add_them") [PgArg "a" "int" True False, PgArg "b" "int" True False] True Nothing []
         liftIO $
           cost `shouldSatisfy` (< Just 10)
 
       context "params=multiple-objects" $ do
         it "should not exceed cost when calling setof composite proc" $ do
           cost <- exec pool [str| [{"id": 1}, {"id": 4}] |] $
-            requestToCallProcQuery (QualifiedIdentifier "test" "get_projects_below") [PgArg "id" "int" True] False (Just MultipleObjects) []
+            requestToCallProcQuery (QualifiedIdentifier "test" "get_projects_below") [PgArg "id" "int" True False] False (Just MultipleObjects) []
           liftIO $ do
             -- lower bound needed for now to make sure that cost is not Nothing
             cost `shouldSatisfy` (> Just 2000)
@@ -56,7 +56,7 @@ main = do
 
         it "should not exceed cost when calling scalar proc" $ do
           cost <- exec pool [str| [{"a": 3, "b": 4}, {"a": 1, "b": 2}, {"a": 8, "b": 7}] |] $
-            requestToCallProcQuery (QualifiedIdentifier "test" "add_them") [PgArg "a" "int" True, PgArg "b" "int" True] True Nothing []
+            requestToCallProcQuery (QualifiedIdentifier "test" "add_them") [PgArg "a" "int" True False, PgArg "b" "int" True False] True Nothing []
           liftIO $
             cost `shouldSatisfy` (< Just 10)
 

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -221,23 +221,34 @@ CREATE FUNCTION varied_arguments(
   date date,
   money money,
   enum enum_menagerie_type,
+  arr text[],
   "integer" integer default 42,
   json json default '{}',
   jsonb jsonb default '{}'
-) RETURNS text
-    LANGUAGE sql
+) RETURNS json
+LANGUAGE sql
 AS $_$
-  SELECT 'Hi'::text;
+  SELECT json_build_object(
+    'double', double,
+    'varchar', "varchar",
+    'boolean', "boolean",
+    'date', date,
+    'money', money,
+    'enum', enum,
+    'arr', arr,
+    'integer', "integer",
+    'json', json,
+    'jsonb', jsonb
+  );
 $_$;
 
-COMMENT ON FUNCTION varied_arguments(double precision, character varying, boolean, date, money, enum_menagerie_type, integer, json, jsonb) IS
+COMMENT ON FUNCTION varied_arguments(double precision, character varying, boolean, date, money, enum_menagerie_type, text[], integer, json, jsonb) IS
 $_$An RPC function
 
 Just a test for RPC function arguments$_$;
 
 
 CREATE FUNCTION json_argument(arg json) RETURNS text
-
 LANGUAGE sql
 AS $_$
   SELECT json_typeof(arg);

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1083,6 +1083,11 @@ create function test.many_inout_params(INOUT num int, INOUT str text, INOUT b bo
   select num, str, b;
 $$ language sql;
 
+CREATE FUNCTION test.variadic_param(VARIADIC v TEXT[] DEFAULT '{}') RETURNS text[]
+LANGUAGE SQL AS $_$
+  SELECT v
+$_$;
+
 create or replace function test.raise_pt402() returns void as $$
 begin
   raise sqlstate 'PT402' using message = 'Payment Required',


### PR DESCRIPTION
Remake of #1552 - new PR for a clean history and easier discussion. Resolves #1470.

This implements variadic arguments for RPCs by either:
- using JSON arrays in the function body or
- using repeated query params

See the test cases for some examples.

To be able to implement this, I had to do the following in 3 commits
- The first commit just improved the "accepts a variety of arguments" test case to include arrays. I had that done in the other PR already and included them here mainly to make sure I'm not breaking regular arrays with everything that follows.
- The second commit is "just" a refactor. The basic idea is to move the column parsing and `findProc` from App to ApiRequest, to be able to later use the result of `findProc` already when parsing the query string - to make sure to only include repeated params for the variadic case and not for regular functions. This also lead to a change in `TargetProc`, which is now passing the `ProcDescription` instead of only a `QualifiedIdentifier` around. To still support the fallback case (i.e. when the schema cache is stale or something) I added a fallback `ProcDescription` to findProc which basically serves only as a container for the identifier which was passed around in that case before. This change also has the side-effect of providing some defaults (volatility, return type), so the places where those were used do not need to make a decision about fallbacks anymore.
- The third commit is the actual implementation of the variadic stuff. Tests and most stuff is almost identical to the changes in the other PR, where they had already been reviewed. The new stuff is all in ApiRequest's `payloadColumns` and `mapFromListWithMultiple`. The latter just appends all params into a list and passes them either as a JSON Array (if variadic) or takes the first element of that list (if non-variadic). For the variadic decision, the result of `findProc` is needed, which in turn is based on `payloadColumns`. To avoid a circular dependency I had to change `payloadColumns` a bit, so that it does not depend on `payload` (which depends on `mapFromListWithMultiple`...) anymore, at least in the cases where we parse the query string.

Note:
The n=1 and n>1 cases are handled through `mapFromListWithMultiple` or an array in the JSON body. For n=0:
- with a JSON body an empty array can be used for the variadic argument
- to call it without arguments through either the query string or by omitting the argument in the json body, one needs to add a `DEFAULT '{}'` to the functions variadic argument definition. This is in line with the default behaviour of postgres.