### PR TITLE
Make transaction-rollback=true the default for test-suite

### DIFF
--- a/test/Feature/DeleteSpec.hs
+++ b/test/Feature/DeleteSpec.hs
@@ -57,14 +57,6 @@ spec =
           , matchHeaders = ["Content-Range" <:> "*/*"]
           }
 
-      it "actually clears items ouf the db" $ do
-        _ <- request methodDelete "/items?id=lt.15" [] ""
-        get "/items"
-          `shouldRespondWith` [json|[{"id":15}]|]
-          { matchStatus  = 200
-          , matchHeaders = ["Content-Range" <:> "0-0/*"]
-          }
-
     context "known route, no records matched" $
       it "includes [] body if return=rep" $
         request methodDelete "/items?id=eq.101"

--- a/test/Feature/EmbedDisambiguationSpec.hs
+++ b/test/Feature/EmbedDisambiguationSpec.hs
@@ -194,9 +194,9 @@ spec =
             { matchHeaders = [matchContentTypeJson] }
 
         it "can request two parents with fks" $
-          get "/articleStars?select=createdAt,article(owner),user(name)&limit=1" `shouldRespondWith`
-            [json|[{"createdAt":"2015-12-08T04:22:57.472738","article":{"owner": "postgrest_test_authenticator"},"user":{"name": "Angela Martin"}}]|]
-            { matchHeaders = [matchContentTypeJson] }
+          get "/articleStars?select=createdAt,article(id),user(name)&limit=1"
+            `shouldRespondWith`
+              [json|[{"createdAt":"2015-12-08T04:22:57.472738","article":{"id": 1},"user":{"name": "Angela Martin"}}]|]
 
         it "can specify a view!fk" $
           get "/message?select=id,body,sender:person_detail!message_sender_fkey(name,sent),recipient:person_detail!message_recipient_fkey(name,received)&id=lt.4" `shouldRespondWith`

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -136,6 +136,13 @@ spec actualPgVersion = do
     context "with no pk supplied" $ do
       context "into a table with auto-incrementing pk" $
         it "succeeds with 201 and location header" $ do
+          -- reset pk sequence first to make test repeatable
+          request methodPost "/rpc/reset_sequence"
+              [("Prefer", "tx=commit")]
+              [json|{"name": "auto_incrementing_pk_id_seq", "value": 2}|]
+            `shouldRespondWith`
+              [json|""|]
+
           post "/auto_incrementing_pk"
               [json| { "non_nullable_string":"not null"} |]
             `shouldRespondWith`
@@ -282,16 +289,30 @@ spec actualPgVersion = do
           , matchHeaders = []
           }
 
-      it "successfully inserts a row with all-default columns with prefer=rep" $
+      it "successfully inserts a row with all-default columns with prefer=rep" $ do
+        -- reset pk sequence first to make test repeatable
+        request methodPost "/rpc/reset_sequence"
+            [("Prefer", "tx=commit")]
+            [json|{"name": "items_id_seq", "value": 20}|]
+          `shouldRespondWith`
+            [json|""|]
+
         request methodPost "/items" [("Prefer", "return=representation")] "{}"
           `shouldRespondWith` [json|[{ id: 20 }]|]
           { matchStatus  = 201,
             matchHeaders = []
           }
 
-      it "successfully inserts a row with all-default columns with prefer=rep and &select=" $
+      it "successfully inserts a row with all-default columns with prefer=rep and &select=" $ do
+        -- reset pk sequence first to make test repeatable
+        request methodPost "/rpc/reset_sequence"
+            [("Prefer", "tx=commit")]
+            [json|{"name": "items_id_seq", "value": 20}|]
+          `shouldRespondWith`
+            [json|""|]
+
         request methodPost "/items?select=id" [("Prefer", "return=representation")] "{}"
-          `shouldRespondWith` [json|[{ id: 21 }]|]
+          `shouldRespondWith` [json|[{ id: 20 }]|]
           { matchStatus  = 201,
             matchHeaders = []
           }

--- a/test/Feature/JsonOperatorSpec.hs
+++ b/test/Feature/JsonOperatorSpec.hs
@@ -202,12 +202,11 @@ spec actualPgVersion = describe "json and jsonb operators" $ do
 
   context "Patching record, in a nonempty table" $
     it "can set a json column to escaped value" $ do
-      _ <- post "/json_table" [json| { data: {"escaped":"bar"} } |]
-      request methodPatch "/json_table?data->>escaped=eq.bar"
-                   [("Prefer", "return=representation")]
-                   [json| { "data": { "escaped":" \"bar" } } |]
-        `shouldRespondWith` [json| [{ "data": { "escaped":" \"bar" } }] |]
-        { matchStatus  = 200 , matchHeaders = [] }
+      request methodPatch "/json_table?data->>id=eq.3"
+          [("Prefer", "return=representation")]
+          [json| { "data": { "id":" \"escaped" } } |]
+        `shouldRespondWith`
+          [json| [{ "data": { "id":" \"escaped" } }] |]
 
   when (actualPgVersion >= pgVersion95) $
     context "json array negative index" $ do

--- a/test/Feature/MultipleSchemaSpec.hs
+++ b/test/Feature/MultipleSchemaSpec.hs
@@ -77,33 +77,37 @@ spec actualPgVersion =
 
     context "Inserting tables on different schemas" $ do
       it "succeeds inserting on default schema and returning it" $
-        request methodPost "/children" [("Prefer", "return=representation")] [json|{"name": "child v1-1", "parent_id": 1}|]
-         `shouldRespondWith`
-         [json|[{"id":1, "name": "child v1-1", "parent_id": 1}]|]
-         {
-           matchStatus = 201
-         , matchHeaders = [matchContentTypeJson, "Content-Profile" <:> "v1"]
-         }
+        request methodPost "/children"
+            [("Prefer", "return=representation")]
+            [json|{"id": 0, "name": "child v1-1", "parent_id": 1}|]
+          `shouldRespondWith`
+            [json|[{"id": 0, "name": "child v1-1", "parent_id": 1}]|]
+            {
+              matchStatus = 201
+            , matchHeaders = ["Content-Profile" <:> "v1"]
+            }
 
       it "succeeds inserting on the v1 schema and returning its parent" $
-        request methodPost "/children?select=id,parent(*)" [("Prefer", "return=representation"), ("Content-Profile", "v1")]
-          [json|{"name": "child v1-2", "parent_id": 2}|]
+        request methodPost "/children?select=id,parent(*)"
+            [("Prefer", "return=representation"), ("Content-Profile", "v1")]
+            [json|{"id": 0, "name": "child v1-2", "parent_id": 2}|]
           `shouldRespondWith`
-          [json|[{"id":2, "parent": {"id": 2, "name": "parent v1-2"}}]|]
-          {
-            matchStatus = 201
-          , matchHeaders = [matchContentTypeJson, "Content-Profile" <:> "v1"]
-          }
+            [json|[{"id": 0, "parent": {"id": 2, "name": "parent v1-2"}}]|]
+            {
+              matchStatus = 201
+            , matchHeaders = ["Content-Profile" <:> "v1"]
+            }
 
       it "succeeds inserting on the v2 schema and returning its parent" $
