### PR TITLE
Add `request.spec` to db-root-spec

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -41,11 +41,11 @@ library
                       PostgREST.Config
                       PostgREST.Config.Database
                       PostgREST.Config.JSPath
+                      PostgREST.Config.PgVersion
                       PostgREST.Config.Proxy
                       PostgREST.ContentType
                       PostgREST.DbStructure
                       PostgREST.DbStructure.Identifiers
-                      PostgREST.DbStructure.PgVersion
                       PostgREST.DbStructure.Proc
                       PostgREST.DbStructure.Relationship
                       PostgREST.DbStructure.Table

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -54,13 +54,13 @@ import qualified PostgREST.Request.DbRequestBuilder as ReqBuilder
 import PostgREST.AppState                (AppState)
 import PostgREST.Config                  (AppConfig (..),
                                           LogLevel (..))
+import PostgREST.Config.PgVersion        (PgVersion (..))
 import PostgREST.ContentType             (ContentType (..))
 import PostgREST.DbStructure             (DbStructure (..),
                                           tablePKCols)
 import PostgREST.DbStructure.Identifiers (FieldName,
                                           QualifiedIdentifier (..),
                                           Schema)
-import PostgREST.DbStructure.PgVersion   (PgVersion (..))
 import PostgREST.DbStructure.Proc        (ProcDescription (..),
                                           ProcVolatility (..))
 import PostgREST.DbStructure.Table       (Table (..))

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -141,11 +141,12 @@ postgrest logLev appState connWorker =
       conf <- AppState.getConfig appState
       maybeDbStructure <- AppState.getDbStructure appState
       pgVer <- AppState.getPgVersion appState
+      jsonDbS <- AppState.getJsonDbS appState
 
       let
         eitherResponse :: IO (Either Error Wai.Response)
         eitherResponse =
-          runExceptT $ postgrestResponse conf maybeDbStructure pgVer (AppState.getPool appState) time req
+          runExceptT $ postgrestResponse conf maybeDbStructure jsonDbS pgVer (AppState.getPool appState) time req
 
       response <- either Error.errorResponseFor identity <$> eitherResponse
 
@@ -159,12 +160,13 @@ postgrest logLev appState connWorker =
 postgrestResponse
   :: AppConfig
   -> Maybe DbStructure
+  -> ByteString
   -> PgVersion
   -> SQL.Pool
   -> UTCTime
   -> Wai.Request
   -> Handler IO Wai.Response
-postgrestResponse conf maybeDbStructure pgVer pool time req = do
+postgrestResponse conf maybeDbStructure jsonDbS pgVer pool time req = do
   body <- lift $ Wai.strictRequestBody req
 
   dbStructure <-
@@ -187,7 +189,7 @@ postgrestResponse conf maybeDbStructure pgVer pool time req = do
 
   runDbHandler pool (txMode apiRequest) jwtClaims .
     Middleware.optionalRollback conf apiRequest $
-      Middleware.runPgLocals conf jwtClaims handleReq apiRequest
+      Middleware.runPgLocals conf jwtClaims handleReq apiRequest jsonDbS
 
 runDbHandler :: SQL.Pool -> SQL.Mode -> Auth.JWTClaims -> DbHandler a -> Handler IO a
 runDbHandler pool mode jwtClaims handler = do

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -28,10 +28,9 @@ import Data.IORef         (IORef, atomicWriteIORef, newIORef,
                            readIORef)
 import Data.Time.Clock    (UTCTime, getCurrentTime)
 
-import PostgREST.Config                (AppConfig (..))
-import PostgREST.DbStructure           (DbStructure)
-import PostgREST.DbStructure.PgVersion (PgVersion (..),
-                                        minimumPgVersion)
+import PostgREST.Config           (AppConfig (..))
+import PostgREST.Config.PgVersion (PgVersion (..), minimumPgVersion)
+import PostgREST.DbStructure      (DbStructure)
 
 import Protolude      hiding (toS)
 import Protolude.Conv (toS)

