### PR TITLE
Improve dev tools in the Nix environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - checkout
       - run:
           name: Install linting and styling scripts
-          command: nix-env -f default.nix -iA devtools
+          command: nix-env -f default.nix -iA style
       - run:
           name: Run linter
           command: |

--- a/default.nix
+++ b/default.nix
@@ -31,9 +31,10 @@ let
 
   overlays =
     [
-      allOverlays.postgresql-default
-      allOverlays.gitignore
+      allOverlays.checked-shell-script
       allOverlays.ghr
+      allOverlays.gitignore
+      allOverlays.postgresql-default
       (allOverlays.haskell-packages { inherit compiler; })
     ];
 
@@ -42,14 +43,14 @@ let
     import nixpkgs { inherit overlays; };
 
   postgresqlVersions =
-    {
-      postgresql-13 = pkgs.postgresql_13;
-      postgresql-12 = pkgs.postgresql_12;
-      postgresql-11 = pkgs.postgresql_11;
-      postgresql-10 = pkgs.postgresql_10;
-      "postgresql-9.6" = pkgs.postgresql_9_6;
-      "postgresql-9.5" = pkgs.postgresql_9_5;
-    };
+    [
+      { name = "postgresql-13"; postgresql = pkgs.postgresql_13; }
+      { name = "postgresql-12"; postgresql = pkgs.postgresql_12; }
+      { name = "postgresql-11"; postgresql = pkgs.postgresql_11; }
+      { name = "postgresql-10"; postgresql = pkgs.postgresql_10; }
+      { name = "postgresql-9.6"; postgresql = pkgs.postgresql_9_6; }
+      { name = "postgresql-9.5"; postgresql = pkgs.postgresql_9_5; }
+    ];
 
   patches =
     pkgs.callPackage nix/patches { };
