### PR TITLE
fix random codecov/project drops in CI, resolves #1800

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -224,8 +224,7 @@ test-suite spec
                     , transformers-base >= 0.4.4 && < 0.5
                     , wai               >= 3.2.1 && < 3.3
                     , wai-extra         >= 3.0.19 && < 3.2
-  ghc-options:        -threaded -rtsopts -with-rtsopts=-N
-                      -O0 -Werror -Wall -fwarn-identities
+  ghc-options:        -O0 -Werror -Wall -fwarn-identities
                       -fno-spec-constr -optP-Wno-nonportable-include-path
                       -fno-warn-missing-signatures
 


### PR DESCRIPTION
I was able to reproduce locally: Running `postgrest-coverage` repeatedly resulted in different `spec.tix` files. Removing `-threaded` from the spec test ghc-options made it consistent across runs again.

Let's see how this unfolds over a few commits to main.

Will let CI run and then merge.