-        request methodPost "/children?select=id,parent(*)" [("Prefer", "return=representation"), ("Content-Profile", "v2")]
-          [json|{"name": "child v2-3", "parent_id": 3}|]
+        request methodPost "/children?select=id,parent(*)"
+            [("Prefer", "return=representation"), ("Content-Profile", "v2")]
+            [json|{"id": 0, "name": "child v2-3", "parent_id": 3}|]
           `shouldRespondWith`
-          [json|[{"id":1, "parent": {"id": 3, "name": "parent v2-3"}}]|]
-          {
-            matchStatus = 201
-          , matchHeaders = [matchContentTypeJson, "Content-Profile" <:> "v2"]
-          }
+            [json|[{"id": 0, "parent": {"id": 3, "name": "parent v2-3"}}]|]
+            {
+              matchStatus = 201
+            , matchHeaders = ["Content-Profile" <:> "v2"]
+            }
 
       it "fails when inserting on an unknown schema" $
         request methodPost "/children" [("Content-Profile", "unknown")]
@@ -180,18 +184,12 @@ spec actualPgVersion =
           }
 
       it "succeeds on deleting on the v2 schema" $ do
-        request methodDelete "/children?id=eq.1" [("Content-Profile", "v2"), ("Prefer", "return=representation")] ""
-          `shouldRespondWith` [json|[{"id": 1, "name": "child v2-1 updated", "parent_id": 3}]|]
-          {
-            matchStatus = 200
-          , matchHeaders = [matchContentTypeJson, "Content-Profile" <:> "v2"]
-          }
-        request methodGet "/children?id=eq.1" [("Accept-Profile", "v2")] ""
-          `shouldRespondWith` "[]"
-          {
-            matchStatus = 200
-          , matchHeaders = [matchContentTypeJson, "Content-Profile" <:> "v2"]
-          }
+        request methodDelete "/children?id=eq.1"
+            [("Content-Profile", "v2"), ("Prefer", "return=representation")]
+            ""
+          `shouldRespondWith`
+            [json|[{"id": 1, "name": "child v2-3", "parent_id": 3}]|]
+            { matchHeaders = ["Content-Profile" <:> "v2"] }
 
       when (actualPgVersion >= pgVersion96) $
         it "succeeds on PUT on the v2 schema" $

--- a/test/Feature/QueryLimitedSpec.hs
+++ b/test/Feature/QueryLimitedSpec.hs
@@ -15,59 +15,56 @@ spec :: SpecWith ((), Application)
 spec =
   describe "Requesting many items with server limits(max-rows) enabled" $ do
     it "restricts results" $
-      get "/items"
-        `shouldRespondWith` [json| [{"id":1},{"id":2}] |]
-        { matchStatus  = 200
-        , matchHeaders = ["Content-Range" <:> "0-1/*"]
-        }
+      get "/items?order=id"
+        `shouldRespondWith`
+          [json| [{"id":1},{"id":2}] |]
+          { matchHeaders = ["Content-Range" <:> "0-1/*"] }
 
     it "respects additional client limiting" $ do
-      r <- request methodGet  "/items"
-                   (rangeHdrs $ ByteRangeFromTo 0 0) ""
-      liftIO $ do
-        simpleHeaders r `shouldSatisfy`
-          matchHeader "Content-Range" "0-0/*"
-        simpleStatus r `shouldBe` ok200
+      request methodGet  "/items"
+          (rangeHdrs $ ByteRangeFromTo 0 0)
+          ""
+        `shouldRespondWith`
+          [json| [{"id":1}] |]
+          { matchHeaders = ["Content-Range" <:> "0-0/*"] }
 
     it "works on all levels" $
       get "/users?select=id,tasks(id)&order=id.asc&tasks.order=id.asc"
-        `shouldRespondWith` [json|[{"id":1,"tasks":[{"id":1},{"id":2}]},{"id":2,"tasks":[{"id":5},{"id":6}]}]|]
-        { matchStatus  = 200
-        , matchHeaders = ["Content-Range" <:> "0-1/*"]
-        }
+        `shouldRespondWith`
+          [json|[{"id":1,"tasks":[{"id":1},{"id":2}]},{"id":2,"tasks":[{"id":5},{"id":6}]}]|]
+          { matchHeaders = ["Content-Range" <:> "0-1/*"] }
 
     it "succeeds in getting parent embeds despite the limit, see #647" $
       get "/tasks?select=id,project:projects(id)&id=gt.5"
-        `shouldRespondWith` [json|[{"id":6,"project":{"id":3}},{"id":7,"project":{"id":4}}]|]
-        { matchStatus  = 200
-        , matchHeaders = ["Content-Range" <:> "0-1/*"]
-        }
+        `shouldRespondWith`
+          [json|[{"id":6,"project":{"id":3}},{"id":7,"project":{"id":4}}]|]
+          { matchHeaders = ["Content-Range" <:> "0-1/*"] }
 
     it "can offset the parent embed, being consistent with the other embed types" $
       get "/tasks?select=id,project:projects(id)&id=gt.5&project.offset=1"
-        `shouldRespondWith` [json|[{"id":6,"project":null}, {"id":7,"project":null}]|]
-        { matchStatus  = 200
-        , matchHeaders = ["Content-Range" <:> "0-1/*"]
-        }
+        `shouldRespondWith`
+          [json|[{"id":6,"project":null}, {"id":7,"project":null}]|]
+          { matchHeaders = ["Content-Range" <:> "0-1/*"] }
 
     context "count=estimated" $ do
       it "uses the query planner guess when query rows > maxRows" $
         request methodHead "/getallprojects_view" [("Prefer", "count=estimated")] ""
-          `shouldRespondWith` ""
-          { matchStatus  = 206
-          , matchHeaders = ["Content-Range" <:> "0-1/2019"]
-          }
+          `shouldRespondWith`
+            ""
+            { matchStatus  = 206
+            , matchHeaders = ["Content-Range" <:> "0-1/2019"]
+            }
 
       it "gives exact count when query rows <= maxRows" $
         request methodHead "/getallprojects_view?id=lt.3" [("Prefer", "count=estimated")] ""
-          `shouldRespondWith` ""
-          { matchStatus  = 200
-          , matchHeaders = ["Content-Range" <:> "0-1/2"]
-          }
+          `shouldRespondWith`
+            ""
+            { matchHeaders = ["Content-Range" <:> "0-1/2"] }
 
       it "only uses the query planner guess if it's indeed greater than the exact count" $
         request methodHead "/get_projects_above_view" [("Prefer", "count=estimated")] ""
-          `shouldRespondWith` ""
-          { matchStatus  = 206
-          , matchHeaders = ["Content-Range" <:> "0-1/3"]
-          }
+          `shouldRespondWith`
+            ""
+            { matchStatus  = 206
+            , matchHeaders = ["Content-Range" <:> "0-1/3"]
+            }

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -401,9 +401,9 @@ spec actualPgVersion = do
         get "/materialized_projects?select=*,users(*)" `shouldRespondWith` 200
 
       it "can request two parents" $
