### PR TITLE
Nix: Add a tool for checking Haskell imports and exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ __pycache__
 *.tix
 coverage
 .hpc
-imports.png

--- a/default.nix
+++ b/default.nix
@@ -124,9 +124,15 @@ rec {
   style =
     pkgs.callPackage nix/style.nix { };
 
+  # Tooling for analyzing Haskell imports and exports.
+  hsie =
+    pkgs.callPackage nix/hsie {
+      ghcWithPackages = pkgs.haskell.packages."${compiler}".ghcWithPackages;
+    };
+
   # Development tools, including linting and styling scripts.
   devtools =
-    pkgs.callPackage nix/devtools.nix { inherit tests style devCabalOptions; };
+    pkgs.callPackage nix/devtools.nix { inherit tests style devCabalOptions hsie; };
 
   # Scripts for publishing new releases.
   release =

--- a/nix/devtools.nix
+++ b/nix/devtools.nix
@@ -131,7 +131,7 @@ let
       ''
         tmpdir="$(mktemp -d)"
         ${dumpMinimalImports} "$tmpdir"
-        ${hsie} -i "$tmpdir" "$@"
+        ${hsie} "$tmpdir" "$@"
         rm -rf "$tmpdir"
       '';
 
@@ -141,7 +141,7 @@ let
         name = "postgrest-hsie-graph-modules";
         docs = "Create a PNG graph of modules imported within the codebase.";
       }
-      ''${hsie} graph-modules -s main -s src | ${graphviz}/bin/dot -Tpng -o "$1"'';
+      ''${hsie} graph-modules main src | ${graphviz}/bin/dot -Tpng -o "$1"'';
 
   hsieGraphSymbols =
     checkedShellScript

--- a/nix/devtools.nix
+++ b/nix/devtools.nix
@@ -125,7 +125,7 @@ let
   hsieMinimalImports =
     checkedShellScript
       {
-        name = "postgrest-hsie-minimalimports";
+        name = "postgrest-hsie-minimal-imports";
         docs = "Run hsie with a provided dump of minimal imports.";
       }
       ''

--- a/nix/devtools.nix
+++ b/nix/devtools.nix
@@ -102,7 +102,7 @@ let
   dumpMinimalImports =
     checkedShellScript
       {
-        name = "postgrest-dumpminimalimports";
+        name = "postgrest-dump-minimal-imports";
         docs = "Dump minimal imports into given directory.";
         inRootDir = true;
       }

--- a/nix/hsie/Main.hs
+++ b/nix/hsie/Main.hs
@@ -138,7 +138,7 @@ main =
              "Check that aliases of imported modules are consistent"
              (pure CheckAliases)
         <> command "check-wildcards"
-             "Check that no unwanted modules are imported as wildcards"
+             "Check that no modules are imported as unqualified wildcards"
              (CheckWildcards <$> O.many okModuleOption)
     command name desc options =
       O.command name . O.info (O.helper <*> options) $ O.progDesc desc

--- a/nix/hsie/Main.hs
+++ b/nix/hsie/Main.hs
@@ -118,7 +118,7 @@ main =
       O.info (O.helper <*> opts) $
         O.fullDesc
         <> O.header "hsie - Swiss army knife for HaSkell Imports and Exports"
-        <> O.progDesc "Parse Haskell code to analyze it's imports and exports"
+        <> O.progDesc "Parse Haskell code to analyze imports and exports"
     opts =
       Options <$> commandOption <*> O.some srcOption
     srcOption =

--- a/nix/hsie/Main.hs
+++ b/nix/hsie/Main.hs
@@ -166,7 +166,7 @@ main =
         <> O.help "Module that is ok to import as wildcard"
 
 run :: Options -> IO ()
-run Options{..} =
+run Options{command, sources} =
   runCommand command . concat =<< mapM sourceSymbols sources
   where
     runCommand :: Command -> [ImportedSymbol] -> IO ()

--- a/nix/hsie/Main.hs
+++ b/nix/hsie/Main.hs
@@ -186,7 +186,7 @@ markInternal symbols =
 -- | Parse all imported symbols from a source of Haskell source files
 sourceSymbols :: FilePath -> IO [ImportedSymbol]
 sourceSymbols source = do
-  files <- filterExts [".hs", "imports"] <$> getFilesRecursive source
+  files <- filterExts [".hs", ".imports"] <$> getFilesRecursive source
   concat <$> mapM moduleSymbols files
   where
     filterExts exts = filter $ flip elem exts . FP.takeExtension

