### PR TITLE
Add log level config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #1119, Allow config file reloading with SIGUSR2 - @steve-chavez
  - #1558, Allow 'Bearer' with and without capitalization as authentication schema - @wolfgangwalther
  - #1559, No downtime when reloading the schema cache with SIGUSR1 - @steve-chavez
- - #504, Add `log-level` config option - @steve-chavez
+ - #504, Add `log-level` config option. The admitted levels are: crit, error, warn and info - @steve-chavez
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #1119, Allow config file reloading with SIGUSR2 - @steve-chavez
  - #1558, Allow 'Bearer' with and without capitalization as authentication schema - @wolfgangwalther
  - #1559, No downtime when reloading the schema cache with SIGUSR1 - @steve-chavez
+ - #504, Add `log-level` config option - @steve-chavez
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #1522, #1528, #1535, Docker images are now built from scratch based on a the static PostgREST executable (#1494) and with Nix instead of a `Dockerfile`. This reduces the compressed image size from over 30mb to about 4mb - @monacoremo
  - #1475, Location header for POST request is only included when PK is available on the table (#1461) - @wolfgangwalther
  - #1560, Volatile RPC called with GET now returns 405 Method not Allowed instead of 500 - @wolfgangwalther
+ - #1604, Change the default logging level to `log-level=error`. Only requests with a status greater or equal than 500 will be logged. If you wish to go back to the previous behaviour and log all the requests, use `log-level=info` - @steve-chavez
 
 ## [7.0.1] - 2020-05-18
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -34,8 +34,7 @@ import PostgREST.DbStructure (getDbStructure, getPgVersion)
 import PostgREST.Error       (PgError (PgError), checkIsFatal,
                               errorPayload)
 import PostgREST.Types       (ConnectionStatus (..), DbStructure,
-                              LogSetup (..), PgVersion (..),
-                              minimumPgVersion)
+                              PgVersion (..), minimumPgVersion)
 import Protolude             hiding (hPutStrLn, head, toS)
 import Protolude.Conv        (toS)
 
@@ -78,6 +77,7 @@ main = do
       defaultSettings
     poolSize = configPoolSize conf
     poolTimeout = configPoolTimeout' conf
+    logLevel = configLogLevel conf
 
   -- create connection pool with the provided settings, returns either a 'Connection' or a 'ConnectionError'. Does not throw.
   pool <- P.acquire (poolSize, poolTimeout, dbUri)
@@ -133,7 +133,7 @@ main = do
 
   let postgrestApplication =
         postgrest
-          LogStdout
+          logLevel
           refConf
           refDbStructure
           pool

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -59,6 +59,7 @@ library
                     , contravariant-extras      >= 0.3.3 && < 0.4
                     , cookie                    >= 0.4.2 && < 0.5
                     , either                    >= 4.4.1 && < 5.1
+                    , fast-logger               >= 2.4.5
                     , gitrev                    >= 1.2 && < 1.4
                     , hasql                     >= 1.4 && < 1.5
                     , hasql-pool                >= 0.5 && < 0.6
@@ -84,6 +85,7 @@ library
                     , wai                       >= 3.2.1 && < 3.3
                     , wai-cors                  >= 0.2.5 && < 0.3
                     , wai-extra                 >= 3.0.19 && < 3.2
+                    , wai-logger                >= 2.3.2
                     , wai-middleware-static     >= 0.8.1 && < 0.10
   default-language:   Haskell2010
   default-extensions: OverloadedStrings

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -65,9 +65,9 @@ import PostgREST.Types
 import Protolude                  hiding (Proxy, intercalate, toS)
 import Protolude.Conv             (toS)
 