-        get "/articleStars?select=createdAt,article:articles(owner),user:users(name)&limit=1" `shouldRespondWith`
-          [json|[{"createdAt":"2015-12-08T04:22:57.472738","article":{"owner": "postgrest_test_authenticator"},"user":{"name": "Angela Martin"}}]|]
-          { matchHeaders = [matchContentTypeJson] }
+        get "/articleStars?select=createdAt,article:articles(id),user:users(name)&limit=1"
+          `shouldRespondWith`
+            [json|[{"createdAt":"2015-12-08T04:22:57.472738","article":{"id": 1},"user":{"name": "Angela Martin"}}]|]
 
       it "can detect relations in views from exposed schema that are based on tables in private schema and have columns renames" $
         get "/articles?id=eq.1&select=id,articleStars(users(*))" `shouldRespondWith`

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -35,7 +35,7 @@ spec actualPgVersion = do
         { matchHeaders = ["Content-Range" <:> "0-0/*"] }
 
     it "matches with equality using not operator" $
-      get "/items?id=not.eq.5"
+      get "/items?id=not.eq.5&order=id"
         `shouldRespondWith` [json| [{"id":1},{"id":2},{"id":3},{"id":4},{"id":6},{"id":7},{"id":8},{"id":9},{"id":10},{"id":11},{"id":12},{"id":13},{"id":14},{"id":15}] |]
         { matchHeaders = ["Content-Range" <:> "0-13/*"] }
 

--- a/test/Feature/RangeSpec.hs
+++ b/test/Feature/RangeSpec.hs
@@ -33,9 +33,11 @@ spec = do
             `shouldRespondWith` [json| [] |] {matchHeaders = ["Content-Range" <:> "*/*"]}
 
         it "returns range Content-Range with range/*" $
-          request methodPost "/rpc/getitemrange" [] defaultRange
-            `shouldRespondWith` [json| [{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9},{"id":10},{"id":11},{"id":12},{"id":13},{"id":14},{"id":15}] |]
-            { matchHeaders = ["Content-Range" <:> "0-14/*"] }
+          post "/rpc/getitemrange?order=id"
+              defaultRange
+            `shouldRespondWith`
+              [json| [{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9},{"id":10},{"id":11},{"id":12},{"id":13},{"id":14},{"id":15}] |]
+              { matchHeaders = ["Content-Range" <:> "0-14/*"] }
 
     context "with range headers" $ do
       context "of acceptable range" $ do
@@ -168,20 +170,16 @@ spec = do
           }
 
       it "succeeds if offset equals 0 as a no-op" $
-        get "/items?select=id&offset=0"
+        get "/items?select=id&offset=0&order=id"
           `shouldRespondWith`
-          [json|[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9},{"id":10},{"id":11},{"id":12},{"id":13},{"id":14},{"id":15}]|]
-          { matchStatus  = 200
-          , matchHeaders = ["Content-Range" <:> "0-14/*"]
-          }
+            [json|[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9},{"id":10},{"id":11},{"id":12},{"id":13},{"id":14},{"id":15}]|]
+            { matchHeaders = ["Content-Range" <:> "0-14/*"] }
 
       it "succeeds if offset is negative as a no-op" $
-        get "/items?select=id&offset=-4"
+        get "/items?select=id&offset=-4&order=id"
           `shouldRespondWith`
-          [json|[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9},{"id":10},{"id":11},{"id":12},{"id":13},{"id":14},{"id":15}]|]
-          { matchStatus  = 200
-          , matchHeaders = ["Content-Range" <:> "0-14/*"]
-          }
+            [json|[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9},{"id":10},{"id":11},{"id":12},{"id":13},{"id":14},{"id":15}]|]
+            { matchHeaders = ["Content-Range" <:> "0-14/*"] }
 
       it "fails if limit equals 0" $
         get "/items?select=id&limit=0"
@@ -199,62 +197,98 @@ spec = do
 
     context "when count=planned" $ do
       it "obtains a filtered range" $ do
-        request methodGet "/items?select=id&id=gt.8" [("Prefer", "count=planned")] ""
-          `shouldRespondWith` [json|[{"id":9}, {"id":10}, {"id":11}, {"id":12}, {"id":13}, {"id":14}, {"id":15}]|]
-          { matchStatus  = 206
-          , matchHeaders = ["Content-Range" <:> "0-6/8"]
-          }
-        request methodGet "/child_entities?select=id&id=gt.3" [("Prefer", "count=planned")] ""
-          `shouldRespondWith` [json|[{"id":4}, {"id":5}, {"id":6}]|]
-          { matchStatus  = 206
-          , matchHeaders = ["Content-Range" <:> "0-2/4"]
-          }
-        request methodGet "/getallprojects_view?select=id&id=lt.3" [("Prefer", "count=planned")] ""
-          `shouldRespondWith` [json|[{"id":1}, {"id":2}]|]
-          { matchStatus  = 206
-          , matchHeaders = ["Content-Range" <:> "0-1/673"]
-          }
+        request methodGet "/items?select=id&id=gt.8"
+            [("Prefer", "count=planned")]
+            ""
+          `shouldRespondWith`
+            [json|[{"id":9}, {"id":10}, {"id":11}, {"id":12}, {"id":13}, {"id":14}, {"id":15}]|]
+            { matchStatus  = 206
+            , matchHeaders = ["Content-Range" <:> "0-6/8"]
+            }
+
+        request methodGet "/child_entities?select=id&id=gt.3"
+            [("Prefer", "count=planned")]
+            ""
+          `shouldRespondWith`
+            [json|[{"id":4}, {"id":5}, {"id":6}]|]
+            { matchStatus  = 206
+            , matchHeaders = ["Content-Range" <:> "0-2/4"]
+            }
+
+        request methodGet "/getallprojects_view?select=id&id=lt.3"
+            [("Prefer", "count=planned")]
+            ""
+          `shouldRespondWith`
+            [json|[{"id":1}, {"id":2}]|]
+            { matchStatus  = 206
+            , matchHeaders = ["Content-Range" <:> "0-1/673"]
+            }
 
       it "obtains the full range" $ do
