### PR TITLE
ci: add coveralls.io integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,7 @@ jobs:
             curl -L https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz | tar zx -C /tmp
             sudo mv /tmp/stack-2.3.1-linux-x86_64/stack /usr/bin
             sudo apt-get update
-            # ncat utility from nmap needed to test socket connection with curl <  7.40
-            sudo apt-get install -y libgmp-dev postgresql-client nmap
+            sudo apt-get install -y libgmp-dev postgresql-client
             sudo apt-get install -y --only-upgrade binutils
             stack setup
       - run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,70 +1,113 @@
-## Travis is only used for building an OSX binary ,
-## no tests are run here.
 language: generic
 
 sudo: false
 
-os:
-- osx
+jobs:
+  include:
+    - name: Build OSX Binary
+      os: osx
+      cache:
+        timeout: 1000
+        directories:
+          - $HOME/.stack
+          - $HOME/.local/bin
+      before_install:
+        - mkdir -p "$HOME/.local/bin"
+        - export PATH="$PATH:$HOME/.local/bin"
+      install:
+        - |
+          if test -f "$HOME/.local/bin/stack"
+            then
+              echo 'Stack is already installed.'
+            else
+              echo "Installing Stack..."
+              travis_retry curl -L https://www.stackage.org/stack/osx-x86_64 > stack.tar.gz
+              gunzip stack.tar.gz
+              tar -x -f stack.tar --strip-components 1
+              mv stack "$HOME/.local/bin/"
+              rm stack.tar
+          fi
+        - |
+          if test -f "$HOME/.local/bin/ghr"
+          then
+            echo 'ghr is already installed.'
+          else
+            echo "Installing ghr..."
+            travis_retry curl -L https://github.com/tcnksm/ghr/releases/download/v0.5.4/ghr_v0.5.4_darwin_386.zip > ghr.zip
+            unzip ghr.zip -d "$HOME/.local/bin"
+            rm ghr.zip
+          fi
+      script:
+        ## Building the whole project can take longer than 50 minutes. Since Travis has a global timeout of 50 minutes
+        ## we compile for 30 minutes tops(`gtimeout 1800`) and quit compiling with no error.
+        ## Since we CACHE the compile results we can continue compiling from where we left off
+        ## on the next commit.
+        - gtimeout 1800 stack build --no-terminal --only-snapshot --install-ghc || (($?==124))
+        - |
+          if test ! "$TRAVIS_TAG"
+          then
+            echo 'No tag pushed. Skip building binary.'
+          else
+            stack build --no-terminal --copy-bins --local-bin-path .
+          fi
+        - |
+          if test ! "$TRAVIS_TAG"
+          then
+            echo 'No tag pushed. Skipping release.'
+          else
+            OWNER="$(echo "$TRAVIS_REPO_SLUG" | cut -f1 -d/)"
+            REPO="$(echo "$TRAVIS_REPO_SLUG" | cut -f2 -d/)"
+            START=$(echo $TRAVIS_TAG | cut -c2-)
+            END='## \['
+            BODY=$(sed -n "1,/$START/d;/$END/q;p" CHANGELOG.md)
+            strip postgrest
+            tar cJf postgrest-$TRAVIS_TAG-osx.tar.xz postgrest
+            ghr -t $GITHUB_TOKEN -u $OWNER -r $REPO -b "$BODY"--replace $TRAVIS_TAG postgrest-$TRAVIS_TAG-osx.tar.xz
+          fi
 
