### PR TITLE
Allow lens-5.0

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -79,7 +79,7 @@ library
                     , insert-ordered-containers >= 0.2.2 && < 0.3
                     , interpolatedstring-perl6  >= 1 && < 1.1
                     , jose                      >= 0.8.1 && < 0.9
-                    , lens                      >= 4.14 && < 4.20
+                    , lens                      >= 4.14 && < 5.1
                     , lens-aeson                >= 1.0.1 && < 1.2
                     , mtl                       >= 2.2.2 && < 2.3
                     , network-uri               >= 2.6.1 && < 2.8
@@ -214,7 +214,7 @@ test-suite spec
                     , hspec-wai         >= 0.10 && < 0.12
                     , hspec-wai-json    >= 0.10 && < 0.12
                     , http-types        >= 0.12.3 && < 0.13
-                    , lens              >= 4.14 && < 4.20
+                    , lens              >= 4.14 && < 5.1
                     , lens-aeson        >= 1.0.1 && < 1.2
                     , monad-control     >= 1.0.1 && < 1.1
                     , postgrest
@@ -260,7 +260,7 @@ test-suite spec-querycost
                      , hspec-wai         >= 0.10 && < 0.12
                      , hspec-wai-json    >= 0.10 && < 0.12
                      , http-types        >= 0.12.3 && < 0.13
-                     , lens              >= 4.14 && < 4.20
+                     , lens              >= 4.14 && < 5.1
                      , lens-aeson        >= 1.0.1 && < 1.2
                      , monad-control     >= 1.0.1 && < 1.1
                      , postgrest


### PR DESCRIPTION
There appear to be no significant changes to the release. Addresses https://github.com/commercialhaskell/stackage/issues/5874. A hackage revision would likely be fine (but I'm not sure how far `main` has diverged from 7.0.1 by now).

Built locally (but didn't run tests) with `stack.yaml` below. Requires swagger2 to also have its bounds relaxed (https://github.com/GetShopTV/swagger2/pull/223), but we'll be able to pick up the swagger2 update automatically since it's likely to stay on 2.6.*.

```
resolver: lts-16.26 # 2020-12-13, GHC 8.8.4

nix:
  packages:
    - pcre
    - pkgconfig
    - postgresql
    - zlib
  # disable pure by default so that the test enviroment can be passed
  pure: false

extra-deps:
- protolude-0.3.0@sha256:8361b811b420585b122a7ba715aa5923834db6e8c36309bf267df2dbf66b95ef,2693
- hasql-notifications-0.1.0.0@sha256:9ab112d2bb5da0d55abd65f0d27a7bb1dc4aeb792518d9a2ea8a16e243e19985,2156
- hasql-dynamic-statements-0.3.1@sha256:c3a2c89c4a8b3711368dbd33f0ccfe46a493faa7efc2c85d3e354c56a01dfc48,2673
- hasql-implicits-0.1.0.2@sha256:5d54e09cb779a209681b139fb3cc726bae75134557932156340cc0a56dd834a8,1361
- ptr-0.16.7.2@sha256:4a91e1342db8e627435a002798d65329a0c09c8632b2e415461b9928785327f9,2686
- lens-5.0.1@sha256:d44156c542b1630337a07cac5824f1846badeb59043adbe8c4e9ed1da89cc13d,15026
- comonad-5.0.8@sha256:a3a140be7a21d6ba16bf9102bf4c79455ff3213679311587bac45ba0723c8d7a,3492
- free-5.1.6@sha256:8289b615eeeedd0b95ae956f0c5ae775e35bbd16588550209ce5551af19161a6,4895
- indexed-traversable-0.1.1@sha256:e330ec1ab336ee2fb1eff117ebe3480d1663396fecd981f185b7123dc7941ae1,2469
- indexed-traversable-instances-0.1@sha256:3aaf97040001bbe583e29c2b9c7d41660df265e6565a0d2ac09a3ed5b8bc21be,2874
- strict-0.4.0.1@sha256:08cf72ad570fddfe3b3424117bf20a303a1fb21047b40c1d6c8004c0e3e02a0b,4124
- th-abstraction-0.4.2.0@sha256:2c754cd15370f8c59c8e6c37d44428a78d0b4afc94e13b3958a1a50cd16f6e84,2124
- aeson-1.5.6.0
- data-fix-0.3.1@sha256:7aee2c0633632479cef93c8000befd5bc950ba7c329d69e918ca520944164e27,1645
- tagged-0.8.6.1@sha256:98e446479bd3fe5bdc5fa63fec2a2f6998e1bb8cb6db1dee611716f588b3ab28,2770
- swagger2-2.6
- profunctors-5.6.2@sha256:4db306297d827cf65a32d9124d6f1a23105479ebb1988783006578bc5d4209da,2377
- semigroupoids-5.3.5@sha256:5ccdfc9937718901b2c4a6829381bc62ebd1368945f89b4afe3ec5d5beae6a12,7221
- bifunctors-5.5.10@sha256:52ae8b959de7bb2d5ec38750b9bc2782c90b5bf48805d635eb6ac0cfeb5b1bd6,3738
- contravariant-1.5.3@sha256:e59a7742e725f94fc6578e3593cd3f6d4e3d46a9510c3a782e5fe5e5f238e3ce,3013
- StateVar-1.2.1@sha256:b8bea664120dc78f5c15d9b8c0947d51dbc58a0b63ee49971fa7caac9f3e0845,1642
- foldl-1.4.11
- insert-ordered-containers-0.2.4
- lens-aeson-1.1.1
- optics-th-0.4
- optics-core-0.4
- optics-extra-0.4
```