-        request methodHead "/items" [("Prefer", "count=planned")] ""
-          `shouldRespondWith` ""
-          { matchStatus  = 200
-          , matchHeaders = ["Content-Range" <:> "0-14/15"]
-          }
-        request methodHead "/child_entities" [("Prefer", "count=planned")] ""
-          `shouldRespondWith` ""
-          { matchStatus  = 200
-          , matchHeaders = ["Content-Range" <:> "0-5/6"]
-          }
-        request methodHead "/getallprojects_view" [("Prefer", "count=planned")] ""
-          `shouldRespondWith` ""
-          { matchStatus  = 206
-          , matchHeaders = ["Content-Range" <:> "0-4/2019"]
-          }
+        request methodHead "/items"
+            [("Prefer", "count=planned")]
+            ""
+          `shouldRespondWith`
+            ""
+            { matchStatus  = 200
+            , matchHeaders = ["Content-Range" <:> "0-14/15"]
+            }
+
+        request methodHead "/child_entities"
+            [("Prefer", "count=planned")]
+            ""
+          `shouldRespondWith`
+            ""
+            { matchStatus  = 200
+            , matchHeaders = ["Content-Range" <:> "0-5/6"]
+            }
+
+        request methodHead "/getallprojects_view"
+            [("Prefer", "count=planned")]
+            ""
+          `shouldRespondWith`
+            ""
+            { matchStatus  = 206
+            , matchHeaders = ["Content-Range" <:> "0-4/2019"]
+            }
 
       it "ignores limit/offset on the planned count" $ do
-        request methodHead "/items?limit=2&offset=3" [("Prefer", "count=planned")] ""
-          `shouldRespondWith` ""
-          { matchStatus  = 206
-          , matchHeaders = ["Content-Range" <:> "3-4/15"]
-          }
-        request methodHead "/child_entities?limit=2" [("Prefer", "count=planned")] ""
-          `shouldRespondWith` ""
-          { matchStatus  = 206
-          , matchHeaders = ["Content-Range" <:> "0-1/6"]
-          }
-        request methodHead "/getallprojects_view?limit=2" [("Prefer", "count=planned")] ""
-          `shouldRespondWith` ""
-          { matchStatus  = 206
-          , matchHeaders = ["Content-Range" <:> "0-1/2019"]
-          }
+        request methodHead "/items?limit=2&offset=3"
+            [("Prefer", "count=planned")]
+            ""
+          `shouldRespondWith`
+            ""
+            { matchStatus  = 206
+            , matchHeaders = ["Content-Range" <:> "3-4/15"]
+            }
+
+        request methodHead "/child_entities?limit=2"
+           [("Prefer", "count=planned")]
+            ""
+          `shouldRespondWith`
+            ""
+            { matchStatus  = 206
+            , matchHeaders = ["Content-Range" <:> "0-1/6"]
+            }
+
+        request methodHead "/getallprojects_view?limit=2"
+            [("Prefer", "count=planned")]
+            ""
+          `shouldRespondWith`
+            ""
+            { matchStatus  = 206
+            , matchHeaders = ["Content-Range" <:> "0-1/2019"]
+            }
 
       it "works with two levels" $
-        request methodHead "/child_entities?select=*,entities(*)" [("Prefer", "count=planned")] ""
-          `shouldRespondWith` ""
-          { matchStatus  = 200
-          , matchHeaders = ["Content-Range" <:> "0-5/6"]
-          }
+        request methodHead "/child_entities?select=*,entities(*)"
+            [("Prefer", "count=planned")]
+            ""
+          `shouldRespondWith`
+            ""
+            { matchStatus  = 200
+            , matchHeaders = ["Content-Range" <:> "0-5/6"]
+            }
 
     context "with range headers" $ do
       context "of acceptable range" $ do

--- a/test/Feature/RollbackSpec.hs
+++ b/test/Feature/RollbackSpec.hs
@@ -15,7 +15,7 @@ import SpecHelper
 -- creates Item to work with for PATCH and DELETE
 postItem =
   request methodPost "/items"
-      [("Prefer", "resolution=ignore-duplicates")]
+      [("Prefer", "tx=commit"), ("Prefer", "resolution=ignore-duplicates")]
       [json|{"id":0}|]
     `shouldRespondWith`
       ""
@@ -23,7 +23,9 @@ postItem =
 
 -- removes Items left over from POST, PUT, and PATCH
 deleteItems =
-  delete "/items?id=lte.0"
+  request methodDelete "/items?id=lte.0"
+      [("Prefer", "tx=commit")]
+      ""
     `shouldRespondWith`
       ""
       { matchStatus  = 204 }
@@ -175,9 +177,8 @@ shouldNotPersistMutations reqHeaders respHeaders = do
 allowed :: SpecWith ((), Application)
 allowed = describe "tx-allow-override = true" $ do
   describe "without Prefer tx" $ do
-    -- TODO: Change this to default to rollback for whole test-suite
     preferDefault `shouldRespondToReads` withoutPreferenceApplied
-    preferDefault `shouldPersistMutations` withoutPreferenceApplied
+    preferDefault `shouldNotPersistMutations` withoutPreferenceApplied
 
   describe "Prefer tx=commit" $ do
     preferCommit `shouldRespondToReads` withPreferenceCommitApplied

--- a/test/Feature/RpcPreRequestGucsSpec.hs
+++ b/test/Feature/RpcPreRequestGucsSpec.hs
@@ -11,62 +11,79 @@ import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 import Text.Heredoc
 
-import Protolude  hiding (get)
+import Protolude  hiding (get, put)
 import SpecHelper
 
 spec :: SpecWith ((), Application)
 spec =
   describe "GUC headers on all methods via pre-request" $ do
     it "succeeds setting the headers on POST" $
-      request methodPost "/items" [] [json|[{"id": 11111}]|]
+      post "/items"
+          [json|[{"id": 11111}]|]
         `shouldRespondWith` ""
-        { matchStatus = 201
-        , matchHeaders = ["X-Custom-Header" <:> "mykey=myval"]
-        }
+          { matchStatus = 201
+          , matchHeaders = ["X-Custom-Header" <:> "mykey=myval"]
+          }
 
     it "succeeds setting the headers on GET and HEAD" $ do
-      request methodGet "/items?id=eq.11111" [("User-Agent", "MSIE 6.0")] mempty
-        `shouldRespondWith` [json|[{"id": 11111}]|]
-        {matchHeaders = [
-            matchContentTypeJson,
-            "Cache-Control" <:> "no-cache, no-store, must-revalidate"]}
+      request methodGet "/items?id=eq.1"
+          [("User-Agent", "MSIE 6.0")]
+          ""
+        `shouldRespondWith`
+          [json|[{"id": 1}]|]
+          { matchHeaders = ["Cache-Control" <:> "no-cache, no-store, must-revalidate"] }
 
-      request methodHead "/items?id=eq.11111" [("User-Agent", "MSIE 7.0")] mempty
-        `shouldRespondWith` ""
-        {matchHeaders = ["Cache-Control" <:> "no-cache, no-store, must-revalidate"]}
+      request methodHead "/items?id=eq.1"
+          [("User-Agent", "MSIE 7.0")]
+          ""
+        `shouldRespondWith`
+          ""
+          { matchHeaders = ["Cache-Control" <:> "no-cache, no-store, must-revalidate"] }
 
-      request methodHead "/projects" [("Accept", "text/csv")] mempty
-        `shouldRespondWith` ""
-        {matchHeaders = ["Content-Disposition" <:> "attachment; filename=projects.csv"]}
+      request methodHead "/projects"
+          [("Accept", "text/csv")]
+          ""
+        `shouldRespondWith`
+          ""
+          { matchHeaders = ["Content-Disposition" <:> "attachment; filename=projects.csv"] }
 
     it "succeeds setting the headers on PATCH" $