--- a/nix/hsie/Main.hs
+++ b/nix/hsie/Main.hs
@@ -14,12 +14,12 @@
 
 module Main (main) where
 
-import qualified Data.Aeson                 as JSON
-import qualified Data.ByteString.Lazy.Char8 as LBS8
-import qualified Data.Csv                   as Csv
-import qualified Data.Map                   as Map
-import qualified Data.Set                   as Set
-import qualified Data.Text                  as T
+import qualified Data.Aeson                              as JSON
+import qualified Data.ByteString.Lazy.Char8              as LBS8
+import qualified Data.Csv                                as Csv
+import qualified Data.Map                                as Map
+import qualified Data.Set                                as Set
+import qualified Data.Text                               as T
 import qualified Data.Text.IO                            as T
 import qualified Dot
 import qualified GHC

--- a/nix/hsie/Main.hs
+++ b/nix/hsie/Main.hs
@@ -1,0 +1,349 @@
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TupleSections     #-}
+{-# LANGUAGE TypeFamilies      #-}
+
+-- | Haskell Imports and Exports tool
+--
+-- This tool parses imports and exports from Haskell source files and provides
+-- analysis on these imports. For example, you can check whether consistent
+-- import aliases are used across your codebase.
+
+module Main (main) where
+
+import qualified Data.Aeson                              as Aeson
+import qualified Data.ByteString.Lazy.Char8              as LBS8
+import qualified Data.Csv                                as Csv
+import qualified Data.Map                                as Map
+import qualified Data.Set                                as Set
+import qualified Data.Text                               as T
+import qualified Data.Text.IO                            as T
+import qualified Dot
+import qualified GHC
+import qualified Language.Haskell.GHC.ExactPrint.Parsers as ExactPrint
+import qualified Options.Applicative                     as O
+import qualified System.FilePath                         as FP
+
+import Control.Applicative        ((<|>))
+import Data.Aeson.Encode.Pretty   (encodePretty)
+import Data.Function              ((&))
+import Data.List                  (intercalate)
+import Data.Maybe                 (catMaybes, mapMaybe)
+import Data.Text                  (Text)
+import GHC.Generics               (Generic)
+import HsExtension                (GhcPs)
+import Module                     (moduleNameString)
+import OccName                    (occNameString)
+import RdrName                    (rdrNameOcc)
+import System.Directory.Recursive (getFilesRecursive)
+import System.Exit                (exitFailure)
+
+-- TYPES
+
+data Options =
+  Options
+    { command :: Command
+    , sources :: [Source]
+    }
+
+data Source
+  = SourceDir FilePath
+  | ImportsDir FilePath
+  deriving (Generic, Aeson.ToJSON)
+
+sourceDir :: Source -> FilePath
+sourceDir (SourceDir path)  = path
+sourceDir (ImportsDir path) = path
+
+instance Csv.ToField Source where
+  toField (SourceDir _)  = "source"
+  toField (ImportsDir _) = "imports"
+
+data Command
+  = Dump OutputFormat
+  | GraphSymbols
+  | GraphModules
+  | CheckAliases
+  | CheckWildcards [Text]
+
+data OutputFormat = OutputCsv | OutputJson
+
+data ImportedSymbol =
+  ImportedSymbol
+    { impSourceFile :: Text
+    , impSourceType :: Source
+    , impFromModule :: Text
+    , impModule     :: Text
+    , impQualified  :: ImportQualified
+    , impAs         :: Maybe Text
+    , impHiding     :: ImportHiding
+    , impSymbol     :: Maybe Text
+    }
+    deriving (Generic, Csv.ToNamedRecord, Csv.DefaultOrdered, Aeson.ToJSON)
+
+data ImportQualified
+  = Qualified
+  | NotQualified
+  deriving (Eq, Generic, Aeson.ToJSON)
+
+instance Csv.ToField ImportQualified where
+  toField Qualified    = "qualified"
+  toField NotQualified = "not qualified"
+
+data ImportHiding
+  = Wildcard
+  | Hiding
+  | NotHiding
+  deriving (Eq, Generic, Aeson.ToJSON)
+
+instance Csv.ToField ImportHiding where
+  toField Wildcard  = "wildcard"
+  toField Hiding    = "hiding"
+  toField NotHiding = "not hiding"
+
+-- | Mapping of modules to their aliases and to the files they are found in
+type ModuleAliases = [(Text, [(Text, [Text])])]
+
+-- | Mapping of modules to files
+type WildcardImports = [(Text, [Text])]
+
+
+-- MAIN
+
+main :: IO ()
+main =
+  run =<< O.customExecParser prefs infoOpts
+  where
+    prefs = O.prefs $ O.subparserInline <> O.showHelpOnEmpty
+    infoOpts =
+      O.info (O.helper <*> opts) $
+        O.fullDesc
+        <> O.header "hsie - Swiss army knife for HaSkell Imports and Exports"
+        <> O.progDesc "Parse Haskell code to analyze it's imports and exports"
+    opts =
+      Options <$> commandOption <*> O.some (srcOption <|> importsOption)
+    srcOption =
+      O.option (SourceDir <$> O.str) $
+        O.long "src"
+        <> O.short 's'
+        <> O.metavar "SRCDIR"
+        <> O.help "Haskell source directory"
+        <> O.action "directory"
+    importsOption =
+      O.option (ImportsDir <$> O.str) $
+        O.long "imports"
+        <> O.short 'i'
+        <> O.metavar "IMPORTSDIR"
+        <> O.help "Imports directory generated with GHC's '--ddump-minimal-imports'"
+        <> O.action "directory"
+    commandOption =
+      O.subparser $
+        command "dump" "Dump imported symbols as CSV or JSON"
+          (Dump <$> jsonOutputFlag)
+        <> command "graph-modules" "Print dot graph of module imports"
+             (pure GraphModules)
+        <> command "graph-symbols" "Print dot graph of symbol imports"
+             (pure GraphSymbols)
+        <> command "check-aliases"
+             "Check that aliases of imported modules are consistent"
+             (pure CheckAliases)
+        <> command "check-wildcards"
+             "Check that no unwanted modules are imported as wildcards"
+             (CheckWildcards <$> O.many okModuleOption)
+    command name desc options =
+      O.command name . O.info (O.helper <*> options) $ O.progDesc desc
+    jsonOutputFlag =
+      O.flag OutputCsv OutputJson $
+        O.long "json" <> O.short 'j' <> O.help "Output JSON"
+    okModuleOption =
+      O.option O.auto $
+        O.long "ok"
+        <> O.short 'o'
+        <> O.metavar "OKMODULE"
+        <> O.help "Module that is ok to import as wildcard"
+
+run :: Options -> IO ()
+run Options{..} =
+  runCommand command . concat =<< mapM sourceSymbols sources
+  where
+    runCommand :: Command -> [ImportedSymbol] -> IO ()
+    runCommand (Dump format) = LBS8.putStr . dump format
+    runCommand GraphSymbols = T.putStr . Dot.encode . symbolsGraph
+    runCommand GraphModules = T.putStr . Dot.encode . modulesGraph
+    runCommand CheckAliases = runInconsistentAliases . inconsistentAliases
+    runCommand (CheckWildcards okModules) = runWildcards . wildcards okModules
+
+    runInconsistentAliases :: ModuleAliases -> IO ()
+    runInconsistentAliases [] = T.putStrLn "No inconsistent module aliases found."
+    runInconsistentAliases xs = T.putStr (formatInconsistentAliases xs) >> exitFailure
+
+    runWildcards :: WildcardImports -> IO ()
+    runWildcards [] = T.putStrLn "No unwanted wildcard imports found."
+    runWildcards xs = T.putStr (formatWildcards xs) >> exitFailure
+
+
+-- SYMBOLS
+
+-- | Parse all imported symbols from a source of Haskell source files
+sourceSymbols :: Source -> IO [ImportedSymbol]
+sourceSymbols source = do
+  files <-
+    case source of
+      SourceDir dirpath ->
+        filterExts [".hs"] <$> getFilesRecursive dirpath
+      ImportsDir dirpath ->
+        filterExts [".imports"] <$> getFilesRecursive dirpath
+  concat <$> mapM moduleSymbols files
+  where
+    filterExts exts = filter $ flip elem exts . FP.takeExtension
+    moduleSymbols filepath = do
+      GHC.HsModule{..} <- parseModule filepath
+      return $ concatMap (importSymbols source filepath . GHC.unLoc) hsmodImports
+
+-- | Parse a Haskell module
+parseModule :: String -> IO (GHC.HsModule GhcPs)
+parseModule filepath = do
+  result <- ExactPrint.parseModule filepath
+  case result of
+    Right (_, hsmod) ->
+      return $ GHC.unLoc hsmod
+    Left (loc, err) ->
+      fail $ "Error with " <> show filepath <> " at " <> show loc <> ": " <> err
+
+-- | Symbols imported in an import declaration.
+--
+-- If the import is a wildcard, i.e. no symbols are selected for import, then
+-- only one item is returned.
+importSymbols :: Source -> FilePath -> GHC.ImportDecl GhcPs -> [ImportedSymbol]
+importSymbols _ _  (GHC.XImportDecl _) = mempty
+importSymbols source filepath GHC.ImportDecl{..} =
+  case ideclHiding of
+    Just (hiding, syms) ->
+      symbol (if hiding then Hiding else NotHiding) . Just . GHC.unLoc <$> GHC.unLoc syms
+    Nothing ->
+      [ symbol Wildcard Nothing ]
+  where
+    symbol hiding sym =
+      ImportedSymbol
+        { impSourceFile = T.pack filepath
+        , impSourceType = source
+        , impFromModule = T.pack $ moduleFromPath filepath
+        , impModule = T.pack . moduleNameString . GHC.unLoc $ ideclName
+        , impQualified = if ideclQualified then Qualified else NotQualified
+        , impAs = T.pack . moduleNameString . GHC.unLoc <$> ideclAs
+        , impHiding = hiding
+        , impSymbol = T.pack . occNameString . rdrNameOcc . GHC.ieName <$> sym
+        }
+    moduleFromPath =
+      intercalate "." . FP.splitDirectories . FP.dropExtension . relativePath
+    relativePath = FP.makeRelative $ sourceDir source
+
+
+-- DUMP
+
+-- | Dump list of symbols as CSV or JSON
+dump :: OutputFormat -> [ImportedSymbol] -> LBS8.ByteString
+dump OutputCsv  = Csv.encodeDefaultOrderedByName
+dump OutputJson = encodePretty
+
+
+-- ALIASES
+
+-- | Find modules that are imported under different aliases
+inconsistentAliases :: [ImportedSymbol] -> ModuleAliases
+inconsistentAliases symbols =
+  fmap moduleAlias symbols
+    & foldr insertSetMapMap Map.empty
+    & Map.map (aliases . Map.toList)
+    & Map.filter ((<) 1 . length)
+    & Map.toList
+  where
+    moduleAlias ImportedSymbol{..} = (impModule, impAs, impSourceFile)
+    insertSetMapMap (k1, k2, v) =
+      Map.insertWith (Map.unionWith Set.union) k1
+        (Map.singleton k2 $ Set.singleton v)
+    aliases :: [(Maybe Text, Set.Set Text)] -> [(Text, [Text])]
+    aliases = mapMaybe (\(k, v) -> fmap (, Set.toList v) k)
+
+formatInconsistentAliases :: ModuleAliases -> Text
+formatInconsistentAliases modules =
+  "The following imports have inconsistent aliases:\n\n"
+    <> T.concat (fmap formatModule modules)
+  where
+    formatModule (modName, aliases) =
+      "Module '"
+        <> modName
+        <> "' has the aliases:\n"
+        <> T.concat (fmap formatAlias aliases)
+        <> "\n"
+    formatAlias (alias, sourceFiles) =
+      "  '"
+        <> alias
+        <> "' in file"
+        <> (if length sourceFiles > 2 then "s" else "")
+        <> ":\n"
+        <> T.concat (fmap formatFile sourceFiles)
+    formatFile sourceFile =
+      "    " <> sourceFile <> "\n"
+
+
+-- WILDCARDS
+
+-- | Find modules that are imported as wildcards, excluding whitelisted modules.
+--
+-- Wildcard imports are ones that are not qualified and do not specify which
+-- symbols should be imported.
+wildcards :: [Text] -> [ImportedSymbol] -> WildcardImports
+wildcards okModules =
+  groupByFile . filter isWildcard . filter (not . isOkModule)
+  where
+    isWildcard ImportedSymbol{..} =
+      impQualified == NotQualified && impHiding /= NotHiding
+    isOkModule = flip Set.member (Set.fromList okModules) . impModule
+    groupByFile = Map.toList . fmap Set.toList . foldr insertMap Map.empty
+    insertMap ImportedSymbol{..} =
+      Map.insertWith Set.union impSourceFile (Set.singleton impModule)
+
+formatWildcards :: WildcardImports -> Text
+formatWildcards files =
+  "Modules in the following files were imported as wildcards:\n\n"
+    <> T.concat (fmap formatFile files)
+  where
+    formatFile (filepath, modules) =
+      "In " <> filepath <> ":\n" <> T.concat (fmap formatModule modules) <> "\n"
+    formatModule moduleName = "  " <> moduleName <> "\n"
+
+
+-- GRAPHS
+
+modulesGraph :: [ImportedSymbol] -> Dot.DotGraph
+modulesGraph symbols =
+  Dot.DotGraph Dot.Strict Dot.Directed (Just "Modules") $ fmap edge edges
+  where
+    edge (from, to) =
+      Dot.StatementEdge $ Dot.EdgeStatement
+        (Dot.ListTwo (edgeNode from) (edgeNode to) mempty) mempty
+    edgeNode t = Dot.EdgeNode $ Dot.NodeId (Dot.Id t) Nothing
+    edges = unique . fmap edgeTuple . filter isInternalModule $ symbols
+    edgeTuple ImportedSymbol{..} = (impFromModule, impModule)
+    isInternalModule = flip Set.member internalModules . impModule
+    internalModules = Set.fromList $ fmap impFromModule symbols
+    unique = Set.toList . Set.fromList
+
+symbolsGraph :: [ImportedSymbol] -> Dot.DotGraph
+symbolsGraph symbols =
+  Dot.DotGraph Dot.Strict Dot.Directed (Just "Symbols") $ fmap edge edges
+  where
+    edge (from, to, symbol) =
+      Dot.StatementEdge $ Dot.EdgeStatement
+        (Dot.ListTwo (edgeNode from) (edgeNode to) mempty)
+          (catMaybes [label <$> symbol])
+    edgeNode t = Dot.EdgeNode $ Dot.NodeId (Dot.Id t) Nothing
+    edges = unique . fmap edgeTuple . filter isInternalModule $ symbols
+    edgeTuple ImportedSymbol{..} = (impFromModule, impModule, impSymbol)
+    internalModules = Set.fromList $ fmap impFromModule symbols
+    isInternalModule = flip Set.member internalModules . impModule
+    label symbol = Dot.Attribute "label" $ Dot.Id symbol
+    unique = Set.toList . Set.fromList

--- a/nix/hsie/Main.hs
+++ b/nix/hsie/Main.hs
@@ -146,7 +146,7 @@ main =
       O.flag OutputCsv OutputJson $
         O.long "json" <> O.short 'j' <> O.help "Output JSON"
     okModuleOption =
-      O.option O.auto $
+      O.strOption $
         O.long "ok"
         <> O.short 'o'
         <> O.metavar "OKMODULE"

--- a/nix/hsie/Main.hs
+++ b/nix/hsie/Main.hs
@@ -150,7 +150,7 @@ main =
         O.long "ok"
         <> O.short 'o'
         <> O.metavar "OKMODULE"
-        <> O.help "Module that is ok to import as wildcard"
+        <> O.help "Module that is ok to import as unqualified wildcard"
 
 run :: Options -> IO ()
 run Options{command, sources} =

--- a/nix/hsie/Main.hs
+++ b/nix/hsie/Main.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TupleSections     #-}
@@ -13,13 +14,12 @@
 
 module Main (main) where
 
-import qualified Data.Aeson                 as Aeson
+import qualified Data.Aeson                 as JSON
 import qualified Data.ByteString.Lazy.Char8 as LBS8
 import qualified Data.Csv                   as Csv
 import qualified Data.Map                   as Map
 import qualified Data.Set                   as Set
 import qualified Data.Text                  as T
---import qualified Data.Text.Lazy.Builder                  as T
 import qualified Data.Text.IO                            as T
 import qualified Dot
 import qualified GHC
@@ -52,7 +52,7 @@ data Options =
 data Source
   = SourceDir FilePath
   | ImportsDir FilePath
-  deriving (Generic, Aeson.ToJSON)
+  deriving (Generic, JSON.ToJSON)
 
 sourceDir :: Source -> FilePath
 sourceDir (SourceDir path)  = path
@@ -82,12 +82,12 @@ data ImportedSymbol =
     , impHiding     :: ImportHiding
     , impSymbol     :: Maybe Text
     }
