### PR TITLE
Enable embedding through multiple layers of views recursively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #1470, Allow calling RPC with variadic argument by passing repeated params - @wolfgangwalther
  - #1559, No downtime when reloading the schema cache with SIGUSR1 - @steve-chavez
  - #504, Add `log-level` config option. The admitted levels are: crit, error, warn and info - @steve-chavez
+ - #1607, Enable embedding through multiple views recursively - @wolfgangwalther
 
 ### Fixed
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -244,7 +244,7 @@ connectionStatus pool =
 fillSchemaCache :: P.Pool -> PgVersion -> IORef AppConfig -> IORef (Maybe DbStructure) -> IO ()
 fillSchemaCache pool actualPgVersion refConf refDbStructure = do
   conf <- readIORef refConf
-  result <- P.use pool $ HT.transaction HT.ReadCommitted HT.Read $ getDbStructure (toList $ configSchemas conf) actualPgVersion
+  result <- P.use pool $ HT.transaction HT.ReadCommitted HT.Read $ getDbStructure (toList $ configSchemas conf) (configExtraSearchPath conf) actualPgVersion
   case result of
     Left e -> do
       -- If this error happens it would mean the connection is down again. Improbable because connectionStatus ensured the connection.

--- a/test/Feature/ExtraSearchPathSpec.hs
+++ b/test/Feature/ExtraSearchPathSpec.hs
@@ -6,7 +6,7 @@ import Test.Hspec
 import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 
-import Protolude
+import Protolude  hiding (get)
 import SpecHelper
 
 spec :: SpecWith ((), Application)
@@ -34,3 +34,6 @@ spec = describe "extra search path" $ do
     request methodGet "/rpc/is_valid_isbn?input=978-0-393-04002-9" [] ""
       `shouldRespondWith` [json|true|]
       { matchHeaders = [matchContentTypeJson] }
+
+  it "can detect fk relations through multiple views recursively when middle views are in extra search path" $
+    get "/consumers_extra_view?select=*,orders_view(*)" `shouldRespondWith` 200

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -421,6 +421,13 @@ spec actualPgVersion = do
           [json|[ { "title": "To Kill a Mockingbird", "author": { "name": "Harper Lee" } } ]|]
           { matchHeaders = [matchContentTypeJson] }
 
+      describe "can detect fk relations through multiple views recursively" $ do
+        it "when all views are public" $
+          get "/consumers_view_view?select=*,orders_view(*)" `shouldRespondWith` 200
+
+        it "when middle view is private" $
+          get "/consumers_private_view?select=*,orders_view(*)" `shouldRespondWith` 200
+
       it "works with views that have subselects" $
         get "/authors_books_number?select=*,books(title)&id=eq.1" `shouldRespondWith`
           [json|[ {"id":1, "name":"George Orwell","num_in_forties":1,"num_in_fifties":0,"num_in_sixties":0,"num_in_all_decades":1,

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -421,12 +421,8 @@ spec actualPgVersion = do
           [json|[ { "title": "To Kill a Mockingbird", "author": { "name": "Harper Lee" } } ]|]
           { matchHeaders = [matchContentTypeJson] }
 
-      describe "can detect fk relations through multiple views recursively" $ do
-        it "when all views are public" $
-          get "/consumers_view_view?select=*,orders_view(*)" `shouldRespondWith` 200
-
-        it "when middle view is private" $
-          get "/consumers_private_view?select=*,orders_view(*)" `shouldRespondWith` 200
+      it "can detect fk relations through multiple views recursively when all views are in api schema" $ do
+        get "/consumers_view_view?select=*,orders_view(*)" `shouldRespondWith` 200
 
       it "works with views that have subselects" $
         get "/authors_books_number?select=*,books(title)&id=eq.1" `shouldRespondWith`

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -54,7 +54,7 @@ GRANT ALL ON TABLE
     , public.public_orders
     , consumers_view
     , consumers_view_view
-    , consumers_private_view
+    , consumers_extra_view
     , orders_view
     , images
     , images_base64

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -53,6 +53,8 @@ GRANT ALL ON TABLE
     , public.public_consumers
     , public.public_orders
     , consumers_view
+    , consumers_view_view
+    , consumers_private_view
     , orders_view
     , images
     , images_base64

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -175,6 +175,14 @@ create view orders_view as
 create view consumers_view as
   select * from public.public_consumers;
 
+create view consumers_view_view as
+  select * from consumers_view;
+
+create view private.consumers_private as
+  select * from consumers_view;
+
+create view consumers_private_view as
+  select * from private.consumers_private;
 
 --
 -- Name: getitemrange(bigint, bigint); Type: FUNCTION; Schema: test; Owner: -

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -178,11 +178,11 @@ create view consumers_view as
 create view consumers_view_view as
   select * from consumers_view;
 
-create view private.consumers_private as
+create view public.consumers_extra as
   select * from consumers_view;
 
-create view consumers_private_view as
-  select * from private.consumers_private;
+create view consumers_extra_view as
+  select * from public.consumers_extra;
 
 --
 -- Name: getitemrange(bigint, bigint); Type: FUNCTION; Schema: test; Owner: -


### PR DESCRIPTION
Resolves #1607.

Changes the `allSourceColumns` query to recurse, when the base relation is still a view or materialized view. The query now returns the "true" base columns through multiple view layers, enabling the embedding of views of views of... you know!
