### PR TITLE
Add support for Prefer tx=rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #1559, No downtime when reloading the schema cache with SIGUSR1 - @steve-chavez
  - #504, Add `log-level` config option. The admitted levels are: crit, error, warn and info - @steve-chavez
  - #1607, Enable embedding through multiple views recursively - @wolfgangwalther
+ - #1598, Allow rollback of the transaction with Prefer tx=rollback - @wolfgangwalther
 
 ### Fixed
  

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -154,8 +154,10 @@ test-suite spec
                       Feature.DeleteSpec
                       Feature.EmbedDisambiguationSpec
                       Feature.ExtraSearchPathSpec
+                      Feature.HtmlRawOutputSpec
                       Feature.InsertSpec
                       Feature.JsonOperatorSpec
+                      Feature.MultipleSchemaSpec
                       Feature.NoJwtSpec
                       Feature.NonexistentSchemaSpec
                       Feature.OpenApiSpec
@@ -164,6 +166,8 @@ test-suite spec
                       Feature.QueryLimitedSpec
                       Feature.QuerySpec
                       Feature.RangeSpec
+                      Feature.RawOutputTypesSpec
+                      Feature.RollbackSpec
                       Feature.RootSpec
                       Feature.RpcPreRequestGucsSpec
                       Feature.RpcSpec
@@ -171,9 +175,6 @@ test-suite spec
                       Feature.UnicodeSpec
                       Feature.UpdateSpec
                       Feature.UpsertSpec
-                      Feature.RawOutputTypesSpec
-                      Feature.HtmlRawOutputSpec
-                      Feature.MultipleSchemaSpec
                       SpecHelper
                       TestTypes
   hs-source-dirs:     test

--- a/src/PostgREST/Types.hs
+++ b/src/PostgREST/Types.hs
@@ -109,6 +109,15 @@ instance Show PreferCount where
   show PlannedCount   = "count=planned"
   show EstimatedCount = "count=estimated"
 
