### PR TITLE
run spec tests in parallel

### DIFF
--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -293,29 +293,30 @@ spec actualPgVersion = do
         -- reset pk sequence first to make test repeatable
         request methodPost "/rpc/reset_sequence"
             [("Prefer", "tx=commit")]
-            [json|{"name": "items_id_seq", "value": 20}|]
+            [json|{"name": "items2_id_seq", "value": 20}|]
           `shouldRespondWith`
             [json|""|]
 
-        request methodPost "/items" [("Prefer", "return=representation")] "{}"
-          `shouldRespondWith` [json|[{ id: 20 }]|]
-          { matchStatus  = 201,
-            matchHeaders = []
-          }
+        request methodPost "/items2"
+            [("Prefer", "return=representation")]
+            [json|{}|]
+          `shouldRespondWith`
+            [json|[{ id: 20 }]|]
+            { matchStatus  = 201 }
 
       it "successfully inserts a row with all-default columns with prefer=rep and &select=" $ do
         -- reset pk sequence first to make test repeatable
         request methodPost "/rpc/reset_sequence"
             [("Prefer", "tx=commit")]
-            [json|{"name": "items_id_seq", "value": 20}|]
+            [json|{"name": "items3_id_seq", "value": 20}|]
           `shouldRespondWith`
             [json|""|]
 
-        request methodPost "/items?select=id" [("Prefer", "return=representation")] "{}"
+        request methodPost "/items3?select=id"
+            [("Prefer", "return=representation")]
+            [json|{}|]
           `shouldRespondWith` [json|[{ id: 20 }]|]
-          { matchStatus  = 201,
-            matchHeaders = []
-          }
+            { matchStatus  = 201 }
 
     context "POST with ?columns parameter" $ do
       it "ignores json keys not included in ?columns" $ do

--- a/test/Feature/RollbackSpec.hs
+++ b/test/Feature/RollbackSpec.hs
@@ -80,7 +80,7 @@ shouldPersistMutations reqHeaders respHeaders = do
         [json|[{"id":0}]|]
         { matchStatus  = 201
         , matchHeaders = respHeaders }
-    get "items?id=eq.0"
+    get "/items?id=eq.0"
       `shouldRespondWith`
         [json|[{"id":0}]|]
     deleteItems
@@ -92,7 +92,7 @@ shouldPersistMutations reqHeaders respHeaders = do
       `shouldRespondWith`
         [json|[{"id":0}]|]
         { matchHeaders = respHeaders }
-    get "items?id=eq.0"
+    get "/items?id=eq.0"
       `shouldRespondWith`
         [json|[{"id":0}]|]
     deleteItems
@@ -105,10 +105,10 @@ shouldPersistMutations reqHeaders respHeaders = do
       `shouldRespondWith`
         [json|[{"id":-1}]|]
         { matchHeaders = respHeaders }
-    get "items?id=eq.0"
+    get "/items?id=eq.0"
       `shouldRespondWith`
         [json|[]|]
-    get "items?id=eq.-1"
+    get "/items?id=eq.-1"
       `shouldRespondWith`
         [json|[{"id":-1}]|]
     deleteItems
@@ -121,7 +121,7 @@ shouldPersistMutations reqHeaders respHeaders = do
       `shouldRespondWith`
         [json|[{"id":0}]|]
         { matchHeaders = respHeaders }
-    get "items?id=eq.0"
+    get "/items?id=eq.0"
       `shouldRespondWith`
         [json|[]|]
 
@@ -134,7 +134,7 @@ shouldNotPersistMutations reqHeaders respHeaders = do
         [json|[{"id":0}]|]
         { matchStatus  = 201
         , matchHeaders = respHeaders }
-    get "items?id=eq.0"
+    get "/items?id=eq.0"
       `shouldRespondWith`
         [json|[]|]
 
@@ -145,7 +145,7 @@ shouldNotPersistMutations reqHeaders respHeaders = do
       `shouldRespondWith`
         [json|[{"id":0}]|]
         { matchHeaders = respHeaders }
-    get "items?id=eq.0"
+    get "/items?id=eq.0"
       `shouldRespondWith`
         [json|[]|]
 
@@ -156,7 +156,7 @@ shouldNotPersistMutations reqHeaders respHeaders = do
       `shouldRespondWith`
         [json|[{"id":0}]|]
         { matchHeaders = respHeaders }
-    get "items?id=eq.0"
+    get "/items?id=eq.0"
       `shouldRespondWith`
         [json|[]|]
     get "items?id=eq.1"
@@ -170,7 +170,7 @@ shouldNotPersistMutations reqHeaders respHeaders = do
       `shouldRespondWith`
         [json|[{"id":1}]|]
         { matchHeaders = respHeaders }
-    get "items?id=eq.1"
+    get "/items?id=eq.1"
       `shouldRespondWith`
         [json|[{"id":1}]|]
 

--- a/test/Feature/UpdateSpec.hs
+++ b/test/Feature/UpdateSpec.hs
@@ -51,31 +51,13 @@ spec = do
 
     context "in a nonempty table" $ do
       it "can update a single item" $ do
-        get "/items?id=eq.42"
-          `shouldRespondWith`
-            [json|[]|]
-
-        request methodPatch "/items?id=eq.2"
-            [("Prefer", "tx=commit")]
+        patch "/items?id=eq.2"
             [json| { "id":42 } |]
           `shouldRespondWith`
             ""
             { matchStatus  = 204
-            , matchHeaders = ["Content-Range" <:> "0-0/*"
-                             , "Preference-Applied" <:> "tx=commit" ]
+            , matchHeaders = ["Content-Range" <:> "0-0/*"]
             }
-
-        -- check it really got updated
-        get "/items?id=eq.42"
-          `shouldRespondWith`
-            [json|[ { "id": 42 } ]|]
-
-        -- put value back for other tests
-        request methodPatch "/items?id=eq.42"
-            [("Prefer", "tx=commit")]
-            [json| { "id":2 } |]
-          `shouldRespondWith`
-            204
 
       it "returns empty array when no rows updated and return=rep" $
         request methodPatch "/items?id=eq.999999"

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -16,6 +16,7 @@ SET search_path = test, "تست", pg_catalog;
 GRANT ALL ON TABLE
     items
     , items2
+    , items3
     , "articleStars"
     , articles
     , auto_incrementing_pk
@@ -143,6 +144,8 @@ GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;
 GRANT USAGE ON SEQUENCE
       auto_incrementing_pk_id_seq
     , items_id_seq
+    , items2_id_seq
+    , items3_id_seq
     , callcounter_count
     , leak_id_seq
 TO postgrest_test_anonymous;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -113,6 +113,10 @@ CREATE TABLE items2 (
     id bigserial primary key
 );
 
+CREATE TABLE items3 (
+    id bigserial primary key
+);
+
 CREATE FUNCTION search(id BIGINT) RETURNS SETOF items
     LANGUAGE plpgsql
     AS $$BEGIN


### PR DESCRIPTION
Now that we are able to run the spec tests repeatedly on the same database, I was wondering whether we could run them in parallel as well. With a few more tests adjusted, this is possible.

I only get an improvment of running postgrest-test-spec-all of about 20-25%. It took ~ 1 min before for me, ~45 seconds now. I had hoped for more, but hey it's still an improvement!