-    deriving (Generic, Csv.ToNamedRecord, Csv.DefaultOrdered, Aeson.ToJSON)
+    deriving (Generic, Csv.ToNamedRecord, Csv.DefaultOrdered, JSON.ToJSON)
 
 data ImportQualified
   = Qualified
   | NotQualified
-  deriving (Eq, Generic, Aeson.ToJSON)
+  deriving (Eq, Generic, JSON.ToJSON)
 
 instance Csv.ToField ImportQualified where
   toField Qualified    = "qualified"
@@ -97,7 +97,7 @@ data ImportHiding
   = Wildcard
   | Hiding
   | NotHiding
-  deriving (Eq, Generic, Aeson.ToJSON)
+  deriving (Eq, Generic, JSON.ToJSON)
 
 instance Csv.ToField ImportHiding where
   toField Wildcard  = "wildcard"

--- a/nix/hsie/README.md
+++ b/nix/hsie/README.md
@@ -52,7 +52,7 @@ To check whether modules are imported under consistent aliases in your project,
 run:
 
 ```
-hsie check-aliase -s main -s src
+hsie check-aliases -s main -s src
 ```
 
 This will exit with a non-zero exit code if any inconsistent aliases are found.

--- a/nix/hsie/README.md
+++ b/nix/hsie/README.md
@@ -1,0 +1,80 @@
+# hsie - Swiss army knife for HaSkell Imports and Exports
+
+This tool parses Haskell source code to analyse the imports and exports in a
+project. It's available in PostgREST's `nix-shell` by default.
+
+## Dumping imports
+
+Given source code in the directories `src` and `main`, for example, you can run:
+
+```
+hsie dump --src src --src main
+```
+
+This dumps all imports of the modules in the given directory to a CSV file,
+printed on `stdout`.
+
+To dump to a JSON file (e.g., to further process with `jq`), add the `--json`
+flag:
+
+```
+hsie dump --json --src src --src main
+```
+
+`-s` is a shorthand for `--src` and `-j` for `--json`:
+
+```
+hsie dump -j -s src -s main
+```
+
+If you dumped minimal imports into the `imports` directory using GHC's
+`--ddump-minimal-imports`, you can analyse them using `--imports` or `-i`:
+
+```
+hsie dump -i imports
+```
+
+## Graphing imports
+
+The tool can generate `graphviz` graphs of module and symbol imports by printing
+a file to `stdout` that can directly be rendered with `dot`:
+
+```
+hsie graph-modules -s src -s main | dot -Tpng -o modules.png
+```
+
+The command `graph-modules` prints a graph of which modules insert which other
+modules. `graph-symbols` shows which symbols are imported from which modules.
+
+## Checking imports
+
+To check whether modules are imported under consistent aliases in your project,
+run:
+
+```
+hsie check-aliase -s main -s src
+```
+
+This will exit with a non-zero exit code if any inconsistent aliases are found.
+
+The following command checks whether any modules are imported as wildcards, i.e.
+not qualified and without specifying symbols.
+
+```
+hsie check-wildcards -s main -s src
+```
+
+To whitelist certain modules to be imported as wildcards, use `--ok`:
+
+```
+hsie check-wildcards -s main -s src --ok Protolude --ok Test.Module
+```
+
+## Current limitations
+
+This tool uses the GHC parser to parse Haskell source code. Language extensions
+required to parse each file are detected based on the `{-# LANGUAGE ... #-}`
+pragmas. If they are not available (e.g., as they are listed as default
+extensions in the `.cabal` file), parses may fail. We can fix this by using
+an extended set of non-conflicting extensions by default, as `hlint` does for
+example.