-      request methodPatch "/items?id=eq.11111" [] [json|[{"id": 11111}]|]
-        `shouldRespondWith` ""
-        { matchStatus = 204
-        , matchHeaders = ["X-Custom-Header" <:> "mykey=myval"]
-        }
+        patch "/items?id=eq.1"
+            [json|[{"id": 11111}]|]
+          `shouldRespondWith` ""
+            { matchStatus = 204
+            , matchHeaders = ["X-Custom-Header" <:> "mykey=myval"]
+            }
 
     it "succeeds setting the headers on PUT" $
-      request methodPut "/items?id=eq.11111" [] [json|[{"id": 11111}]|]
+      put "/items?id=eq.1"
+          [json|[{"id": 1}]|]
         `shouldRespondWith` ""
-        { matchStatus = 204
-        , matchHeaders = ["X-Custom-Header" <:> "mykey=myval"]
-        }
+          { matchStatus = 204
+          , matchHeaders = ["X-Custom-Header" <:> "mykey=myval"]
+          }
 
     it "succeeds setting the headers on DELETE" $
-      request methodDelete "/items?id=eq.11111" [] mempty
-        `shouldRespondWith` ""
-        { matchStatus = 204
-        , matchHeaders = ["X-Custom-Header" <:> "mykey=myval"]
-        }
+      delete "/items?id=eq.1"
+        `shouldRespondWith`
+          ""
+          { matchStatus = 204
+          , matchHeaders = ["X-Custom-Header" <:> "mykey=myval"]
+          }
     it "can override the Content-Type header" $ do
-      request methodHead "/clients?id=eq.1" [] mempty
-        `shouldRespondWith` ""
-        { matchStatus = 200
-        , matchHeaders = ["Content-Type" <:> "application/custom+json"]
-        }
-      request methodHead "/rpc/getallprojects" [] mempty
-        `shouldRespondWith` ""
-        { matchStatus = 200
-        , matchHeaders = ["Content-Type" <:> "application/custom+json"]
-        }
+      request methodHead "/clients?id=eq.1"
+          []
+          ""
+        `shouldRespondWith`
+          ""
+          { matchStatus = 200
+          , matchHeaders = ["Content-Type" <:> "application/custom+json"]
+          }
+      request methodHead "/rpc/getallprojects"
+          []
+          ""
+        `shouldRespondWith`
+          ""
+          { matchStatus = 200
+          , matchHeaders = ["Content-Type" <:> "application/custom+json"]
+          }

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -891,11 +891,13 @@ spec actualPgVersion =
                 "Set-Cookie" <:> "id=a3fWa; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Secure; HttpOnly"]}
 
       it "can override the Location header on a trigger" $
-        request methodPost "/stuff" [] [json|[{"id": 1, "name": "stuff 1"}]|]
-          `shouldRespondWith` ""
-          { matchStatus = 201
-          , matchHeaders = ["Location" <:> "/stuff?id=eq.1&overriden=true"]
-          }
+        post "/stuff"
+            [json|[{"id": 2, "name": "stuff 2"}]|]
+          `shouldRespondWith`
+            ""
+            { matchStatus = 201
+            , matchHeaders = ["Location" <:> "/stuff?id=eq.2&overriden=true"]
+            }
 
       -- On https://github.com/PostgREST/postgrest/issues/1427#issuecomment-595907535
       -- it was reported that blank headers ` : ` where added and that cause proxies to fail the requests.
@@ -935,8 +937,10 @@ spec actualPgVersion =
             }
 
         it "can override the status through trigger" $
-          request methodPatch "/stuff?id=eq.1" [] [json|[{"name": "updated stuff 1"}]|]
-            `shouldRespondWith` 205
+          patch "/stuff?id=eq.1"
+              [json|[{"name": "updated stuff 1"}]|]
+            `shouldRespondWith`
+              205
 
         it "fails when setting invalid status guc" $
           get "/rpc/send_bad_status"

--- a/test/Feature/SingularSpec.hs
+++ b/test/Feature/SingularSpec.hs
@@ -15,8 +15,7 @@ import SpecHelper
 spec :: SpecWith ((), Application)
 spec =
   describe "Requesting singular json object" $ do
-    let pgrstObj = "application/vnd.pgrst.object+json"
-        singular = ("Accept", pgrstObj)
+    let singular = ("Accept", "application/vnd.pgrst.object+json")
 
     context "with GET request" $ do
       it "fails for zero rows" $
@@ -49,48 +48,52 @@ spec =
 
     context "when updating rows" $ do
       it "works for one row with return=rep" $ do
-        post "/addresses" [json| { id: 97, address: "A Street" } |]
-        request methodPatch "/addresses?id=eq.97"
-           [("Prefer", "return=representation"), singular]
-           [json| { address: "B Street" } |]
+        request methodPatch "/addresses?id=eq.1"
+            [("Prefer", "return=representation"), singular]
+            [json| { address: "B Street" } |]
           `shouldRespondWith`
-            [json|{"id":97,"address":"B Street"}|]
+            [json|{"id":1,"address":"B Street"}|]
             { matchHeaders = [matchContentTypeSingular] }
 
       it "works for one row with return=minimal" $
-        request methodPatch
-          "/addresses?id=eq.97"
-          [("Prefer", "return=minimal"), singular]
-          [json| { address: "C Street" } |]
+        request methodPatch "/addresses?id=eq.1"
+            [("Prefer", "return=minimal"), singular]
+            [json| { address: "C Street" } |]
           `shouldRespondWith`
             ""
             { matchStatus  = 204 }
 
       it "raises an error for multiple rows" $ do
-        _ <- post "/addresses" [json| { id: 98, address: "xxx" } |]
-        _ <- post "/addresses" [json| { id: 99, address: "yyy" } |]
-        p <- request methodPatch "/addresses?id=gt.0"
-                [singular]
-                [json| { address: "zzz" } |]
-        liftIO $ do
-          simpleStatus p `shouldBe` notAcceptable406
-          isErrorFormat (simpleBody p) `shouldBe` True
+        request methodPatch "/addresses"
+            [("Prefer", "tx=commit"), singular]
+            [json| { address: "zzz" } |]
+          `shouldRespondWith`
+            [json|{"details":"Results contain 4 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned"}|]
+            { matchStatus  = 406
+            , matchHeaders = [ matchContentTypeSingular
+                             , "Preference-Applied" <:> "tx=commit" ]
+            }
 
         -- the rows should not be updated, either
-        get "/addresses?id=eq.98" `shouldRespondWith` [json|[{"id":98,"address":"xxx"}]|]
+        get "/addresses?id=eq.1"
+          `shouldRespondWith`
+            [json|[{"id":1,"address":"address 1"}]|]
 
       it "raises an error for multiple rows with return=rep" $ do
