### PR TITLE
Fix "function string_agg(integer, unknown) does not exist"

### DIFF
--- a/src/PostgREST/Private/QueryFragment.hs
+++ b/src/PostgREST/Private/QueryFragment.hs
@@ -101,7 +101,7 @@ asJsonSingleF returnsScalar
   | otherwise     = "coalesce(string_agg(to_json(_postgrest_t)::text, ','), '')::character varying"
 
 asBinaryF :: FieldName -> SqlFragment
-asBinaryF fieldName = "coalesce(string_agg(_postgrest_t." <> pgFmtIdent fieldName <> ", ''), '')"
+asBinaryF fieldName = "coalesce(string_agg(_postgrest_t." <> pgFmtIdent fieldName <> "::text, ''::text), '')"
 
 locationF :: [Text] -> SqlFragment
 locationF pKeys = [qc|(


### PR DESCRIPTION
This commit type-casts arguments to the PostgreSQL function `string_agg` in order to avoid `string_agg(integer, unknown)` and instead appropriately call `string_agg(text, text)`.

Closes #1755 