--- a/nix/hsie/README.md
+++ b/nix/hsie/README.md
@@ -8,7 +8,7 @@ project. It's available in PostgREST's `nix-shell` by default.
 Given source code in the directories `src` and `main`, for example, you can run:
 
 ```
-hsie dump --src src --src main
+hsie dump-imports src main
 ```
 
 This dumps all imports of the modules in the given directory to a CSV file,
@@ -18,20 +18,7 @@ To dump to a JSON file (e.g., to further process with `jq`), add the `--json`
 flag:
 
 ```
-hsie dump --json --src src --src main
-```
-
-`-s` is a shorthand for `--src` and `-j` for `--json`:
-
-```
-hsie dump -j -s src -s main
-```
-
-If you dumped minimal imports into the `imports` directory using GHC's
-`--ddump-minimal-imports`, you can analyse them using `--imports` or `-i`:
-
-```
-hsie dump -i imports
+hsie dump-imports --json src main
 ```
 
 ## Graphing imports
@@ -40,7 +27,7 @@ The tool can generate `graphviz` graphs of module and symbol imports by printing
 a file to `stdout` that can directly be rendered with `dot`:
 
 ```
-hsie graph-modules -s src -s main | dot -Tpng -o modules.png
+hsie graph-modules src main | dot -Tpng -o modules.png
 ```
 
 The command `graph-modules` prints a graph of which modules insert which other