-        _ <- post "/addresses" [json| { id: 100, address: "xxx" } |]
-        _ <- post "/addresses" [json| { id: 101, address: "yyy" } |]
-        p <- request methodPatch "/addresses?id=gt.0"
-                [("Prefer", "return=representation"), singular]
-                [json| { address: "zzz" } |]
-        liftIO $ do
-          simpleStatus p `shouldBe` notAcceptable406
-          isErrorFormat (simpleBody p) `shouldBe` True
+        request methodPatch "/addresses"
+            [("Prefer", "tx=commit"), ("Prefer", "return=representation"), singular]
+            [json| { address: "zzz" } |]
+          `shouldRespondWith`
+            [json|{"details":"Results contain 4 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned"}|]
+            { matchStatus  = 406
+            , matchHeaders = [ matchContentTypeSingular
+                             , "Preference-Applied" <:> "tx=commit" ]
+            }
 
         -- the rows should not be updated, either
-        get "/addresses?id=eq.100" `shouldRespondWith` [json|[{"id":100,"address":"xxx"}]|]
+        get "/addresses?id=eq.1"
+          `shouldRespondWith`
+            [json|[{"id":1,"address":"address 1"}]|]
 
       it "raises an error for zero rows" $
         request methodPatch "/items?id=gt.0&id=lt.0"
@@ -123,51 +126,60 @@ spec =
 
       it "works for one row with return=minimal" $ do
         request methodPost "/addresses"
-          [("Prefer", "return=minimal"), singular]
-          [json| [ { id: 103, address: "xxx" } ] |]
+            [("Prefer", "return=minimal"), singular]
+            [json| [ { id: 103, address: "xxx" } ] |]
           `shouldRespondWith` ""
-          { matchStatus  = 201
-          , matchHeaders = ["Content-Range" <:> "*/*"]
-          }
-        -- and the element should exist
-        get "/addresses?id=eq.103"
-          `shouldRespondWith` [json|[{"id":103,"address":"xxx"}]|]
-          { matchStatus  = 200
-          , matchHeaders = []
-          }
+            { matchStatus  = 201
+            , matchHeaders = ["Content-Range" <:> "*/*"]
+            }
 
       it "raises an error when attempting to create multiple entities" $ do
-        p <- request methodPost
-          "/addresses"
-          [singular]
-          [json| [ { id: 200, address: "xxx" }, { id: 201, address: "yyy" } ] |]
-        liftIO $ simpleStatus p `shouldBe` notAcceptable406
+        request methodPost "/addresses"
+            [("Prefer", "tx=commit"), singular]
+            [json| [ { id: 200, address: "xxx" }, { id: 201, address: "yyy" } ] |]
+          `shouldRespondWith`
+            [json|{"details":"Results contain 2 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned"}|]
+            { matchStatus  = 406
+            , matchHeaders = [ matchContentTypeSingular
+                             , "Preference-Applied" <:> "tx=commit" ]
+            }
 
         -- the rows should not exist, either
-        get "/addresses?id=eq.200" `shouldRespondWith` "[]"
+        get "/addresses?id=eq.200"
+          `shouldRespondWith`
+            "[]"
 
       it "raises an error when attempting to create multiple entities with return=rep" $ do
-        p <- request methodPost
-          "/addresses"
-          [("Prefer", "return=representation"), singular]
-          [json| [ { id: 202, address: "xxx" }, { id: 203, address: "yyy" } ] |]
-        liftIO $ simpleStatus p `shouldBe` notAcceptable406
+        request methodPost "/addresses"
+            [("Prefer", "tx=commit"), ("Prefer", "return=representation"), singular]
+            [json| [ { id: 202, address: "xxx" }, { id: 203, address: "yyy" } ] |]
+          `shouldRespondWith`
+            [json|{"details":"Results contain 2 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned"}|]
+            { matchStatus  = 406
+            , matchHeaders = [ matchContentTypeSingular
+                             , "Preference-Applied" <:> "tx=commit" ]
+            }
 
         -- the rows should not exist, either
-        get "/addresses?id=eq.202" `shouldRespondWith` "[]"
+        get "/addresses?id=eq.202"
+          `shouldRespondWith`
+            "[]"
 
       it "raises an error regardless of return=minimal" $ do
         request methodPost "/addresses"
-                [("Prefer", "return=minimal"), singular]
-                [json| [ { id: 204, address: "xxx" }, { id: 205, address: "yyy" } ] |]
+            [("Prefer", "tx=commit"), ("Prefer", "return=minimal"), singular]
+            [json| [ { id: 204, address: "xxx" }, { id: 205, address: "yyy" } ] |]
           `shouldRespondWith`
-                  [json|{"details":"Results contain 2 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned"}|]
-                  { matchStatus  = 406
-                  , matchHeaders = [matchContentTypeSingular]
-                  }
+            [json|{"details":"Results contain 2 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned"}|]
+            { matchStatus  = 406
+            , matchHeaders = [ matchContentTypeSingular
+                             , "Preference-Applied" <:> "tx=commit" ]
+            }
 
         -- the rows should not exist, either
-        get "/addresses?id=eq.204" `shouldRespondWith` "[]"
+        get "/addresses?id=eq.204"
+          `shouldRespondWith`
+            "[]"
 
       it "raises an error when creating zero entities" $
         request methodPost "/addresses"
@@ -203,28 +215,40 @@ spec =
         liftIO $ simpleBody p `shouldBe` ""
 
       it "raises an error when attempting to delete multiple entities" $ do
-        let firstItems = "/items?id=gt.0&id=lt.6"
-        request methodDelete firstItems
-          [singular] ""
-          `shouldRespondWith` 406
+        request methodDelete "/items?id=gt.0&id=lt.6"
+            [("Prefer", "tx=commit"), singular]
+            ""
+          `shouldRespondWith`
+            [json|{"details":"Results contain 5 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned"}|]
+            { matchStatus  = 406
+            , matchHeaders = [ matchContentTypeSingular
+                             , "Preference-Applied" <:> "tx=commit" ]
+            }
 
-        get firstItems
-          `shouldRespondWith` [json| [{"id":1},{"id":2},{"id":3},{"id":4},{"id":5}] |]
-          { matchStatus  = 200
-          , matchHeaders = ["Content-Range" <:> "0-4/*"]
-          }
+        -- the rows should still exist
+        get "/items?id=gt.0&id=lt.6"
+          `shouldRespondWith`
+            [json| [{"id":1},{"id":2},{"id":3},{"id":4},{"id":5}] |]
+            { matchStatus  = 200
+            , matchHeaders = ["Content-Range" <:> "0-4/*"]
+            }
 
       it "raises an error when attempting to delete multiple entities with return=rep" $ do
-        let firstItems = "/items?id=gt.5&id=lt.11"
-        request methodDelete firstItems
-          [("Prefer", "return=representation"), singular] ""
-          `shouldRespondWith` 406
+        request methodDelete "/items?id=gt.5&id=lt.11"
+            [("Prefer", "tx=commit"), ("Prefer", "return=representation"), singular] ""
+          `shouldRespondWith`
+            [json|{"details":"Results contain 5 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned"}|]
+            { matchStatus  = 406
+            , matchHeaders = [ matchContentTypeSingular
+                             , "Preference-Applied" <:> "tx=commit" ]
+            }
 
