### PR TITLE
nix: Fix build errors with stale .tix files present

### DIFF
--- a/nix/overlays/checked-shell-script/checked-shell-script.nix
+++ b/nix/overlays/checked-shell-script/checked-shell-script.nix
@@ -22,6 +22,14 @@ let
         ''
           #!${runtimeShell}
           set -euo pipefail
+
+          # make sure that no script creates conflicting tix files
+          # postgrest-coverage will override HPCTIXFILE to make proper use of it
+          if test ! -v HPCTIXFILE; then
+            hpctixdir=$(mktemp -d)
+            export HPCTIXFILE="$hpctixdir"/postgrest.tix
+            trap 'rm -rf $hpctixdir' EXIT
+          fi
         ''
         + lib.optionalString inRootDir ''
           cd "$(${git}/bin/git rev-parse --show-toplevel)"
@@ -32,7 +40,7 @@ let
             exit 1
           fi
         ''
-        + text;
+        + "(${text})";
 
       checkPhase =
         ''

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -24,6 +24,11 @@ flag dev
   manual:      True
   description: Development flags
 
+flag hpc
+  default:     True
+  manual:      True
+  description: Enable HPC (dev only)
+
 library
   default-language:   Haskell2010
   default-extensions: OverloadedStrings
@@ -92,18 +97,20 @@ library
                     , wai-extra                 >= 3.0.19 && < 3.2
                     , wai-logger                >= 2.3.2
                     , wai-middleware-static     >= 0.8.1 && < 0.10
+                      -- -fno-spec-constr may help keep compile time memory use in check,
+                      --   see https://gitlab.haskell.org/ghc/ghc/issues/16017#note_219304
+                      -- -optP-Wno-nonportable-include-path
+                      --   prevents build failures on case-insensitive filesystems (macos),
+                      --   see https://github.com/commercialhaskell/stack/issues/3918
+  ghc-options:        -Werror -Wall -fwarn-identities
+                      -fno-spec-constr -optP-Wno-nonportable-include-path
+
   if flag(dev)
-    ghc-options: -O0 -Werror -Wall -fwarn-identities
-                 -fno-spec-constr -optP-Wno-nonportable-include-path
-                 -fhpc -hpcdir .hpc
+    ghc-options: -O0
+    if flag(hpc)
+      ghc-options: -fhpc -hpcdir .hpc
   else
-    ghc-options: -O2 -Werror -Wall -fwarn-identities
-                 -fno-spec-constr -optP-Wno-nonportable-include-path
-          -- -fno-spec-constr may help keep compile time memory use in check,
-          --   see https://gitlab.haskell.org/ghc/ghc/issues/16017#note_219304
-          -- -optP-Wno-nonportable-include-path
-          --   prevents build failures on case-insensitive filesystems (macos),
-          --   see https://github.com/commercialhaskell/stack/issues/3918
+    ghc-options: -O2
 
 executable postgrest
   default-language:   Haskell2010
@@ -131,15 +138,16 @@ executable postgrest
                     , time                >= 1.6 && < 1.11
                     , wai                 >= 3.2.1 && < 3.3
                     , warp                >= 3.2.12 && < 3.4
-  if flag(dev)
-    ghc-options:      -threaded -rtsopts "-with-rtsopts=-N -I2"
-                      -O0 -Werror -Wall -fwarn-identities
-                      -fno-spec-constr -optP-Wno-nonportable-include-path
-                      -fhpc -hpcdir .hpc
-  else
-    ghc-options:      -threaded -rtsopts "-with-rtsopts=-N -I2"
+  ghc-options:        -threaded -rtsopts "-with-rtsopts=-N -I2"
                       -O2 -Werror -Wall -fwarn-identities
                       -fno-spec-constr -optP-Wno-nonportable-include-path
+
+  if flag(dev)
+    ghc-options: -O0
+    if flag(hpc)
+      ghc-options: -fhpc -hpcdir .hpc
+  else
+    ghc-options: -O2
 
   if !os(windows)
     build-depends: unix


### PR DESCRIPTION
Since we enabled the hpc flags on every build (even without `postgrest-coverage`), `.tix` files are created on every command. Sometimes regular commands (test-spec, test-io, build, run) will fail because of those stale `.tix` files.

Here, I add a tmp `HPCTIXFILE` location for every nix script to avoid those files from ever appearing. This can be overriden either from inside the script by setting the `HPCTIXFILE` location manually (as is done in `postgrest-coverage`) or from the outside by setting `HPCTIXFILE` before running the command.