@@ -52,7 +39,7 @@ To check whether modules are imported under consistent aliases in your project,
 run:
 
 ```
-hsie check-aliases -s main -s src
+hsie check-aliases main src
 ```
 
 This will exit with a non-zero exit code if any inconsistent aliases are found.
@@ -61,13 +48,13 @@ The following command checks whether any modules are imported as wildcards, i.e.
 not qualified and without specifying symbols.
 
 ```
-hsie check-wildcards -s main -s src
+hsie check-wildcards main src
 ```
 
 To whitelist certain modules to be imported as wildcards, use `--ok`:
 
 ```
-hsie check-wildcards -s main -s src --ok Protolude --ok Test.Module
+hsie check-wildcards main src --ok Protolude --ok Test.Module
 ```
 
 ## Current limitations

--- a/nix/hsie/default.nix
+++ b/nix/hsie/default.nix
@@ -1,0 +1,30 @@
+{ ghcWithPackages
+, runCommand
+}:
+let
+  name = "hsie";
+  src = ./Main.hs;
+  modules = ps: [
+    ps.aeson
+    ps.aeson-pretty
+    ps.cassava
+    ps.dir-traverse
+    ps.dot
+    ps.ghc-exactprint
+    ps.optparse-applicative
+  ];
+  ghc = ghcWithPackages modules;
+  executable =
+    runCommand "haskellimports" { inherit name; }
+      "${ghc}/bin/ghc -O -Werror -Wall -package ghc ${src} -o $out";
+  bin =
+    runCommand name { inherit executable name; }
+      ''
+        mkdir -p $out/bin
+        ln -s $executable $out/bin/$name
+      '';
+  bashCompletion =
+    runCommand "${name}-bash-completion" { }
+      "${executable} --bash-completion-script ${executable} > $out";
+in
+executable // { inherit bashCompletion bin; }

