### PR TITLE
remove io tests from stack-test because of random segmentation faults

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,12 +71,6 @@ jobs:
           command: |
             POSTGREST_TEST_CONNECTION=$(test/create_test_db "postgres://circleci@localhost" postgrest_test) \
               stack test
-      - run:
-          name: run io tests
-          command: |
-            export PATH="~/.local/bin:$PATH"
-            stack install --fast -j1
-            test/io-tests.sh
 
   # Run memory usage tests based on stack and docker.
   stack-test-memory:


### PR DESCRIPTION
this is just to debug - nothing to merge, yet.

Right now, `stack-test` often fails with a segmentation fault during the io-tests. I tried to reproduce locally, but couldn't. Here, I ripped out all the other CI pipelines (no need to run them loads of times) and removed some `> /dev/null` redirections. Hopefully I can reproduce the error when running the CI pipeline a couple of times and get more useful logging output.

Let's see what happens.