### PR TITLE
Add nightly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,19 +224,27 @@ workflows:
           # Make sure that this job also runs when releases are tagged.
           filters:
             tags:
-              only: /v[0-9]+(\.[0-9]+)*/
+              only:
+                - /v[0-9]+(\.[0-9]+)*/
+                - nightly
       - stack-test:
           filters:
             tags:
-              only: /v[0-9]+(\.[0-9]+)*/
+              only:
+                - /v[0-9]+(\.[0-9]+)*/
+                - nightly
       - stack-test-memory:
           filters:
             tags:
-              only: /v[0-9]+(\.[0-9]+)*/
+              only:
+                - /v[0-9]+(\.[0-9]+)*/
+                - nightly
       - nix-build-test:
           filters:
             tags:
-              only: /v[0-9]+(\.[0-9]+)*/
+              only:
+                - /v[0-9]+(\.[0-9]+)*/
+                - nightly
       - release:
           requires:
             - style-check
@@ -245,6 +253,8 @@ workflows:
             - nix-build-test
           filters:
             tags:
-              only: /v[0-9]+(\.[0-9]+)*/
+              only:
+                - /v[0-9]+(\.[0-9]+)*/
+                - nightly
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,14 @@ jobs:
             nix-env -iA cachix -f https://cachix.org/api/v1/install
             cachix use postgrest
       - run:
+          name: Change postgrest.cabal if nightly
+          command: |
+            if test "$CIRCLE_TAG" = "nightly"
+            then
+              cabal_nightly_version=$(git show -s --format='%cd' --date='format:%Y%m%d')
+              sed -i "s/^version:.*/version:$cabal_nightly_version/" postgrest.cabal
+            fi
+      - run:
           name: Build all derivations from default.nix and push results to Cachix
           command: |
             # Only push to the cache when CircleCI makes the CACHIX_SIGNING_KEY

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ jobs:
           name: Publish Docker images
           command: |
             export DOCKER_REPO=postgrest
-            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            postgrest-docker-login
             postgrest-release-dockerhub
             postgrest-release-dockerhubdescription
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,13 +140,13 @@ jobs:
           command: |
             export GITHUB_USERNAME="$CIRCLE_PROJECT_USERNAME"
             export GITHUB_REPONAME="$CIRCLE_PROJECT_REPONAME"
-            postgrest-release-github
+            postgrest-release-github $CIRCLE_TAG
       - run:
           name: Publish Docker images
           command: |
             export DOCKER_REPO=postgrest
             postgrest-docker-login
-            postgrest-release-dockerhub
+            postgrest-release-dockerhub $CIRCLE_TAG
             postgrest-release-dockerhubdescription
 
   # Build everything in default.nix, push to the Cachix binary cache and run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,10 +119,14 @@ jobs:
   # Publish a new release. This only runs when a release is tagged (see
   # workflow below).
   release:
-    docker:
-      - image: nixos/nix:2.3
+    machine: true
     steps:
       - checkout
+      - run:
+          name: Install Nix
+          command: |
+            curl -L https://nixos.org/nix/install | sh
+            echo "source $HOME/.nix-profile/etc/profile.d/nix.sh" >> $BASH_ENV
       - run:
           name: Install and use the Cachix binary cache
           command: |
@@ -137,7 +141,6 @@ jobs:
             export GITHUB_USERNAME="$CIRCLE_PROJECT_USERNAME"
             export GITHUB_REPONAME="$CIRCLE_PROJECT_REPONAME"
             postgrest-release-github
-      - setup_remote_docker
       - run:
           name: Publish Docker images
           command: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,7 +10,7 @@ build_task:
     folder: /var/cache/pkg
 
   install_script:
-    - pkg install -y postgresql95-client ghc hs-cabal-install jq
+    - pkg install -y postgresql95-client ghc hs-cabal-install jq git
 
   # cache the hackage index file and downloads which are
   # cabal v2-update downloads an incremental update, so we don't need to keep this up2date