--- a/nix/hsie/default.nix
+++ b/nix/hsie/default.nix
@@ -14,17 +14,17 @@ let
     ps.optparse-applicative
   ];
   ghc = ghcWithPackages modules;
-  executable =
-    runCommand "haskellimports" { inherit name; }
-      "${ghc}/bin/ghc -O -Werror -Wall -package ghc ${src} -o $out";
+  hsie =
+    runCommand "haskellimports" { inherit name src; }
+      "${ghc}/bin/ghc -O -Werror -Wall -package ghc $src -o $out";
   bin =
-    runCommand name { inherit executable name; }
+    runCommand name { inherit hsie name; }
       ''
         mkdir -p $out/bin
-        ln -s $executable $out/bin/$name
+        ln -s $hsie $out/bin/$name
       '';
   bashCompletion =
-    runCommand "${name}-bash-completion" { }
-      "${executable} --bash-completion-script ${executable} > $out";
+    runCommand "${name}-bash-completion" { inherit bin name; }
+      "${hsie} --bash-completion-script $bin/bin/$name > $out";
 in
-executable // { inherit bashCompletion bin; }
+hsie // { inherit bashCompletion bin; }

--- a/nix/hsie/default.nix
+++ b/nix/hsie/default.nix
@@ -25,6 +25,6 @@ let
       '';
   bashCompletion =
     runCommand "${name}-bash-completion" { inherit bin name; }
