### PR TITLE
Add test to ignore functions unnamed arguments for rpc disambiguation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #1585, Fix error messages on connection failure for localized postgres on Windows - @wolfgangwalther
  - #1636, Fix `application/octet-stream` appending `charset=utf-8` - @steve-chavez
  - #1615, Fix RPC return type handling and embedding for domains with composite base type - @wolfgangwalther
- - #1469, Fix overloading of functions with unnamed arguments - @wolfgangwalther
+ - #1469, #1638 Fix overloading of functions with unnamed arguments - @wolfgangwalther
 
 ### Changed
 

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -970,6 +970,12 @@ create function test.ret_setof_integers() returns setof integer as $$
   values (1), (2), (3);
 $$ language sql;
 
+-- this function does not have named arguments and should be ignored
+-- if it's not ignored, it will break the test for the function before
+create function test.ret_setof_integers(int, int) returns integer AS $$
+  values (1);
+$$ language sql;
+
 create function test.ret_scalars() returns table(
   a text, b test.enum_menagerie_type, c test.one_nine, d int4range
 ) as $$


### PR DESCRIPTION
Resolves #1638.

This has in fact already been fixed in e08bb3a197cbc03e5c623b9847651880955e45b8.

Just added another function with the same name as a set-returning function to the fixtures. Before this commit, this breaks a test, but now it passes. Confirms, that it is fixed already.