-postgrest :: LogSetup -> IORef AppConfig -> IORef (Maybe DbStructure) -> P.Pool -> IO UTCTime -> IO () -> Application
-postgrest logS refConf refDbStructure pool getTime connWorker =
-  pgrstMiddleware logS $ \ req respond -> do
+postgrest :: LogLevel -> IORef AppConfig -> IORef (Maybe DbStructure) -> P.Pool -> IO UTCTime -> IO () -> Application
+postgrest logLev refConf refDbStructure pool getTime connWorker =
+  pgrstMiddleware logLev $ \ req respond -> do
     time <- getTime
     body <- strictRequestBody req
     maybeDbStructure <- readIORef refDbStructure

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -266,11 +266,12 @@ readAppConfig cfgPath = do
     parseLogLevel :: C.Key -> C.Parser C.Config LogLevel
     parseLogLevel k =
       C.optional k C.string >>= \case
-        Nothing -> pure LogInfo
-        Just "" -> pure LogInfo
-        Just "crit" -> pure LogCrit
-        Just "info" -> pure LogInfo
-        Just _ -> fail "Invalid logging level. Check your configuration."
+        Nothing      -> pure LogInfo
+        Just ""      -> pure LogInfo
+        Just "crit"  -> pure LogCrit
+        Just "error" -> pure LogError
+        Just "info"  -> pure LogInfo
+        Just _       -> fail "Invalid logging level. Check your configuration."
 
     reqString :: C.Key -> C.Parser C.Config Text
     reqString k = C.required k C.string

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -195,7 +195,7 @@ readPathShowHelp = customExecParser parserPrefs opts
           |# raw-media-types="image/png, image/jpg"
           |
           |## logging level, the admitted values are: crit, error, warn and info.
-          |# log-level = "info"
+          |# log-level = "error"
           |]
 
 -- | Parse the config file
@@ -266,8 +266,8 @@ readAppConfig cfgPath = do
     parseLogLevel :: C.Key -> C.Parser C.Config LogLevel
     parseLogLevel k =
       C.optional k C.string >>= \case
-        Nothing      -> pure LogInfo
-        Just ""      -> pure LogInfo
+        Nothing      -> pure LogError
+        Just ""      -> pure LogError
         Just "crit"  -> pure LogCrit
         Just "error" -> pure LogError
         Just "warn"  -> pure LogWarn

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -194,7 +194,7 @@ readPathShowHelp = customExecParser parserPrefs opts
           |## content types to produce raw output
           |# raw-media-types="image/png, image/jpg"
           |
-          |## logging level. The admitted values are: info and crit
+          |## logging level, the admitted values are: crit, error, warn and info.
           |# log-level = "info"
           |]
 
@@ -270,6 +270,7 @@ readAppConfig cfgPath = do
         Just ""      -> pure LogInfo
         Just "crit"  -> pure LogCrit
         Just "error" -> pure LogError
+        Just "warn"  -> pure LogWarn
         Just "info"  -> pure LogInfo
         Just _       -> fail "Invalid logging level. Check your configuration."
 

--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -30,7 +30,7 @@ import Network.Wai.Middleware.Static        (only, staticPolicy)
 import PostgREST.ApiRequest   (ApiRequest (..))
 import PostgREST.Config       (AppConfig (..))
 import PostgREST.QueryBuilder (setLocalQuery, setLocalSearchPathQuery)
-import PostgREST.Types        (LogSetup (..))
+import PostgREST.Types        (LogLevel (..))
 import Protolude              hiding (head, toS)
 import Protolude.Conv         (toS)
 
@@ -57,9 +57,9 @@ runPgLocals conf claims app req = do
     anon = JSON.String . toS $ configAnonRole conf
     preReq = (\f -> "select " <> toS f <> "();") <$> configPreReq conf
 
-pgrstMiddleware :: LogSetup -> Application -> Application
-pgrstMiddleware logs =
-    (if logs == LogQuiet then id else logStdout)
+pgrstMiddleware :: LogLevel -> Application -> Application
+pgrstMiddleware logLev =
+    (if logLev == LogCrit then id else logStdout)
   . gzip def
   . cors corsPolicy
   . staticPolicy (only [("favicon.ico", "static/favicon.ico")])

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -539,4 +539,4 @@ data ConnectionStatus
   | FatalConnectionError Text
   deriving (Eq, Show)
 
