### PR TITLE
Fix embedding through views with subqueries inside function calls

### DIFF
--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -454,6 +454,12 @@ spec actualPgVersion = do
           [json|[{"title":"1984","first_publisher":"Secker & Warburg","author":{"name":"George Orwell"}}]|]
           { matchHeaders = [matchContentTypeJson] }
 
+      it "works with views that have subselects in a function call" $
+        get "/authors_have_book_in_decade2?select=*,books(title)&id=eq.3"
+          `shouldRespondWith`
+            [json|[ {"id":3,"name":"Antoine de Saint-Exupéry","has_book_in_forties":true,"has_book_in_fifties":false,
+                     "has_book_in_sixties":false,"books":[{"title":"The Little Prince"}]} ]|]
+
       it "works with views that have CTE" $
         get "/odd_years_publications?select=title,publication_year,first_publisher,author:authors(name)&id=in.(1,2,3)" `shouldRespondWith`
           [json|[

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -96,6 +96,7 @@ GRANT ALL ON TABLE
     , jsonb_test
     , authors_books_number
     , authors_have_book_in_decade
+    , authors_have_book_in_decade2
     , forties_and_fifties_books
     , odd_years_publications
     , foos

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1433,6 +1433,24 @@ select
   end as has_book_in_sixties
 from private.authors x;
 
+create view test.authors_have_book_in_decade2 as
+select
+  id,
+  name,
+  coalesce(
+    (select true from test.forties_books where author_id=x.id limit 1),
+    false
+  ) as has_book_in_forties,
+  coalesce(
+    (select true from test.fifties_books where author_id=x.id limit 1),
+    false
+  ) as has_book_in_fifties,
+  coalesce(
+    (select true from test.sixties_books where author_id=x.id limit 1),
+    false
+  ) as has_book_in_sixties
+from private.authors x;
+
 create view test.forties_and_fifties_books as
 select x.id, x.title, x.publication_year, y.name as first_publisher, x.author_id
 from (


### PR DESCRIPTION
Resolves #1608, resolves #1635.

This is on top of the changes in #1625. Will rebase, once the other one is merged.

Background:
Due to the nested nature of `pg_node_tree`, it is not possible to correctly parse all kinds of views with just a regex. This replaces that parsing by using the postgres `json` parser. First the `pg_node_tree` is reformatted to proper json with a series of `replace()` and `regexp_replace()` calls. After that, a cast to json is possible and the TargetEntries can easily be extracted.

The json that is produced is a very much stripped down version of the node tree, that has just two parts left:
- the fields that we require for our query
- the whole structure, i.e. all object and array brackets with some empty string keys, where required

It looks roughly like this:
```json
[
  {
    "": [
      {"":{},"":{}},
      {"":{},"":{}},
      {"":{}},
      {"":{}},
      {"":{}},
      {"":{},"":[{},{},{},{},{},{},{},{},{},{},{},{},{},{}]},
      {"":{},"":[{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}]}
    ],
    "": {
      "":[{"":{},"":{"":{},"":{},"":{"":[{},{}]}},"":{"":[{},{}]}}],
      "":{"":[{},{"":[{},{},{}]}]}
    },
    "targetList": [
      {
        "": {},
        "resno": 1,
        "resorigtbl": 27118,
        "resorigcol": 1
      },
      {
        "": {},
        "resno": 2,
        "resorigtbl": 27118,
        "resorigcol": 2
      },
      {
        "": {},
        "resno": 3,
        "resorigtbl": 27118,
        "resorigcol": 3
      }
    ],
    "": [{},{}]
  }
]
```

Using the big test schema, I get 1 more available column to embed on and the following timings for n=100:

```
query  | plan [ms] | execution [ms]
master | 1.71      | 681.5
#1625  | 2.60      | 417.5
json   | 2.67      | 574.2
```

Those numbers are from a different (less powerful) machine compared to those reported in #1625. Here I don't get a factor of 2x between master and the optimized regex query, more like 1,5x. Considering that I started with ~8000ms for the json approach, I'm quite happy that I was able to make it faster than the current master.

While #1625 is even faster, the json approach has a lot of upside, not only the "subquery inside a function call" that I had fixed initially. Since we now have the full node tree available, we can extend the parsing to support set operations (unions, ...). This will be part of a diffrent PR, though. Once we support UNION, we should be able to give embedding hints (#1179) like this:

```sql
CREATE VIEW xy AS
SELECT a, b, foreign_key_column FROM base_table WHERE false
UNION
SELECT my_regular_view_which_is_not_detected_because_of_crazy_functions
FROM base_table
```

The first select would basically serve as an embedding hint producing no rows. 

_@steve-chavez: Since this is still faster than current master/v7, I think you will still be able to call it "The Performance Release" if you want to, even when you merge both #1625 and this one. ;)_