-cache:
-  timeout: 1000
-  directories:
-    - $HOME/.stack
-    - $HOME/.local/bin
-
-before_install:
-- mkdir -p "$HOME/.local/bin"
-- export PATH="$PATH:$HOME/.local/bin"
-
-install:
-- |
-  if test -f "$HOME/.local/bin/stack"
-    then
-      echo 'Stack is already installed.'
-    else
-      echo "Installing Stack..."
-      travis_retry curl -L https://www.stackage.org/stack/osx-x86_64 > stack.tar.gz
-      gunzip stack.tar.gz
-      tar -x -f stack.tar --strip-components 1
-      mv stack "$HOME/.local/bin/"
-      rm stack.tar
-  fi
-- |
-  if test -f "$HOME/.local/bin/ghr"
-  then
-    echo 'ghr is already installed.'
-  else
-    echo "Installing ghr..."
-    travis_retry curl -L https://github.com/tcnksm/ghr/releases/download/v0.5.4/ghr_v0.5.4_darwin_386.zip > ghr.zip
-    unzip ghr.zip -d "$HOME/.local/bin"
-    rm ghr.zip
-  fi
-
-script:
-## Building the whole project can take longer than 50 minutes. Since Travis has a global timeout of 50 minutes
-## we compile for 30 minutes tops(`gtimeout 1800`) and quit compiling with no error.
-## Since we CACHE the compile results we can continue compiling from where we left off
-## on the next commit.
-- gtimeout 1800 stack build --no-terminal --only-snapshot --install-ghc || (($?==124))
-- |
-  if test ! "$TRAVIS_TAG"
-  then
-    echo 'No tag pushed. Skip building binary.'
-  else
-    stack build --no-terminal --copy-bins --local-bin-path .
-  fi
-- |
-  if test ! "$TRAVIS_TAG"
-  then
-    echo 'No tag pushed. Skipping release.'
-  else
-    OWNER="$(echo "$TRAVIS_REPO_SLUG" | cut -f1 -d/)"
-    REPO="$(echo "$TRAVIS_REPO_SLUG" | cut -f2 -d/)"
-    START=$(echo $TRAVIS_TAG | cut -c2-)
-    END='## \['
-    BODY=$(sed -n "1,/$START/d;/$END/q;p" CHANGELOG.md)
-    strip postgrest
-    tar cJf postgrest-$TRAVIS_TAG-osx.tar.xz postgrest
-    ghr -t $GITHUB_TOKEN -u $OWNER -r $REPO -b "$BODY"--replace $TRAVIS_TAG postgrest-$TRAVIS_TAG-osx.tar.xz
-  fi
+    - name: Code Coverage
+      os: linux
+      dist: focal
+      addons:
+        apt:
+          update: true
+          packages:
+            - postgresql-12
+      cache:
+        yarn: true
+        timeout: 1000
+        directories:
+          - $HOME/.local/bin
+          - $HOME/.stack
+          - .stack-work
+      before_install: |
+        export PATH="$PATH:$HOME/.local/bin:/usr/lib/postgresql/12/bin"
+      install: |
+        if [[ ! -f "$HOME/.local/bin/stack" ]]
+        then
+          travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+        fi
+        if [[ ! -f "$HOME/.local/bin/shc" ]]
+        then
+          travis_retry curl -L https://github.com/rubik/stack-hpc-coveralls/releases/download/v0.0.4.0/shc-linux-x64-8.0.1.tar.bz2 | tar -xj -C ~/.local/bin
+        fi
+        travis_wait stack --no-terminal setup
+        travis_wait stack --no-terminal install hpc
+      script: |
+        travis_wait 50 stack --no-terminal build --fast -j1 --coverage
+        travis_wait 50 stack --no-terminal build --fast -j1 --coverage --test --no-run-tests
+        test/with_tmp_db stack --no-terminal test --coverage
+        test/with_tmp_db stack --no-terminal exec test/io-tests.sh
+      after_script: |
+        export _HPC_DIR=$(stack path --local-hpc-root)
+        export _MIX_DIR=$(stack path --dist-dir)
+        export _PKG_NAME=$(stack exec -- ghc-pkg field postgrest key --simple-output)
+        # merge the results from `stack test` and the io tests and exclude Paths_postgrest
+        stack --no-terminal exec hpc -- sum --union --exclude=Paths_postgrest --output=/tmp/all.tix $_HPC_DIR/combined/all/all.tix test/io-tests/postgrest.tix
+        # fix a bug in stack-hpc-coveralls
+        mv $_MIX_DIR/hpc/Main.mix $_MIX_DIR/hpc/$_PKG_NAME/Main.mix
+        mv $_MIX_DIR/hpc/UnixSocket.mix $_MIX_DIR/hpc/$_PKG_NAME/UnixSocket.mix
+        sed -i -r "s/(Main|UnixSocket)/$_PKG_NAME\/\1/g" /tmp/all.tix
+        # upload to coveralls
+        mv /tmp/all.tix $_HPC_DIR/combined/all/all.tix
+        shc combined all

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Docs](https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat)](http://postgrest.org)
 [![Docker Stars](https://img.shields.io/docker/pulls/postgrest/postgrest.svg)](https://hub.docker.com/r/postgrest/postgrest/)
 [![Build Status](https://circleci.com/gh/PostgREST/postgrest/tree/master.svg?style=shield)](https://circleci.com/gh/PostgREST/postgrest/tree/master)
+[![Coverage Status](https://img.shields.io/coveralls/github/PostgREST/postgrest)](https://coveralls.io/github/PostgREST/postgrest)
 [![Hackage docs](https://img.shields.io/hackage/v/postgrest.svg?label=hackage)](http://hackage.haskell.org/package/postgrest)
 
 PostgREST serves a fully RESTful API from any existing PostgreSQL

--- a/nix/README.md
+++ b/nix/README.md
@@ -97,7 +97,7 @@ postgrest-test-spec-all             postgrest-test-spec-postgresql-9.6
 
 ```
 
-Note that `postgrest-tests-io` is now also available.
+Note that `postgrest-test-io` is now also available.
 
 To run one-off commands, you can also use `nix-shell --run <command>`, which
 will lauch the Nix shell, run that one command and exit. Note that the tab
@@ -168,7 +168,7 @@ give you some more background and details on how it works.
 
 ### `default.nix`
 
-[`default.nix`](../default.nix) is our 'respository expression' that pulls all
+[`default.nix`](../default.nix) is our 'repository expression' that pulls all
 the pieces that we define with Nix together. It returns a set (like a dict in
 other programming languages), where each attribute is a derivation that Nix
 knows how to build, like the `postgrest` attribute from earlier.


### PR DESCRIPTION
Wouldn't it be good to have code coverage tools in CI as well?

I have found 3 packages that send hpc coverage results to one of the ci services, but only `stack-hpc-coveralls` seems to be compatible to stack. The other 2 use cabal.

I thought it would make sense to use `stack-test` for that purpose. I'm not sure why that was specifically targeting the oldest supported PG version and changed that to the latest. Coverage results seem to be more interesting against the latest version, as that might touch more features, which are not enabled for older versions!?

To make this work, @steve-chavez, you would have to register the postgrest repo with coveralls.io. I'm not sure whether we need to add a token somewhere. The coveralls docs suggest we have to, but the source code for `stack-hpc-coveralls` tells me that the repo_token command line option is only used in case the CI is detected as `travis-ci`.

If you want to do that, I suggest you register the repo and we see what happens.