### PR TITLE
fix appveyor build script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ build_script:
 - stack setup --no-terminal > nul
 # Appveyor has a timeout of 60 mins, building can take longer, limit the time and make sure this succeeds,
 # previous work will get cached and finish on next commit
-- bash -lc "timeout 2700 'C:\projects\postgrest\stack.exe' build -j1 --copy-bins --local-bin-path . || true"
+- bash -lc "timeout 2700 'C:\projects\postgrest\stack.exe' build -j1 --copy-bins --local-bin-path . || (($?==124))"
 
 artifacts:
 - path: postgrest.exe

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -67,7 +67,9 @@ main = do
     host = configHost conf
     port = configPort conf
     maybeSocketAddr = configSocket conf
+#ifndef mingw32_HOST_OS
     socketFileMode = configSocketMode conf
+#endif
     dbUri = toS (configDbUri conf)
     (dbChannelEnabled, dbChannel) = (configDbChannelEnabled conf, toS $ configDbChannel conf)
     serverSettings =


### PR DESCRIPTION
Seems like the appveyor build is silently throwing errors right now. This is because the error code is swallowed. This change should make it pass on a timeout, but fail on every other error.