### PR TITLE
WIP: Get DbStructure in a single query

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,7 @@ let
   src =
     pkgs.lib.sourceFilesBySuffices
       (pkgs.gitignoreSource ./.)
-      [ ".cabal" ".hs" ".lhs" "LICENSE" ];
+      [ ".cabal" ".hs" ".lhs" ".sql" "LICENSE" ];
 
   # Commit of the Nixpkgs repository that we want to use.
   nixpkgsVersion =

--- a/default.nix
+++ b/default.nix
@@ -111,7 +111,9 @@ rec {
 
   # Scripts for running tests.
   tests =
-    pkgs.callPackage nix/tests.nix { inherit postgrest postgrestStatic postgrestProfiled postgresqlVersions; };
+    pkgs.callPackage nix/tests.nix {
+      inherit postgrest postgrestStatic postgrestProfiled postgresqlVersions;
+    };
 
   # Development tools, including linting and styling scripts.
   devtools =

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -31,6 +31,7 @@ import PostgREST.Config      (AppConfig (..), configPoolTimeout',
                               prettyVersion, readPathShowHelp,
                               readValidateConfig)
 import PostgREST.DbStructure (getDbStructure, getPgVersion)
+import qualified PostgREST.DbStructure as DbStructure
 import PostgREST.Error       (PgError (PgError), checkIsFatal,
                               errorPayload)
 import PostgREST.Types       (ConnectionStatus (..), DbStructure,
@@ -242,7 +243,8 @@ connectionStatus pool =
 fillSchemaCache :: P.Pool -> PgVersion -> IORef AppConfig -> IORef (Maybe DbStructure) -> IO ()
 fillSchemaCache pool actualPgVersion refConf refDbStructure = do
   conf <- readIORef refConf
-  result <- P.use pool $ HT.transaction HT.ReadCommitted HT.Read $ getDbStructure (toList $ configSchemas conf) actualPgVersion
+  mode <- DbStructure.getMode
+  result <- P.use pool $ HT.transaction HT.ReadCommitted HT.Read $ getDbStructure mode (toList $ configSchemas conf) actualPgVersion
   case result of
     Left e -> do
       -- If this error happens it would mean the connection is down again. Improbable because connectionStatus ensured the connection.

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -26,18 +26,21 @@ import Network.Wai.Handler.Warp (defaultSettings, runSettings,
                                  setHost, setPort, setServerName)
 import System.IO                (BufferMode (..), hSetBuffering)
 
-import PostgREST.App         (postgrest)
-import PostgREST.Config      (AppConfig (..), configPoolTimeout',
-                              prettyVersion, readPathShowHelp,
-                              readValidateConfig)
-import PostgREST.DbStructure (getDbStructure, getPgVersion)
+import           PostgREST.App         (postgrest)
+import           PostgREST.Config      (AppConfig (..),
+                                        configPoolTimeout',
+                                        prettyVersion,
+                                        readPathShowHelp,
+                                        readValidateConfig)
+import           PostgREST.DbStructure (getDbStructure, getPgVersion)
 import qualified PostgREST.DbStructure as DbStructure
-import PostgREST.Error       (PgError (PgError), checkIsFatal,
-                              errorPayload)
-import PostgREST.Types       (ConnectionStatus (..), DbStructure,
-                              PgVersion (..), minimumPgVersion)
-import Protolude             hiding (hPutStrLn, head, toS)
-import Protolude.Conv        (toS)
+import           PostgREST.Error       (PgError (PgError),
+                                        checkIsFatal, errorPayload)
+import           PostgREST.Types       (ConnectionStatus (..),
+                                        DbStructure, PgVersion (..),
+                                        minimumPgVersion)
+import           Protolude             hiding (hPutStrLn, head, toS)
+import           Protolude.Conv        (toS)
 
 
 #ifndef mingw32_HOST_OS

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -61,6 +61,7 @@ library
                     , cookie                    >= 0.4.2 && < 0.5
                     , either                    >= 4.4.1 && < 5.1
                     , fast-logger               >= 2.4.5
+                    , file-embed                >= 0.0.11.0 && < 0.0.12
                     , gitrev                    >= 1.2 && < 1.4
                     , hasql                     >= 1.4 && < 1.5
                     , hasql-pool                >= 0.5 && < 0.6
@@ -137,6 +138,7 @@ executable postgrest
     ghc-options:      -threaded -rtsopts "-with-rtsopts=-N -I2"
                       -O2 -Wall -fwarn-identities
                       -fno-spec-constr -optP-Wno-nonportable-include-path
+  extra-source-files: src/PostgREST/dbstructure.sql
 
   if !os(windows)
     build-depends: unix

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -36,6 +36,7 @@ library
                       PostgREST.OpenAPI
                       PostgREST.Parsers
                       PostgREST.QueryBuilder
+                      PostgREST.MegaQuery
                       PostgREST.Statements
                       PostgREST.RangeQuery
                       PostgREST.Types

--- a/shell.nix
+++ b/shell.nix
@@ -26,7 +26,7 @@ lib.overrideDerivation postgrest.env (
       base.buildInputs ++ [
         pkgs.cabal-install
         pkgs.cabal2nix
-        pkgs.postgresql
+        pkgs.postgresql_9_4
         postgrest.nixpkgsUpgrade
         postgrest.devtools
         postgrest.tests

--- a/showdbstructure
+++ b/showdbstructure
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname "$0")"
+
+tempfile="$(mktemp)"
+
+trap 'rm $tempfile' exit
+
+script="
+  \set ON_ERROR_STOP on
+
+  prepare dbstructure(name[]) as
+    $(cat "$dir"/src/PostgREST/dbstructure.sql)
+    ;
+
+  \timing on
+
+  \o $tempfile
+  execute dbstructure(array['$1']);
+"
+
+echo "$script" | psql -q
+
+sed -n 3p < "$tempfile" | jq "$2"
+
+sed -n 3p < "$tempfile" | jq . | wc -l

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -32,9 +32,8 @@ import qualified Hasql.Encoders      as HE
 import qualified Hasql.Session       as H
 import qualified Hasql.Statement     as H
 import qualified Hasql.Transaction   as HT
-import qualified System.IO.Error as E
+import qualified System.IO.Error     as E
 
-import System.Environment            (getEnv)
 import Data.Set                      as S (fromList)
 import Data.Text                     (breakOn, dropAround, split,
                                       splitOn, strip)
@@ -42,11 +41,12 @@ import GHC.Exts                      (groupWith)
 import Protolude                     hiding (toS)
 import Protolude.Conv                (toS)
 import Protolude.Unsafe              (unsafeHead)
+import System.Environment            (getEnv)
 import Text.InterpolatedString.Perl6 (q, qc)
 
-import PostgREST.Private.Common
-import PostgREST.Types
-import qualified PostgREST.MegaQuery as MegaQuery
+import qualified PostgREST.MegaQuery      as MegaQuery
+import           PostgREST.Private.Common
+import           PostgREST.Types
 
 
 data DbStructureMode = ClassicMode | MegaMode deriving (Eq, Show)
@@ -58,7 +58,7 @@ getDbStructure mode schemas pgVer =
     dbStructure <- getDbStructureClassic schemas pgVer
     case mode of
       ClassicMode -> pure dbStructure
-      MegaMode -> MegaQuery.getDbStructure schemas dbStructure
+      MegaMode    -> MegaQuery.getDbStructure schemas dbStructure
 
 getMode :: IO DbStructureMode
 getMode =

--- a/src/PostgREST/MegaQuery.hs
+++ b/src/PostgREST/MegaQuery.hs
@@ -38,12 +38,12 @@ getDbStructure schemas baseDbStructure =
       newDbStructure = parseDbStructure raw
 
     return Types.DbStructure
-      { Types.dbTables = Types.dbTables newDbStructure
+      { Types.pgVersion = Types.pgVersion newDbStructure
+      , Types.dbTables = Types.dbTables newDbStructure
+      , Types.dbProcs = Types.dbProcs newDbStructure
       , Types.dbColumns = Types.dbColumns baseDbStructure
       , Types.dbRelations = Types.dbRelations baseDbStructure
       , Types.dbPrimaryKeys = Types.dbPrimaryKeys baseDbStructure
-      , Types.dbProcs = Types.dbProcs newDbStructure
-      , Types.pgVersion = Types.pgVersion baseDbStructure
       }
 
 

--- a/src/PostgREST/MegaQuery.hs
+++ b/src/PostgREST/MegaQuery.hs
@@ -42,7 +42,7 @@ getDbStructure schemas baseDbStructure =
       , Types.dbColumns = Types.dbColumns baseDbStructure
       , Types.dbRelations = Types.dbRelations baseDbStructure
       , Types.dbPrimaryKeys = Types.dbPrimaryKeys baseDbStructure
-      , Types.dbProcs = Types.dbProcs baseDbStructure
+      , Types.dbProcs = Types.dbProcs newDbStructure
       , Types.pgVersion = Types.pgVersion baseDbStructure
       }
 
@@ -128,12 +128,12 @@ loadRelation tabs cols raw =
     <*> M.lookup (relFTableOid raw) tabs
 
 loadRelation' :: RawRelation -> Columns -> Maybe Types.Junction -> RawTable -> RawTable -> Types.Relation
-loadRelation' raw cols junc tab fTab =
-  let
-    lookupCol :: RawTable -> ColPosition -> Maybe RawColumn
-    lookupCol t pos =
-      M.lookup (tableOid t, pos) cols
-  in
+loadRelation' raw _ junc tab fTab =
+  --let
+  --  lookupCol :: RawTable -> ColPosition -> Maybe RawColumn
+  --  lookupCol t pos =
+  --    M.lookup (tableOid t, pos) cols
+  --in
   Types.Relation
     { Types.relTable = loadTable tab
     , Types.relFTable = loadTable fTab
@@ -174,7 +174,7 @@ loadJunction' raw cols tab =
 
 procsMap :: [ProcDescription] -> ProcsMap
 procsMap procs =
-  M.fromListWith (++) . map (\(x,y) -> (x, [y])) . sort $ map addKey procs
+  M.fromListWith (++) . reverse . map (\(x,y) -> (x, [y])) . sort $ map addKey procs
 
 loadProc :: RawProcDescription -> ProcDescription
 loadProc raw =

--- a/src/PostgREST/MegaQuery.hs
+++ b/src/PostgREST/MegaQuery.hs
@@ -35,10 +35,10 @@ getDbStructure schemas baseDbStructure =
     HT.sql "set local schema ''"
     raw <- getRawDbStructure schemas
     let
-      _ = parseDbStructure raw
+      newDbStructure = parseDbStructure raw
 
     return Types.DbStructure
-      { Types.dbTables = Types.dbTables baseDbStructure
+      { Types.dbTables = Types.dbTables newDbStructure
       , Types.dbColumns = Types.dbColumns baseDbStructure
       , Types.dbRelations = Types.dbRelations baseDbStructure
       , Types.dbPrimaryKeys = Types.dbPrimaryKeys baseDbStructure

--- a/src/PostgREST/MegaQuery.hs
+++ b/src/PostgREST/MegaQuery.hs
@@ -1,18 +1,364 @@
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE QuasiQuotes           #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeSynonymInstances  #-}
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DeriveGeneric         #-}
 module PostgREST.MegaQuery (getDbStructure) where
 
-import qualified Hasql.Transaction   as HT
+import           Control.Exception
+import qualified Data.Aeson                    as Aeson
+import           Data.Aeson (FromJSON)
+import qualified Data.FileEmbed                as FileEmbed
+import qualified Data.HashMap.Strict           as M
+import qualified Data.List                     as L
+import           Data.String
+import qualified Hasql.Decoders                as HD
+import qualified Hasql.Encoders                as HE
+import qualified Hasql.Statement               as H
+import qualified Hasql.Transaction             as HT
+import qualified PostgREST.Private.Common as Common
+import           PostgREST.Types hiding (Table(..), Column(..), Relation(..), Junction(..))
 
 import qualified PostgREST.Types as Types
 import Protolude
 
 
 getDbStructure :: [Types.Schema] -> Types.DbStructure -> HT.Transaction Types.DbStructure
-getDbStructure _ baseDbStructure =
-  return Types.DbStructure
-    { Types.dbTables = Types.dbTables baseDbStructure
-    , Types.dbColumns = Types.dbColumns baseDbStructure
-    , Types.dbRelations = Types.dbRelations baseDbStructure
-    , Types.dbPrimaryKeys = Types.dbPrimaryKeys baseDbStructure
-    , Types.dbProcs = Types.dbProcs baseDbStructure
-    , Types.pgVersion = Types.pgVersion baseDbStructure
+getDbStructure schemas baseDbStructure =
+  do
+    -- This voids the search path. The following queries need this for getting the
+    -- fully qualified name(schema.name) of every db object.
+    HT.sql "set local schema ''"
+    raw <- getRawDbStructure schemas
+    let
+      _ = parseDbStructure raw
+
+    return Types.DbStructure
+      { Types.dbTables = Types.dbTables baseDbStructure
+      , Types.dbColumns = Types.dbColumns baseDbStructure
+      , Types.dbRelations = Types.dbRelations baseDbStructure
+      , Types.dbPrimaryKeys = Types.dbPrimaryKeys baseDbStructure
+      , Types.dbProcs = Types.dbProcs baseDbStructure
+      , Types.pgVersion = Types.pgVersion baseDbStructure
+      }
+
+
+parseDbStructure :: RawDbStructure -> DbStructure
+parseDbStructure raw =
+  let
+    tabs = fmap loadTable $ rawDbTables raw
+
+    tabsMap :: Tables
+    tabsMap =
+      M.fromList . map (\table -> (tableOid table, table)) $ rawDbTables raw
+
+    cols = catMaybes . fmap (loadColumn tabsMap) $ rawDbColumns raw
+
+    colsMap :: Columns
+    colsMap =
+      M.fromList . map (\col -> ((colTableOid col, colPosition col), col)) $ rawDbColumns raw
+
+    rels = catMaybes . fmap (loadRelation tabsMap colsMap) $ rawDbRels raw
+
+    procs = procsMap $ fmap loadProc $ rawDbProcs raw
+
+    cols' = addForeignKeys rels cols
+  in
+  DbStructure
+    { dbTables = tabs
+    , dbColumns = cols'
+    , dbRelations = rels
+    , dbPrimaryKeys = []
+    , dbProcs = procs
+    , pgVersion = rawDbPgVer raw
     }
+
+loadTable :: RawTable -> Types.Table
+loadTable raw =
+  Types.Table
+    { Types.tableSchema = tableSchema raw
+    , Types.tableName = tableName raw
+    , Types.tableDescription = tableDescription raw
+    , Types.tableInsertable = tableInsertable raw
+    --, Types.tableIsAccessible = tableIsAccessible raw
+    }
+
+loadColumn :: Tables -> RawColumn -> Maybe Types.Column
+loadColumn tabsMap col =
+  loadColumn' col <$> M.lookup (colTableOid col) tabsMap
+
+loadColumn' :: RawColumn -> RawTable -> Types.Column
+loadColumn' col tab =
+  Types.Column
+    { Types.colTable = loadTable tab
+    , Types.colPosition = colPosition col
+    , Types.colName = colName col
+    , Types.colDescription = colDescription col
+    , Types.colNullable = colNullable col
+    , Types.colType = colType col
+    , Types.colUpdatable = colUpdatable col
+    , Types.colMaxLen = colMaxLen col
+    , Types.colPrecision = colPrecision col
+    , Types.colDefault = colDefault col
+    , Types.colEnum = colEnum col
+    , Types.colFK = colFK col
+    --, Types.colIsPrimaryKey = colIsPrimaryKey col
+    }
+
+type Tables = M.HashMap Oid RawTable
+
+type Columns = M.HashMap (Oid, ColPosition) RawColumn
+
+loadRelation :: Tables -> Columns -> RawRelation -> Maybe Types.Relation
+loadRelation tabs cols raw =
+  let
+    junction =
+      case relJunction raw of
+        Just j ->
+          loadJunction tabs cols j
+        Nothing ->
+          Nothing
+  in
+  loadRelation' raw cols junction
+    <$> M.lookup (relTableOid raw) tabs
+    <*> M.lookup (relFTableOid raw) tabs
+
+loadRelation' :: RawRelation -> Columns -> Maybe Types.Junction -> RawTable -> RawTable -> Types.Relation
+loadRelation' raw cols junc tab fTab =
+  let
+    lookupCol :: RawTable -> ColPosition -> Maybe RawColumn
+    lookupCol t pos =
+      M.lookup (tableOid t, pos) cols
+  in
+  Types.Relation
+    { Types.relTable = loadTable tab
+    , Types.relFTable = loadTable fTab
+    , Types.relConstraint = relConstraint raw
+    , Types.relType = relType raw
+    , Types.relJunction = junc
+    , Types.relColumns = []
+        --fmap (\c -> loadColumn' c tab) . catMaybes .
+        --  fmap ((lookupCol tab) . fromCol) $ relColMap raw
+    , Types.relFColumns = []
+        --fmap (\c -> loadColumn' c fTab) . catMaybes .
+        --  fmap ((lookupCol fTab) . toCol) $ relColMap raw
+    }
+
+loadJunction :: Tables -> Columns -> RawJunction -> Maybe Types.Junction
+loadJunction tabs cols raw =
+  loadJunction' raw cols
+    <$> M.lookup (junTableOid raw) tabs
+
+loadJunction' :: RawJunction -> Columns -> RawTable -> Types.Junction
+loadJunction' raw cols tab =
+  let
+    lookupCol :: RawTable -> ColPosition -> Maybe RawColumn
+    lookupCol t pos =
+        M.lookup (tableOid t, pos) cols
+  in
+  Types.Junction
+    { Types.junTable = loadTable tab
+    , Types.junConstraint1 = junConstraint1 raw
+    , Types.junConstraint2 = junConstraint2 raw
+    , Types.junCols1 =
+        fmap (\c -> loadColumn' c tab) . catMaybes .
+          fmap ((lookupCol tab) . fromCol) $ junColMap raw
+    , Types.junCols2 =
+        fmap (\c -> loadColumn' c tab) . catMaybes .
+          fmap ((lookupCol tab) . toCol) $ junColMap raw
+    }
+
+procsMap :: [ProcDescription] -> ProcsMap
+procsMap procs =
+  M.fromListWith (++) . map (\(x,y) -> (x, [y])) . sort $ map addKey procs
+
+loadProc :: RawProcDescription -> ProcDescription
+loadProc raw =
+  ProcDescription
+    { pdSchema = procSchema raw
+    , pdName = procName raw
+    , pdDescription = procDescription raw
+    , pdArgs = procArgs raw
+    , pdReturnType =
+        parseRetType
+          (procReturnTypeQi raw)
+          (procReturnTypeIsSetof raw)
+          (procReturnTypeIsComposite raw)
+    , pdVolatility = procVolatility raw
+    --, pdIsAccessible = procIsAccessible raw
+    }
+
+addKey :: ProcDescription -> (QualifiedIdentifier, ProcDescription)
+addKey pd = (QualifiedIdentifier (pdSchema pd) (pdName pd), pd)
+
+parseRetType :: QualifiedIdentifier -> Bool -> Bool -> RetType
+parseRetType qi isSetOf isComposite
+  | isSetOf = SetOf pgType
+  | otherwise = Single pgType
+  where
+    pgType = if isComposite then Composite qi else Scalar qi
+
+addForeignKeys :: [Types.Relation] -> [Types.Column] -> [Types.Column]
+addForeignKeys rels = map addFk
+  where
+    addFk col =
+      col { Types.colFK = fk col }
+
+    fk col =
+      find (lookupFn col) rels >>= relToFk col
+
+    lookupFn :: Types.Column -> Types.Relation -> Bool
+    lookupFn c Types.Relation{Types.relColumns=cs, Types.relType=rty} =
+      c `elem` cs && rty == M2O
+
+    relToFk col Types.Relation{Types.relColumns=cols, Types.relFColumns=colsF} =
+      do
+        pos <- L.elemIndex col cols
+        colF <- atMay colsF pos
+        return $ ForeignKey colF
+
+
+-- RAW DB STRUCTURE
+
+getRawDbStructure :: [Schema] -> HT.Transaction RawDbStructure
+getRawDbStructure schemas =
+  do
+    value <- HT.statement schemas rawDbStructureQuery
+
+    case Aeson.fromJSON value of
+      Aeson.Success m ->
+        return m
+      Aeson.Error err ->
+        throw $ DbStructureDecodeException err
+
+data DbStructureDecodeException =
+    DbStructureDecodeException String
+    deriving Show
+
+instance Exception DbStructureDecodeException
+
+rawDbStructureQuery :: H.Statement [Schema] Aeson.Value
+rawDbStructureQuery =
+  let
+    sql =
+      $(FileEmbed.embedFile "src/PostgREST/dbstructure.sql")
+
+    decode =
+      HD.singleRow $ Common.column HD.json
+  in
+  H.Statement sql (Common.arrayParam HE.text) decode True
+
+
+-- Types
+
+type Oid = String
+
+type ColPosition = Int32
+
+data RawDbStructure =
+  RawDbStructure
+    { rawDbPgVer  :: PgVersion
+    , rawDbTables :: [RawTable]
+    , rawDbColumns :: [RawColumn]
+    , rawDbProcs :: [RawProcDescription]
+    , rawDbRels :: [RawRelation]
+    --, rawDbSchemas :: [SchemaDescription]
+    }
+    deriving (Show, Eq, Generic)
+
+instance FromJSON RawDbStructure where
+  parseJSON =
+    Aeson.genericParseJSON aesonOptions
+
+data RawProcDescription =
+  RawProcDescription
+    { procSchema :: Schema
+    , procName :: Text
+    , procDescription :: Maybe Text
+    , procReturnTypeQi :: QualifiedIdentifier
+    , procReturnTypeIsSetof :: Bool
+    , procReturnTypeIsComposite :: Bool
+    , procVolatility :: ProcVolatility
+    , procIsAccessible :: Bool
+    , procArgs :: [PgArg]
+    } deriving (Show, Eq, Generic)
+
+instance FromJSON RawProcDescription where
+  parseJSON =
+    Aeson.genericParseJSON aesonOptions
+
+data RawTable =
+  RawTable
+    { tableOid :: Oid
+    , tableSchema :: Schema
+    , tableName :: TableName
+    , tableDescription :: Maybe Text
+    , tableInsertable :: Bool
+    , tableIsAccessible :: Bool
+    } deriving (Show, Eq, Generic)
+
+instance FromJSON RawTable where
+  parseJSON =
+    Aeson.genericParseJSON aesonOptions
+
+data RawColumn =
+  RawColumn
+    { colTableOid :: Oid
+    , colPosition :: ColPosition
+    , colName :: FieldName
+    , colDescription :: Maybe Text
+    , colNullable :: Bool
+    , colType :: Text
+    , colUpdatable :: Bool
+    , colMaxLen :: Maybe Int32
+    , colPrecision :: Maybe Int32
+    , colDefault :: Maybe Text
+    , colEnum :: [Text]
+    , colFK :: Maybe ForeignKey
+    , colIsPrimaryKey :: Bool
+    } deriving (Show, Eq, Generic)
+
+instance FromJSON RawColumn where
+  parseJSON =
+    Aeson.genericParseJSON aesonOptions
+
+data RawRelation =
+  RawRelation
+    { relTableOid :: Oid
+    , relFTableOid :: Oid
+    , relConstraint :: Maybe ConstraintName
+    --, relColMap :: [ColMapping]
+    , relType :: Cardinality
+    , relJunction :: Maybe RawJunction -- ^ Junction for M2M Cardinality
+    } deriving (Show, Eq, Generic)
+
+instance FromJSON RawRelation where
+  parseJSON =
+    Aeson.genericParseJSON aesonOptions
+
+data ColMapping =
+  ColMapping
+    { fromCol :: Int32
+    , toCol :: Int32
+    } deriving (Show, Eq, Generic)
+
+instance FromJSON ColMapping where
+  parseJSON =
+    Aeson.genericParseJSON aesonOptions
+
+-- | Junction table on an M2M relationship
+data RawJunction =
+  Junction
+    { junTableOid :: Oid
+    , junConstraint1 :: Maybe ConstraintName
+    , junConstraint2 :: Maybe ConstraintName
+    , junColMap :: [ColMapping]
+    } deriving (Show, Eq, Generic)
+
+instance FromJSON RawJunction where
+  parseJSON =
+    Aeson.genericParseJSON aesonOptions

--- a/src/PostgREST/MegaQuery.hs
+++ b/src/PostgREST/MegaQuery.hs
@@ -1,0 +1,18 @@
+module PostgREST.MegaQuery (getDbStructure) where
+
+import qualified Hasql.Transaction   as HT
+
+import qualified PostgREST.Types as Types
+import Protolude
+
+
+getDbStructure :: [Types.Schema] -> Types.DbStructure -> HT.Transaction Types.DbStructure
+getDbStructure _ baseDbStructure =
+  return Types.DbStructure
+    { Types.dbTables = Types.dbTables baseDbStructure
+    , Types.dbColumns = Types.dbColumns baseDbStructure
+    , Types.dbRelations = Types.dbRelations baseDbStructure
+    , Types.dbPrimaryKeys = Types.dbPrimaryKeys baseDbStructure
+    , Types.dbProcs = Types.dbProcs baseDbStructure
+    , Types.pgVersion = Types.pgVersion baseDbStructure
+    }

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -10,9 +10,9 @@ module PostgREST.Types where
 import Control.Lens.Getter (view)
 import Control.Lens.Tuple  (_1)
 
+import           Data.Aeson               (FromJSON)
 import qualified Data.Aeson               as JSON
 import qualified Data.Aeson               as Aeson
-import Data.Aeson (FromJSON)
 import qualified Data.ByteString          as BS
 import qualified Data.ByteString.Internal as BS (c2w)
 import qualified Data.ByteString.Lazy     as BL
@@ -583,4 +583,4 @@ instance FromJSON ProcVolatility where
   parseJSON (Aeson.String "v") = pure Volatile
   parseJSON (Aeson.String "s") = pure Stable
   parseJSON (Aeson.String "i") = pure Immutable
-  parseJSON _ = empty
+  parseJSON _                  = empty

--- a/src/PostgREST/dbstructure.sql
+++ b/src/PostgREST/dbstructure.sql
@@ -1,0 +1,507 @@
+with
+  -- Postgres version
+
+  pg_version as (
+    select
+      current_setting('server_version_num')::integer as pgv_num,
+      current_setting('server_version') as pgv_name
+  ),
+
+
+  -- Schema descriptions
+
+  schemas as (
+    select
+      n.oid as schema_oid,
+      n.nspname as schema_name,
+      description as schema_description
+    from
+      pg_namespace n
+      left join pg_description d on d.objoid = n.oid
+    where
+      n.nspname = any ($1)
+  ),
+
+
+  -- Procedures
+
+  procs as (
+    select
+      p.oid as proc_oid,
+      pn.nspname as proc_schema,
+      p.proname as proc_name,
+      d.description as proc_description,
+      json_build_object(
+        'qi_schema', tn.nspname,
+        'qi_name', coalesce(comp.relname, t.typname)
+      ) as proc_return_type_qi,
+      p.proretset as proc_return_type_is_setof,
+      (
+        t.typtype = 'c'
+        or (t.typtype = 'p' and coalesce(comp.relname, t.typname) = 'record')
+        -- Only pg pseudo type that is a row type is 'record'
+      ) as proc_return_type_is_composite,
+      p.provolatile as proc_volatility,
+      has_function_privilege(p.oid, 'execute') as proc_is_accessible,
+      coalesce(array(
+        select
+          json_build_object(
+            'pga_name', parsed.name,
+            'pga_type', parsed.typ,
+            'pga_req', not parsed.has_default
+          )
+        from
+          regexp_split_to_table(pg_get_function_arguments(p.oid), ', ') as args
+          , regexp_split_to_array(args, ' DEFAULT ') as args_with_default
+          , regexp_matches(
+              args_with_default[1],
+              '^(IN |INOUT |OUT |)(([^\" ]\S*?)|\"(\S+?)\")( (.+?))?$'
+          ) as groups
+          , lateral (
+              select
+                groups[1] as inout,
+                coalesce(groups[3], groups[4]) as name,
+                coalesce(groups[6], '') as typ,
+                args_with_default[2] is not null as has_default
+          ) as parsed
+        where parsed.inout <> 'OUT '
+      ), array[]::json[]) as proc_args
+    from
+      pg_proc p
+      join pg_namespace pn on pn.oid = p.pronamespace
+      join pg_type t on t.oid = p.prorettype
+      join pg_namespace tn on tn.oid = t.typnamespace
+      left join pg_class comp on comp.oid = t.typrelid
+      left join pg_description as d on d.objoid = p.oid
+    where
+      pn.nspname = any ($1)
+  ),
+
+
+  -- Tables
+
+  tables as (
+    select
+      c.oid as table_oid,
+      n.nspname as table_schema,
+      c.relname as table_name,
+      d.description as table_description,
+      (
+        c.relkind in ('r', 'v', 'f')
+
+        and pg_relation_is_updatable(c.oid, true) & 8 = 8
+
+        -- The function `pg_relation_is_updateable` returns a bitmask where 8
+        -- corresponds to `1 << CMD_INSERT` in the PostgreSQL source code, i.e.
+        -- it's possible to insert into the relation.
+        or exists (
+          select 1
+          from pg_trigger
+          where
+            pg_trigger.tgrelid = c.oid
+            and (pg_trigger.tgtype::integer & 69) = 69
+            -- The trigger type `tgtype` is a bitmask where 69 corresponds to
+            -- TRIGGER_TYPE_ROW + TRIGGER_TYPE_INSTEAD + TRIGGER_TYPE_INSERT
+            -- in the PostgreSQL source code.
+        )
+      ) as table_insertable,
+      (
+        pg_has_role(c.relowner, 'USAGE')
+        or has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
+        or has_any_column_privilege(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES')
+      ) as table_is_accessible
+    from
+      pg_class c
+      join pg_namespace n
+        on n.oid = c.relnamespace
+      left join pg_catalog.pg_description as d
+        on d.objoid = c.oid and d.objsubid = 0
+    where
+      c.relkind in ('v','r','m','f')
+      and n.nspname not in ('pg_catalog'::name, 'information_schema'::name)
+  ),
+
+
+  -- Source columns, query explanation at
+  -- https://gist.github.com/steve-chavez/7ee0e6590cddafb532e5f00c46275569
+
+  view_col_rels as (
+    select
+      c.oid as view_oid,
+      targetentries.attnum as view_col_position,
+      targetentries.table_oid,
+      targetentries.table_col_position
+    from
+      pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+      join pg_rewrite r on r.ev_class = c.oid
+      join pg_attribute a on a.attrelid = c.oid
+      , lateral (
+          select
+            matches[1]::smallint as attnum,
+            matches[2] as attname,
+            matches[3]::oid as table_oid,
+            matches[3]::smallint as table_col_position
+          from
+            regexp_matches(
+              r.ev_action,
+              ':resno (\d+) :resname (\S+) :ressortgroupref \d+ :resorigtbl (\d+) :resorigcol (\d+)',
+              'g'
+            ) as matches
+          where
+            matches[3] <> '0'
+        ) targetentries
+    where
+      c.relkind in ('v', 'm')
+      and n.nspname = any ($1::name[])
+      and targetentries.attnum = a.attnum
+      and targetentries.attname = a.attname
+/*
+    select
+      c.oid as view_oid,
+      substring(entry from ':resno (\d+) ')::smallint as view_col_position,
+      substring(entry from ':resorigtbl (\d+) ')::oid as table_oid,
+      substring(entry from ':resorigcol (\d+) ')::smallint as table_col_position
+    from
+      pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+      join pg_rewrite r on r.ev_class = c.oid
+      , (
+          -- "result" appears when the subselect is used inside "case when", see
+          -- `authors_have_book_in_decade` fixture
+          -- "resno"  appears in every other case
+          select
+            case when (select pgv_num from pg_version) < 100000 then
+              ':subselect {.*?:constraintDeps <>} :location \d+} :res(no|ult)'
+            else
+              ':subselect {.*?:stmt_len 0} :location \d+} :res(no|ult)'
+            end as subselect
+        ) as subselect
+      , regexp_replace(r.ev_action, subselect.subselect, '', 'g') as x
+      , regexp_split_to_array(x, 'targetList') as target_lists
+      , regexp_split_to_array(
+          target_lists[array_upper(target_lists, 1)], ':onConflict'
+        ) last_target_list
+      , unnest(regexp_split_to_array(last_target_list[1]::text, 'TARGETENTRY')) as entry
+    where
+      c.relkind in ('v', 'm')
+      and n.nspname = any ($1::name[])
+*/
+),
+
+
+  -- Primary keys
+
+  table_primary_keys as (
+    select
+      r.oid as pk_table_oid,
+      a.attnum as pk_col_position
+    from
+      pg_constraint c
+      join pg_class r on r.oid = c.conrelid
+      join pg_namespace nr on nr.oid = r.relnamespace
+      join pg_attribute a on a.attrelid = r.oid
+      , unnest(c.conkey) as con(key)
+    where
+      c.contype = 'p'
+      and r.relkind = 'r'
+      --and nr.nspname not in ('pg_catalog', 'information_schema')
+      and nr.nspname = any($1::name[])
+      and not pg_is_other_temp_schema(nr.oid)
+      and a.attnum = con.key
+      and not a.attisdropped
+  ),
+
+  view_primary_keys as (
+    select
+      view_cols.view_oid as pk_table_oid,
+      view_col_position as pk_col_position
+    from
+      table_primary_keys pks
+      join view_col_rels view_cols
+        on view_cols.table_oid = pks.pk_table_oid
+  ),
+
+  primary_keys as (
+    select * from table_primary_keys
+    union all
+    select * from view_primary_keys
+  ),
+
+  -- Columns
+
+  columns as (
+    select
+      a.attrelid as col_table_oid,
+      a.attnum as col_position,
+      a.attname as col_name,
+      d.description as col_description,
+      pg_get_expr(ad.adbin, ad.adrelid)::text as col_default,
+      not (a.attnotnull or t.typtype = 'd' and t.typnotnull) as col_nullable,
+      case
+        when t.typtype = 'd' then
+          case
+            when bt.typelem <> 0::oid and bt.typlen = (-1) then
+              'ARRAY'::text
+            when nbt.nspname = 'pg_catalog'::name then
+              format_type(t.typbasetype, null::integer)
+            else
+              format_type(a.atttypid, a.atttypmod)
+          end
+        else
+          case
+            when t.typelem <> 0::oid and t.typlen = (-1) then
+              'ARRAY'
+            when nt.nspname = 'pg_catalog'::name then
+              format_type(a.atttypid, null::integer)
+            else
+              format_type(a.atttypid, a.atttypmod)
+          end
+      end as col_type,
+      information_schema._pg_char_max_length(truetypid, truetypmod) as col_max_len,
+      information_schema._pg_numeric_precision(truetypid, truetypmod) as col_precision,
+      (
+        c.relkind in ('r', 'v', 'f')
+        and pg_column_is_updatable(c.oid::regclass, a.attnum, false)
+      ) col_updatable,
+      coalesce(enum_info.vals, array[]::text[]) as col_enum,
+      pks is not null as col_is_primary_key
+    from
+      pg_attribute a
+      left join pg_description d on d.objoid = a.attrelid and d.objsubid = a.attnum
+      left join pg_attrdef ad on a.attrelid = ad.adrelid and a.attnum = ad.adnum
+      join pg_class c on c.oid = a.attrelid
+      join pg_namespace nc on nc.oid = c.relnamespace
+      join pg_type t on t.oid = a.atttypid
+      join pg_namespace nt on t.typnamespace = nt.oid
+      left join pg_type bt on t.typtype = 'd' and t.typbasetype = bt.oid
+      left join pg_namespace nbt on bt.typnamespace = nbt.oid
+      left join primary_keys pks
+        on
+          pks.pk_table_oid = a.attrelid
+          and pks.pk_col_position = a.attnum
+      , lateral (
+          select array_agg(e.enumlabel order by e.enumsortorder) as vals
+          from
+            pg_type et
+            join pg_enum e on et.oid = e.enumtypid
+          where
+            et.oid = t.oid
+      ) as enum_info
+      , information_schema._pg_truetypid(a.*, t.*) truetypid
+      , information_schema._pg_truetypmod(a.*, t.*) truetypmod
+    where
+      a.attnum <> 0
+      and not a.attisdropped
+      and c.relkind in ('r', 'v', 'f', 'm')
+      --and (nc.nspname = any ($1::name[]) or pks is not null)
+      and nc.nspname = any ($1::name[])
+      and not pg_is_other_temp_schema(c.relnamespace)
+  ),
+
+
+  -- M2O relations
+
+  table_table_m2o_rel_cols as (
+    select
+      c.conname as rel_constraint,
+      c.conrelid as rel_table_oid,
+      c.confrelid as rel_f_table_oid,
+      col_map.from_col,
+      col_map.to_col
+    from
+      pg_constraint c
+      join pg_class rel on rel.oid = c.conrelid
+      join pg_class frel on frel.oid = c.confrelid
+      , unnest(c.conkey, c.confkey) as col_map(from_col, to_col)
+    where
+      confrelid != 0
+      and exists(
+        select 1
+        from schemas s
+        where s.schema_oid in (rel.relnamespace, frel.relnamespace)
+      )
+  ),
+
+  view_table_m2o_rel_cols as (
+    select
+      rel_constraint,
+      view_col_rels.view_oid as rel_table_oid,
+      rel_f_table_oid,
+      view_col_rels.view_col_position as from_col,
+      to_col
+    from
+      table_table_m2o_rel_cols rel_cols
+      join view_col_rels
+        on view_col_rels.table_oid = rel_cols.rel_table_oid
+        and view_col_rels.table_col_position = rel_cols.from_col
+  ),
+
+  table_view_m2o_rel_cols as (
+    select
+      rel_constraint,
+      rel_table_oid,
+      view_col_rels.view_oid as rel_f_table_oid,
+      from_col,
+      view_col_rels.view_col_position as to_col
+    from
+      table_table_m2o_rel_cols rel_cols
+      join view_col_rels
+        on view_col_rels.table_oid = rel_cols.rel_f_table_oid
+        and view_col_rels.table_col_position = rel_cols.to_col
+  ),
+
+  view_view_m2o_rel_cols as (
+    select
+      rel_constraint,
+      left_view.view_oid as rel_table_oid,
+      right_view.view_oid as rel_f_table_oid,
+      left_view.view_col_position as from_col,
+      right_view.view_col_position as to_col
+    from
+      table_table_m2o_rel_cols rel_cols
+      join view_col_rels left_view
+        on left_view.table_oid = rel_cols.rel_table_oid
+        and left_view.table_col_position = rel_cols.from_col
+      join view_col_rels right_view
+        on right_view.table_oid = rel_cols.rel_f_table_oid
+        and right_view.table_col_position = rel_cols.to_col
+  ),
+
+  m2o_rel_cols as (
+    select * from table_table_m2o_rel_cols
+    union all
+    select * from view_table_m2o_rel_cols
+    union all
+    select * from table_view_m2o_rel_cols
+    union all
+    select * from view_view_m2o_rel_cols
+  ),
+
+  m2o_rels as (
+    select
+      rel_constraint,
+      rel_table_oid,
+      rel_f_table_oid,
+      array_agg (
+        array[from_col, to_col]
+      ) as rel_col_map
+    from
+      m2o_rel_cols
+    group by rel_constraint, rel_table_oid, rel_f_table_oid
+    order by rel_table_oid, rel_col_map
+  ),
+
+  o2m_rels as (
+    select
+      rel_constraint,
+      rel_f_table_oid as rel_table_oid,
+      rel_table_oid as rel_f_table_oid,
+      array_agg (
+        array[to_col, from_col]
+      ) as rel_col_map
+    from
+      m2o_rel_cols
+    group by rel_constraint, rel_table_oid, rel_f_table_oid
+    order by rel_table_oid, rel_col_map
+/*  ),
+
+  m2m_rels as (
+    select
+      left_rels.rel_f_table_oid as rel_table_oid,
+      right_rels.rel_f_table_oid as rel_f_table_oid,
+      m2m_col_maps.m2m_col_map as rel_col_map,
+      json_build_object(
+        'jun_table_oid', left_rels.rel_table_oid,
+        'jun_constraint1', left_rels.rel_constraint,
+        'jun_constraint2', right_rels.rel_constraint,
+        'jun_col_map', junction_col_maps.junction_col_map
+      ) as rel_junction
+    from
+      m2o_rels left_rels
+      , lateral (
+          select array_agg(from_col order by from_col) as col_map
+          from unnest(left_rels.rel_col_map) as col_map(from_col smallint, to_col smallint)
+        ) left_cols
+      , lateral (
+          select array_agg(to_col order by from_col) as col_map
+          from unnest(left_rels.rel_col_map) as col_map(from_col smallint, to_col smallint)
+        ) left_f_cols
+      , m2o_rels right_rels
+      , lateral (
+          select array_agg(from_col order by from_col) as col_map
+          from unnest(right_rels.rel_col_map) as col_map(from_col smallint, to_col smallint)
+        ) right_cols
+      , lateral (
+          select array_agg(to_col order by from_col) as col_map
+          from unnest(right_rels.rel_col_map) as col_map(from_col smallint, to_col smallint)
+        ) right_f_cols
+      , lateral (
+          select array_agg(m2m_col_map) as m2m_col_map
+          from
+            unnest(left_f_cols.col_map, right_f_cols.col_map) as m2m_col_map(from_col, to_col)
+        ) as m2m_col_maps
+      , lateral (
+          select array_agg(junction_col_map) as junction_col_map
+          from
+            unnest(left_cols.col_map, right_cols.col_map) as junction_col_map(from_col, to_col)
+        ) as junction_col_maps
+    where
+      left_rels.rel_table_oid = right_rels.rel_table_oid
+      and left_cols <> right_cols
+      and array_length(junction_col_maps.junction_col_map, 1) = 1
+
+*/  ),
+
+  rels as (
+    select
+      'M2O' as rel_type,
+      rel_constraint,
+      rel_table_oid,
+      rel_f_table_oid,
+      rel_col_map,
+      null::json as rel_junction
+    from m2o_rels
+    union all
+    select
+      'O2M' as rel_type,
+      rel_constraint,
+      rel_table_oid,
+      rel_f_table_oid,
+      rel_col_map,
+      null::json as rel_junction
+    from o2m_rels
+/*
+    union all
+    select
+      'M2M' as rel_type,
+      null::text as rel_constraint,
+      rel_table_oid,
+      rel_f_table_oid,
+      rel_col_map,
+      rel_junction
+    from m2m_rels
+*/
+  )
+
+  -- Main query
+select
+  json_build_object(
+    'raw_db_procs', coalesce(procs_agg.array_agg, array[]::record[]),
+    'raw_db_schemas', coalesce(schemas_agg.array_agg, array[]::record[]),
+    'raw_db_tables', coalesce(tables_agg.array_agg, array[]::record[]),
+    'raw_db_columns', coalesce(columns_agg.array_agg, array[]::record[]),
+    --'raw_db_m2o_rels', coalesce(m2o_rels_agg.array_agg, array[]::record[]),
+    --'raw_db_view_col_rels', coalesce(view_col_rels_agg.array_agg, array[]::record[]),
+    'raw_db_rels', coalesce(rels_agg.array_agg, array[]::record[]),
+    'raw_db_pg_ver', pg_version
+  ) as dbstructure
+from
+  (select array_agg(procs order by proc_oid) from procs) procs_agg,
+  (select array_agg(schemas order by schema_oid) from schemas) schemas_agg,
+  (select array_agg(tables order by table_oid) from tables) as tables_agg,
+  (select array_agg(columns order by col_table_oid, col_position) from columns) as columns_agg,
+  --(select array_agg(m2o_rels) from m2o_rels) as m2o_rels_agg,
+  --(select array_agg(view_col_rels) from view_col_rels) as view_col_rels_agg,
+  (select array_agg(rels) from rels) as rels_agg,
+  pg_version

--- a/src/PostgREST/dbstructure.sql
+++ b/src/PostgREST/dbstructure.sql
@@ -187,7 +187,7 @@ with
       c.relkind in ('v', 'm')
       and n.nspname = any ($1::name[])
 */
-),
+  ),
 
 
   -- Primary keys
@@ -376,7 +376,7 @@ with
     select * from table_view_m2o_rel_cols
     union all
     select * from view_view_m2o_rel_cols
-  ),
+/*  ),
 
   m2o_rels as (
     select
@@ -404,7 +404,7 @@ with
       m2o_rel_cols
     group by rel_constraint, rel_table_oid, rel_f_table_oid
     order by rel_table_oid, rel_col_map
-/*  ),
+*//*  ),
 
   m2m_rels as (
     select
@@ -451,7 +451,7 @@ with
       and left_cols <> right_cols
       and array_length(junction_col_maps.junction_col_map, 1) = 1
 
-*/  ),
+*/ /* ),
 
   rels as (
     select
@@ -471,7 +471,7 @@ with
       rel_col_map,
       null::json as rel_junction
     from o2m_rels
-/*
+*//*
     union all
     select
       'M2M' as rel_type,
@@ -491,9 +491,9 @@ select
     'raw_db_schemas', coalesce(schemas_agg.array_agg, array[]::record[]),
     'raw_db_tables', coalesce(tables_agg.array_agg, array[]::record[]),
     'raw_db_columns', coalesce(columns_agg.array_agg, array[]::record[]),
-    --'raw_db_m2o_rels', coalesce(m2o_rels_agg.array_agg, array[]::record[]),
+    'raw_db_m2o_rels', coalesce(null, array[]::record[]),
     --'raw_db_view_col_rels', coalesce(view_col_rels_agg.array_agg, array[]::record[]),
-    'raw_db_rels', coalesce(rels_agg.array_agg, array[]::record[]),
+    'raw_db_rels', coalesce(null, array[]::record[]),
     'raw_db_pg_ver', pg_version
   ) as dbstructure
 from
@@ -503,5 +503,5 @@ from
   (select array_agg(columns order by col_table_oid, col_position) from columns) as columns_agg,
   --(select array_agg(m2o_rels) from m2o_rels) as m2o_rels_agg,
   --(select array_agg(view_col_rels) from view_col_rels) as view_col_rels_agg,
-  (select array_agg(rels) from rels) as rels_agg,
+  --(select array_agg(rels) from rels) as rels_agg,
   pg_version

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -12,14 +12,15 @@ import Data.Time.Clock    (getCurrentTime)
 import Data.IORef
 import Test.Hspec
 
-import PostgREST.App         (postgrest)
-import PostgREST.Config      (AppConfig (..))
-import PostgREST.DbStructure (getDbStructure, getPgVersion)
-import PostgREST.Types       (LogLevel (..), pgVersion95, pgVersion96)
+import           PostgREST.App         (postgrest)
+import           PostgREST.Config      (AppConfig (..))
+import           PostgREST.DbStructure (getDbStructure, getPgVersion)
 import qualified PostgREST.DbStructure as DbStructure
-import Protolude             hiding (toList, toS)
-import Protolude.Conv        (toS)
-import SpecHelper
+import           PostgREST.Types       (LogLevel (..), pgVersion95,
+                                        pgVersion96)
+import           Protolude             hiding (toList, toS)
+import           Protolude.Conv        (toS)
+import           SpecHelper
 
 import qualified Feature.AndOrParamsSpec
 import qualified Feature.AsymmetricJwtSpec


### PR DESCRIPTION
This is a new attempt at https://github.com/PostgREST/postgrest/pull/1513

Currently the DbStructure ("schema cache") is loaded based on multiple queries. This has some performance issues for large schemas and the `DbStructure.hs` file has become difficult to maintain. Getting everything we need in one query might make it easier to debug PostgREST (by 'seeing what PostgREST sees') and accelerate the development of new features/improvements. 

# How it works

Differently from the previous attempt, this keeps any changes to the existing schema cache and queries as minimal as possible for now while adding a new way to get the schema cache.

The new way to get the schema cache can be activated via the environment variable `POSTGREST_MEGAQUERY`. For example, run `POSTGREST_MEGAQUERY=1 postgrest path/to/postgrest.conf` to try the new mode.

This means that PostgREST will behave as normal usually, but the new DbStructure path can be switched on for automated or manual testing of the new path

Currently, only part of the data is sourced from the new query, and it falls back to the standard DbStructure data for the other parts I haven’t yet solved (currently version, tables and procs are sourced from the new path, everything else from the old one). This should enable nice incremental development with diffing of results where necessary to fix bugs

If you have an idea for a less silly name, please let me know :-) I would change the name of the new module and the name of the env variable accordingly.

# Next steps tbd
- Develop this step by step, keeping all tests passing until the new path is completely independent from the old one

Then, possibly:
- Merge (earliest after the next release, but don’t think this will progress that fast)
- Integrate new path in CI (should be as simple as adding POSTGREST_MEGAQUERY=1 postgrest-test-spec-all)
- release beta versions and have power users test the new path with the env flag
- Transitional releases (tbd if needed?)
- One release with both paths, old one as default
- One release with both paths, new one as default
- At some point, kill the old path, reap all the simplification gains (and possibly performance, e.g. from more efficient data structures)