@@ -111,9 +112,13 @@ rec {
   tests =
     pkgs.callPackage nix/tests.nix { inherit postgrest postgrestStatic postgrestProfiled postgresqlVersions; };
 
+  # Linting and styling scripts.
+  style =
+    pkgs.callPackage nix/style.nix { };
+
   # Development tools, including linting and styling scripts.
   devtools =
-    pkgs.callPackage nix/devtools.nix { };
+    pkgs.callPackage nix/devtools.nix { inherit tests style; };
 
   # Scripts for publishing new releases.
   release =

--- a/default.nix
+++ b/default.nix
@@ -64,6 +64,10 @@ let
   staticHaskellPackage =
     import nix/static-haskell-package.nix { inherit nixpkgs compiler patches allOverlays; };
 
+  # Options passed to cabal in dev tools and tests
+  devCabalOptions =
+    "-f FailOnWarn --test-show-detail=direct";
+
   profiledHaskellPackages =
     pkgs.haskell.packages."${compiler}".extend (self: super:
       {
@@ -110,7 +114,7 @@ rec {
 
   # Scripts for running tests.
   tests =
-    pkgs.callPackage nix/tests.nix { inherit postgrest postgrestStatic postgrestProfiled postgresqlVersions; };
+    pkgs.callPackage nix/tests.nix { inherit postgrest postgrestStatic postgrestProfiled postgresqlVersions devCabalOptions; };
 
   # Linting and styling scripts.
   style =
@@ -118,7 +122,7 @@ rec {
 
   # Development tools, including linting and styling scripts.
   devtools =
-    pkgs.callPackage nix/devtools.nix { inherit tests style; };
+    pkgs.callPackage nix/devtools.nix { inherit tests style devCabalOptions; };
 
   # Scripts for publishing new releases.
   release =

--- a/nix/README.md
+++ b/nix/README.md
@@ -59,7 +59,7 @@ Within `nix-shell`, you can run Cabal commands as usual. You can also run
 stack with the `--nix` option, which causes stack to pick up the non-Haskell
 dependencies from the same pinned Nixpkgs version that the Nix builds use.
 
-## Aside: Working with `nix-shell` and the PostgREST utility scripts
+## Working with `nix-shell` and the PostgREST utility scripts
 
 The PostgREST utilities available in `nix-shell` all have names that begin with
 `postgrest-`, so you can use tab completion (typing `postgrest-` and pressing
@@ -74,6 +74,7 @@ postgrest-style-check               postgrest-test-spec-postgresql-13
 postgrest-test-spec                 postgrest-test-spec-postgresql-9.5
 postgrest-test-spec-all             postgrest-test-spec-postgresql-9.6
 postgrest-test-spec-postgresql-10
+...
 
 [nix-shell]$
 
@@ -94,6 +95,7 @@ postgrest-style-check               postgrest-test-spec-postgresql-12
 postgrest-test-io                   postgrest-test-spec-postgresql-13
 postgrest-test-spec                 postgrest-test-spec-postgresql-9.5
 postgrest-test-spec-all             postgrest-test-spec-postgresql-9.6
+...
 
 ```
 
@@ -160,6 +162,20 @@ $ nix-shell --run postgrest-lint
 $ nix-shell --run postgrest-style
 
 ```
+
+There is also `postgrest-style-check` that exits with a non-zero exit code if
+the check resulted in any uncommited changes. It's mostly useful for CI.
+
+## General development tools
+
+Tools like `postgrest-build`, `postgrest-run` etc. are simple wrappers around
+`cabal` and should do what you expect. `postgrest-check` runs most checks that will
+also run in CI, with the exception of the IO and Memory checks that need to be run
+separately.
+
+`postgrest-watch` takes a command as an argument that it will re-run if any source
+file is changed. For example, `postgrest-watch postgrest-test-spec-all` will re-run
+the full spec test suite against all PostgreSQL versions on every change.
 
 ## Tour
 

--- a/nix/devtools.nix
+++ b/nix/devtools.nix
@@ -1,6 +1,7 @@
 { buildEnv
 , cabal-install
 , checkedShellScript
+, devCabalOptions
 , entr
 , git
 , silver-searcher
@@ -25,11 +26,11 @@ let
 
   build =
     checkedShellScript "postgrest-build"
-      ''exec ${cabal-install}/bin/cabal v2-build -f FailOnWarn "$@"'';
+      ''exec ${cabal-install}/bin/cabal v2-build ${devCabalOptions} "$@"'';
 
   run =
     checkedShellScript "postgrest-run"
-      ''exec ${cabal-install}/bin/cabal v2-run postgrest -f FailOnWarn -- "$@"'';
+      ''exec ${cabal-install}/bin/cabal v2-run postgrest ${devCabalOptions} -- "$@"'';
 
   clean =
     checkedShellScript "postgrest-clean"

--- a/nix/devtools.nix
+++ b/nix/devtools.nix
@@ -13,7 +13,7 @@ let
       ''
         rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
 
-        ${silver-searcher}/bin/ag -l . "$rootdir" | ${entr}/bin/entr "$@"
+        ${silver-searcher}/bin/ag -l . "$rootdir" | ${entr}/bin/entr -r "$@"
       '';
 
   pushCachix =

--- a/nix/docker/default.nix
+++ b/nix/docker/default.nix
@@ -1,4 +1,8 @@
-{ buildEnv, postgrest, dockerTools, writeShellScriptBin }:
+{ buildEnv
+, postgrest
+, dockerTools
+, checkedShellScript
+}:
 let
   config =
     ./postgrest.conf;
@@ -52,7 +56,7 @@ let
 
   # Helper script for loading the image.
   load =
-    writeShellScriptBin "postgrest-docker-load"
+    checkedShellScript "postgrest-docker-load"
       ''
         docker load -i ${image}
       '';
@@ -60,5 +64,5 @@ in
 buildEnv
   {
     name = "postgrest-docker";
-    paths = [ load ];
+    paths = [ load.bin ];
   } // { inherit image config; }

--- a/nix/overlays/checked-shell-script/checked-shell-script.nix
+++ b/nix/overlays/checked-shell-script/checked-shell-script.nix
@@ -1,0 +1,43 @@
+# Create a bash script that is checked with shellcheck. You can either use it
+# directly, or use the .bin attribute to get the script in a bin/ directory,
+# to be used in a path for example.
+{ writeTextFile
+, runtimeShell
+, runCommand
+, stdenv
+, shellcheck
+}:
+name: text:
+let
+  writeBin =
+    name: text:
+    writeTextFile {
+      inherit name;
+      executable = true;
+      destination = "/bin/${name}";
+
+      text =
+        ''
+          #!${runtimeShell}
+          set -euo pipefail
+
+          ${text}
+        '';
+
+      checkPhase =
+        ''
+          # check syntax
+          ${stdenv.shell} -n $out/bin/${name}
+
+          # check for shellcheck recommendations
+          ${shellcheck}/bin/shellcheck $out/bin/${name}
+        '';
+    };
+
+  bin =
+    writeBin name text;
+
+  script =
+    runCommand name { inherit bin name; } "ln -s $bin/bin/$name $out";
+in
+script // { inherit bin; }

--- a/nix/overlays/checked-shell-script/default.nix
+++ b/nix/overlays/checked-shell-script/default.nix
@@ -1,0 +1,6 @@
+self: super:
+# Overlay that adds `checkedShellScript`, an enhanced version of
+# writeShellScript and writeShellScriptBin
+{
+  checkedShellScript = super.callPackage ./checked-shell-script.nix { };
+}

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -1,6 +1,7 @@
 {
-  gitignore = import ./gitignore.nix;
+  checked-shell-script = import ./checked-shell-script;
   ghr = import ./ghr;
+  gitignore = import ./gitignore.nix;
   haskell-packages = import ./haskell-packages.nix;
   postgresql-default = import ./postgresql-default.nix;
 }

--- a/nix/style.nix
+++ b/nix/style.nix
@@ -1,0 +1,49 @@
+{ buildEnv
+, checkedShellScript
+, git
+, hlint
+, nixpkgs-fmt
+, silver-searcher
+, stylish-haskell
+}:
+let
+  style =
+    checkedShellScript "postgrest-style"
+      ''
+        rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
+
+        # Format Nix files
+        ${nixpkgs-fmt}/bin/nixpkgs-fmt "$rootdir" > /dev/null 2> /dev/null
+
+        # Format Haskell files
+        ${silver-searcher}/bin/ag -l -g '\.l?hs$' . "$rootdir" \
+          | xargs ${stylish-haskell}/bin/stylish-haskell -i
+      '';
+
+  # Script to check whether any uncommited changes result from postgrest-style
+  styleCheck =
+    checkedShellScript "postgrest-style-check"
+      ''
+        ${style}
+
+        ${git}/bin/git diff-index --exit-code HEAD -- '*.hs' '*.lhs' '*.nix'
+      '';
+
+  lint =
+    checkedShellScript "postgrest-lint"
+      ''
+        rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
+
+        # Lint Haskell files
+        ${silver-searcher}/bin/ag -l -g '\.l?hs$' "$rootdir" \
+          | xargs ${hlint}/bin/hlint -X QuasiQuotes -X NoPatternSynonyms
+      '';
+in
+buildEnv {
+  name = "postgrest-devtools";
+  paths = [
+    style.bin
+    styleCheck.bin
+    lint.bin
+  ];
+}

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -4,6 +4,7 @@
 , cabal-install
 , checkedShellScript
 , curl
+, devCabalOptions
 , git
 , haskell
 , lib
@@ -44,8 +45,7 @@ let
 
         trap 'echo "Failed on ${postgresql.name}"' exit
 
-        ${withTmpDb postgresql} ${cabal-install}/bin/cabal v2-test -f FailOnWarn \
-          --test-show-detail=direct
+        ${withTmpDb postgresql} ${cabal-install}/bin/cabal v2-test ${devCabalOptions}
 
         trap "" exit
 

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -2,6 +2,7 @@
 
 { buildEnv
 , cabal-install
+, checkedShellScript
 , curl
 , git
 , haskell
@@ -13,17 +14,13 @@
 , postgrestStatic
 , postgrestProfiled
 , runtimeShell
-, writeShellScript
-, writeShellScriptBin
 }:
 let
   # Wrap the `test/with_tmp_db` script with the required dependencies from Nix.
   withTmpDb =
     postgresql:
-    writeShellScript "postgrest-test-${postgresql.name}"
+    checkedShellScript "postgrest-test-${postgresql.name}"
       ''
-        set -euo pipefail
-
         export PATH=${postgresql}/bin:${git}/bin:${runtimeShell}/bin:"$PATH"
 
         exec ${../test/with_tmp_db} "$@"
@@ -33,12 +30,11 @@ let
   # PostgreSQL.
   testSpec =
     name: postgresql:
-    writeShellScriptBin
+    checkedShellScript
       name
       ''
-        set -euo pipefail
-
-        export PATH="$(cat ${postgrest.env})"/bin:"$PATH"
+        env="$(cat ${postgrest.env})"
+        export PATH="$env/bin:$PATH"
 
         cat << EOF
 
@@ -46,8 +42,12 @@ let
 
         EOF
 
+        trap 'echo "Failed on ${postgresql.name}"' exit
+
         ${withTmpDb postgresql} ${cabal-install}/bin/cabal v2-test -f FailOnWarn \
           --test-show-detail=direct
+
+        trap "" exit
 
         cat << EOF
 
@@ -59,8 +59,9 @@ let
   # Create a `testSpec` for each PostgreSQL version that we want to test
   # against.
   testSpecVersions =
-    lib.mapAttrsToList
-      (name: postgresql: testSpec "postgrest-test-spec-${name}" postgresql)
+    builtins.map
+      ({ name, postgresql }:
+        (testSpec "postgrest-test-spec-${name}" postgresql).bin)
       postgresqlVersions;
 
   # Helper script for running the tests against all PostgreSQL versions.
@@ -69,20 +70,14 @@ let
       testRunners =
         map (test: "${test}/bin/${test.name}") testSpecVersions;
     in
-    writeShellScriptBin "postgrest-test-spec-all"
-      ''
-        set -euo pipefail
-
-        ${lib.concatStringsSep "\n" testRunners}
-      '';
+    checkedShellScript "postgrest-test-spec-all"
+      (lib.concatStringsSep "\n" testRunners);
 
   testIO =
     name: postgresql:
-    writeShellScriptBin
+    checkedShellScript
       name
       ''
-        set -euo pipefail
-
         rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
         cd "$rootdir"
 
@@ -93,11 +88,9 @@ let
 
   testMemory =
     name: postgresql:
-    writeShellScriptBin
+    checkedShellScript
       name
       ''
-        set -euo pipefail
-
         rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
         cd "$rootdir"
 
@@ -115,8 +108,8 @@ buildEnv
 
     paths =
       [
-        (testSpec "postgrest-test-spec" postgresql)
-        testSpecAllVersions
+        (testSpec "postgrest-test-spec" postgresql).bin
+        testSpecAllVersions.bin
       ] ++ testSpecVersions;
   }
   # The IO an memory tests have large dependencies (a static and a profiled
@@ -125,8 +118,8 @@ buildEnv
   # them available through separate attributes:
   // {
   ioTests =
-    (testIO "postgrest-test-io" postgresql);
+    (testIO "postgrest-test-io" postgresql).bin;
 
   memoryTests =
-    (testMemory "postgrest-test-memory" postgresql);
+    (testMemory "postgrest-test-memory" postgresql).bin;
 }

--- a/shell.nix
+++ b/shell.nix
@@ -30,6 +30,7 @@ lib.overrideDerivation postgrest.env (
         postgrest.nixpkgsUpgrade
         postgrest.devtools
         postgrest.tests
+        postgrest.style
       ]
       ++ lib.optional ioTests postgrest.tests.ioTests
       ++ lib.optional memoryTests postgrest.tests.memoryTests


### PR DESCRIPTION
@wolfgangwalther has started using the nix tooling and had a plethora of excellent ideas to improve the developer experience. Should not be too difficult to realize, so tracking here:

* [x] add a script to watch for changes (e.g. to re-run tests)
  * [x] add docs
* [x] add a script to run all checks
* [x] add a script to push all artifacts to cachix
* [x] on failure in postgrest-test-spec-all, print the failing postgres version before exiting
* [x] run tests against postgest in ascending/chronological order in postgrest-test-spec-all (was alphabetical)
* [x] add docs on postgrest-style-check

Tbd/potentially for later PRs:
* integrate coverage
* option to preserve temporary dbs and explore them
* script to run postgrest against a temporary db

Edit: tracking those in #1671 

* [x] Refactoring: will also use this opportunity to factor out `set -euo pipefail` from writeShellScriptBin uses and lint bash scripts that we define in Nix.