### PR TITLE
dev: improve postgrest-watch experience

### DIFF
--- a/nix/devtools.nix
+++ b/nix/devtools.nix
@@ -14,7 +14,9 @@ let
       ''
         rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
 
-        ${silver-searcher}/bin/ag -l . "$rootdir" | ${entr}/bin/entr -r "$@"
+        while true; do
+          (! ${silver-searcher}/bin/ag -l . "$rootdir" | ${entr}/bin/entr -dr "$@")
+        done
       '';
 
   pushCachix =

--- a/nix/style.nix
+++ b/nix/style.nix
@@ -16,7 +16,8 @@ let
         ${nixpkgs-fmt}/bin/nixpkgs-fmt "$rootdir" > /dev/null 2> /dev/null
 
         # Format Haskell files
-        ${silver-searcher}/bin/ag -l -g '\.l?hs$' . "$rootdir" \
+        # --vimgrep fixes a bug in ag: https://github.com/ggreer/the_silver_searcher/issues/753
+        ${silver-searcher}/bin/ag -l --vimgrep -g '\.l?hs$' . "$rootdir" \
           | xargs ${stylish-haskell}/bin/stylish-haskell -i
       '';
 
@@ -35,7 +36,8 @@ let
         rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
 
         # Lint Haskell files
-        ${silver-searcher}/bin/ag -l -g '\.l?hs$' "$rootdir" \
+        # --vimgrep fixes a bug in ag: https://github.com/ggreer/the_silver_searcher/issues/753
+        ${silver-searcher}/bin/ag -l --vimgrep -g '\.l?hs$' "$rootdir" \
           | xargs ${hlint}/bin/hlint -X QuasiQuotes -X NoPatternSynonyms
       '';
 in

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -13,6 +13,7 @@
 , postgrest
 , postgrestStatic
 , postgrestProfiled
+, procps
 , runtimeShell
 }:
 let
@@ -78,7 +79,7 @@ let
       name
       ''
         env="$(cat ${postgrest.env})"
-        export PATH="$env/bin:${curl}/bin:$PATH"
+        export PATH="$env/bin:${curl}/bin:${procps}/bin:$PATH"
 
         rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
         cd "$rootdir"

--- a/shell.nix
+++ b/shell.nix
@@ -38,7 +38,8 @@ lib.overrideDerivation postgrest.env (
 
     shellHook =
       ''
-        complete -c postgrest-watch
+        source ${pkgs.bashCompletion}/etc/profile.d/bash_completion.sh
+        complete -F _command postgrest-watch
       '';
   }
 )

--- a/test/io-tests/configs/app-settings.config
+++ b/test/io-tests/configs/app-settings.config
@@ -2,6 +2,7 @@ db-uri = "$(POSTGREST_TEST_CONNECTION)"
 db-schema = "test"
 db-anon-role = "postgrest_test_anonymous"
 db-pool = 1
+db-pool-timeout = 1
 server-host = "127.0.0.1"
 server-port = 49421
 


### PR DESCRIPTION
This PR does:
* speed up io tests
* avoid infinite loop while watching io tests
* improve auto-complete with postgrest-watch postgrest-run
* detect when files are added or deleted

TODO:
* [x] fix `postgrest-watch postgrest-lint` 