### PR TITLE
ci: fix cirrus build timeout

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,7 +37,7 @@ build_task:
         sed -i '' "s/^version:.*/version:$cabal_nightly_version/" postgrest.cabal
       fi
       ## compile for 30 minutes tops
-    - timeout 1800 cabal v2-build -j1 || (($?==124))
+    - timeout 1800 cabal v2-build -j1 || test "$?" = "124"
 
   publish_script:
     - |


### PR DESCRIPTION
Related to https://github.com/PostgREST/postgrest/pull/1813#issuecomment-819066151.

Let's see whether that works better.