### PR TITLE
fix: fix OpenAPI pk/fk note not being overridable

### DIFF
--- a/test/Feature/MultipleSchemaSpec.hs
+++ b/test/Feature/MultipleSchemaSpec.hs
@@ -217,7 +217,9 @@ spec actualPgVersion =
                     "type" : "object",
                     "properties" : {
                       "id" : {
-                        "description" : "Note:\nThis is a Primary Key.<pk/>",
+                        "additionalProperties": {
+                          "description": "Note:\nThis is a Primary Key.<pk/>"
+                        },
                         "format" : "integer",
                         "type" : "integer"
                       },
@@ -246,7 +248,9 @@ spec actualPgVersion =
                     "type" : "object",
                     "properties" : {
                       "id" : {
-                        "description" : "Note:\nThis is a Primary Key.<pk/>",
+                        "additionalProperties": {
+                          "description": "Note:\nThis is a Primary Key.<pk/>"
+                        },
                         "format" : "integer",
                         "type" : "integer"
                       },
@@ -275,7 +279,9 @@ spec actualPgVersion =
                     "type" : "object",
                     "properties" : {
                       "id" : {
-                        "description" : "Note:\nThis is a Primary Key.<pk/>",
+                        "additionalProperties": {
+                          "description": "Note:\nThis is a Primary Key.<pk/>"
+                        },
                         "format" : "integer",
                         "type" : "integer"
                       },
@@ -304,7 +310,9 @@ spec actualPgVersion =
                     "type" : "object",
                     "properties" : {
                       "id" : {
-                        "description" : "Note:\nThis is a Primary Key.<pk/>",
+                        "additionalProperties": {
+                          "description": "Note:\nThis is a Primary Key.<pk/>"
+                        },
                         "format" : "integer",
                         "type" : "integer"
                       },

--- a/test/Feature/OpenApiSpec.hs
+++ b/test/Feature/OpenApiSpec.hs
@@ -114,7 +114,7 @@ spec = describe "OpenAPI" $ do
             }
           |]
 
-    it "includes definitions to tables" $ do
+    it "includes definitions to tables(with id pk comment overwritten)" $ do
       r <- simpleBody <$> get "/"
 
       let def = r ^? key "definitions" . key "child_entities"
@@ -128,9 +128,12 @@ spec = describe "OpenAPI" $ do
               "description": "child_entities comment",
               "properties": {
                 "id": {
-                  "description": "child_entities id comment\n\nNote:\nThis is a Primary Key.<pk/>",
+                  "description": "child_entities id comment",
                   "format": "integer",
-                  "type": "integer"
+                  "type": "integer",
+                  "additionalProperties": {
+                    "description": "Note:\nThis is a Primary Key.<pk/>"
+                  }
                 },
                 "name": {
                   "description": "child_entities name comment. Can be longer than sixty-three characters long",
@@ -138,9 +141,11 @@ spec = describe "OpenAPI" $ do
                   "type": "string"
                 },
                 "parent_id": {
-                  "description": "Note:\nThis is a Foreign Key to `entities.id`.<fk table='entities' column='id'/>",
                   "format": "integer",
-                  "type": "integer"
+                  "type": "integer",
+                  "additionalProperties": {
+                    "description": "Note:\nThis is a Foreign Key to `entities.id`.<fk table='entities' column='id'/>"
+                  }
                 }
               },
               "required": [
@@ -240,7 +245,9 @@ spec = describe "OpenAPI" $ do
             {
               "format": "integer",
               "type": "integer",
-              "description": "Note:\nThis is a Foreign Key to `pages.link`.<fk table='pages' column='link'/>"
+              "additionalProperties": {
+                "description": "Note:\nThis is a Foreign Key to `pages.link`.<fk table='pages' column='link'/>"
+              }
             }
           |]
 


### PR DESCRIPTION
Resolves #1700.

I've just allowed overriding the notes with the db comment.

I looked into adding `x-primary-key` or `x-foreign-key` fields to not lose the metadata, but seems this is not easy with our current swagger lib: https://github.com/GetShopTV/swagger2/issues/113#issuecomment-558185318.

Still I think this is a better behavior, I'll leave adding the extensions for our future OpenAPI-in-SQL https://github.com/PostgREST/postgrest/issues/1698.