-      "${hsie} --bash-completion-script $bin/bin/$name > $out";
+      "$bin/bin/$name --bash-completion-script $bin/bin/$name > $out";
 in
 hsie // { inherit bashCompletion bin; }

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -32,7 +32,6 @@ flag hpc
 library
   default-language:   Haskell2010
   default-extensions: OverloadedStrings
-                      QuasiQuotes
                       NoImplicitPrelude
   hs-source-dirs:     src
   exposed-modules:    PostgREST.ApiRequest
@@ -116,7 +115,6 @@ library
 executable postgrest
   default-language:   Haskell2010
   default-extensions: OverloadedStrings
-                      QuasiQuotes
                       NoImplicitPrelude
   hs-source-dirs:     main
   main-is:            Main.hs

--- a/shell.nix
+++ b/shell.nix
@@ -31,6 +31,7 @@ lib.overrideDerivation postgrest.env (
         postgrest.devtools
         postgrest.tests
         postgrest.style
+        postgrest.hsie.bin
       ]
       ++ lib.optional memoryTests postgrest.tests.memoryTests
       ++ lib.optional docker postgrest.docker
@@ -47,6 +48,7 @@ lib.overrideDerivation postgrest.env (
         complete -F _command postgrest-with-postgresql-10
         complete -F _command postgrest-with-postgresql-9.6
         complete -F _command postgrest-with-postgresql-9.5
+        source ${postgrest.hsie.bashCompletion}
       '';
   }
 )

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -16,6 +16,7 @@ Other hardcoded options such as the minimum version number also belong here.
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuasiQuotes           #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}

