### PR TITLE
[for discussion] Integrate a load test into the local dev tools and CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
             fi
       - run:
           name: Install testing scripts
-          command: nix-env -f default.nix -iA tests tests.ioTests tests.memoryTests
+          command: nix-env -f default.nix -iA tests tests.ioTests tests.memoryTests loadtest
       - run:
           name: Skip tests on build failure
           command: circleci-agent step halt
@@ -213,6 +213,9 @@ jobs:
           name: Run memory tests
           command: postgrest-test-memory
           when: always
+      - run:
+          name: Run load test
+          command: postgrest-loadtest
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
             postgrest-release-dockerhub
             postgrest-release-dockerhubdescription
 
-  # Build everything in default.nix, push to the Cachix binary cache and run tests
+  # Build everything in default.nix, run tests and push to the Cachix binary cache
   nix-build-test:
     machine: true
     steps:
@@ -162,18 +162,6 @@ jobs:
           command: |
             nix-env -iA cachix -f https://cachix.org/api/v1/install
             cachix use postgrest
-      - run:
-          name: Build all derivations from default.nix and push results to Cachix
-          command: |
-            # Only push to the cache when CircleCI makes the CACHIX_SIGNING_KEY
-            # available (e.g. not for pull requests).
-            if [ -n "${CACHIX_SIGNING_KEY:-""}" ]; then
-              echo "Building and caching all derivations..."
-              nix-build | cachix push postgrest
-            else
-              echo "Building all derivations (caching skipped for outside pull requests)..."
-              nix-build
-            fi
       - run:
           name: Install testing scripts
           command: nix-env -f default.nix -iA tests tests.ioTests tests.memoryTests loadtest
@@ -216,6 +204,21 @@ jobs:
       - run:
           name: Run load test
           command: postgrest-loadtest
+          when: always
+      - run:
+          name: Build all derivations from default.nix
+          command: nix-build
+      - run:
+          name: Push built artifacts to Cachix
+          command: |
+            # Only push to the cache when CircleCI makes the CACHIX_SIGNING_KEY
+            # available (e.g. not for pull requests).
+            if [ -n "${CACHIX_SIGNING_KEY:-""}" ]; then
+              echo "Pushing to Cachix..."
+              make cachix-push-all
+            else
+              echo "Skipping push to Cachix."
+            fi
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ result*
 dist-newstyle
 postgrest.hp
 postgrest.prof
+__pycache__

--- a/default.nix
+++ b/default.nix
@@ -35,6 +35,7 @@ let
       allOverlays.gitignore
       allOverlays.ghr
       (allOverlays.haskell-packages { inherit compiler; })
+      allOverlays.locust
     ];
 
   # Evaluated expression of the Nixpkgs repository.

--- a/default.nix
+++ b/default.nix
@@ -108,9 +108,12 @@ rec {
   nixpkgsUpgrade =
     pkgs.callPackage nix/nixpkgs-upgrade.nix { };
 
+  withTmpDb =
+    pkgs.callPackage nix/withtmpdb.nix { };
+
   # Scripts for running tests.
   tests =
-    pkgs.callPackage nix/tests.nix { inherit postgrest postgrestStatic postgrestProfiled postgresqlVersions; };
+    pkgs.callPackage nix/tests.nix { inherit postgrest postgrestStatic postgrestProfiled postgresqlVersions withTmpDb; };
 
   # Development tools, including linting and styling scripts.
   devtools =
@@ -122,4 +125,7 @@ rec {
       inherit docker;
       postgrest = postgrestStatic;
     };
+
+  loadtest =
+    pkgs.callPackage nix/loadtest.nix { inherit withTmpDb; postgrest = postgrestStatic; };
 }

--- a/nix/loadtest.nix
+++ b/nix/loadtest.nix
@@ -41,7 +41,7 @@ let
 
         ${locust}/bin/locust -f ${../test/loadtest/locustfile.py} \
             -H http://localhost:3080 --users 100 --spawn-rate 20 \
-            --headless -t 60s
+            --headless -t 2m
       '';
 
   postgrestConf =
