### PR TITLE
Codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,6 @@
 codecov:
   branch: master
+  require_ci_to_pass: false
 
 comment: false
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Docs](https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat)](http://postgrest.org)
 [![Docker Stars](https://img.shields.io/docker/pulls/postgrest/postgrest.svg)](https://hub.docker.com/r/postgrest/postgrest/)
 [![Build Status](https://circleci.com/gh/PostgREST/postgrest/tree/master.svg?style=shield)](https://circleci.com/gh/PostgREST/postgrest/tree/master)
-[![Coverage Status](https://img.shields.io/coveralls/github/PostgREST/postgrest)](https://coveralls.io/github/PostgREST/postgrest)
+[![Coverage Status](https://img.shields.io/codecov/c/github/postgrest/postgrest/master)](https://app.codecov.io/gh/PostgREST/postgrest)
 [![Hackage docs](https://img.shields.io/hackage/v/postgrest.svg?label=hackage)](http://hackage.haskell.org/package/postgrest)
 
 PostgREST serves a fully RESTful API from any existing PostgreSQL


### PR DESCRIPTION
The master branch now has coverage, so we can add the badge in the Readme.

Until now, I have not seen any GitHub checks / status reports from codecov, yet. I have requested to install the codecov App in the repo, @steve-chavez will have to approve it.

Keeping this as WIP, until that's done to test the codecov status reports.