--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -20,7 +20,7 @@ import Text.Heredoc (str)
 
 import PostgREST.AppState    (AppState)
 import PostgREST.Config      (AppConfig (..))
-import PostgREST.DbStructure (getDbStructure)
+import PostgREST.DbStructure (queryDbStructure)
 import PostgREST.Version     (prettyVersion)
 import PostgREST.Workers     (reReadConfig)
 
@@ -56,7 +56,7 @@ dumpSchema appState = do
   result <-
     P.use (AppState.getPool appState) $
       HT.transaction HT.ReadCommitted HT.Read $
-        getDbStructure
+        queryDbStructure
           (toList configDbSchemas)
           configDbExtraSearchPath
           configDbPreparedStatements

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -72,7 +72,7 @@ data AppConfig = AppConfig
   , configDbPoolTimeout         :: NominalDiffTime
   , configDbPreRequest          :: Maybe QualifiedIdentifier
   , configDbPreparedStatements  :: Bool
-  , configDbRootSpec            :: Maybe Text
+  , configDbRootSpec            :: Maybe QualifiedIdentifier
   , configDbSchemas             :: NonEmpty Text
   , configDbConfig              :: Bool
   , configDbTxAllowOverride     :: Bool
@@ -117,7 +117,7 @@ toText conf =
       ,("db-pool-timeout",               show . floor . configDbPoolTimeout)
       ,("db-pre-request",            q . maybe mempty show . configDbPreRequest)
       ,("db-prepared-statements",        T.toLower . show . configDbPreparedStatements)
-      ,("db-root-spec",              q . fromMaybe mempty . configDbRootSpec)
+      ,("db-root-spec",              q . maybe mempty show . configDbRootSpec)
       ,("db-schemas",                q . T.intercalate "," . toList . configDbSchemas)
       ,("db-config",                 q . T.toLower . show . configDbConfig)
       ,("db-tx-end",                 q . showTxEnd)
@@ -202,8 +202,8 @@ parser optPath env dbSettings =
     <*> (fmap toQi <$> optWithAlias (optString "db-pre-request")
                                     (optString "pre-request"))
     <*> (fromMaybe True <$> optBool "db-prepared-statements")
-    <*> optWithAlias (optString "db-root-spec")
-                     (optString "root-spec")
+    <*> (fmap toQi <$> optWithAlias (optString "db-root-spec")
+                                    (optString "root-spec"))
     <*> (fromList . splitOnCommas <$> reqWithAlias (optValue "db-schemas")
                                                    (optValue "db-schema")
                                                    "missing key: either db-schemas or db-schema must be set")

