### PR TITLE
Allow headers only POST request and default the request to minimal

### DIFF
--- a/src/PostgREST/Request/ApiRequest.hs
+++ b/src/PostgREST/Request/ApiRequest.hs
@@ -334,12 +334,10 @@ userApiRequest confSchemas rootSpec dbStructure req reqBody
         split :: BS.ByteString -> [Text]
         split = map T.strip . T.split (==',') . toS
   representation
-    | hasPrefer (show Full) = Full
-    | hasPrefer (show None) = None
+    | hasPrefer (show Full)        = Full
+    | hasPrefer (show None)        = None
     | hasPrefer (show HeadersOnly) = HeadersOnly
-    | otherwise             = if action == ActionCreate
-                                then HeadersOnly -- Assume the user wants the Location header(for POST) by default
-                                else None
+    | otherwise                    = None
   auth = fromMaybe "" $ lookupHeader hAuthorization
   tokenStr = case T.split (== ' ') (toS auth) of
     ("Bearer" : t : _) -> t

--- a/src/PostgREST/Request/ApiRequest.hs
+++ b/src/PostgREST/Request/ApiRequest.hs
@@ -336,6 +336,7 @@ userApiRequest confSchemas rootSpec dbStructure req reqBody
   representation
     | hasPrefer (show Full) = Full
     | hasPrefer (show None) = None
+    | hasPrefer (show HeadersOnly) = HeadersOnly
     | otherwise             = if action == ActionCreate
                                 then HeadersOnly -- Assume the user wants the Location header(for POST) by default
                                 else None

--- a/src/PostgREST/Request/Preferences.hs
+++ b/src/PostgREST/Request/Preferences.hs
@@ -22,7 +22,7 @@ data PreferRepresentation
 instance Show PreferRepresentation where
   show Full        = "return=representation"
   show None        = "return=minimal"
-  show HeadersOnly = mempty
+  show HeadersOnly = "return=headers-only"
 
 data PreferParameters
   = SingleObject    -- ^ Pass all parameters as a single json object to a stored procedure

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -111,12 +111,21 @@ spec actualPgVersion = do
                            , "Content-Range" <:> "*/*" ]
           }
 
-    context "requesting no representation" $
+    context "requesting headers only representation" $
       it "should not throw and return location header when selecting without PK" $
-        request methodPost "/projects?select=name,client_id" []
+        request methodPost "/projects?select=name,client_id" [("Prefer", "return=headers-only")]
           [json|{"id":11,"name":"New Project","client_id":2}|] `shouldRespondWith` ""
           { matchStatus  = 201
           , matchHeaders = [ "Location" <:> "/projects?id=eq.11"
+                           , "Content-Range" <:> "*/*" ]
+          }
+    
+    context "requesting no representation" $
+      it "should not throw and return location header when selecting without PK" $
+        request methodPost "/projects?select=name,client_id" []
+          [json|{"id":12,"name":"New Project","client_id":2}|] `shouldRespondWith` ""
+          { matchStatus  = 201
+          , matchHeaders = [ "Location" <:> "/projects?id=eq.12"
                            , "Content-Range" <:> "*/*" ]
           }
 

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -119,7 +119,7 @@ spec actualPgVersion = do
           , matchHeaders = [ "Location" <:> "/projects?id=eq.11"
                            , "Content-Range" <:> "*/*" ]
           }
-    
+
     context "requesting no representation" $
       it "should not throw and return no location header when selecting without PK" $
         request methodPost "/projects?select=name,client_id" []
@@ -524,7 +524,7 @@ spec actualPgVersion = do
           `shouldRespondWith`
             ""
             { matchStatus  = 201
-            , matchHeaders = [ "Content-Range" <:> "*/*" ]
+            , matchHeaders = [ matchHeaderAbsent hLocation ]
             }
 
     context "requesting header only representation" $


### PR DESCRIPTION
Fixes #1656.

Allows returning only the Location header using "Prefer return=headers-only".
Defaults the POST request made without Prefer header to minimal instead of headers only.