### PR TITLE
perf: change Text queries to ByteString

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -187,7 +187,7 @@ app dbStructure proc cols conf apiRequest =
                         , Just $ contentRangeH 1 0 $ if shouldCount then Just queryTotal else Nothing
                         , if null pkCols && isNothing (iOnConflict apiRequest)
                             then Nothing
-                            else (\x -> ("Preference-Applied", encodeUtf8 (show x))) <$> iPreferResolution apiRequest
+                            else (\x -> ("Preference-Applied", BS.pack (show x))) <$> iPreferResolution apiRequest
                         ] ++ ctHeaders)) (unwrapGucHeader <$> ghdrs)
                   if contentType == CTSingularJSON && queryTotal /= 1
                     then do

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -62,10 +62,10 @@ decodeContentType ct = case BS.takeWhile (/= BS.c2w ';') ct of
   ct'                                 -> CTOther ct'
 
 -- | A SQL query that can be executed independently
-type SqlQuery = Text
+type SqlQuery = ByteString
 
 -- | A part of a SQL query that cannot be executed independently
-type SqlFragment = Text
+type SqlFragment = ByteString
 
 data PreferResolution = MergeDuplicates | IgnoreDuplicates deriving Eq
 instance Show PreferResolution where

--- a/test/QueryCost.hs
+++ b/test/QueryCost.hs
@@ -68,7 +68,7 @@ exec pool input query =
 
 explainCost :: SqlQuery -> H.Statement ByteString (Maybe Int64)
 explainCost query =
-  H.Statement (encodeUtf8 sql) (HE.param $ HE.nonNullable HE.unknown) decodeExplain False
+  H.Statement sql (HE.param $ HE.nonNullable HE.unknown) decodeExplain False
  where
    sql = "EXPLAIN (FORMAT JSON) " <> query
    decodeExplain :: HD.Result (Maybe Int64)


### PR DESCRIPTION
Improves performance by not utf8 encoding the full queries with `encodeUtf8`(done in `unicodeStatement`). It only encodes certain parts like pg identifiers and literals.

I get around ~220 req/s more on my load tests more with this change.

This is also a gradual step needed to use the Snippet type from [hasql-dynamic-statements](http://hackage.haskell.org/package/hasql-dynamic-statements-0.3.1/docs/Hasql-DynamicStatements-Snippet.html). We'll get prepared statements for GET when this library is integrated.