@@ -65,7 +65,7 @@ let
         events {}
 
         http {
-            access_log access.log;
+            access_log access.log combined buffer=32k flush=5m;
             client_body_temp_path . 1 2;
             proxy_temp_path proxy_temp;
             fastcgi_temp_path fastcgi_temp;

--- a/nix/loadtest.nix
+++ b/nix/loadtest.nix
@@ -1,0 +1,100 @@
+{ postgrest
+, envsubst
+, locust
+, openresty
+, postgresql
+, withTmpDb
+, writeShellScript
+, writeShellScriptBin
+, writeText
+}:
+
+let
+  runner =
+    writeShellScript "postgrest-loadtest-runner"
+      ''
+        set -euo pipefail
+
+        tmpdir=$(mktemp -d)
+        trap "rm -r $tmpdir" exit
+
+        export POSTGREST_TEST_DIR="$tmpdir"
+
+        ${postgrest}/bin/postgrest ${postgrestConf} &
+        postgrestPID=$!
+
+        export POSTGREST_API_URL="http://localhost:3000"
+
+        mkdir -p "$tmpdir"/{logs,conf}
+        touch "$tmpdir"/logs/{error.log,access.log}
+        ${envsubst}/bin/envsubst -i ${nginxConf} \
+          -o "$tmpdir/conf/nginx.conf"
+
+        ${openresty}/bin/openresty -p "$tmpdir" &
+        nginxPID=$!
+
+        cleanup() {
+          kill $postgrestPID $nginxPID || true
+          rm -r "$tmpdir"
+        }
+
+        trap cleanup exit
+
+        ${locust}/bin/locust -f ${../test/loadtest/locustfile.py} \
+            -H http://localhost:3080 --users 100 --spawn-rate 20
+            # --headless -t 60s
+      '';
+
+  postgrestConf =
+    writeText "postgrest.conf"
+      ''
+        db-uri = "$(POSTGREST_TEST_CONNECTION)"
+        db-schema = "test"
+        db-anon-role = "postgrest_test_anonymous"
+        db-pool = 1
+        server-port = 3000
+        jwt-secret = "reallyreallyreallyreallyverysafe"
+      '';
+
+  nginxConf =
+    writeText "nginx.conf"
+      ''
+        daemon off;
+        error_log stderr info;
+        pid nginx.pid;
+
+        events {}
+
+        http {
+            access_log access.log;
+            client_body_temp_path . 1 2;
+            proxy_temp_path proxy_temp;
+            fastcgi_temp_path fastcgi_temp;
+            uwsgi_temp_path uwsgi_temp;
+            scgi_temp_path scgi_temp;
+
+            include ${openresty}/nginx/conf/mime.types;
+            default_type application/ocet-stream;
+
+            gzip off;
+            sendfile on;
+
+            keepalive_timeout 65s;
+
+            server {
+                listen 3080;
+
+                location / {
+                    more_clear_input_headers Accept-Encoding;
+                    proxy_pass $POSTGREST_API_URL;
+                }
+            }
+        }
+      '';
+in
+writeShellScriptBin "postgrest-loadtest"
+  ''
+    set -euo pipefail
+
+    ${withTmpDb postgresql} ${runner}
+  ''

--- a/nix/loadtest.nix
+++ b/nix/loadtest.nix
@@ -8,7 +8,6 @@
 , writeShellScriptBin
 , writeText
 }:
-
 let
   runner =
     writeShellScript "postgrest-loadtest-runner"
@@ -41,8 +40,8 @@ let
         trap cleanup exit
 
         ${locust}/bin/locust -f ${../test/loadtest/locustfile.py} \
-            -H http://localhost:3080 --users 100 --spawn-rate 20
-            # --headless -t 60s
+            -H http://localhost:3080 --users 100 --spawn-rate 20 \
+            --headless -t 60s
       '';
 
   postgrestConf =

--- a/nix/loadtest.nix
+++ b/nix/loadtest.nix
@@ -41,7 +41,7 @@ let
 
         ${locust}/bin/locust -f ${../test/loadtest/locustfile.py} \
             -H http://localhost:3080 --users 100 --spawn-rate 20 \
