### PR TITLE
Fix RPC returns

### DIFF
--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -226,8 +226,12 @@ procsSqlQuery = [q|
     tn.nspname AS schema,
     COALESCE(comp.relname, t.typname) AS name,
     p.proretset AS rettype_is_setof,
-    -- Only pg pseudo type that is a row type is 'record'
-    (t.typtype = 'c' or t.typtype = 'p' and t.typname = 'record') AS rettype_is_composite,
+    (t.typtype = 'c'
+     -- Only pg pseudo type that is a row type is 'record'
+     or t.typtype = 'p' and t.typname = 'record'
+     -- if any INOUT or OUT arguments present, treat as composite
+     or COALESCE(proargmodes::text[] && '{b,o}', false)
+    ) AS rettype_is_composite,
     p.provolatile
   FROM pg_proc p
   JOIN pg_namespace pn ON pn.oid = p.pronamespace

--- a/src/PostgREST/Private/QueryFragment.hs
+++ b/src/PostgREST/Private/QueryFragment.hs
@@ -90,11 +90,15 @@ asCsvF = asCsvHeaderF <> " || '\n' || " <> asCsvBodyF
       ")"
     asCsvBodyF = "coalesce(string_agg(substring(_postgrest_t::text, 2, length(_postgrest_t::text) - 2), '\n'), '')"
 
-asJsonF :: SqlFragment
-asJsonF = "coalesce(json_agg(_postgrest_t), '[]')::character varying"
+asJsonF :: Bool -> SqlFragment
+asJsonF returnsScalar
+  | returnsScalar = "coalesce(json_agg(_postgrest_t.pgrst_scalar), '[]')::character varying"
+  | otherwise     = "coalesce(json_agg(_postgrest_t), '[]')::character varying"
 
-asJsonSingleF :: SqlFragment --TODO! unsafe when the query actually returns multiple rows, used only on inserting and returning single element
-asJsonSingleF = "coalesce(string_agg(row_to_json(_postgrest_t)::text, ','), '')::character varying "
+asJsonSingleF :: Bool -> SqlFragment --TODO! unsafe when the query actually returns multiple rows, used only on inserting and returning single element
+asJsonSingleF returnsScalar
+  | returnsScalar = "coalesce(string_agg(to_json(_postgrest_t.pgrst_scalar)::text, ','), '')::character varying"
+  | otherwise     = "coalesce(string_agg(to_json(_postgrest_t)::text, ','), '')::character varying"
 
 asBinaryF :: FieldName -> SqlFragment
 asBinaryF fieldName = "coalesce(string_agg(_postgrest_t." <> pgFmtIdent fieldName <> ", ''), '')"

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -203,7 +203,13 @@ specifiedProcArgs keys proc =
 procReturnsScalar :: ProcDescription -> Bool
 procReturnsScalar proc = case proc of
   ProcDescription{pdReturnType = (Single (Scalar _))} -> True
+  ProcDescription{pdReturnType = (SetOf (Scalar _))}  -> True
   _                                                   -> False
+
+procReturnsSingle :: ProcDescription -> Bool
+procReturnsSingle proc = case proc of
+  ProcDescription{pdReturnType = (Single _)} -> True
+  _                                          -> False
 
 procTableName :: ProcDescription -> Maybe TableName
 procTableName proc = case pdReturnType proc of

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -821,14 +821,22 @@ spec actualPgVersion = do
     it "fails if a single column is not selected" $ do
       request methodGet "/images?select=img,name&name=eq.A.png" (acceptHdrs "application/octet-stream") ""
         `shouldRespondWith`
-        [json| {"message":"application/octet-stream requested but more than one column was selected"} |]
-        { matchStatus = 406
-        , matchHeaders = [matchContentTypeJson]
-        }
-      request methodGet "/images?select=*&name=eq.A.png" (acceptHdrs "application/octet-stream") ""
-        `shouldRespondWith` 406
-      request methodGet "/images?name=eq.A.png" (acceptHdrs "application/octet-stream") ""
-        `shouldRespondWith` 406
+          [json| {"message":"application/octet-stream requested but more than one column was selected"} |]
+          { matchStatus = 406 }
+
+      request methodGet "/images?select=*&name=eq.A.png"
+          (acceptHdrs "application/octet-stream")
+          ""
+        `shouldRespondWith`
+          [json| {"message":"application/octet-stream requested but more than one column was selected"} |]
+          { matchStatus = 406 }
+
+      request methodGet "/images?name=eq.A.png"
+          (acceptHdrs "application/octet-stream")
+          ""
+        `shouldRespondWith`
+          [json| {"message":"application/octet-stream requested but more than one column was selected"} |]
+          { matchStatus = 406 }
 
     it "concatenates results if more than one row is returned" $
       request methodGet "/images_base64?select=img&name=in.(A.png,B.png)" (acceptHdrs "application/octet-stream") ""

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1618,6 +1618,12 @@ create or replace function welcome() returns text as $$
 select 'Welcome to PostgREST'::text;
 $$ language sql;
 
+create or replace function welcome_twice() returns setof text as $$
+select 'Welcome to PostgREST'
+union all
+select 'Welcome to PostgREST';
+$$ language sql;
+
 create or replace function "welcome.html"() returns text as $_$
 select $$
 <html>


### PR DESCRIPTION
This PR fixes a couple of things regarding the returns of RPC calls:
1. The 1st commit is something that I discovered while fixing the other stuff and has - to my knowledge - not been reported, so far. This comment tells the whole story: `_   -> Scalar qi -- 'b'ase, 'd'omain, 'e'num, 'r'ange`. Domain types were always treated as `Scalar` here. That, of course, is not correct once a domain has a composite base type (this seems to be possible to do starting with PG 11, which might explain why it was done that way earlier on). Test added, test failed - confirmed.
The solution is to add a recursive CTE to the proc query, to replace the return type characteristics with those of the base type for domains. The recursive query makes sure, that this works also for domains of domains of domains.... Schema and name of the base type are taken as well, to make embedding work against domains of table types. Added a test for that as well.

2. When I tried to add the next test case, I was stuck quite a bit of time because of a strange "No function matches the given name and argument types." error. It turns out I had naively used just `json` without `pg_catalog.` prefix as an argument type, but json was overloaded as a table name.
To prevent others stumbling across the same thing when adding new tests, I decided to rename the json table. The 2nd commit contains this refactor. I also changed all occurences of `pg_catalog.json` to `json` in `schema.sql` to make sure that a lot of tests start failing once anybody tries to come up with another table/type named `json` again....

3. Next up in the 3rd commit is #1469, which, imho, has multiple dimensions (see below). The obvious thing here is, that overloading is broken with `Prefer: params=single-object`. I added the test-case that @steve-chavez suggested in #1469 slightly adapted. The problem here is, that `findProc` looks for a function with the number of arguments==1, but `decodeProcs` throws away unnamed arguments. So the `ProcDescription` for this overloaded function contained 0 arguments, was never matched by `findProc` and everything went downhill from there.
The fix is to allow `decodeProcs` to parse unnamed arguments. This does not fix it 100%, yet, as it would not properly parse `character varying`. But since we only care for unnamed `json` arguments anyway, that should not be a problem. If somebody wanted to create arguments with spaces in their name, that could lead to problems as well... but I guess that's for another day. I left a todo comment for future reference. Resolves #1469.

4. Next, another small refactor of tests, because the next commit below initially failed on some of the tests due to whitespace changes in the json response. To keep the other commit a bit easier to review, I moved this refactor into a separate one.
To properly test for json responses, the `[str|...|]` QuasiQuoter was replaced with `[json|...|` everywhere. `shouldRespondWith` is overloaded when the json qq is used, so that the response status and content type header (defaults to `application/json`) are checked as well. Because of that some of the tests had to be fixed to test for the singular header. The tests that I touched this way, I also reformatted a bit, to match with the format that is used in most of the other tests.

5. Looking again at #1469, there is something else happening as well: Because the overloading detection was broken, the called RPC was not found in the definitions. When the function returns a scalar (like `json` in this case) it returns the kind of "ugly" json object with the function name as a key. This is normally prevented by the `returnsScalar` branch, which is not executed in this case. The same thing happens when the schema cache is stale (e.g. because a new function was added) or the function returns SetOf Scalar (e.g. `SETOF json` as mentioned in https://github.com/PostgREST/postgrest/issues/1466#issuecomment-694119550).
This can be improved on by moving the whole scalar/composite decision into SQL. To do this, I first added a test-case that creates a new RPC on-the-fly without cache reload. This was therefore consistently called without the `returnsScalar` branch, before my changes were made.
Now, the basic idea of this change is to give the function a consistent name with `AS pgrst_scalar` and then, once the result's row has been encoded in a json object, check whether the key `pgrst_scalar` is part of this object (scalar case) or not (composite case). To do this, the encoding of each row and the aggregation in a json array have to separated. Before, both had been done by `json_agg`, now `to_jsonb` is used to first encode in json, then make the scalar/composite decision, then use `json_agg` at last. The intermediary type has to be `jsonb`, because the `?` operator ("does key exist?") is only available for `jsonb` and not `json`. The intermediate jsonb type results in the whitespace changes mentioned in the refactor above.
Additionally `returnsScalar` is replaced with `returnsSingle` to be able to still tell whether an array or a scalar/object should be returned. This decision can not be made yet in SQL, although I already have some ideas for that, too.
I did add a test for #1584 which is passing now as well. Resolves #1584.

The last part changes the return values of RPCs in some ways that break existing tests. I left those tests unchanged for now, to have them shown up with expected and new output in the CI test output. Those broken tests boil down to 3 core changes:
- RPCs with a return type of `Single Composite X`, e.g. `RETURNS table_type`, now return an object instead of an array with exactly one object. This was actually something that bothered me a few times already. When I have a function that never returns more than 1 row per definition (no setof), I don't want to receive an array - and I don't want to have to set the `application/vnd.pgrst.object+json` accept header all the time.
Example:
```
  test/Feature/RpcSpec.hs:283:9:
  5) Feature.RpcSpec, remote procedure call, proc return types, returns single row from table
       body mismatch:
         expected: [{"id":2}]
         but got:  {"id": 2}
```
- RPCs with a return type of `SetOf Scalar Y`, e.g. `RETURNS SETOF int`, now return a json array with those scalars - and not an array of objects with a single key (= function's name). This has been considered a bug in various issues, yet it's coded into some tests that expect exactly this kind of response.
Example:
```
  test/Feature/RpcSpec.hs:242:9:
  2) Feature.RpcSpec, remote procedure call, proc return types, returns setof integers
       body mismatch:
         expected: [{"ret_setof_integers":1},{"ret_setof_integers":2},{"ret_setof_integers":3}]
         but got:  [1, 2, 3]
```
- RPCs with `INOUT / OUT` params now return an object all the time. Before the change, a single `OUT` param would have lead to a scalar output, while multiple `OUT` params would have been an object. This was quite inconsistent.
Example:
```
  test/Feature/RpcSpec.hs:416:9:
  7) Feature.RpcSpec, remote procedure call, procs with OUT/INOUT params, returns a scalar result when there is a single OUT param
       body mismatch:
         expected: 6
         but got:  {"num_plus_one": 6}
```

I am not sure whether those last two bullet points were actually designed that way on purpose or whether they were just accepted as fact with the current implementation. If all those changes are ok to do, I will change the tests accordingly. We will need to mention those explicitely in the changelog / a migration guide / an appropriate place, of course.

There's one more test that is failing right now, where I don't know how we should proceed with that, yet. This is whenever binary output is requested without `select=` from a RPC that returns a composite type. The test output changes as follows:
```
  test/Feature/RpcSpec.hs:655:11:
  13) Feature.RpcSpec, remote procedure call, binary output, Proc that returns rows, fails if a single column is not selected
       status mismatch:
         expected: 406
         but got:  400
       body mismatch:
         expected: {"message":"application/octet-stream requested but more than one column was selected"}
         but got:  {"hint":null,"details":null,"code":"42703","message":"column _postgrest_t.pgrst_scalar does not exist"}
```
Unfortunately, it's not possible to detect this case anymore before making the request, because the scalar/composite decision is made in SQL. There's a couple of ways to go forward with this:
- leave the error message like that (pgrst_scalar does not exist...)
- catch this exact error in `Errors.hs` and rewrite it to the one it was before (not sure whether that's even possible)
- delay the proper err msg until we have the possibility to create SQL functions: In that case we could raise a custom error from the query itself, when we hit that situation.

Since all those changes are closely related and partly dependent on each other, I put this all into one PR. To make reviewing easier, I tried to split it into easy-to-consume commits, despite some refactors inbetween.