### PR TITLE
run stylish-haskell v0.12.1.0

### DIFF
--- a/src/PostgREST/DbRequestBuilder.hs
+++ b/src/PostgREST/DbRequestBuilder.hs
@@ -303,7 +303,7 @@ mutateRequest schema tName apiRequest pkCols readReq = mapLeft errorResponseFor 
            not (null (S.fromList pkCols)) &&
            all (\case
               Filter _ (OpExpr False (Op "eq" _)) -> True
-              _ -> False) flts
+              _                                   -> False) flts
           then Insert qi (iColumns apiRequest) (Just (MergeDuplicates, pkCols)) <$> combinedLogic <*> pure returnings
         else
           Left InvalidFilters) =<< filters


### PR DESCRIPTION
I updated stylish-haskell again (after it was broken in #1616 at first) and now I only get a small diff, that doesn't look too bad.

Couldn't get nix-shell to run yet, so I'm not sure whether the older stylish-haskell will revert this change... Let's see whether CI complains!