-        get firstItems
+        -- the rows should still exist
+        get "/items?id=gt.5&id=lt.11"
           `shouldRespondWith` [json| [{"id":6},{"id":7},{"id":8},{"id":9},{"id":10}] |]
-          { matchStatus  = 200
-          , matchHeaders = ["Content-Range" <:> "0-4/*"]
-          }
+            { matchStatus  = 200
+            , matchHeaders = ["Content-Range" <:> "0-4/*"]
+            }
 
       it "raises an error when deleting zero entities" $
         request methodDelete "/items?id=lt.0"
@@ -277,18 +301,24 @@ spec =
                 , matchHeaders = [matchContentTypeSingular]
                 }
 
-      it "executes the proc exactly once per request" $ do
-        request methodPost "/rpc/getproject?select=id,name" [] [json| {"id": 1} |]
-          `shouldRespondWith` [json|[{"id":1,"name":"Windows 7"}]|]
-
-        request methodPost "/rpc/setprojects" [singular]
-                [json| {"id_l": 1, "id_h": 2, "name": "changed"} |]
+      it "fails for multiple rows with rolled back changes" $ do
+        post "/rpc/getproject?select=id,name"
+            [json| {"id": 1} |]
           `shouldRespondWith`
-                [json|{"details":"Results contain 2 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned"}|]
-                { matchStatus  = 406
-                , matchHeaders = [matchContentTypeSingular]
-                }
+            [json|[{"id":1,"name":"Windows 7"}]|]
 
-        -- should not actually have executed the function
-        request methodPost "/rpc/getproject?select=id,name" [] [json| {"id": 1} |]
-          `shouldRespondWith` [json|[{"id":1,"name":"Windows 7"}]|]
+        request methodPost "/rpc/setprojects"
+            [("Prefer", "tx=commit"), singular]
+            [json| {"id_l": 1, "id_h": 2, "name": "changed"} |]
+          `shouldRespondWith`
+            [json|{"details":"Results contain 2 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned"}|]
+            { matchStatus  = 406
+            , matchHeaders = [ matchContentTypeSingular
+                             , "Preference-Applied" <:> "tx=commit" ]
+            }
+
+        -- should rollback function
+        post "/rpc/getproject?select=id,name"
+            [json| {"id": 1} |]
+          `shouldRespondWith`
+            [json|[{"id":1,"name":"Windows 7"}]|]

--- a/test/Feature/SingularSpec.hs
+++ b/test/Feature/SingularSpec.hs
@@ -226,7 +226,7 @@ spec =
             }
 
         -- the rows should still exist
-        get "/items?id=gt.0&id=lt.6"
+        get "/items?id=gt.0&id=lt.6&order=id"
           `shouldRespondWith`
             [json| [{"id":1},{"id":2},{"id":3},{"id":4},{"id":5}] |]
             { matchStatus  = 200

--- a/test/Feature/UnicodeSpec.hs
+++ b/test/Feature/UnicodeSpec.hs
@@ -2,6 +2,7 @@ module Feature.UnicodeSpec where
 
 import Network.Wai (Application)
 
+import Network.HTTP.Types
 import Test.Hspec
 import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
@@ -16,9 +17,19 @@ spec =
       get "/%D9%85%D9%88%D8%A7%D8%B1%D8%AF"
         `shouldRespondWith` "[]"
 
-      void $ post "/%D9%85%D9%88%D8%A7%D8%B1%D8%AF"
-        [json| { "هویت": 1 } |]
+      request methodPost "/%D9%85%D9%88%D8%A7%D8%B1%D8%AF"
+          [("Prefer", "tx=commit"), ("Prefer", "return=representation")]
+          [json| { "هویت": 1 } |]
+        `shouldRespondWith`
+          [json| [{ "هویت": 1 }] |]
+          { matchStatus = 201 }
 
       get "/%D9%85%D9%88%D8%A7%D8%B1%D8%AF"
-        `shouldRespondWith` [json| [{ "هویت": 1 }] |]
-        { matchHeaders = [matchContentTypeJson] }
+        `shouldRespondWith`
+          [json| [{ "هویت": 1 }] |]
+
+      request methodDelete "/%D9%85%D9%88%D8%A7%D8%B1%D8%AF"
+          [("Prefer", "tx=commit")]
+          ""
+        `shouldRespondWith`
+          204

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -96,39 +96,32 @@ main = do
       nonexistentSchemaApp = appDbs testNonexistentSchemaCfg
       multipleSchemaApp    = appDbs testMultipleSchemaCfg
 
-  let reset, analyze :: IO ()
-      reset = resetDb testDbConn
+  let analyze :: IO ()
       analyze = do
         analyzeTable testDbConn "items"
         analyzeTable testDbConn "child_entities"
 
       specs = uncurry describe <$> [
-          ("Feature.AuthSpec"                , Feature.AuthSpec.spec actualPgVersion)
-        , ("Feature.RawOutputTypesSpec"      , Feature.RawOutputTypesSpec.spec)
+          ("Feature.AndOrParamsSpec"         , Feature.AndOrParamsSpec.spec actualPgVersion)
+        , ("Feature.AuthSpec"                , Feature.AuthSpec.spec actualPgVersion)
         , ("Feature.ConcurrentSpec"          , Feature.ConcurrentSpec.spec)
         , ("Feature.CorsSpec"                , Feature.CorsSpec.spec)
+        , ("Feature.DeleteSpec"              , Feature.DeleteSpec.spec)
+        , ("Feature.EmbedDisambiguationSpec" , Feature.EmbedDisambiguationSpec.spec)
+        , ("Feature.InsertSpec"              , Feature.InsertSpec.spec actualPgVersion)
         , ("Feature.JsonOperatorSpec"        , Feature.JsonOperatorSpec.spec actualPgVersion)
         , ("Feature.OpenApiSpec"             , Feature.OpenApiSpec.spec)
         , ("Feature.OptionsSpec"             , Feature.OptionsSpec.spec)
         , ("Feature.QuerySpec"               , Feature.QuerySpec.spec actualPgVersion)
-        , ("Feature.EmbedDisambiguationSpec" , Feature.EmbedDisambiguationSpec.spec)
+        , ("Feature.RawOutputTypesSpec"      , Feature.RawOutputTypesSpec.spec)
         , ("Feature.RollbackAllowedSpec"     , Feature.RollbackSpec.allowed)
         , ("Feature.RpcSpec"                 , Feature.RpcSpec.spec actualPgVersion)
-        , ("Feature.AndOrParamsSpec"         , Feature.AndOrParamsSpec.spec actualPgVersion)
+        , ("Feature.SingularSpec"            , Feature.SingularSpec.spec)
+        , ("Feature.UpdateSpec"              , Feature.UpdateSpec.spec)
         , ("Feature.UpsertSpec"              , Feature.UpsertSpec.spec)
         ]
 
-      mutSpecs = uncurry describe <$> [
-          ("Feature.DeleteSpec"             , Feature.DeleteSpec.spec)
-        , ("Feature.InsertSpec"             , Feature.InsertSpec.spec actualPgVersion)
-        , ("Feature.SingularSpec"           , Feature.SingularSpec.spec)
-        , ("Feature.UpdateSpec"             , Feature.UpdateSpec.spec)
-        ]
-
   hspec $ do
-    -- Only certain Specs need a database reset, this should be used with care as it slows down the whole test suite.
-    mapM_ (afterAll_ reset . before withApp) mutSpecs
-
     mapM_ (before withApp) specs
 
     -- we analyze to get accurate results from EXPLAIN

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -90,7 +90,7 @@ _baseCfg = let secret = Just $ encodeUtf8 "reallyreallyreallyreallyverysafe" in
   , configRawMediaTypes     = []
   , configJWKS              = parseSecret <$> secret
   , configLogLevel          = LogCrit
-  , configTxRollbackAll     = False
+  , configTxRollbackAll     = True
   , configTxAllowOverride   = True
   , configDbPrepared        = True
   }

