### PR TITLE
Add --dump-schema

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -2,6 +2,7 @@
 
 module Main where
 
+import qualified Data.Aeson                 as Aeson
 import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Lazy       as LBS
 import qualified Hasql.Connection           as C
@@ -19,7 +20,6 @@ import Control.Debounce         (debounceAction, debounceEdge,
 import Control.Retry            (RetryStatus, capDelay,
                                  exponentialBackoff, retrying,
                                  rsPreviousDelay)
-import Data.Aeson               (encode)
 import Data.IORef               (IORef, atomicWriteIORef, newIORef,
                                  readIORef)
 import Data.String              (IsString (..))
@@ -88,11 +88,13 @@ main = do
 
   case cliCommand opts of
     CmdDumpConfig ->
-      dumpAppConfig conf
+      do
+        putStr $ dumpAppConfig conf
+        exitSuccess
     CmdDumpSchema ->
       do
-        schema <- dumpSchema conf
-        putStrLn schema
+        dumpedSchema <- dumpSchema conf
+        putStrLn dumpedSchema
         exitSuccess
     CmdRun ->
       pass
@@ -351,7 +353,7 @@ dumpSchema conf =
             (configDbPreparedStatements conf)
     Right dbStructure <- S.run getDbStructureTransaction conn
     C.release conn
-    return $ encode dbStructure
+    return $ Aeson.encode dbStructure
 
 
 -- Utilitarian functions.

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -108,6 +108,7 @@ executable postgrest
   main-is:            Main.hs
   hs-source-dirs:     main
   build-depends:      base                >= 4.9 && < 4.15
+                    , aeson               >= 1.4.7 && < 1.6
                     , auto-update         >= 0.1.4 && < 0.2
                     , base64-bytestring   >= 1 && < 1.3
                     , bytestring          >= 0.10.8 && < 0.11

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -160,7 +160,7 @@ readCLIShowHelp = customExecParser parserPrefs opts
         <|>
         flag CmdRun CmdDumpSchema (
           long "dump-schema" <>
-          help "Dump loaded schema and exit"
+          help "Dump loaded schema as JSON and exit (for debugging, output structure is unstable)"
         )
       )
       <*>

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -76,7 +76,11 @@ data CLI = CLI
   { cliCommand :: Command
   , cliPath    :: FilePath }
 
-data Command = CmdRun | CmdDumpConfig deriving (Eq)
+data Command
+  = CmdRun
+  | CmdDumpConfig
+  | CmdDumpSchema
+  deriving (Eq)
 
 -- | Config file settings for the server
 data AppConfig = AppConfig {
@@ -148,10 +152,18 @@ readCLIShowHelp = customExecParser parserPrefs opts
 
     cliParser :: Parser CLI
     cliParser = CLI <$>
-      flag CmdRun CmdDumpConfig (
-        long "dump-config" <>
-        help "Dump loaded configuration and exit"
-      ) <*>
+      (
+        flag CmdRun CmdDumpConfig (
+          long "dump-config" <>
+          help "Dump loaded configuration and exit"
+        )
+        <|>
+        flag CmdRun CmdDumpSchema (
+          long "dump-schema" <>
+          help "Dump loaded schema and exit"
+        )
+      )
+      <*>
       strArgument (
         metavar "FILENAME" <>
         help "Path to configuration file"

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -249,15 +249,11 @@ readCLIShowHelp = customExecParser parserPrefs opts
           |]
 
 -- | Dump the config
-dumpAppConfig :: AppConfig -> IO ()
-dumpAppConfig conf = do
-  putStr dump
-  exitSuccess
-
+dumpAppConfig :: AppConfig -> Text
+dumpAppConfig conf =
+  unlines $ (\(k, v) -> k <> " = " <> v) <$>
+    pgrstSettings ++ appSettings
   where
-    dump = unlines $ (\(k, v) -> k <> " = " <> v) <$>
-      pgrstSettings ++ appSettings
-
     -- apply conf to all pgrst settings
     pgrstSettings = (\(k, v) -> (k, v conf)) <$>
       [("db-anon-role",              q . configDbAnonRole)


### PR DESCRIPTION
Add a `--dump-schema` option that pretty-prints the schema cache and exits.

This does not pretty print at this stage - thinking about outputting JSON, which would require adding some Aeson derivations on the DbStructure types. WDYT?