-            --headless -t 2m
+            --reset-stats --only-summary --headless -t 1m
       '';
 
   postgrestConf =

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -2,5 +2,6 @@
   gitignore = import ./gitignore.nix;
   ghr = import ./ghr;
   haskell-packages = import ./haskell-packages.nix;
+  locust = import ./locust;
   postgresql-default = import ./postgresql-default.nix;
 }

--- a/nix/overlays/locust/default.nix
+++ b/nix/overlays/locust/default.nix
@@ -1,0 +1,8 @@
+self: super:
+
+let
+  flask-basicauth = super.python38Packages.callPackage ./flask-basicauth.nix { };
+in
+{
+  locust = super.python38Packages.callPackage ./locust.nix { inherit flask-basicauth; };
+}

--- a/nix/overlays/locust/default.nix
+++ b/nix/overlays/locust/default.nix
@@ -1,5 +1,4 @@
 self: super:
-
 let
   flask-basicauth = super.python38Packages.callPackage ./flask-basicauth.nix { };
 in

--- a/nix/overlays/locust/flask-basicauth.nix
+++ b/nix/overlays/locust/flask-basicauth.nix
@@ -1,0 +1,30 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, flask
+, unittest2
+}:
+
+buildPythonPackage rec {
+  pname = "flask-basicauth";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "jpvanhal";
+    repo = "flask-basicauth";
+    rev = "v${version}";
+    sha256 = "1xkhw5nkhwwzxcz54mr9wzzpx4657scmdim1b2p7km886cxg9ac5";
+  };
+
+  propagatedBuildInputs =
+    [
+      flask
+    ];
+  checkInputs = [ unittest2 ];
+
+  doCheck = false;
+
+  meta = {
+    homepage = "https://github.com/jpvanhal/flask-basicauth";
+    description = "HTTP basic access authentication for Flask.";
+  };
+}

--- a/nix/overlays/locust/locust.nix
+++ b/nix/overlays/locust/locust.nix
@@ -11,6 +11,7 @@
 , pyquery
 , pyzmq
 , requests
+, requests-unixsocket
 , unittest2
 }:
 
@@ -37,6 +38,7 @@ buildPythonPackage rec {
       pyquery
       pyzmq
       requests
+      requests-unixsocket
     ];
   checkInputs = [ mock unittest2 ];
   # remove file which attempts to do GET request

--- a/nix/overlays/locust/locust.nix
+++ b/nix/overlays/locust/locust.nix
@@ -1,0 +1,54 @@
+{ buildPythonPackage
+, ConfigArgParse
+, fetchFromGitHub
+, flask
+, flask-basicauth
+, gevent
+, geventhttpclient
+, mock
+, msgpack
+, psutil
+, pyquery
+, pyzmq
+, requests
+, unittest2
+}:
+
+buildPythonPackage rec {
+  pname = "locustio";
+  version = "1.2.3";
+
+  src = fetchFromGitHub {
+    owner = "locustio";
+    repo = "locust";
+    rev = version;
+    sha256 = "11y28hi28m98dl26v9wxx4nl5756vpfgvg4crpsm93hrx7w8043q";
+  };
+
+  propagatedBuildInputs =
+    [
+      ConfigArgParse
+      flask
+      flask-basicauth
+      gevent
+      geventhttpclient
+      msgpack
+      psutil
+      pyquery
+      pyzmq
+      requests
+    ];
+  checkInputs = [ mock unittest2 ];
+  # remove file which attempts to do GET request
+  preCheck = ''
+    rm locust/test/test_stats.py
+  '';
+
+  # Running tests will take some more work
+  doCheck = false;
+
+  meta = {
+    homepage = "https://locust.io/";
+    description = "Scalable user load testing tool written in Python";
+  };
+}

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -12,23 +12,10 @@
 , postgrest
 , postgrestStatic
 , postgrestProfiled
-, runtimeShell
-, writeShellScript
 , writeShellScriptBin
+, withTmpDb
 }:
 let
-  # Wrap the `test/with_tmp_db` script with the required dependencies from Nix.
-  withTmpDb =
-    postgresql:
-    writeShellScript "postgrest-test-${postgresql.name}"
-      ''
-        set -euo pipefail
-
-        export PATH=${postgresql}/bin:${git}/bin:${runtimeShell}/bin:"$PATH"
-
-        exec ${../test/with_tmp_db} "$@"
-      '';
-
   # Script to run the Haskell test suite against a specific version of
   # PostgreSQL.
   testSpec =