--- a/src/PostgREST/Private/QueryFragment.hs
+++ b/src/PostgREST/Private/QueryFragment.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LambdaCase  #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-|
 Module      : PostgREST.Private.QueryFragment
 Description : Helper functions for PostgREST.QueryBuilder.

--- a/src/PostgREST/Statements.hs
+++ b/src/PostgREST/Statements.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE QuasiQuotes #-}
 {-|
 Module      : PostgREST.Statements
 Description : PostgREST single SQL statements.


### PR DESCRIPTION
This uses the actual GHC parser, so it should be fairly robust. Works on both our Haskell modules and the ones generated with `-ddump-minmal-imports`.

To use:

```bash
nix-build -A haskellimports
./result src/PostgREST/App.hs
```

Example output so far:

```csv
source,moduleName,impQualified,impAs,impHiding,symbolName
src/PostgREST/App.hs,Control.Monad.Except,false,,false,liftEither
src/PostgREST/App.hs,Data.Either.Combinators,false,,false,mapLeft
src/PostgREST/App.hs,Data.IORef,false,,false,IORef
src/PostgREST/App.hs,Data.IORef,false,,false,readIORef
src/PostgREST/App.hs,Data.List,false,,false,union
src/PostgREST/App.hs,Data.Time.Clock,false,,false,UTCTime
src/PostgREST/App.hs,Data.ByteString.Char8,true,BS8,,
src/PostgREST/App.hs,Data.ByteString.Lazy,true,LBS,,
src/PostgREST/App.hs,Data.Set,true,Set,,
src/PostgREST/App.hs,Hasql.DynamicStatements.Snippet,true,SQL,,
src/PostgREST/App.hs,Hasql.Pool,true,SQL,,
src/PostgREST/App.hs,Hasql.Transaction,true,SQL,,
src/PostgREST/App.hs,Hasql.Transaction.Sessions,true,SQL,,
src/PostgREST/App.hs,Network.HTTP.Types.Header,true,HTTP,,
src/PostgREST/App.hs,Network.HTTP.Types.Status,true,HTTP,,
src/PostgREST/App.hs,Network.HTTP.Types.URI,true,HTTP,,
src/PostgREST/App.hs,Network.Wai,true,Wai,,
src/PostgREST/App.hs,PostgREST.ApiRequest,true,ApiRequest,,
src/PostgREST/App.hs,PostgREST.Auth,true,Auth,,
src/PostgREST/App.hs,PostgREST.DbRequestBuilder,true,ReqBuilder,,
src/PostgREST/App.hs,PostgREST.DbStructure,true,DbStructure,,
src/PostgREST/App.hs,PostgREST.Error,true,Error,,
src/PostgREST/App.hs,PostgREST.Middleware,true,Middleware,,
src/PostgREST/App.hs,PostgREST.OpenAPI,true,OpenAPI,,
src/PostgREST/App.hs,PostgREST.QueryBuilder,true,QueryBuilder,,
src/PostgREST/App.hs,PostgREST.RangeQuery,true,RangeQuery,,
src/PostgREST/App.hs,PostgREST.Statements,true,Statements,,
src/PostgREST/App.hs,PostgREST.ApiRequest,false,,false,Action
src/PostgREST/App.hs,PostgREST.ApiRequest,false,,false,ApiRequest
src/PostgREST/App.hs,PostgREST.ApiRequest,false,,false,InvokeMethod
src/PostgREST/App.hs,PostgREST.ApiRequest,false,,false,Target
src/PostgREST/App.hs,PostgREST.Config,false,,false,AppConfig
src/PostgREST/App.hs,PostgREST.Error,false,,false,Error
src/PostgREST/App.hs,PostgREST.Types,false,,,
src/PostgREST/App.hs,Protolude,false,,true,Handler
src/PostgREST/App.hs,Protolude,false,,true,toS
src/PostgREST/App.hs,Protolude.Conv,false,,false,toS
```

Example usage in nix/devtools.nix, WIP.

@wolfgangwalther : This might be useful for many automated checks and analysis on our imports. Any comments or ideas?