### PR TITLE
Allow wai-middleware-static 0.9

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -84,7 +84,7 @@ library
                     , wai                       >= 3.2.1 && < 3.3
                     , wai-cors                  >= 0.2.5 && < 0.3
                     , wai-extra                 >= 3.0.19 && < 3.2
-                    , wai-middleware-static     >= 0.8.1 && < 0.9
+                    , wai-middleware-static     >= 0.8.1 && < 0.10
   default-language:   Haskell2010
   default-extensions: OverloadedStrings
                       QuasiQuotes


### PR DESCRIPTION
Changelog:
- Only serve static files on HEAD or GET requests.

The old behaviour seemed wrong, but I'm not 100% sure we don't rely on it. Let's see what the tests say. :)

Stackage tracking issue: https://github.com/commercialhaskell/stackage/issues/5672