--- a/src/PostgREST/Config/PgVersion.hs
+++ b/src/PostgREST/Config/PgVersion.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric  #-}
-module PostgREST.DbStructure.PgVersion
+module PostgREST.Config.PgVersion
   ( PgVersion(..)
   , minimumPgVersion
   , pgVersion95

--- a/src/PostgREST/Config/Proxy.hs
+++ b/src/PostgREST/Config/Proxy.hs
@@ -1,4 +1,3 @@
-
 {-|
 Module      : PostgREST.Private.ProxyUri
 Description : Proxy Uri validator

--- a/src/PostgREST/DbStructure/Identifiers.hs
+++ b/src/PostgREST/DbStructure/Identifiers.hs
@@ -6,9 +6,12 @@ module PostgREST.DbStructure.Identifiers
   , Schema
   , TableName
   , FieldName
+  , toQi
   ) where
 
 import qualified Data.Aeson as JSON
+import qualified Data.Text  as T
+import qualified GHC.Show
 
 import Protolude
 
@@ -22,6 +25,17 @@ data QualifiedIdentifier = QualifiedIdentifier
   deriving (Eq, Ord, Generic, JSON.ToJSON, JSON.ToJSONKey)
 
 instance Hashable QualifiedIdentifier
+
+instance Show QualifiedIdentifier where
+  show (QualifiedIdentifier s i) =
+    (if T.null s then mempty else toS s <> ".") <> toS i
+
+-- TODO: Handle a case where the QI comes like this: "my.fav.schema"."my.identifier"
+-- Right now it only handles the schema.identifier case
+toQi :: Text -> QualifiedIdentifier
+toQi txt = case T.drop 1 <$> T.breakOn "." txt of
+  (i, "") -> QualifiedIdentifier mempty i
+  (s, i)  -> QualifiedIdentifier s i
 
 type Schema = Text
 type TableName = Text

--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -42,7 +42,7 @@ import System.Log.FastLogger     (toLogStr)
 import PostgREST.Config             (AppConfig (..), LogLevel (..))
 import PostgREST.Error              (Error, errorResponseFor)
 import PostgREST.GucHeader          (addHeadersIfNotIncluded)
-import PostgREST.Query.SqlFragment  (intercalateSnippet,
+import PostgREST.Query.SqlFragment  (fromQi, intercalateSnippet,
                                      unknownLiteral)
 import PostgREST.Request.ApiRequest (ApiRequest (..))
 
@@ -75,7 +75,7 @@ runPgLocals conf claims app req = do
     searchPathSql =
       let schemas = T.intercalate ", " (iSchema req : configDbExtraSearchPath conf) in
       setConfigLocal mempty ("search_path", schemas)
-    preReqSql = (\f -> "select " <> toS f <> "();") <$> configDbPreRequest conf
+    preReqSql = (\f -> "select " <> fromQi f <> "();") <$> configDbPreRequest conf
 
     -- | Do a pg set_config(setting, value, true) call. This is equivalent to a SET LOCAL.
     setConfigLocal :: Text -> (Text, Text) -> H.Snippet

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -135,6 +135,7 @@ pgFmtLit x =
    then "E" <> slashed
    else slashed
 
+-- TODO: refactor by following https://github.com/PostgREST/postgrest/pull/1631#issuecomment-711070833
 pgFmtIdent :: Text -> SqlFragment
 pgFmtIdent x = encodeUtf8 $ "\"" <> T.replace "\"" "\"\"" (trimNullChars x) <> "\""
 

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -32,7 +32,7 @@ module PostgREST.Query.SqlFragment
   , returningF
   , selectBody
   , sourceCTEName
-  , unknownLiteral
+  , unknownEncoder
   , intercalateSnippet
   ) where
 

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -46,9 +46,9 @@ import qualified Hasql.Encoders                  as HE
 import Data.Foldable                 (foldr1)
 import Text.InterpolatedString.Perl6 (qc)
 
+import PostgREST.Config.PgVersion        (PgVersion, pgVersion96)
 import PostgREST.DbStructure.Identifiers (FieldName,
                                           QualifiedIdentifier (..))
-import PostgREST.DbStructure.PgVersion   (PgVersion, pgVersion96)
 import PostgREST.RangeQuery              (NonnegRange, allRange,
                                           rangeLimit, rangeOffset)
 import PostgREST.Request.Types           (Alias, Field, Filter (..),

--- a/src/PostgREST/Query/Statements.hs
+++ b/src/PostgREST/Query/Statements.hs
@@ -29,9 +29,9 @@ import Data.Maybe                (fromJust)
 import Data.Text.Read            (decimal)
 import Network.HTTP.Types.Status (Status)
 
-import PostgREST.DbStructure.PgVersion (PgVersion)
-import PostgREST.Error                 (Error (..))
-import PostgREST.GucHeader             (GucHeader)
+import PostgREST.Config.PgVersion (PgVersion)
+import PostgREST.Error            (Error (..))
+import PostgREST.GucHeader        (GucHeader)
 
 import PostgREST.DbStructure.Identifiers (FieldName)
 import PostgREST.Query.SqlFragment

--- a/src/PostgREST/Workers.hs
+++ b/src/PostgREST/Workers.hs
@@ -7,6 +7,7 @@ module PostgREST.Workers
   , listener
   ) where
 
+import qualified Data.Aeson                 as JSON
 import qualified Data.ByteString            as BS
 import qualified Hasql.Connection           as C
 import qualified Hasql.Notifications        as N
@@ -172,6 +173,8 @@ loadSchemaCache appState = do
 
     Right dbStructure -> do
       AppState.putDbStructure appState dbStructure
+      when (isJust configDbRootSpec) $
+        AppState.putJsonDbS appState $ toS $ JSON.encode dbStructure
       putStrLn ("Schema cache loaded" :: Text)
       return SCLoaded
 

--- a/src/PostgREST/Workers.hs
+++ b/src/PostgREST/Workers.hs
@@ -17,14 +17,13 @@ import Control.Retry (RetryStatus, capDelay, exponentialBackoff,
                       retrying, rsPreviousDelay)
 import Data.Text.IO  (hPutStrLn)
 
-import PostgREST.AppState              (AppState)
-import PostgREST.Config                (AppConfig (..), readAppConfig)
-import PostgREST.Config.Database       (loadDbSettings)
-import PostgREST.DbStructure           (getDbStructure, getPgVersion)
-import PostgREST.DbStructure.PgVersion (PgVersion (..),
-                                        minimumPgVersion)
-import PostgREST.Error                 (PgError (PgError),
-                                        checkIsFatal, errorPayload)
+import PostgREST.AppState         (AppState)
+import PostgREST.Config           (AppConfig (..), readAppConfig)
+import PostgREST.Config.Database  (queryDbSettings, queryPgVersion)
+import PostgREST.Config.PgVersion (PgVersion (..), minimumPgVersion)
+import PostgREST.DbStructure      (queryDbStructure)
+import PostgREST.Error            (PgError (PgError), checkIsFatal,
+                                   errorPayload)
 
 import qualified PostgREST.AppState as AppState
 
@@ -117,7 +116,7 @@ connectionStatus pool =
 
     getConnectionStatus :: IO ConnectionStatus
     getConnectionStatus = do
-      pgVersion <- P.use pool getPgVersion
+      pgVersion <- P.use pool queryPgVersion
       case pgVersion of
         Left e -> do
           let err = PgError False e
@@ -152,7 +151,7 @@ loadSchemaCache appState = do
   AppConfig{..} <- AppState.getConfig appState
   result <-
     P.use (AppState.getPool appState) . HT.transaction HT.ReadCommitted HT.Read $
-      getDbStructure (toList configDbSchemas) configDbExtraSearchPath configDbPreparedStatements
+      queryDbStructure (toList configDbSchemas) configDbExtraSearchPath configDbPreparedStatements
   case result of
     Left e -> do
       let
@@ -227,7 +226,7 @@ reReadConfig startingUp appState = do
   AppConfig{..} <- AppState.getConfig appState
   dbSettings <-
     if configDbConfig then
-      loadDbSettings (AppState.getPool appState)
+      queryDbSettings (AppState.getPool appState)
     else
       pure mempty
   readAppConfig dbSettings configFilePath (Just configDbUri) >>= \case

--- a/test/Feature/AndOrParamsSpec.hs
+++ b/test/Feature/AndOrParamsSpec.hs
@@ -7,7 +7,7 @@ import Test.Hspec
 import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 
-import PostgREST.DbStructure.PgVersion (PgVersion, pgVersion112)
+import PostgREST.Config.PgVersion (PgVersion, pgVersion112)
 
 import Protolude  hiding (get)
 import SpecHelper

--- a/test/Feature/AuthSpec.hs
+++ b/test/Feature/AuthSpec.hs
@@ -7,7 +7,7 @@ import Test.Hspec
 import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 
-import PostgREST.DbStructure.PgVersion (PgVersion, pgVersion112)
+import PostgREST.Config.PgVersion (PgVersion, pgVersion112)
 
 import Protolude  hiding (get)
 import SpecHelper

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -11,8 +11,8 @@ import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 import Text.Heredoc
 
-import PostgREST.DbStructure.PgVersion (PgVersion, pgVersion112,
-                                        pgVersion130)
+import PostgREST.Config.PgVersion (PgVersion, pgVersion112,
+                                   pgVersion130)
 
 import Protolude  hiding (get)
 import SpecHelper

--- a/test/Feature/JsonOperatorSpec.hs
+++ b/test/Feature/JsonOperatorSpec.hs
@@ -7,8 +7,8 @@ import Test.Hspec
 import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 
-import PostgREST.DbStructure.PgVersion (PgVersion, pgVersion112,
-                                        pgVersion121, pgVersion95)
+import PostgREST.Config.PgVersion (PgVersion, pgVersion112,
+                                   pgVersion121, pgVersion95)
 
 import Protolude  hiding (get)
 import SpecHelper

--- a/test/Feature/MultipleSchemaSpec.hs
+++ b/test/Feature/MultipleSchemaSpec.hs
@@ -15,7 +15,7 @@ import Test.Hspec.Wai.JSON
 import Protolude
 import SpecHelper
 
-import PostgREST.DbStructure.PgVersion (PgVersion, pgVersion96)
+import PostgREST.Config.PgVersion (PgVersion, pgVersion96)
 
 spec :: PgVersion -> SpecWith ((), Application)
 spec actualPgVersion =

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -8,9 +8,9 @@ import Test.Hspec          hiding (pendingWith)
 import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 
-import PostgREST.DbStructure.PgVersion (PgVersion, pgVersion112,
-                                        pgVersion121, pgVersion96)
-import Protolude                       hiding (get)
+import PostgREST.Config.PgVersion (PgVersion, pgVersion112,
+                                   pgVersion121, pgVersion96)
+import Protolude                  hiding (get)
 import SpecHelper
 
 spec :: PgVersion -> SpecWith ((), Application)

--- a/test/Feature/RootSpec.hs
+++ b/test/Feature/RootSpec.hs
@@ -26,5 +26,9 @@ spec =
     it "accepts application/json" $
       request methodGet "/"
         [("Accept", "application/json")] "" `shouldRespondWith`
-        [json| [{"table": "items"}, {"table": "subitems"}] |]
+        [json| {
+            "tableName": "orders_view", "tableSchema": "test",
+            "tableDeletable": true, "tableUpdatable": true,
+            "tableInsertable": true, "tableDescription": null
+          } |]
         { matchHeaders = [matchContentTypeJson] }

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -11,10 +11,10 @@ import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 import Text.Heredoc
 
-import PostgREST.DbStructure.PgVersion (PgVersion, pgVersion100,
-                                        pgVersion109, pgVersion110,
-                                        pgVersion112, pgVersion114,
-                                        pgVersion96)
+import PostgREST.Config.PgVersion (PgVersion, pgVersion100,
+                                   pgVersion109, pgVersion110,
+                                   pgVersion112, pgVersion114,
+                                   pgVersion96)
 
 import Protolude  hiding (get)
 import SpecHelper

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -8,12 +8,13 @@ import Data.List.NonEmpty (toList)
 
 import Test.Hspec
 
-import PostgREST.App                   (postgrest)
-import PostgREST.Config                (AppConfig (..), LogLevel (..))
-import PostgREST.DbStructure           (getDbStructure, getPgVersion)
-import PostgREST.DbStructure.PgVersion (pgVersion96)
-import Protolude                       hiding (toList, toS)
-import Protolude.Conv                  (toS)
+import PostgREST.App              (postgrest)
+import PostgREST.Config           (AppConfig (..), LogLevel (..))
+import PostgREST.Config.Database  (queryPgVersion)
+import PostgREST.Config.PgVersion (pgVersion96)
+import PostgREST.DbStructure      (queryDbStructure)
+import Protolude                  hiding (toList, toS)
+import Protolude.Conv             (toS)
 import SpecHelper
 
 import qualified PostgREST.AppState as AppState
@@ -57,7 +58,7 @@ main = do
 
   pool <- P.acquire (3, 10, toS testDbConn)
 
-  actualPgVersion <- either (panic.show) id <$> P.use pool getPgVersion
+  actualPgVersion <- either (panic.show) id <$> P.use pool queryPgVersion
 
   baseDbStructure <-
     loadDbStructure pool
@@ -204,4 +205,4 @@ main = do
 
   where
     loadDbStructure pool schemas extraSearchPath =
-      either (panic.show) id <$> P.use pool (HT.transaction HT.ReadCommitted HT.Read $ getDbStructure (toList schemas) extraSearchPath True)
+      either (panic.show) id <$> P.use pool (HT.transaction HT.ReadCommitted HT.Read $ queryDbStructure (toList schemas) extraSearchPath True)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,5 +1,6 @@
 module Main where
 
+import qualified Data.Aeson                 as JSON
 import qualified Hasql.Pool                 as P
 import qualified Hasql.Transaction.Sessions as HT
 
@@ -68,19 +69,25 @@ main = do
   let
     -- For tests that run with the same refDbStructure
     app cfg = do
-      appState <- AppState.initWithPool pool $ cfg testDbConn
+      let config = cfg testDbConn
+      appState <- AppState.initWithPool pool config
       AppState.putPgVersion appState actualPgVersion
       AppState.putDbStructure appState baseDbStructure
+      when (isJust $ configDbRootSpec config) $
+        AppState.putJsonDbS appState $ toS $ JSON.encode baseDbStructure
       return ((), postgrest LogCrit appState $ pure ())
 
     -- For tests that run with a different DbStructure(depends on configSchemas)
     appDbs cfg = do
+      let config = cfg testDbConn
       customDbStructure <-
         loadDbStructure pool
-          (configDbSchemas $ cfg testDbConn)
-          (configDbExtraSearchPath $ cfg testDbConn)
-      appState <- AppState.initWithPool pool $ cfg testDbConn
+          (configDbSchemas config)
+          (configDbExtraSearchPath config)
+      appState <- AppState.initWithPool pool config
       AppState.putDbStructure appState customDbStructure
+      when (isJust $ configDbRootSpec config) $
+        AppState.putJsonDbS appState $ toS $ JSON.encode baseDbStructure
       return ((), postgrest LogCrit appState $ pure ())
 
   let withApp              = app testCfg

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -22,10 +22,12 @@ import Test.Hspec
 import Test.Hspec.Wai
 import Text.Heredoc
 
-import PostgREST.Config (AppConfig (..), JSPathExp (..),
-                         LogLevel (..), parseSecret)
-import Protolude        hiding (toS)
-import Protolude.Conv   (toS)
+import PostgREST.Config                  (AppConfig (..),
+                                          JSPathExp (..),
+                                          LogLevel (..), parseSecret)
+import PostgREST.DbStructure.Identifiers (QualifiedIdentifier (..))
+import Protolude                         hiding (toS)
+import Protolude.Conv                    (toS)
 
 matchContentTypeJson :: MatchHeader
 matchContentTypeJson = "Content-Type" <:> "application/json; charset=utf-8"
@@ -79,7 +81,7 @@ _baseCfg = let secret = Just $ encodeUtf8 "reallyreallyreallyreallyverysafe" in
   , configDbMaxRows             = Nothing
   , configDbPoolSize            = 10
   , configDbPoolTimeout         = 10
-  , configDbPreRequest          = Just "test.switch_role"
+  , configDbPreRequest          = Just $ QualifiedIdentifier "test" "switch_role"
   , configDbPreparedStatements  = True
   , configDbRootSpec            = Nothing
   , configDbSchemas             = fromList ["test"]
@@ -169,7 +171,7 @@ testCfgHtmlRawOutput :: Text -> AppConfig
 testCfgHtmlRawOutput testDbConn = (testCfg testDbConn) { configRawMediaTypes = ["text/html"] }
 
 testCfgResponseHeaders :: Text -> AppConfig
-testCfgResponseHeaders testDbConn = (testCfg testDbConn) { configDbPreRequest = Just "custom_headers" }
+testCfgResponseHeaders testDbConn = (testCfg testDbConn) { configDbPreRequest = Just $ QualifiedIdentifier mempty "custom_headers" }
 
 testMultipleSchemaCfg :: Text -> AppConfig
 testMultipleSchemaCfg testDbConn = (testCfg testDbConn) { configDbSchemas = fromList ["v1", "v2"] }

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -165,7 +165,7 @@ testCfgExtraSearchPath :: Text -> AppConfig
 testCfgExtraSearchPath testDbConn = (testCfg testDbConn) { configDbExtraSearchPath = ["public", "extensions"] }
 
 testCfgRootSpec :: Text -> AppConfig
-testCfgRootSpec testDbConn = (testCfg testDbConn) { configDbRootSpec = Just "root"}
+testCfgRootSpec testDbConn = (testCfg testDbConn) { configDbRootSpec = Just $ QualifiedIdentifier mempty "root"}
 
 testCfgHtmlRawOutput :: Text -> AppConfig
 testCfgHtmlRawOutput testDbConn = (testCfg testDbConn) { configRawMediaTypes = ["text/html"] }

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1713,9 +1713,9 @@ returns integer as $$
   select a + b;
 $$ language sql;
 
-create function root() returns jsonb as $_$
+create or replace function root() returns json as $_$
 declare
-openapi jsonb = $$
+openapi json = $$
   {
     "swagger": "2.0",
     "info":{
@@ -1724,22 +1724,12 @@ openapi jsonb = $$
     }
   }
 $$;
-simple jsonb = $$
-  [
-    {
-      "table":"items"
-    },
-    {
-      "table":"subitems"
-    }
-  ]
-$$;
 begin
 case current_setting('request.header.accept', true)
   when 'application/openapi+json' then
     return openapi;
   when 'application/json' then
-    return simple;
+    return (current_setting('request.spec', true)::json)->'dbRelationships'->0->'relTable';
   else
     return openapi;
   end case;


### PR DESCRIPTION
Aims to close https://github.com/PostgREST/postgrest/issues/1731. Partially addresses https://github.com/PostgREST/postgrest/issues/1698.

When `db-root-spec` is used and when the root endpoint(`/`) is requested, this will add a `request.spec` GUC for that transaction.

The `request.spec` GUC is PostgREST schema cache in plain json(no OpenAPI), it contains the relationships between tables/views we infer, among other things.

Example usage:

```sql
create or replace function root_override() returns json as $$
  select current_setting('request.spec', true)::json;
$$ language sql;

-- on the config file, add:
-- db-root-spec = "root_override"
```

Doing a `GET /`, will obtain the following [big json](https://gist.github.com/steve-chavez/bccb5ae9f426fd247bedec3cebdc76a2)(this one uses our test suite fixtures), the `dbRelations` key contains the relationships, the `relType` is the cardinality.

Requesting `root_override` is done as regular RPC, the function can contain parameters, return any type, filters can be applied, etc. The function can internally omit certain fields or add new ones.

### Caveat

`db-root-spec` disables the default OpenAPI output.

### TODO

- [x] Cache the `request.spec` json. It would be wasteful to convert the `dbStructure` to json on each request.
- [x] Our current OpenAPI output considers the JWT role privileges for including accessible tables/procs. Not sure if this should be done by the root-spec as well or if we should leave it to the SQL function. **For a later enhancement if needed**.
- [x] Define a better name for the `request.spec` GUC. **Keep the name**(as decided [below](https://github.com/PostgREST/postgrest/pull/1794#issuecomment-844585519)).
- [x] Add tests

### Implementation notes

- On https://github.com/PostgREST/postgrest/issues/1698#issuecomment-748536949, we discussed adding an special parameter to the root spec function for passing the schema cache. This option needed special handling in code(injecting the parameter without allowing the user to edit it through the url, appending the json to the payload, etc), passing a GUC was much more simple to implement. 