### PR TITLE
Use cabal v2-exec to run io tests, include io tests in nix-shell by default; remove obsolete ncat dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
             fi
       - run:
           name: Install testing scripts
-          command: nix-env -f default.nix -iA tests tests.ioTests tests.memoryTests
+          command: nix-env -f default.nix -iA tests tests.memoryTests
       - run:
           name: Skip tests on build failure
           command: circleci-agent step halt

--- a/nix/README.md
+++ b/nix/README.md
@@ -80,26 +80,26 @@ postgrest-test-spec-postgresql-10
 
 ```
 
-Some additional modules like `ioTests`, `memoryTests`, `docker` and `release`
+Some additional modules like `memoryTests`, `docker` and `release`
 have large dependencies that would need to be built before the shell becomes
 available, which could take an especially long time if the cachix binary cache
 is not used. You can activate those by passing a flag to `nix-shell`, which
 will make the respective utilites available:
 
 ```
-$ nix-shell --arg ioTests true
+$ nix-shell --arg memoryTests true
 [nix-shell]$ postgrest-<tab>
 postgrest-lint                      postgrest-test-spec-postgresql-10
 postgrest-style                     postgrest-test-spec-postgresql-11
 postgrest-style-check               postgrest-test-spec-postgresql-12
-postgrest-test-io                   postgrest-test-spec-postgresql-13
+postgrest-test-memory               postgrest-test-spec-postgresql-13
 postgrest-test-spec                 postgrest-test-spec-postgresql-9.5
 postgrest-test-spec-all             postgrest-test-spec-postgresql-9.6
 ...
 
 ```
 
-Note that `postgrest-test-io` is now also available.
+Note that `postgrest-test-memory` is now also available.
 
 To run one-off commands, you can also use `nix-shell --run <command>`, which
 will lauch the Nix shell, run that one command and exit. Note that the tab
@@ -138,14 +138,14 @@ temporary test databases:
 
 ```bash
 # Run the tests against the most recent version of PostgreSQL:
-$ nix-shell --arg tests true --run postgrest-test-spec
+$ nix-shell --run postgrest-test-spec
 
 # Run the tests against all supported versions of PostgreSQL:
-$ nix-shell --arg tests true --run postgrest-test-spec-all
+$ nix-shell --run postgrest-test-spec-all
 
 # Run the tests against a specific version of PostgreSQL (use tab-completion in
 # nix-shell to see all available versions):
-$ nix-shell --arg tests true --run postgrest-test-spec-postgresql-9.5
+$ nix-shell --run postgrest-test-spec-postgresql-9.5
 
 ```
 

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -8,7 +8,6 @@
 , git
 , haskell
 , lib
-, ncat
 , postgresql
 , postgresqlVersions
 , postgrest
@@ -78,12 +77,14 @@ let
     checkedShellScript
       name
       ''
+        env="$(cat ${postgrest.env})"
+        export PATH="$env/bin:${curl}/bin:$PATH"
+
         rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
         cd "$rootdir"
 
-        export PATH="${curl}/bin:$PATH"
-
-        ${withTmpDb postgresql} ${cabal-install}/bin/cabal v2-exec ${devCabalOptions} "$rootdir"/test/io-tests.sh
+        ${cabal-install}/bin/cabal v2-build ${devCabalOptions}
+        ${cabal-install}/bin/cabal v2-exec ${withTmpDb postgresql} "$rootdir"/test/io-tests.sh
       '';
 
   testMemory =

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -81,9 +81,9 @@ let
         rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
         cd "$rootdir"
 
-        export PATH="${postgrestStatic}/bin:${curl}/bin:${ncat}/bin:$PATH"
+        export PATH="${curl}/bin:$PATH"
 
-        ${withTmpDb postgresql} "$rootdir"/test/io-tests.sh
+        ${withTmpDb postgresql} ${cabal-install}/bin/cabal v2-exec ${devCabalOptions} "$rootdir"/test/io-tests.sh
       '';
 
   testMemory =
@@ -110,16 +110,13 @@ buildEnv
       [
         (testSpec "postgrest-test-spec" postgresql).bin
         testSpecAllVersions.bin
+        (testIO "postgrest-test-io" postgresql).bin
       ] ++ testSpecVersions;
   }
-  # The IO an memory tests have large dependencies (a static and a profiled
-  # build of PostgREST respectively) and are run less often than the spec
-  # tests, so we don't include them in the default test environment. We make
-  # them available through separate attributes:
+  # The memory tests have large dependencies (a profiled build of PostgREST)
+  # and are run less often than the spec tests, so we don't include them in 
+  # the default test environment. We make them available through a separate attribute:
   // {
-  ioTests =
-    (testIO "postgrest-test-io" postgresql).bin;
-
   memoryTests =
     (testMemory "postgrest-test-memory" postgresql).bin;
 }

--- a/shell.nix
+++ b/shell.nix
@@ -9,7 +9,7 @@
 #
 # We highly recommend that use the PostgREST binary cache by installing cachix
 # (https://app.cachix.org/) and running `cachix use postgrest`.
-{ ioTests ? false, memoryTests ? false, docker ? false, release ? false }:
+{ memoryTests ? false, docker ? false, release ? false }:
 let
   postgrest =
     import ./default.nix;
@@ -32,7 +32,6 @@ lib.overrideDerivation postgrest.env (
         postgrest.tests
         postgrest.style
       ]
-      ++ lib.optional ioTests postgrest.tests.ioTests
       ++ lib.optional memoryTests postgrest.tests.memoryTests
       ++ lib.optional docker postgrest.docker
       ++ lib.optional release postgrest.release;

--- a/test/io-tests.sh
+++ b/test/io-tests.sh
@@ -2,8 +2,7 @@
 # Run unit tests for Input/Ouput of PostgREST seen as a black box
 # with test output in Test Anything Protocol format.
 #
-# These tests expect that `postgrest` is on the PATH, as well as `curl` and
-# `ncat` (from the nmap package in some distribution).
+# These tests expect that `postgrest` is on the PATH, as well as `curl`
 #
 # References:
 #   [1] Test Anything Protocol


### PR DESCRIPTION
As mentioned in #1666 and #1671, this runs the io-tests with `cabal v2-exec`. I need to use those currently, so went ahead with that.

This does not change the memory tests, those are going to be a bit trickier.

Would love to have your feedback on this @monacoremo.