@@ -43,9 +43,7 @@ build_task:
 
         if test $CIRRUS_TAG = "nightly"
         then
-          date=$(date +'%F')
-          sha=$(echo $CIRRUS_CHANGE_IN_REPO | head -c7)
-          suffix=$date-$sha
+          suffix=$(git show -s --format="%cd-%h" --date="format:%Y-%m-%d-%H-%M")
           bin_name=postgrest-nightly-$suffix-freebsd.tar.xz
         else
           bin_name=postgrest-$CIRRUS_TAG-freebsd.tar.xz

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,14 +2,16 @@ freebsd_instance:
   image: freebsd-12-1-release-amd64
 
 build_task:
+  env:
+    TOKEN: ENCRYPTED[c99babbf04e8a33962ffbbc75bf20d3abe408f9bede5ed5d8956cd24da6fdb34266c920984cc43f8106ef3423fba0e98]
   # caches the freebsd package downloads
   # saves probably just a couple of seconds, but hey...
   pkg_cache:
     folder: /var/cache/pkg
 
   install_script:
-    - pkg install -y postgresql95-client ghc hs-cabal-install
-  
+    - pkg install -y postgresql95-client ghc hs-cabal-install jq
+
   # cache the hackage index file and downloads which are
   # cabal v2-update downloads an incremental update, so we don't need to keep this up2date
   packages_cache:
@@ -29,5 +31,35 @@ build_task:
     - cabal v2-update
     - cabal v2-build
 