-data LogLevel = LogCrit | LogError | LogInfo deriving (Eq, Show)
+data LogLevel = LogCrit | LogError | LogWarn | LogInfo deriving (Eq, Show)

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -539,4 +539,4 @@ data ConnectionStatus
   | FatalConnectionError Text
   deriving (Eq, Show)
 
-data LogLevel = LogCrit | LogInfo deriving (Eq, Show)
+data LogLevel = LogCrit | LogError | LogInfo deriving (Eq, Show)

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -539,5 +539,4 @@ data ConnectionStatus
   | FatalConnectionError Text
   deriving (Eq, Show)
 
--- | Logging setup
-data LogSetup = LogQuiet | LogStdout deriving (Eq, Show)
+data LogLevel = LogCrit | LogInfo deriving (Eq, Show)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -15,7 +15,7 @@ import Test.Hspec
 import PostgREST.App         (postgrest)
 import PostgREST.Config      (AppConfig (..))
 import PostgREST.DbStructure (getDbStructure, getPgVersion)
-import PostgREST.Types       (LogSetup (..), pgVersion95, pgVersion96)
+import PostgREST.Types       (LogLevel (..), pgVersion95, pgVersion96)
 import Protolude             hiding (toList, toS)
 import Protolude.Conv        (toS)
 import SpecHelper
@@ -67,13 +67,13 @@ main = do
     -- For tests that run with the same refDbStructure
     app cfg = do
       refConf <- newIORef $ cfg testDbConn
-      return ((), postgrest LogQuiet refConf refDbStructure pool getTime $ pure ())
+      return ((), postgrest LogCrit refConf refDbStructure pool getTime $ pure ())
 
     -- For tests that run with a different DbStructure(depends on configSchemas)
     appDbs cfg = do
       dbs <- (newIORef . Just) =<< setupDbStructure pool (configSchemas $ cfg testDbConn) actualPgVersion
       refConf <- newIORef $ cfg testDbConn
-      return ((), postgrest LogQuiet refConf dbs pool getTime $ pure ())
+      return ((), postgrest LogCrit refConf dbs pool getTime $ pure ())
 
   let withApp              = app testCfg
       maxRowsApp           = app testMaxRowsCfg

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -24,7 +24,7 @@ import Text.Heredoc
 
 import PostgREST.Auth   (parseSecret)
 import PostgREST.Config (AppConfig (..))
-import PostgREST.Types  (JSPathExp (..))
+import PostgREST.Types  (JSPathExp (..), LogLevel (..))
 import Protolude        hiding (toS)
 import Protolude.Conv   (toS)
 
@@ -89,6 +89,7 @@ _baseCfg = let secret = Just $ encodeUtf8 "reallyreallyreallyreallyverysafe" in
   , configRootSpec          = Nothing
   , configRawMediaTypes     = []
   , configJWKS              = parseSecret <$> secret
+  , configLogLevel          = LogCrit
   }
 
 testCfg :: Text -> AppConfig


### PR DESCRIPTION
Add the `log-level` config option. The admitted values are:

- `crit`: No requests are logged. Only startup and db connection recovery messages are logged.
- `error`: Only failed requests(status >=400) are logged.
- `info`: All requests are logged. This is the only level we've been offering until now.

Partly addresses: https://github.com/PostgREST/postgrest/issues/540 (`debug` level for another PR).

### Perf

According to my load tests, the lower levels give more requests per second:

- `crit`: 208 req/s more on average.
- `error`: 170 req/s more on average.

Which makes sense because our default `info` level doesn't buffer the log messages. It writes them to disk, directly.
The `error` level is a bit slower because of the status filtering.

### Changing the default log level

- Should we change the default log level to `error`? It certainly looks better for production.
- When PostgREST is behind nginx, the `access.log` already contains the logged requests. In these cases the `crit` level could be used. Since we're usually behind a proxy, perhaps we could default to `crit` instead?