### PR TITLE
Fix notify config

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -80,7 +80,7 @@ postgrest logLev refConf refDbStructure pool getTime connWorker =
             Left err -> return . errorResponseFor $ err
             Right apiRequest -> do
               -- The jwt must be checked before touching the db.
-              attempt <- attemptJwtClaims (configJWKS conf) (configJwtAudience conf) (toS $ iJWT apiRequest) time (rightToMaybe $ configJwtRoleClaimKey conf)
+              attempt <- attemptJwtClaims (configJWKS conf) (configJwtAudience conf) (toS $ iJWT apiRequest) time (configJwtRoleClaimKey conf)
               case jwtClaims attempt of
                 Left errJwt -> return . errorResponseFor $ errJwt
                 Right claims -> do

--- a/src/PostgREST/Auth.hs
+++ b/src/PostgREST/Auth.hs
@@ -54,7 +54,7 @@ jwtClaims attempt =
   Receives the JWT secret and audience (from config) and a JWT and returns a map
   of JWT claims.
 -}
-attemptJwtClaims :: Maybe JWKSet -> Maybe StringOrURI -> LByteString -> UTCTime -> Maybe JSPath -> IO JWTAttempt
+attemptJwtClaims :: Maybe JWKSet -> Maybe StringOrURI -> LByteString -> UTCTime -> JSPath -> IO JWTAttempt
 attemptJwtClaims _ _ "" _ _ = return $ JWTClaims M.empty
 attemptJwtClaims maybeSecret audience payload time jspath =
   case maybeSecret of
@@ -72,11 +72,11 @@ attemptJwtClaims maybeSecret audience payload time jspath =
   Turn JWT ClaimSet into something easier to work with,
   also here the jspath is applied to put the "role" in the map
 -}
-claims2map :: ClaimsSet -> Maybe JSPath -> M.HashMap Text JSON.Value
+claims2map :: ClaimsSet -> JSPath -> M.HashMap Text JSON.Value
 claims2map claims jspath = (\case
     val@(JSON.Object o) ->
       let role = maybe M.empty (M.singleton "role") $
-                 walkJSPath (Just val) =<< jspath in
+                 walkJSPath (Just val) jspath in
       M.delete "role" o `M.union` role -- mutating the map
     _ -> M.empty
   ) $ JSON.toJSON claims

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -312,7 +312,7 @@ pickProxy proxy
   -- should never happen
   -- since the request would have been rejected by the middleware if proxy uri
   -- is malformed
-  | isMalformedProxyUri proxy = Nothing
+  | isMalformedProxyUri $ fromMaybe mempty proxy = Nothing
   | otherwise = Just Proxy {
     proxyScheme = scheme
   , proxyHost = host'

--- a/src/PostgREST/Private/ProxyUri.hs
+++ b/src/PostgREST/Private/ProxyUri.hs
@@ -25,9 +25,8 @@ import Protolude.Conv (toS)
   http://postgrest.com/openapi.json
   https://postgrest.com:8080/openapi.json
 -}
-isMalformedProxyUri :: Maybe Text -> Bool
-isMalformedProxyUri Nothing =  False
-isMalformedProxyUri (Just uri)
+isMalformedProxyUri :: Text -> Bool
+isMalformedProxyUri uri
   | isAbsoluteURI (toS uri) = not $ isUriValid $ toURI uri
   | otherwise = True
 

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -82,7 +82,7 @@ _baseCfg = let secret = Just $ encodeUtf8 "reallyreallyreallyreallyverysafe" in
   , configDbUri                 = mempty
   , configJWKS                  = parseSecret <$> secret
   , configJwtAudience           = Nothing
-  , configJwtRoleClaimKey       = Right [JSPKey "role"]
+  , configJwtRoleClaimKey       = [JSPKey "role"]
   , configJwtSecret             = secret
   , configJwtSecretIsBase64     = False
   , configLogLevel              = LogCrit
@@ -91,7 +91,7 @@ _baseCfg = let secret = Just $ encodeUtf8 "reallyreallyreallyreallyverysafe" in
   , configServerHost            = "localhost"
   , configServerPort            = 3000
   , configServerUnixSocket      = Nothing
-  , configServerUnixSocketMode  = Right 432
+  , configServerUnixSocketMode  = 432
   , configDbTxAllowOverride     = True
   , configDbTxRollbackAll       = True
   }

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1955,3 +1955,15 @@ begin
   perform pg_notify('pgrst', 'reload config');
   perform pg_notify('pgrst', 'reload schema');
 end $_$ volatile security definer language plpgsql ;
+
+create or replace function test.invalid_role_claim_key_reload() returns void as $_$
+begin
+  alter role postgrest_test_authenticator set pgrst."jwt-role-claim-key" = 'test';
+  perform pg_notify('pgrst', 'reload config');
+end $_$ volatile security definer language plpgsql ;
+
+create or replace function test.reset_invalid_role_claim_key() returns void as $_$
+begin
+  alter role postgrest_test_authenticator set pgrst."jwt-role-claim-key" = '."a"."role"';
+  perform pg_notify('pgrst', 'reload config');
+end $_$ volatile security definer language plpgsql ;

--- a/test/io-tests/fixtures.yaml
+++ b/test/io-tests/fixtures.yaml
@@ -173,5 +173,4 @@ invalidroleclaimkeys:
   - '.role##'
   - '.my_role;;domain'
   - '.#$$%&$%/'
-  - ''
   - '1234'


### PR DESCRIPTION
## Bug fix

Fixes a bug in the recently added https://github.com/PostgREST/postgrest/pull/1729.

When altering a config with an invalid setting and reloading:

```sql
ALTER ROLE postgrest_test_authenticator SET pgrst."jwt-role-claim-key" = 'invalid';
NOTIFY pgrst, 'reload config';
```

postgrest will respond with:

```
Retrying listening for notifications on the pgrst channel..
Attempting to connect to the database...
Connection successful
Listening for notifications on the pgrst channel
Schema cache loaded
```

This is because the `readConfig` function panicked and killed the `listener` thread.

## Solution

Don't panic on `readConfig` and instead do it on the `Main.hs` module.

So with this change, postgrest will respond with:

```
Failed config reload. Error in config: "\"failed to parse role-claim-key value (asdf)\" (line 1, column 1):\nunexpected \"a\"\nexpecting period (.)"
```