+data PreferTransaction
+  = Commit   -- Commit transaction - the default.
+  | Rollback -- Rollback transaction after sending the response - does not persist changes, e.g. for running tests.
+  deriving Eq
+
+instance Show PreferTransaction where
+  show Commit   = "tx=commit"
+  show Rollback = "tx=rollback"
+
 data DbStructure = DbStructure {
   dbTables      :: [Table]
 , dbColumns     :: [Column]

--- a/test/Feature/RollbackSpec.hs
+++ b/test/Feature/RollbackSpec.hs
@@ -1,0 +1,218 @@
+module Feature.RollbackSpec where
+
+import Network.Wai (Application)
+
+import Network.HTTP.Types
+import Test.Hspec
+import Test.Hspec.Wai
+import Test.Hspec.Wai.JSON
+
+import Protolude  hiding (get)
+import SpecHelper
+
+-- two helpers functions to make sure that each test can setup and cleanup properly
+
+-- creates Item to work with for PATCH and DELETE
+postItem =
+  request methodPost "/items"
+      [("Prefer", "resolution=ignore-duplicates")]
+      [json|{"id":0}|]
+    `shouldRespondWith`
+      ""
+      { matchStatus  = 201 }
+
+-- removes Items left over from POST, PUT, and PATCH
+deleteItems =
+  delete "/items?id=lte.0"
+    `shouldRespondWith`
+      ""
+      { matchStatus  = 204 }
+
+preferDefault  = [("Prefer", "return=representation")]
+preferCommit   = [("Prefer", "return=representation"), ("Prefer", "tx=commit")]
+preferRollback = [("Prefer", "return=representation"), ("Prefer", "tx=rollback")]
+
+withoutPreferenceApplied      = []
+withPreferenceCommitApplied   = [ "Preference-Applied" <:> "tx=commit" ]
+withPreferenceRollbackApplied = [ "Preference-Applied" <:> "tx=rollback" ]
+
+shouldRespondToReads reqHeaders respHeaders = do
+  it "responds to GET" $ do
+    request methodGet "/items?id=eq.1"
+        reqHeaders
+        ""
+      `shouldRespondWith`
+        [json|[{"id":1}]|]
+        { matchHeaders = respHeaders }
+
+  it "responds to HEAD" $ do
+    request methodHead "/items?id=eq.1"
+        reqHeaders
+        ""
+      `shouldRespondWith`
+        ""
+        { matchHeaders = respHeaders }
+
+  it "responds to GET on RPC" $ do
+    request methodGet "/rpc/search?id=1"
+        reqHeaders
+        ""
+      `shouldRespondWith`
+        [json|[{"id":1}]|]
+        { matchHeaders = respHeaders }
+
+  it "responds to POST on RPC" $ do
+    request methodPost "/rpc/search"
+        reqHeaders
+        [json|{"id":1}|]
+      `shouldRespondWith`
+        [json|[{"id":1}]|]
+        { matchHeaders = respHeaders }
+
+shouldPersistMutations reqHeaders respHeaders = do
+  it "does persist post" $ do
+    request methodPost "/items"
+        reqHeaders
+        [json|{"id":0}|]
+      `shouldRespondWith`
+        [json|[{"id":0}]|]
+        { matchStatus  = 201
+        , matchHeaders = respHeaders }
+    get "items?id=eq.0"
+      `shouldRespondWith`
+        [json|[{"id":0}]|]
+    deleteItems
+
+  it "does persist put" $ do
+    request methodPut "/items?id=eq.0"
+        reqHeaders
+        [json|{"id":0}|]
+      `shouldRespondWith`
+        [json|[{"id":0}]|]
+        { matchHeaders = respHeaders }
+    get "items?id=eq.0"
+      `shouldRespondWith`
+        [json|[{"id":0}]|]
+    deleteItems
+
+  it "does persist patch" $ do
+    postItem
+    request methodPatch "/items?id=eq.0"
+        reqHeaders
+        [json|{"id":-1}|]
+      `shouldRespondWith`
+        [json|[{"id":-1}]|]
+        { matchHeaders = respHeaders }
+    get "items?id=eq.0"
+      `shouldRespondWith`
+        [json|[]|]
+    get "items?id=eq.-1"
+      `shouldRespondWith`
+        [json|[{"id":-1}]|]
+    deleteItems
+
+  it "does persist delete" $ do
+    postItem
+    request methodDelete "/items?id=eq.0"
+        reqHeaders
+        ""
+      `shouldRespondWith`
+        [json|[{"id":0}]|]
+        { matchHeaders = respHeaders }
+    get "items?id=eq.0"
+      `shouldRespondWith`
+        [json|[]|]
+
+shouldNotPersistMutations reqHeaders respHeaders = do
+  it "does not persist post" $ do
+    request methodPost "/items"
+        reqHeaders
+        [json|{"id":0}|]
+      `shouldRespondWith`
+        [json|[{"id":0}]|]
+        { matchStatus  = 201
+        , matchHeaders = respHeaders }
+    get "items?id=eq.0"
+      `shouldRespondWith`
+        [json|[]|]
+
+  it "does not persist put" $ do
+    request methodPut "/items?id=eq.0"
+        reqHeaders
+        [json|{"id":0}|]
+      `shouldRespondWith`
+        [json|[{"id":0}]|]
+        { matchHeaders = respHeaders }
+    get "items?id=eq.0"
+      `shouldRespondWith`
+        [json|[]|]
+
+  it "does not persist patch" $ do
+    request methodPatch "/items?id=eq.1"
+        reqHeaders
+        [json|{"id":0}|]
+      `shouldRespondWith`
+        [json|[{"id":0}]|]
+        { matchHeaders = respHeaders }
+    get "items?id=eq.0"
+      `shouldRespondWith`
+        [json|[]|]
+    get "items?id=eq.1"
+      `shouldRespondWith`
+        [json|[{"id":1}]|]
+
+  it "does not persist delete" $ do
+    request methodDelete "/items?id=eq.1"
+        reqHeaders
+        ""
+      `shouldRespondWith`
+        [json|[{"id":1}]|]
+        { matchHeaders = respHeaders }
+    get "items?id=eq.1"
+      `shouldRespondWith`
+        [json|[{"id":1}]|]
+
+allowed :: SpecWith ((), Application)
+allowed = describe "tx-allow-override = true" $ do
+  describe "without Prefer tx" $ do
+    -- TODO: Change this to default to rollback for whole test-suite
+    preferDefault `shouldRespondToReads` withoutPreferenceApplied
+    preferDefault `shouldPersistMutations` withoutPreferenceApplied
+
+  describe "Prefer tx=commit" $ do
+    preferCommit `shouldRespondToReads` withPreferenceCommitApplied
+    preferCommit `shouldPersistMutations` withPreferenceCommitApplied
+
+  describe "Prefer tx=rollback" $ do
+    preferRollback `shouldRespondToReads` withPreferenceRollbackApplied
+    preferRollback `shouldNotPersistMutations` withPreferenceRollbackApplied
+
+disallowed :: SpecWith ((), Application)
+disallowed = describe "tx-rollback-all = false, tx-allow-override = false" $ do
+  describe "without Prefer tx" $ do
+    preferDefault `shouldRespondToReads` withoutPreferenceApplied
+    preferDefault `shouldPersistMutations` withoutPreferenceApplied
+
+  describe "Prefer tx=commit" $ do
+    preferCommit `shouldRespondToReads` withoutPreferenceApplied
+    preferCommit `shouldPersistMutations` withoutPreferenceApplied
+
+  describe "Prefer tx=rollback" $ do
+    preferRollback `shouldRespondToReads` withoutPreferenceApplied
+    preferRollback `shouldPersistMutations` withoutPreferenceApplied
+
+
+forced :: SpecWith ((), Application)
+forced = describe "tx-rollback-all = true, tx-allow-override = false" $ do
+  describe "without Prefer tx" $ do
+    preferDefault `shouldRespondToReads` withoutPreferenceApplied
+    preferDefault `shouldNotPersistMutations` withoutPreferenceApplied
+
+  describe "Prefer tx=commit" $ do
+    preferCommit `shouldRespondToReads` withoutPreferenceApplied
+    preferCommit `shouldNotPersistMutations` withoutPreferenceApplied
+
+  describe "Prefer tx=rollback" $ do
+    preferRollback `shouldRespondToReads` withoutPreferenceApplied
+    preferRollback `shouldNotPersistMutations` withoutPreferenceApplied
+

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -43,6 +43,7 @@ import qualified Feature.QueryLimitedSpec
 import qualified Feature.QuerySpec
 import qualified Feature.RangeSpec
 import qualified Feature.RawOutputTypesSpec
+import qualified Feature.RollbackSpec
 import qualified Feature.RootSpec
 import qualified Feature.RpcPreRequestGucsSpec
 import qualified Feature.RpcSpec
@@ -87,6 +88,8 @@ main = do
       rootSpecApp          = app testCfgRootSpec
       htmlRawOutputApp     = app testCfgHtmlRawOutput
       responseHeadersApp   = app testCfgResponseHeaders
+      disallowRollbackApp  = app testCfgDisallowRollback
+      forceRollbackApp     = app testCfgForceRollback
 
       extraSearchPathApp   = appDbs testCfgExtraSearchPath
       unicodeApp           = appDbs testUnicodeCfg
@@ -109,6 +112,7 @@ main = do
         , ("Feature.OptionsSpec"             , Feature.OptionsSpec.spec)
         , ("Feature.QuerySpec"               , Feature.QuerySpec.spec actualPgVersion)
         , ("Feature.EmbedDisambiguationSpec" , Feature.EmbedDisambiguationSpec.spec)
+        , ("Feature.RollbackAllowedSpec"     , Feature.RollbackSpec.allowed)
         , ("Feature.RpcSpec"                 , Feature.RpcSpec.spec actualPgVersion)
         , ("Feature.AndOrParamsSpec"         , Feature.AndOrParamsSpec.spec actualPgVersion)
         , ("Feature.UpsertSpec"              , Feature.UpsertSpec.spec)
@@ -175,6 +179,13 @@ main = do
     before extraSearchPathApp $
       describe "Feature.ExtraSearchPathSpec" Feature.ExtraSearchPathSpec.spec
 
+    -- this test runs with tx-rollback-all = false and tx-allow-override = false
+    before disallowRollbackApp $
+      describe "Feature.RollbackDisallowedSpec" Feature.RollbackSpec.disallowed
+
+    -- this test runs with tx-rollback-all = true and tx-allow-override = false
+    before forceRollbackApp $
+      describe "Feature.RollbackForcedSpec" Feature.RollbackSpec.forced
 
     when (actualPgVersion >= pgVersion96) $ do
       -- this test runs with a root spec function override

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -90,10 +90,18 @@ _baseCfg = let secret = Just $ encodeUtf8 "reallyreallyreallyreallyverysafe" in
   , configRawMediaTypes     = []
   , configJWKS              = parseSecret <$> secret
   , configLogLevel          = LogCrit
+  , configTxRollbackAll     = False
+  , configTxAllowOverride   = True
   }
 
 testCfg :: Text -> AppConfig
 testCfg testDbConn = _baseCfg { configDbUri = testDbConn }
