### PR TITLE
Add postgrest-coverage to show and upload hpc reports to codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,6 +234,13 @@ jobs:
           name: Run memory tests
           command: postgrest-test-memory
           when: always
+      - run:
+          name: Run coverage
+          command: postgrest-coverage
+      - run:
+          name: Upload coverage to codecov
+          command: bash <(curl -s https://codecov.io/bash) -f coverage/codecov.json
+
 
 workflows:
   version: 2

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,17 @@
+codecov:
+  branch: master
+
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%
+        only_pulls: false
+    patch:
+      default:
+        target: auto
+        threshold: 0%
+        only_pulls: true

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ dist-newstyle
 postgrest.hp
 postgrest.prof
 __pycache__
+*.tix
+coverage
+.hpc

--- a/default.nix
+++ b/default.nix
@@ -66,7 +66,7 @@ let
 
   # Options passed to cabal in dev tools and tests
   devCabalOptions =
-    "-f FailOnWarn --test-show-detail=direct";
+    "-f dev --test-show-detail=direct";
 
   profiledHaskellPackages =
     pkgs.haskell.packages."${compiler}".extend (self: super:
@@ -87,7 +87,7 @@ rec {
   # libraries and documentation. We disable running the test suite on Nix
   # builds, as they require a database to be set up.
   postgrestPackage =
-    lib.dontCheck (lib.enableCabalFlag postgrest "FailOnWarn");
+    lib.dontCheck postgrest;
 
   # Static executable.
   postgrestStatic =
@@ -114,7 +114,11 @@ rec {
 
   # Scripts for running tests.
   tests =
-    pkgs.callPackage nix/tests.nix { inherit postgrest postgrestStatic postgrestProfiled postgresqlVersions devCabalOptions; };
+    pkgs.callPackage nix/tests.nix {
+      inherit postgrest postgrestProfiled postgresqlVersions devCabalOptions;
+      ghc = pkgs.haskell.compiler."${compiler}";
+      hpc-codecov = pkgs.haskell.packages."${compiler}".hpc-codecov;
+    };
 
   # Linting and styling scripts.
   style =

--- a/nix/devtools.nix
+++ b/nix/devtools.nix
@@ -72,6 +72,8 @@ let
       }
       ''
         ${cabal-install}/bin/cabal v2-clean
+        # clean old coverage data, too
+        rm -rf .hpc coverage
       '';
 
   check =

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -19,12 +19,17 @@ source-repository head
   type:     git
   location: git://github.com/PostgREST/postgrest.git
 
-flag FailOnWarn
+flag dev
   default:     False
   manual:      True
-  description: No warnings allowed
+  description: Development flags
 
 library
+  default-language:   Haskell2010
+  default-extensions: OverloadedStrings
+                      QuasiQuotes
+                      NoImplicitPrelude
+  hs-source-dirs:     src
   exposed-modules:    PostgREST.ApiRequest
                       PostgREST.App
                       PostgREST.Auth
@@ -43,7 +48,6 @@ library
                       PostgREST.Private.Common
                       PostgREST.Private.ProxyUri
                       PostgREST.Private.QueryFragment
-  hs-source-dirs:     src
   build-depends:      base                      >= 4.9 && < 4.15
                     , HTTP                      >= 4000.3.7 && < 4000.4
                     , Ranged-sets               >= 0.3 && < 0.5
@@ -88,15 +92,12 @@ library
                     , wai-extra                 >= 3.0.19 && < 3.2
                     , wai-logger                >= 2.3.2
                     , wai-middleware-static     >= 0.8.1 && < 0.10
-  default-language:   Haskell2010
-  default-extensions: OverloadedStrings
-                      QuasiQuotes
-                      NoImplicitPrelude
-  if flag(FailOnWarn)
-    ghc-options: -O2 -Werror -Wall -fwarn-identities
+  if flag(dev)
+    ghc-options: -O0 -Werror -Wall -fwarn-identities
                  -fno-spec-constr -optP-Wno-nonportable-include-path
+                 -fhpc -hpcdir .hpc
   else
-    ghc-options: -O2 -Wall -fwarn-identities
+    ghc-options: -O2 -Werror -Wall -fwarn-identities
                  -fno-spec-constr -optP-Wno-nonportable-include-path
           -- -fno-spec-constr may help keep compile time memory use in check,
           --   see https://gitlab.haskell.org/ghc/ghc/issues/16017#note_219304
@@ -105,8 +106,12 @@ library
           --   see https://github.com/commercialhaskell/stack/issues/3918
 
 executable postgrest
-  main-is:            Main.hs
+  default-language:   Haskell2010
+  default-extensions: OverloadedStrings
+                      QuasiQuotes
+                      NoImplicitPrelude
   hs-source-dirs:     main
+  main-is:            Main.hs
   build-depends:      base                >= 4.9 && < 4.15
                     , aeson               >= 1.4.7 && < 1.6
                     , auto-update         >= 0.1.4 && < 0.2
@@ -126,17 +131,14 @@ executable postgrest
                     , time                >= 1.6 && < 1.11
                     , wai                 >= 3.2.1 && < 3.3
                     , warp                >= 3.2.12 && < 3.4
-  default-language:   Haskell2010
-  default-extensions: OverloadedStrings
-                      QuasiQuotes
-                      NoImplicitPrelude
-  if flag(FailOnWarn)
+  if flag(dev)
     ghc-options:      -threaded -rtsopts "-with-rtsopts=-N -I2"
-                      -O2 -Werror -Wall -fwarn-identities
+                      -O0 -Werror -Wall -fwarn-identities
                       -fno-spec-constr -optP-Wno-nonportable-include-path
+                      -fhpc -hpcdir .hpc
   else
     ghc-options:      -threaded -rtsopts "-with-rtsopts=-N -I2"
-                      -O2 -Wall -fwarn-identities
+                      -O2 -Werror -Wall -fwarn-identities
                       -fno-spec-constr -optP-Wno-nonportable-include-path
 
   if !os(windows)
@@ -145,6 +147,11 @@ executable postgrest
 
 test-suite spec
   type:               exitcode-stdio-1.0
+  default-language:   Haskell2010
+  default-extensions: OverloadedStrings
+                      QuasiQuotes
+                      NoImplicitPrelude
+  hs-source-dirs:     test
   main-is:            Main.hs
   other-modules:      Feature.AndOrParamsSpec
                       Feature.AsymmetricJwtSpec
@@ -179,7 +186,6 @@ test-suite spec
                       Feature.UpsertSpec
                       SpecHelper
                       TestTypes
-  hs-source-dirs:     test
   build-depends:      base              >= 4.9 && < 4.15
                     , aeson             >= 1.4.7 && < 1.6
                     , aeson-qq          >= 0.8.1 && < 0.9
@@ -211,20 +217,21 @@ test-suite spec
                     , transformers-base >= 0.4.4 && < 0.5
                     , wai               >= 3.2.1 && < 3.3
                     , wai-extra         >= 3.0.19 && < 3.2
-  default-language:   Haskell2010
-  default-extensions: OverloadedStrings
-                      QuasiQuotes
-                      NoImplicitPrelude
   ghc-options:        -threaded -rtsopts -with-rtsopts=-N
+                      -O0 -Werror -Wall -fwarn-identities
+                      -fno-spec-constr -optP-Wno-nonportable-include-path
+                      -fno-warn-missing-signatures
 
-Test-Suite spec-querycost
-  Type:                exitcode-stdio-1.0
-  Default-Language:    Haskell2010
-  default-extensions:  OverloadedStrings, QuasiQuotes, NoImplicitPrelude
-  Hs-Source-Dirs:      test
-  Main-Is:             QueryCost.hs
-  Other-Modules:       SpecHelper
-  Build-Depends:       base              >= 4.9 && < 4.15
+test-suite spec-querycost
+  type:                exitcode-stdio-1.0
+  default-language:    Haskell2010
+  default-extensions:  OverloadedStrings
+                       QuasiQuotes
+                       NoImplicitPrelude
+  hs-source-dirs:      test
+  main-is:             QueryCost.hs
+  other-modules:       SpecHelper
+  build-depends:       base              >= 4.9 && < 4.15
                      , aeson             >= 1.4.7 && < 1.6
                      , aeson-qq          >= 0.8.1 && < 0.9
                      , async             >= 2.1.1 && < 2.3
@@ -256,3 +263,5 @@ Test-Suite spec-querycost
                      , transformers-base >= 0.4.4 && < 0.5
                      , wai               >= 3.2.1 && < 3.3
                      , wai-extra         >= 3.0.19 && < 3.2
+  ghc-options:         -O0 -Werror -Wall -fwarn-identities
+                       -fno-spec-constr -optP-Wno-nonportable-include-path

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,5 @@
 resolver: lts-16.26 # 2020-12-13, GHC 8.8.4
 
-flags:
-  postgrest:
-    FailOnWarn: true
-
 nix:
   packages:
     - pcre

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -1,14 +1,10 @@
 module Feature.InsertSpec where
 
-import qualified Data.Aeson as JSON
-
 import Data.List              (lookup)
-import Data.Maybe             (fromJust)
 import Network.Wai            (Application)
 import Network.Wai.Test       (SResponse (simpleBody, simpleHeaders, simpleStatus))
 import Test.Hspec             hiding (pendingWith)
 import Test.Hspec.Wai.Matcher (bodyEquals)
-import TestTypes              (CompoundPK (..), IncPK (..))
 
 import Network.HTTP.Types
 import Test.Hspec.Wai
@@ -441,9 +437,6 @@ spec actualPgVersion = do
 
   describe "Row level permission" $
     it "set user_id when inserting rows" $ do
-      post "/postgrest/users" [json| { "id":"jdoe", "pass": "1234", "role": "postgrest_test_author" } |]
-      post "/postgrest/users" [json| { "id":"jroe", "pass": "1234", "role": "postgrest_test_author" } |]
-
       request methodPost "/authors_only"
           [ authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoicG9zdGdyZXN0X3Rlc3RfYXV0aG9yIiwiaWQiOiJqZG9lIn0.B-lReuGNDwAlU1GOC476MlO0vAt9JNoHIlxg2vwMaO0", ("Prefer", "return=representation") ]
           [json| { "secret": "nyancat" } |]

--- a/test/Feature/QueryLimitedSpec.hs
+++ b/test/Feature/QueryLimitedSpec.hs
@@ -1,7 +1,6 @@
 module Feature.QueryLimitedSpec where
 
-import Network.Wai      (Application)
-import Network.Wai.Test (SResponse (simpleHeaders, simpleStatus))
+import Network.Wai (Application)
 
 import Network.HTTP.Types
 import Test.Hspec

--- a/test/Feature/RollbackSpec.hs
+++ b/test/Feature/RollbackSpec.hs
@@ -7,8 +7,7 @@ import Test.Hspec
 import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 
-import Protolude  hiding (get)
-import SpecHelper
+import Protolude hiding (get)
 
 -- two helpers functions to make sure that each test can setup and cleanup properly
 

--- a/test/Feature/RpcPreRequestGucsSpec.hs
+++ b/test/Feature/RpcPreRequestGucsSpec.hs
@@ -1,18 +1,13 @@
 module Feature.RpcPreRequestGucsSpec where
 
-import qualified Data.ByteString.Lazy as BL (empty)
-
-import Network.Wai      (Application)
-import Network.Wai.Test (SResponse (simpleBody, simpleHeaders, simpleStatus))
+import Network.Wai (Application)
 
 import Network.HTTP.Types
 import Test.Hspec          hiding (pendingWith)
 import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
-import Text.Heredoc
 
-import Protolude  hiding (get, put)
-import SpecHelper
+import Protolude hiding (get, put)
 
 spec :: SpecWith ((), Application)
 spec =

--- a/test/Feature/UnicodeSpec.hs
+++ b/test/Feature/UnicodeSpec.hs
@@ -7,8 +7,7 @@ import Test.Hspec
 import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 
-import Protolude  hiding (get)
-import SpecHelper
+import Protolude hiding (get)
 
 spec :: SpecWith ((), Application)
 spec =

--- a/test/Feature/UpdateSpec.hs
+++ b/test/Feature/UpdateSpec.hs
@@ -1,14 +1,11 @@
 module Feature.UpdateSpec where
 
-import Data.List        (lookup)
-import Network.Wai      (Application)
-import Network.Wai.Test (SResponse (simpleBody, simpleHeaders, simpleStatus))
-import Test.Hspec       hiding (pendingWith)
+import Network.Wai (Application)
+import Test.Hspec  hiding (pendingWith)
 
 import Network.HTTP.Types
 import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
-import Text.Heredoc
 
 import Protolude  hiding (get)
 import SpecHelper

--- a/test/QueryCost.hs
+++ b/test/QueryCost.hs
@@ -5,7 +5,6 @@ import qualified Data.Aeson.Lens                   as L
 import qualified Hasql.Decoders                    as HD
 import qualified Hasql.DynamicStatements.Snippet   as H
 import qualified Hasql.DynamicStatements.Statement as H
-import qualified Hasql.Encoders                    as HE
 import qualified Hasql.Pool                        as P
 import qualified Hasql.Statement                   as H
 import qualified Hasql.Transaction                 as HT

--- a/test/io-tests/test_io.py
+++ b/test/io-tests/test_io.py
@@ -75,13 +75,16 @@ def defaultenv():
 
 def dumpconfig(configpath=None, env=None, stdin=None):
     "Dump the config as parsed by PostgREST."
+    env = env or {}
+
     command = [POSTGREST_BIN, "--dump-config"]
+    env["HPCTIXFILE"] = os.getenv("HPCTIXFILE", "")
 
     if configpath:
         command.append(configpath)
 
     process = subprocess.Popen(
-        command, env=env or {}, stdin=subprocess.PIPE, stdout=subprocess.PIPE
+        command, env=env, stdin=subprocess.PIPE, stdout=subprocess.PIPE
     )
 
     process.stdin.write(stdin or b"")
@@ -96,6 +99,7 @@ def dumpconfig(configpath=None, env=None, stdin=None):
 @contextlib.contextmanager
 def run(configpath=None, stdin=None, env=None, port=None):
     "Run PostgREST and yield an endpoint that is ready for connections."
+    env = env or {}
 
     with tempfile.TemporaryDirectory() as tmpdir:
         if port:
@@ -108,11 +112,12 @@ def run(configpath=None, stdin=None, env=None, port=None):
             baseurl = "http+unix://" + urllib.parse.quote_plus(str(socketfile))
 
         command = [POSTGREST_BIN]
+        env["HPCTIXFILE"] = os.getenv("HPCTIXFILE", "")
 
         if configpath:
             command.append(configpath)
 
-        process = subprocess.Popen(command, stdin=subprocess.PIPE, env=env or {})
+        process = subprocess.Popen(command, stdin=subprocess.PIPE, env=env)
 
         try:
             process.stdin.write(stdin or b"")


### PR DESCRIPTION
`postgrest-coverage` is here.

Some background on the why and how: When I introduced code coverage in CI a while back, I went with a combination of stack, coveralls, `stack-hpc-coveralls` and travis. I turns out that this has many disadvantages. This PR replaces everything, and we are now using cabal, codecov, `hpc-codecov` and circleci.

This has the following advantages:
- Coveralls does not support partial line coverage at all - codecov does. Of course some information is still lost, because the hpc coverage info is very detailed for expressions, etc. - but having that marked as partial line coverage instead of "no coverage at all" will hopefully be much better.
- Only travis supported token-less upload of coverage reports for coveralls. For codecov, we can do the same from circleci. Travis had huge delays for the coverage job in the last couple of months, because of their move to new infrastructure. Most of our jobs are running on circleci and on the nix pipeline, so it's good that we can add the coverage here as well.
- Of course using a cabal based setup instead of stack is better, because our whole nix tooling is cabal-based.
- `hpc-codecov` seems to be much more maintained than `stack-hpc-coveralls`. At least there were some recent commits to the former, while the latter didn't have much done in the last years. Also the new tool is "build tool agnostic", so it does not care whether it's stack or cabal. It just doesn't make any assumptions of directory structure. Since we're copying together various `.tix` files from different tests (spec and io so far), this makes it easier to handle.

I have not had a look at a codecov coverage report for the repo, yet, but I'm sure it will be better than what we have right now.

TODO:
- [x] fix ci failure
- [x] register repo at codecov.io
- [x] add overlay for deliberately untested code