### PR TITLE
improve error output for io-tests and with_tmp_db

### DIFF
--- a/test/with_tmp_db
+++ b/test/with_tmp_db
@@ -78,7 +78,14 @@ until pg_isready >> "$setuplog"; do
   sleep 0.1
 done
 
+stopped=0
 stop() {
+  # cleaning up once is enough; otherwise we get some errors
+  if [ $stopped -eq 1 ]; then
+    return
+  fi
+  stopped=1
+
   log "Stopping the database cluster..."
   pg_ctl stop -m i >> "$setuplog"
 


### PR DESCRIPTION
We used to get some "segmentation faults" for the io tests in CI. I am currently trying to set up a nix-based coverage script - and ran into those errors again.

It turns out that the seg fault is just bash complaining, because some traps are set where bash tries to kill itself multiple times. Something similar happenend in `with_tmp_db`, where those calls led to errors regarding the log file, because it didn't exist anymore.

After fixing all those traps and obsolete output I was left with.. nothing. The actual error that I was looking for was still hidden, because all postgrest stderr is piped to `/dev/null` in the `io-tests.sh`. Some errors during the test are expected, so it's fine to filter those out, but in my case I had some startup errors for postgrest due to missing libraries and stuff like this. With the change here, those errors will not be filtered out anymore.

I'm pretty sure that with those changes we will get useful error message next time the io-tests in CI fail that way. So don't be afraid of seg faults, @monacoremo, when trying to set up the circle caching again. Those are a thing of the past now!