### PR TITLE
feat: add request.param guc

### DIFF
--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -129,6 +129,7 @@ data ApiRequest = ApiRequest {
   , iMethod               :: ByteString                       -- ^ Raw request method
   , iProfile              :: Maybe Schema                     -- ^ The request profile for enabling use of multiple schemas. Follows the spec in hhttps://www.w3.org/TR/dx-prof-conneg/ttps://www.w3.org/TR/dx-prof-conneg/.
   , iSchema               :: Schema                           -- ^ The request schema. Can vary depending on iProfile.
+  , iParams               :: [(Text, Text)]                   -- ^ All request params
   }
 
 -- | Examines HTTP request and translates it into user intent.
@@ -177,6 +178,7 @@ userApiRequest confSchemas rootSpec dbStructure req reqBody
       , iMethod = method
       , iProfile = profile
       , iSchema = schema
+      , iParams = second (toS . fromMaybe mempty) <$> qParams
       }
  where
   -- queryString with '+' converted to ' '(space)

--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -49,13 +49,14 @@ runPgLocals :: AppConfig   -> M.HashMap Text JSON.Value ->
                ApiRequest  -> H.Transaction Response
 runPgLocals conf claims app req = do
   H.statement mempty $ H.dynamicallyParameterized
-    ("select " <> intercalateSnippet ", " (searchPathSql : roleSql ++ claimsSql ++ [methodSql, pathSql] ++ headersSql ++ cookiesSql ++ appSettingsSql))
+    ("select " <> intercalateSnippet ", " (searchPathSql : roleSql ++ claimsSql ++ [methodSql, pathSql] ++ headersSql ++ cookiesSql ++ paramsSql ++ appSettingsSql))
     HD.noResult (configDbPreparedStatements conf)
   traverse_ H.sql preReqSql
   app req
   where
     methodSql = setConfigLocal mempty ("request.method", toS $ iMethod req)
     pathSql = setConfigLocal mempty ("request.path", toS $ iPath req)
+    paramsSql = setConfigLocal "request.param." <$> iParams req
     headersSql = setConfigLocal "request.header." <$> iHeaders req
     cookiesSql = setConfigLocal "request.cookie." <$> iCookies req
     claimsWithRole =


### PR DESCRIPTION
As discussed on https://github.com/PostgREST/postgrest/issues/915#issuecomment-744736038. This adds the `request.param` GUC.

This is the draft implementation. Not efficient because it leads to a lot of new prepared statements(no reuse).
Each query param `?select=id,name&id=eq.1&name=eq.project&order=id` will get its own parameter:

```sql
select 
  set_config('request.param.id', $1, true),
  set_config('request.param.name', $2, true),
  set_config('request.param.select', $3, true),
  set_config('request.param.order', $4, true);
```

### Ideas

- Convert all the query parameters to a single json, like mentioned in https://github.com/PostgREST/postgrest/pull/1600#issuecomment-738232201. Would lead to reusing prepared statements.
- How about having a single GUC for the filters only?
  - It can be like `request.param.filters`. This would be a JSON object: `{"id": "eq.1", "name": "eq.project"}`. There wouldn't be a `request.param.id` or `request.param.name`.
  - With this we could disable update/delete with no filters globally by using `pre-request`. It'd be easier to validate that filters are present by having them on a single json.

  ```sql
  create or replace function update_delete_restrictions() returns void as $$
  declare
    req_filters text = nullif(current_setting('request.param.filters', true), '{}');
    req_method text = current_setting('request.method', true);
  begin
  if req_method similar to 'PATCH|DELETE' and req_filters is null then
    RAISE EXCEPTION 'UPDATE or DELETE is not allowed without filters'
    USING HINT = 'Add filters to the request';
  end if;
  end $$ language plpgsql;
  ```
  (this would be more flexible than doing it as config option as proposed on https://github.com/PostgREST/postgrest/issues/699#issuecomment-716266488)