### PR TITLE
Fix "unused-imports" warning for windows build

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -32,11 +32,7 @@ import System.IO                (BufferMode (..), hSetBuffering)
 import Text.Printf              (hPrintf)
 
 import PostgREST.App         (postgrest)
-import PostgREST.Config      (AppConfig (..), CLI (..), Command (..),
-                              Environment, configDbPoolTimeout',
-                              dumpAppConfig, prettyVersion,
-                              readCLIShowHelp, readEnvironment,
-                              readValidateConfig)
+import PostgREST.Config
 import PostgREST.DbStructure (getDbStructure, getPgVersion)
 import PostgREST.Error       (PgError (PgError), checkIsFatal,
                               errorPayload)


### PR DESCRIPTION
When merging #1691 I introduced the failing appveyor windows build. It didn't fail when merging, because the windows build was not finished yet (cancelled after timeout). Now it has been failing ever since. I first thought this was a caching issue, but it turns out it is for real - one of the imports is not used for the Windows build.