+
+testCfgDisallowRollback :: Text -> AppConfig
+testCfgDisallowRollback testDbConn = (testCfg testDbConn) { configTxRollbackAll = False, configTxAllowOverride = False }
+
+testCfgForceRollback :: Text -> AppConfig
+testCfgForceRollback testDbConn = (testCfg testDbConn) { configTxRollbackAll = True, configTxAllowOverride = False }
 
 testCfgNoJWT :: Text -> AppConfig
 testCfgNoJWT testDbConn = (testCfg testDbConn) { configJwtSecret = Nothing, configJWKS = Nothing }


### PR DESCRIPTION
Resolves #1598.

In that issue we discussed `Prefer: rollback` vs. `Prefer: tx=rollback`. I implemented the latter and also added `Prefer: tx=commit` (the default) for completeness (see #1656 as well).

---

This would also allow adding another config option to use `rollback` as the default, to be overwritten with `Prefer: tx=commit`. This would be something that I would run the test environment in my projects with, because those automated tests should almost never change the database for real.

Now that I write this, I wonder whether we should change the config option `allow-rollback` to something like `allow-prefer-tx` now. This would allow us to allow/deny the use of `tx=commit`, when the default is `rollback`.

The combo of `tx-default = rollback` and `allow-prefer-tx = false` could be a cool thing to setup a demo postgrest server, where everyone can make requests against a test schema immediately, maybe even from a web-interface?

Would `rollback-by-default = true | false` or `tx-default = commit | rollback` be better? Any other ideas?

---

Back to the current PR. `Prefer: tx=rollback` is only applied for POST, PUT, PATCH and DELETE requests and only when those do not return with an error. Not for GET and HEAD. The `Preference-Applied` header is set accordingly. When a request returns an error, the transaction is rolled back anyway, the error is returned regularly and the `Preference-Applied` header is not set.

TODO:

- [x] Add `Preference-Applied` header for explicit `tx=commit`.
- [x] Rename `allow-rollback` to `allow-prefer-tx` or something better
- [x] Add test for `ActionInvoke`
- [x] Add `rollback-by-default` config option

And then for another PR: Make `rollback` the default for our spec-tests. This will require quite a bit of cleanup. My goal would be to be able to run the whole test suite multiple times against the same database without recreating the schema.

