### PR TITLE
fix tests to be independent of JSON ordering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
   # that we support.
   stack-test:
     docker:
-      - image: circleci/buildpack-deps:trusty
+      - image: cimg/base:2021.03
         environment:
           - PGHOST=localhost
       - image: circleci/postgres:9.5
@@ -71,7 +71,7 @@ jobs:
   # Run memory usage tests based on stack and docker.
   stack-test-memory:
     docker:
-      - image: circleci/buildpack-deps:trusty
+      - image: cimg/base:2021.03
         environment:
           - PGHOST=localhost
           - TERM=xterm

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -8,7 +8,7 @@ import qualified Data.Set               as S
 import qualified System.IO.Error        as E
 
 import Data.Aeson           (Value (..), decode, encode)
-import Data.CaseInsensitive (CI (..))
+import Data.CaseInsensitive (CI (..), original)
 import Data.List            (lookup)
 import Data.List.NonEmpty   (fromList)
 import Network.Wai.Test     (SResponse (simpleBody, simpleHeaders, simpleStatus))
@@ -32,6 +32,12 @@ matchContentTypeJson = "Content-Type" <:> "application/json; charset=utf-8"
 
 matchContentTypeSingular :: MatchHeader
 matchContentTypeSingular = "Content-Type" <:> "application/vnd.pgrst.object+json; charset=utf-8"
+
+matchHeaderAbsent :: HeaderName -> MatchHeader
+matchHeaderAbsent name = MatchHeader $ \headers _body ->
+  case lookup name headers of
+    Just _  -> Just $ "unexpected header: " <> toS (original name) <> "\n"
+    Nothing -> Nothing
 
 validateOpenApiResponse :: [Header] -> WaiSession () ()
 validateOpenApiResponse headers = do


### PR DESCRIPTION
This is prompted by a report that postgrest tests fail with newest hashable due to unstable order in aeson output: https://github.com/commercialhaskell/stackage/issues/5878. Stackage doesn't actually run postgrest tests, so this change isn't required, but the underlying issue *does* cause test failures.

The PR addresses two issues:
- cryptonite-0.27 build failure on the legacy circleci base image
- test failures due to changed JSON ordering with hashable-1.3.1.0

There's a bit more detail in the commit messages.