### PR TITLE
improve cirrus build time by properly using cabal cache

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,54 +2,32 @@ freebsd_instance:
   image: freebsd-12-1-release-amd64
 
 build_task:
-  env:
-    ASSUME_ALWAYS_YES: YES
+  # caches the freebsd package downloads
+  # saves probably just a couple of seconds, but hey...
+  pkg_cache:
+    folder: /var/cache/pkg
+
   install_script:
-    ## TODO: Some of these workaround steps might be unneeded now
-    ## gmake required, otherwise bsd make is used and some cryptic "No operator" errors are shown
-    - pkg install -y gmake
-    ## gcc required, otherwise warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]
-    - pkg install -y gcc
-    - pkg install -y libiconv
-    - pkg install -y gmp
-    - pkg install -y postgresql95-client
-    - pkg install -y pkgconf
-    - pkg install -y ghc
-    - pkg install -y hs-cabal-install
-  cabal_cache:
-    folder: ~/.cabal
+    - pkg install -y postgresql95-client ghc hs-cabal-install
+  
+  # cache the hackage index file and downloads which are
+  # cabal v2-update downloads an incremental update, so we don't need to keep this up2date
+  packages_cache:
+    # warning: don't use ~/.cabal here, this will break the cache
+    folder: /.cabal/packages
+    reupload_on_changes: false
+
+  # cache the dependencies built by cabal
+  # they have to be uploaded on every change to make the next build fast
+  store_cache:
+    # warning: don't use ~/.cabal here, this will break the cache
+    folder: /.cabal/store
     fingerprint_script: cat postgrest.cabal
+    reupload_on_changes: true
+
   build_script:
     - cabal v2-update
     - cabal v2-build
+
   binaries_artifacts:
     path: "dist-newstyle/build/x86_64-freebsd/ghc-8.6.5/postgrest-7.0.1/x/postgrest/build/postgrest/*"
-  #binary_script:
-    #- mkdir bin
-    ## cabal v2-install --installdir=.
-    ## the installdir option is not working on this cabal version(form hs-cabal-install), so the binary must be extrated from the path
-    ## this is too brittle so for now we don't use it
-    #- ldd /tmp/cirrus-ci-build/dist-newstyle/build/x86_64-freebsd/ghc-8.6.5/postgrest-7.0.1/x/postgrest/build/postgrest/postgrest
-    #- mv /tmp/cirrus-ci-build/dist-newstyle/build/x86_64-freebsd/ghc-8.6.5/postgrest-7.0.1/x/postgrest/build/postgrest/postgrest bin/
-  ## https://cirrus-ci.org/guide/writing-tasks/#artifacts-instruction
-  #binaries_artifacts:
-    #path: bin/
-  cleanup_script:
-    - rm -rf ~/.cabal/logs
-    - rm  ~/.cabal/config
-
-#publish_task:
-  #skip: $CIRRUS_TAG == ""
-  #env:
-    #TOKEN: ENCRYPTED[c99babbf04e8a33962ffbbc75bf20d3abe408f9bede5ed5d8956cd24da6fdb34266c920984cc43f8106ef3423fba0e98]
-  #depends_on:
-    #- build
-  #script:
-    ## https://cirrus-ci.org/guide/writing-tasks/#artifacts-instruction
-    #- wget https://api.cirrus-ci.com/v1/artifact/github/$CIRRUS_REPO_FULL_NAME/build/binaries/bin/postgrest
-    #- tar cvJf postgrest-$CIRRUS_TAG-freebsd.tar.xz -C ~/project/result/bin postgrest
-    ### The CIRRUS_RELEASE env var is not the same as the tag. It's an id for the release.
-    #- curl -X POST --data-binary @$NAME \
-      #-H "Authorization:token ${TOKEN}" \
-      #-H "Content-Type:application/octet-stream" \
-      #"https://uploads.github.com/repos/$CIRRUS_REPO_FULL_NAME/releases/${CIRRUS_RELEASE}/assets?name=${NAME}"


### PR DESCRIPTION
So I had a look at the cirrus build, that takes like forever all the time.

Looking at the output, it seems to me like the cabal cache is not updated properly and all dependencies are built again every time. The cache update is based on the contents of `postgrest.cabal` - but since there are version ranges given in this file, I could imagine that cabal still decides to download newer packages and not use those from cache.

I tried removing the `fingerprint_script` line. Now it should default back to `reupload_on_changes: true` and scan the `~/.cabal` folder for changes to upload.

Let's see what happens when I trigger this twice.
