### PR TITLE
nix: add "cd $rootdir" to all shell scripts via checked-shell-script

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -37,7 +37,7 @@ GHC version and all the build dependencies.
 We recommend that you use the PostgREST binary cache on
 [cachix](https://cachix.org/):
 
-```
+```bash
 # Install cachix:
 nix-env -iA cachix -f https://cachix.org/api/v1/install
 
@@ -70,7 +70,7 @@ The PostgREST utilities available in `nix-shell` all have names that begin with
 `postgrest-`, so you can use tab completion (typing `postgrest-` and pressing
 `<tab>`) in `nix-shell` to see all that are available:
 
-```
+```bash
 # Note: The utilities listed here might not be up to date.
 [nix-shell]$ postgrest-<tab>
 postgrest-lint                      postgrest-test-spec-postgresql-11
@@ -88,10 +88,10 @@ postgrest-test-spec-postgresql-10
 Some additional modules like `memoryTests`, `docker` and `release`
 have large dependencies that would need to be built before the shell becomes
 available, which could take an especially long time if the cachix binary cache
-is not used. You can activate those by passing a flag to `nix-shell`, which
-will make the respective utilites available:
+is not used. You can activate those by passing a flag to `nix-shell` with
+`nix-shell --arg <module> true`. This will make the respective utilites available:
 
-```
+```bash
 $ nix-shell --arg memoryTests true
 [nix-shell]$ postgrest-<tab>
 postgrest-lint                      postgrest-test-spec-postgresql-10
@@ -111,7 +111,7 @@ will lauch the Nix shell, run that one command and exit. Note that the tab
 completion will not work with `nix-shell --run`, as Nix has yet to evaluate
 our Nix expressions to see which utilities are available.
 
-```
+```bash
 $ nix-shell --run postgrest-style
 
 # Note that you need to quote any arguments that you would like to pass to
@@ -122,7 +122,7 @@ $ nix-shell --run "postgrest-foo --bar"
 
 A third option is to install utilities that you use very often locally:
 
-```
+```bash
 $ nix-env -f default.nix -iA devtools
 
 # `postgrest-style` can now be run directly:
@@ -134,6 +134,16 @@ If you use `nix-shell` very often, you might like to use
 https://github.com/xzfc/cached-nix-shell, which skips evaluating all our Nix
 expressions if nothing changed, reducing startup time for the shell
 considerably.
+
+Note: Once inside nix-shell, the utilities work from any directory inside
+the PostgREST repo. Paths are resolved relative to the repo root:
+
+```bash
+$ cd src
+# Even though the current directory is ./src, the config path must still start
+# from the repo root:
+$ postgrest-run test/io-tests/configs/simple.conf
+```
 
 ## Testing
 

--- a/nix/devtools.nix
+++ b/nix/devtools.nix
@@ -3,7 +3,6 @@
 , checkedShellScript
 , devCabalOptions
 , entr
-, git
 , silver-searcher
 , style
 , tests
@@ -12,10 +11,8 @@ let
   watch =
     checkedShellScript "postgrest-watch"
       ''
-        rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
-
         while true; do
-          (! ${silver-searcher}/bin/ag -l . "$rootdir" | ${entr}/bin/entr -dr "$@")
+          (! ${silver-searcher}/bin/ag -l . | ${entr}/bin/entr -dr "$@")
         done
       '';
 

--- a/nix/overlays/checked-shell-script/checked-shell-script.nix
+++ b/nix/overlays/checked-shell-script/checked-shell-script.nix
@@ -1,11 +1,12 @@
 # Create a bash script that is checked with shellcheck. You can either use it
 # directly, or use the .bin attribute to get the script in a bin/ directory,
 # to be used in a path for example.
-{ writeTextFile
-, runtimeShell
+{ git
 , runCommand
-, stdenv
+, runtimeShell
 , shellcheck
+, stdenv
+, writeTextFile
 }:
 name: text:
 let
@@ -19,6 +20,14 @@ let
         ''
           #!${runtimeShell}
           set -euo pipefail
+
+          cd "$(${git}/bin/git rev-parse --show-toplevel)"
+
+          if test ! -f postgrest.cabal; then
+            >&2 echo "Couldn't find postgrest.cabal. Please make sure to" \
+                     "run this command somewhere in the PostgREST repo."
+            exit 1
+          fi
 
           ${text}
         '';

--- a/nix/style.nix
+++ b/nix/style.nix
@@ -11,18 +11,16 @@ let
   style =
     checkedShellScript "postgrest-style"
       ''
-        rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
-
         # Format Nix files
-        ${nixpkgs-fmt}/bin/nixpkgs-fmt "$rootdir" > /dev/null 2> /dev/null
+        ${nixpkgs-fmt}/bin/nixpkgs-fmt . > /dev/null 2> /dev/null
 
         # Format Haskell files
         # --vimgrep fixes a bug in ag: https://github.com/ggreer/the_silver_searcher/issues/753
-        ${silver-searcher}/bin/ag -l --vimgrep -g '\.l?hs$' . "$rootdir" \
+        ${silver-searcher}/bin/ag -l --vimgrep -g '\.l?hs$' . \
           | xargs ${stylish-haskell}/bin/stylish-haskell -i
 
         # Format Python files
-        ${black}/bin/black "$rootdir" 2> /dev/null
+        ${black}/bin/black . 2> /dev/null
       '';
 
   # Script to check whether any uncommited changes result from postgrest-style
@@ -37,11 +35,9 @@ let
   lint =
     checkedShellScript "postgrest-lint"
       ''
-        rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
-
         # Lint Haskell files
         # --vimgrep fixes a bug in ag: https://github.com/ggreer/the_silver_searcher/issues/753
-        ${silver-searcher}/bin/ag -l --vimgrep -g '\.l?hs$' "$rootdir" \
+        ${silver-searcher}/bin/ag -l --vimgrep -g '\.l?hs$' . \
           | xargs ${hlint}/bin/hlint -X QuasiQuotes -X NoPatternSynonyms
       '';
 in

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -6,14 +6,13 @@
 , curl
 , devCabalOptions
 , diffutils
-, git
 , haskell
 , lib
 , postgresql
 , postgresqlVersions
 , postgrest
-, postgrestStatic
 , postgrestProfiled
+, postgrestStatic
 , procps
 , python3
 , runtimeShell
@@ -25,7 +24,7 @@ let
     postgresql:
     checkedShellScript "postgrest-test-${postgresql.name}"
       ''
-        export PATH=${postgresql}/bin:${git}/bin:"$PATH"
+        export PATH=${postgresql}/bin:"$PATH"
 
         exec ${../test/with_tmp_db} "$@"
       '';
@@ -106,12 +105,9 @@ let
         env="$(cat ${postgrest.env})"
         export PATH="$env/bin:$PATH"
 
-        rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
-        cd "$rootdir"
-
         ${cabal-install}/bin/cabal v2-build ${devCabalOptions}
         ${cabal-install}/bin/cabal v2-exec ${withTmpDb postgresql} \
-          ${ioTestPython}/bin/pytest -- -v "$rootdir"/test/io-tests "$@"
+          ${ioTestPython}/bin/pytest -- -v test/io-tests "$@"
       '';
 
   testMemory =
@@ -119,12 +115,9 @@ let
     checkedShellScript
       name
       ''
-        rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
-        cd "$rootdir"
-
         export PATH="${postgrestProfiled}/bin:${curl}/bin:$PATH"
 
-        ${withTmpDb postgresql} "$rootdir/test/memory-tests.sh"
+        ${withTmpDb postgresql} test/memory-tests.sh
       '';
 
   dumpSchema =
@@ -132,9 +125,6 @@ let
     checkedShellScript
       name
       ''
-        rootdir="$(${git}/bin/git rev-parse --show-toplevel)"
-        cd "$rootdir"
-
         env="$(cat ${postgrest.env})"
         export PATH="$env/bin:$PATH"
 

--- a/test/with_tmp_db
+++ b/test/with_tmp_db
@@ -34,8 +34,6 @@ if [ "$#" -lt 1 ]; then
   usage
 fi
 
-rootdir="$(git rev-parse --show-toplevel)"
-
 # All data will be stored in a temporary directory.
 tmpdir="$(mktemp -d)"
 
@@ -105,7 +103,7 @@ psql -v ON_ERROR_STOP=1 >> "$setuplog" << EOF
   create extension pgcrypto;
   alter database $PGDATABASE set request.jwt.claim.id = '-1';
   alter role $PGUSER set default_text_search_config to english;
-  \i $rootdir/test/fixtures/load.sql
+  \i test/fixtures/load.sql
 EOF
 
 log "Done. Running command..."


### PR DESCRIPTION
As discussed in https://github.com/PostgREST/postgrest/pull/1694#discussion_r545403933

@monacoremo: I felt like a `postgrest-rootdir` was not necessary and just added it to the checked-shell-script wrapper. What do you think?