--- a/nix/withtmpdb.nix
+++ b/nix/withtmpdb.nix
@@ -1,0 +1,15 @@
+# Wrap the `test/with_tmp_db` script with the required dependencies from Nix.
+{ git
+, runtimeShell
+, writeShellScript
+}:
+
+postgresql:
+writeShellScript "postgrest-test-${postgresql.name}"
+  ''
+    set -euo pipefail
+
+    export PATH=${postgresql}/bin:${git}/bin:${runtimeShell}/bin:"$PATH"
+
+    exec ${../test/with_tmp_db} "$@"
+  ''

--- a/shell.nix
+++ b/shell.nix
@@ -27,6 +27,7 @@ lib.overrideDerivation postgrest.env (
         pkgs.cabal-install
         pkgs.cabal2nix
         pkgs.postgresql
+        pkgs.locust
         postgrest.nixpkgsUpgrade
         postgrest.devtools
         postgrest.tests

--- a/shell.nix
+++ b/shell.nix
@@ -31,6 +31,7 @@ lib.overrideDerivation postgrest.env (
         postgrest.nixpkgsUpgrade
         postgrest.devtools
         postgrest.tests
+        postgrest.loadtest
       ]
       ++ lib.optional ioTests postgrest.tests.ioTests
       ++ lib.optional memoryTests postgrest.tests.memoryTests

--- a/shell.nix
+++ b/shell.nix
@@ -9,7 +9,7 @@
 #
 # We highly recommend that use the PostgREST binary cache by installing cachix
 # (https://app.cachix.org/) and running `cachix use postgrest`.
-{ ioTests ? false, memoryTests ? false, docker ? false, release ? false }:
+{ ioTests ? false, memoryTests ? false, docker ? false, release ? false, loadtest ? false }:
 let
   postgrest =
     import ./default.nix;
@@ -31,11 +31,11 @@ lib.overrideDerivation postgrest.env (
         postgrest.nixpkgsUpgrade
         postgrest.devtools
         postgrest.tests
-        postgrest.loadtest
       ]
       ++ lib.optional ioTests postgrest.tests.ioTests
       ++ lib.optional memoryTests postgrest.tests.memoryTests
       ++ lib.optional docker postgrest.docker
-      ++ lib.optional release postgrest.release;
+      ++ lib.optional release postgrest.release
+      ++ lib.optional loadtest postgrest.loadtest;
   }
 )

--- a/test/loadtest/locustfile.py
+++ b/test/loadtest/locustfile.py
@@ -1,0 +1,18 @@
+from locust import task, between
+from locust.contrib.fasthttp import FastHttpUser
+
+
+class PostgRESTUser(FastHttpUser):
+    wait_time = between(0.05, 0.2)
+
+    @task(1)
+    def index(self):
+        self.client.get("/")
+
+    @task(10)
+    def articles(self):
+        self.client.get("/articles")
+
+    @task(10)
+    def orders(self):
+        self.client.get("/orders?select=name")


### PR DESCRIPTION
This is an experiment on integrating a load test into the local dev tools and CI.

To run the loadtest locally, run `postgrest-loadtest` in nix-shell. This will run for 60s by default.

This is based on https://locust.io/, but happy to try other frameworks out if you have suggestions!

The locustfile could be extended with more complex reads, writes etc. that can then be selected via tags to simulate different workloads.

The Postgres database, PostgREST server, Nginx reverse proxy and the load all run on the same machine with this setup, which makes it easy to quickly run locally and in CI, but it impairs comparability.

Todos:
- [ ] output a human readable report (perhaps with Github checks integration?)
- [ ] validate that the results are sufficiently stable across runs
- [ ] compare performance (e.g. to current master) and potentially fail if a certain threshold is passed?
- [x] make `postgrest-loadtest` an option in nix-shell in order to maintain fast nix-shell startup without cachix
- [ ] add more cases to be tested (get with embed, post etc.)
- ...