-  binaries_artifacts:
-    path: "dist-newstyle/build/x86_64-freebsd/ghc-8.6.5/postgrest-7.0.1/x/postgrest/build/postgrest/*"
+  publish_script:
+    - |
+      if test ! "$CIRRUS_TAG"
+      then
+        echo 'No tag pushed. Skip release.'
+      else
+        cabal v2-install
+
+        bin_name=""
+
+        if test $CIRRUS_TAG = "nightly"
+        then
+          date=$(date +'%F')
+          sha=$(echo $CIRRUS_CHANGE_IN_REPO | head -c7)
+          suffix=$date-$sha
+          bin_name=postgrest-nightly-$suffix-freebsd.tar.xz
+        else
+          bin_name=postgrest-$CIRRUS_TAG-freebsd.tar.xz
+        fi
+
+        release_id=$(curl -s https://api.github.com/repos/$CIRRUS_REPO_FULL_NAME/releases/tags/$CIRRUS_TAG | jq .id)
+
+        echo "Uploading $bin_name to gh release: $release_id"
+
+        tar cvJf $bin_name --dereference -C /.cabal/bin postgrest
+
+        ## We don't use ghr here because it doesn't provide freebsd binaries: https://github.com/tcnksm/ghr/issues/127
+        curl -X POST --data-binary @$bin_name \
+          -H "Authorization:token $TOKEN" \
+          -H "Content-Type:application/octet-stream" \
+          "https://uploads.github.com/repos/$CIRRUS_REPO_FULL_NAME/releases/$release_id/assets?name=$bin_name"
+      fi

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,6 +29,12 @@ build_task:
 
   build_script:
     - cabal v2-update
+    - |
+      if test "$CIRRUS_TAG" = "nightly"
+      then
+        cabal_nightly_version=$(git show -s --format='%cd' --date='format:%Y%m%d')
+        sed -i '' "s/^version:.*/version:$cabal_nightly_version/" postgrest.cabal
+      fi
     - cabal v2-build
 
   publish_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,12 @@ jobs:
             rm ghr.zip
           fi
       script:
+        - |
+          if test "$TRAVIS_TAG" = "nightly"
+          then
+            cabal_nightly_version=$(git show -s --format='%cd' --date='format:%Y%m%d')
+            sed -i '' "s/^version:.*/version:$cabal_nightly_version/" postgrest.cabal
+          fi
         ## Building the whole project can take longer than 50 minutes. Since Travis has a global timeout of 50 minutes
         ## we compile for 30 minutes tops(`gtimeout 1800`) and quit compiling with no error.
         ## Since we CACHE the compile results we can continue compiling from where we left off

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,9 +59,7 @@ jobs:
             repo="$(echo "$TRAVIS_REPO_SLUG" | cut -f2 -d/)"
             if test $TRAVIS_TAG = "nightly"
             then
-              date=$(date +'%F')
-              sha=$(echo $TRAVIS_COMMIT | head -c7)
-              suffix=$date-$sha
+              suffix=$(git show -s --format="%cd-%h" --date="format:%Y-%m-%d-%H-%M")
               strip postgrest
               tar cJf postgrest-nightly-$suffix-osx.tar.xz postgrest
               ghr -t $GITHUB_TOKEN -u $owner -r $repo --replace nightly postgrest-nightly-$suffix-osx.tar.xz

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,14 +55,24 @@ jobs:
           then
             echo 'No tag pushed. Skipping release.'
           else
-            OWNER="$(echo "$TRAVIS_REPO_SLUG" | cut -f1 -d/)"
-            REPO="$(echo "$TRAVIS_REPO_SLUG" | cut -f2 -d/)"
-            START=$(echo $TRAVIS_TAG | cut -c2-)
-            END='## \['
-            BODY=$(sed -n "1,/$START/d;/$END/q;p" CHANGELOG.md)
-            strip postgrest
-            tar cJf postgrest-$TRAVIS_TAG-osx.tar.xz postgrest
-            ghr -t $GITHUB_TOKEN -u $OWNER -r $REPO -b "$BODY"--replace $TRAVIS_TAG postgrest-$TRAVIS_TAG-osx.tar.xz
+            owner="$(echo "$TRAVIS_REPO_SLUG" | cut -f1 -d/)"
+            repo="$(echo "$TRAVIS_REPO_SLUG" | cut -f2 -d/)"
+            if test $TRAVIS_TAG = "nightly"
+            then
+              date=$(date +'%F')
+              sha=$(echo $TRAVIS_COMMIT | head -c7)
+              suffix=$date-$sha
+              strip postgrest
+              tar cJf postgrest-nightly-$suffix-osx.tar.xz postgrest
+              ghr -t $GITHUB_TOKEN -u $owner -r $repo --replace nightly postgrest-nightly-$suffix-osx.tar.xz
+            else
+              start=$TRAVIS_TAG
+              end='## \['
+              body=$(sed -n "1,/$start/d;/$end/q;p" CHANGELOG.md)
+              strip postgrest
+              tar cJf postgrest-$TRAVIS_TAG-osx.tar.xz postgrest
+              ghr -t $GITHUB_TOKEN -u $owner -r $repo -b "$body"--replace $TRAVIS_TAG postgrest-$TRAVIS_TAG-osx.tar.xz
+            fi
           fi
 
     - name: Code Coverage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,5 +32,16 @@ artifacts:
 - path: postgrest.exe
 
 deploy_script:
-- IF DEFINED APPVEYOR_REPO_TAG_NAME 7z a -tzip postgrest-%APPVEYOR_REPO_TAG_NAME%-windows-x64.zip postgrest.exe
-- IF DEFINED APPVEYOR_REPO_TAG_NAME bash -lc " exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && ghr -t $GITHUB_TOKEN -u $APPVEYOR_ACCOUNT_NAME -r $APPVEYOR_PROJECT_NAME -b \"$(sed -n \"1,/$(echo $APPVEYOR_REPO_TAG_NAME | cut -c2-)/d;/## \[/q;p\" CHANGELOG.md)\" --replace $APPVEYOR_REPO_TAG_NAME postgrest-$APPVEYOR_REPO_TAG_NAME-windows-x64.zip"
+## set the env vars outside of the IF because that doesn't work: https://stackoverflow.com/questions/9102422/windows-batch-set-inside-if-not-working
+- set DATE=%APPVEYOR_REPO_COMMIT_TIMESTAMP:~0,10%
+- set SHA=%APPVEYOR_REPO_COMMIT:~0,7%
+- set SUFFIX=%DATE%-%SHA%
+- IF DEFINED APPVEYOR_REPO_TAG_NAME (
+    IF "%APPVEYOR_REPO_TAG_NAME%"=="nightly" (
+      7z a -tzip postgrest-nightly-%SUFFIX%-windows-x64.zip postgrest.exe &&
+      bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && ghr -t $GITHUB_TOKEN -u $APPVEYOR_ACCOUNT_NAME -r $APPVEYOR_PROJECT_NAME --replace nightly postgrest-nightly-$SUFFIX-windows-x64.zip"
+    ) ELSE (
+      7z a -tzip postgrest-%APPVEYOR_REPO_TAG_NAME%-windows-x64.zip postgrest.exe &&
+      bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && ghr -t $GITHUB_TOKEN -u $APPVEYOR_ACCOUNT_NAME -r $APPVEYOR_PROJECT_NAME -b \"`sed -n \"1,/$APPVEYOR_REPO_TAG_NAME/d;/## \[/q;p\" CHANGELOG.md`\" --replace $APPVEYOR_REPO_TAG_NAME postgrest-$APPVEYOR_REPO_TAG_NAME-windows-x64.zip"
+    )
+  )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,8 @@ install:
 - go get -u github.com/tcnksm/ghr
 
 build_script:
+- ps: $env:cabal_nightly_version=(git show -s --format='%cd' --date='format:%Y%m%d')
+- IF "%APPVEYOR_REPO_TAG_NAME%"=="nightly" bash -lc "sed -i -r \"s/^(version:\s+)\S+$/\1$cabal_nightly_version/\" postgrest.cabal"
 - stack setup --no-terminal > nul
 # Appveyor has a timeout of 60 mins, building can take longer, limit the time and make sure this succeeds,
 # previous work will get cached and finish on next commit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,14 +32,12 @@ artifacts:
 - path: postgrest.exe
 
 deploy_script:
-## set the env vars outside of the IF because that doesn't work: https://stackoverflow.com/questions/9102422/windows-batch-set-inside-if-not-working
-- set DATE=%APPVEYOR_REPO_COMMIT_TIMESTAMP:~0,10%
-- set SHA=%APPVEYOR_REPO_COMMIT:~0,7%
-- set SUFFIX=%DATE%-%SHA%
+## Use powershell(ps) for this because CMD commands having "%" don't work(even by escaping with "%%"). See https://github.com/appveyor/ci/issues/246.
+- ps: $env:suffix=(git show -s --format="%cd-%h" --date="format:%Y-%m-%d-%H-%M")
 - IF DEFINED APPVEYOR_REPO_TAG_NAME (
     IF "%APPVEYOR_REPO_TAG_NAME%"=="nightly" (
-      7z a -tzip postgrest-nightly-%SUFFIX%-windows-x64.zip postgrest.exe &&
-      bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && ghr -t $GITHUB_TOKEN -u $APPVEYOR_ACCOUNT_NAME -r $APPVEYOR_PROJECT_NAME --replace nightly postgrest-nightly-$SUFFIX-windows-x64.zip"
+      7z a -tzip postgrest-nightly-%suffix%-windows-x64.zip postgrest.exe &&
+      bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && ghr -t $GITHUB_TOKEN -u $APPVEYOR_ACCOUNT_NAME -r $APPVEYOR_PROJECT_NAME --replace nightly postgrest-nightly-$suffix-windows-x64.zip"
     ) ELSE (
       7z a -tzip postgrest-%APPVEYOR_REPO_TAG_NAME%-windows-x64.zip postgrest.exe &&
       bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && ghr -t $GITHUB_TOKEN -u $APPVEYOR_ACCOUNT_NAME -r $APPVEYOR_PROJECT_NAME -b \"`sed -n \"1,/$APPVEYOR_REPO_TAG_NAME/d;/## \[/q;p\" CHANGELOG.md`\" --replace $APPVEYOR_REPO_TAG_NAME postgrest-$APPVEYOR_REPO_TAG_NAME-windows-x64.zip"

--- a/nix/release/default.nix
+++ b/nix/release/default.nix
@@ -41,6 +41,15 @@ let
           --replace v${version} \
           ${releaseFiles}
       '';
+  # Wrapper for login with docker. $DOCKER_USER/$DOCKER_PASS vars come from CircleCI.
+  # The DOCKER_USER is not the same as DOCKER_REPO because we use the https://hub.docker.com/u/postgrestbot account for uploading to dockerhub.
+  dockerLogin =
+    writeShellScriptBin "postgrest-docker-login"
+      ''
+        set -euo pipefail
+
+        docker login -u $DOCKER_USER -p $DOCKER_PASS
+      '';
 
   # Script for publishing a new release on Docker Hub.
   dockerHub =
@@ -97,5 +106,5 @@ let
 in
 buildEnv {
   name = "postgrest-release";
-  paths = [ github dockerHub dockerHubDescription ];
+  paths = [ github dockerLogin dockerHub dockerHubDescription ];
 }

--- a/nix/release/default.nix
+++ b/nix/release/default.nix
@@ -22,9 +22,7 @@ let
 
         if test $version = "nightly"
         then
-          date=$(date +'%F')
-          sha=$(echo $CIRCLE_SHA1 | head -c7)
-          suffix=$date-$sha
+          suffix=$(git show -s --format="%cd-%h" --date="format:%Y-%m-%d-%H-%M")
           tar cvJf postgrest-nightly-$suffix-linux-x64-static.tar.xz \
             -C ${postgrest}/bin postgrest
 
@@ -72,9 +70,7 @@ let
 
         if test $version = "nightly"
         then
-          date=$(date +'%F')
-          sha=$(echo $CIRCLE_SHA1 | head -c7)
-          suffix=$date-$sha
+          suffix=$(git show -s --format="%cd-%h" --date="format:%Y-%m-%d-%H-%M")
 
           docker tag postgrest:latest "$DOCKER_REPO"/postgrest:nightly-$suffix
           docker push "$DOCKER_REPO"/postgrest:nightly-$suffix

--- a/nix/release/default.nix
+++ b/nix/release/default.nix
@@ -81,9 +81,9 @@ let
 
         # Login to Docker Hub and get a token.
         token="$(
-          ${curl}/bin/curl -sH "Content-Type: application/json" \
-            --data-urlencode "username=$DOCKER_USERNAME" \
-            --data-urlencode "password=$DOCKER_PASSWORD" \
+          ${curl}/bin/curl -s \
+            --data-urlencode "username=$DOCKER_USER" \
+            --data-urlencode "password=$DOCKER_PASS" \
             "https://hub.docker.com/v2/users/login/" \
             | ${jq}/bin/jq -r .token
         )"


### PR DESCRIPTION
Fixes #1645. Adds nightly builds for Linux, Windows, OSX, FreeBSD. The results would look like this(using my own repos for the examples): 

- For github: https://github.com/steve-chavez/postgrest/releases/tag/nightly.
- For dockerhub: https://hub.docker.com/layers/stevechavez/postgrest/nightly-2020-11-09-bd4ddd0/images/sha256-4bade454085b08006f6d307a4b0deec63c769d7c7500bf4a55dfee972cbedd0d

### Reasoning

Didn't like the idea of spamming the GitHub releases page and creating tags with every build, so all the nightly builds will be added on a single release. For dockerhub, new tags will be created.

### Workflow

The workflow is partly manual and partly automated. These manual steps are required for releasing a nightly:

```bash
git tag -f nightly
git push <remote> nightly -f
```

Then all of the CI's process should kick in and release the nightlies.

I think the workflow is good because not every commit(refactors, ci changes, readme, etc) would need a nightly.