--- a/test/fixtures/data.sql
+++ b/test/fixtures/data.sql
@@ -359,6 +359,9 @@ TRUNCATE TABLE child_entities CASCADE;
 INSERT INTO child_entities VALUES (1, 'child entity 1', 1);
 INSERT INTO child_entities VALUES (2, 'child entity 2', 1);
 INSERT INTO child_entities VALUES (3, 'child entity 3', 2);
+INSERT INTO child_entities VALUES (4, 'child entity 4', 1);
+INSERT INTO child_entities VALUES (5, 'child entity 5', 1);
+INSERT INTO child_entities VALUES (6, 'child entity 6', 2);
 
 TRUNCATE TABLE grandchild_entities CASCADE;
 INSERT INTO grandchild_entities VALUES (1, 'grandchild entity 1', 1, null, null, null);
@@ -626,8 +629,17 @@ INSERT INTO unit_workdays VALUES(1, '2019-12-02', 1, 1, 2, 3);
 TRUNCATE TABLE v1.parents CASCADE;
 INSERT INTO v1.parents VALUES(1, 'parent v1-1'), (2, 'parent v1-2');
 
+TRUNCATE TABLE v1.children CASCADE;
+INSERT INTO v1.children VALUES(1, 'child v1-1', 1), (2, 'child v1-2', 2);
+
 TRUNCATE TABLE v2.parents CASCADE;
 INSERT INTO v2.parents VALUES(3, 'parent v2-3'), (4, 'parent v2-4');
 
+TRUNCATE TABLE v2.children CASCADE;
+INSERT INTO v2.children VALUES(1, 'child v2-3', 3);
+
 TRUNCATE TABLE v2.another_table CASCADE;
 INSERT INTO v2.another_table VALUES(5, 'value 5'), (6, 'value 6');
+
+TRUNCATE TABLE private.stuff CASCADE;
+INSERT INTO private.stuff (id, name) VALUES (1, 'stuff 1');

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -144,8 +144,6 @@ GRANT USAGE ON SEQUENCE
     , items_id_seq
     , callcounter_count
     , leak_id_seq
-    , v1.children_id_seq
-    , v2.children_id_seq
 TO postgrest_test_anonymous;
 
 -- Privileges for non anonymous users

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -365,6 +365,16 @@ CREATE FUNCTION callcounter() RETURNS bigint
     SELECT nextval('test.callcounter_count');
 $_$;
 
+CREATE FUNCTION reset_sequence(name TEXT, value INTEGER) RETURNS void
+SECURITY DEFINER
+LANGUAGE plpgsql AS $_$
+BEGIN
+  EXECUTE FORMAT($exec$
+    ALTER SEQUENCE %s RESTART WITH %s
+  $exec$, name, value);
+END
+$_$;
+
 --
 -- Name: singlejsonparam(json); Type: FUNCTION; Schema: test; Owner: -
 --

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1825,8 +1825,8 @@ create table v1.parents (
 );
 
 create table v1.children (
-  id       serial primary key
-, name    text
+  id int primary key
+, name text
 , parent_id int
 , constraint parent foreign key(parent_id)
   references v1.parents(id)
@@ -1843,7 +1843,7 @@ create table v2.parents (
 );
 
 create table v2.children (
-  id    serial primary key
+  id int primary key
 , name text
 , parent_id int
 , constraint parent foreign key(parent_id)


### PR DESCRIPTION
Follow-up on #1659:

> And then for another PR: Make rollback the default for our spec-tests. This will require quite a bit of cleanup. My goal would be to be able to run the whole test suite multiple times against the same database without recreating the schema.

This is based on the other PR, so the diff is a bit longer than it should be. Still, it's huge. I hope it looks better with "Hide whitespace changes" turned on.

Quick guide on how to look at this:
- Everything in `src/...` is from the other PR. Ignore here.
- Changes have been made to `test/Main.hs` and `test/SpecHelper.hs`. Removed the schema reloading, re-ordered the tests and enabled `transaction-rollback = true`. This caused a lot of broken tests.
- Everything in `test/Feature/...` + `test/fixtures/...` is fixing those tests, so that they don't depend on the result of other tests anymore. As always, every test-case I touched, I also reformatted / refactored. This might increase the diff here, but I hope to be able to make all those test-cases consistently structured down the road. This helps me a lot to understand the tests quickly when reading them. The changes to the tests, that I had to make to account for the rolled back transactions are often quite similar. For every kind of change, I will comment on an example.

When refactoring / reformatting the tests, I did the following:
- When possible, replaced code like this:
```haskell
p <- request ...
liftIO $do
  simpleBody p `shouldBe` ...
  simpleStatus p `shouldBe` ...
... lookup hLocation $ simpleHeaders p
...
```
with:
```haskell
request ...
  `shouldRespondWith`
    <body>
    { matchStatus = ...
    , matchHeaders = ... }
```

Much easier to read, because it follows the same structure that almost all the tests have.

- When possible replaced `request methodPost ...` with the short form `post ...` (for all http methods). Fewer empty arrays and empty bodies that way.

- Formatted the requests around `shouldRespondWith` with consistent indentation and newlines, like this:
```haskell
request <method> <uri>
    <headers>
    <body>
  `shouldRespondWith`
    <body>
    <status/headers>
```

For me, it's much easier to immediately see what's going on, compared to when the `shouldRespondWith` is sometimes hidden somewhere on the same line as other things.

- Changed `[str|...json data...|]` to `[json|...json data...|]`. This is essential, because `shouldRespondWith` will then do a json-comparison and ignore formatting, which sometimes causes trouble. It does also include a check for the `application/json` content-type by default. I don't think there were any changes of this, in this PR.

- Removed obsolete `matchContentTypeJson` (see last point why, it's included already) and `matchStatus = 200` (the default check).

@steve-chavez do you think this formatting / structure for tests is something that we can "formalize" a bit more, even without a linter / style-check that covers for it? Any suggestions for improvement?