### PR TITLE
ci: split nix-build-test into nix-build nix-test and introduce circle ci contexts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,13 @@ jobs:
           when: on_fail
       - run:
           name: Upload coverage to codecov
-          command: bash <(curl -s https://codecov.io/bash) -f coverage/codecov.json
+          command: |
+            # Modified from:
+            # https://docs.codecov.io/docs/about-the-codecov-bash-uploader#validating-the-bash-script
+            curl -s https://codecov.io/bash > codecov;
+            VERSION=$(grep 'VERSION=\".*\"' codecov | cut -d'"' -f2);
+            shasum -a 512 -c <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA512SUM | grep codecov)
+            bash codecov -f coverage/codecov.json
       - run:
           name: Run the spec tests against PostgreSQL 12
           command: postgrest-with-postgresql-12 postgrest-test-spec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,50 +68,6 @@ jobs:
           command: |
             test/create_test_db "postgres://circleci@localhost" postgrest_test stack test
 
-  # Run memory usage tests based on stack and docker.
-  stack-test-memory:
-    docker:
-      - image: cimg/base:2021.03
-        environment:
-          - PGHOST=localhost
-          - TERM=xterm
-      - image: circleci/postgres:12
-        environment:
-          - POSTGRES_USER=circleci
-          - POSTGRES_DB=circleci
-          - POSTGRES_HOST_AUTH_METHOD=trust
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-          - v1-stack-prof-dependencies-{{ checksum "postgrest.cabal" }}-{{ checksum "stack.yaml" }}
-      - run:
-          name: install stack & dependencies
-          command: |
-            curl -L https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz | tar zx -C /tmp
-            sudo mv /tmp/stack-2.3.1-linux-x86_64/stack /usr/bin
-            sudo apt-get update
-            sudo apt-get install -y libgmp-dev postgresql-client
-            stack setup
-      - run:
-          name: build dependencies with profiling enabled
-          command: |
-            stack build --profile -j1  --only-dependencies
-      - save_cache:
-          paths:
-            - "~/.stack"
-            - ".stack-work"
-          key: v1-stack-prof-dependencies-{{ checksum "postgrest.cabal" }}-{{ checksum "stack.yaml" }}
-      - run:
-          name: install with profiling enabled
-          command: |
-            stack install --profile -j1
-      - run:
-          name: run memory usage tests
-          command: |
-            export PATH="~/.local/bin:$PATH"
-            test/create_test_db "postgres://circleci@localhost" postgrest_test test/memory-tests.sh
-
   # Publish a new release. This only runs when a release is tagged (see
   # workflow below).
   release:
@@ -268,12 +224,6 @@ workflows:
               only:
                 - /v[0-9]+(\.[0-9]+)*/
                 - nightly
-      - stack-test-memory:
-          filters:
-            tags:
-              only:
-                - /v[0-9]+(\.[0-9]+)*/
-                - nightly
       - nix-build:
           filters:
             tags:
@@ -292,7 +242,6 @@ workflows:
           requires:
             - style-check
             - stack-test
-            - stack-test-memory
             - nix-build
             - nix-test
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,47 +211,44 @@ jobs:
           name: Install testing scripts
           command: nix-env -f default.nix -iA tests tests.memoryTests
       - run:
-          name: Skip tests on build failure
+          name: Run coverage (io tests and spec tests against PostgreSQL 13)
+          command: postgrest-coverage
+          when: always
+      - run:
+          name: Skip tests on build or primary test failure
           command: circleci-agent step halt
           when: on_fail
       - run:
-          name: Run the spec tests against PostgreSQL 9.5
-          command: postgrest-with-postgresql-9.5 postgrest-test-spec
-          when: always
+          name: Upload coverage to codecov
+          command: bash <(curl -s https://codecov.io/bash) -f coverage/codecov.json
       - run:
-          name: Run the spec tests against PostgreSQL 9.6
-          command: postgrest-with-postgresql-9.6 postgrest-test-spec
-          when: always
-      - run:
-          name: Run the spec tests against PostgreSQL 10
-          command: postgrest-with-postgresql-10 postgrest-test-spec
+          name: Run the spec tests against PostgreSQL 12
+          command: postgrest-with-postgresql-12 postgrest-test-spec
           when: always
       - run:
           name: Run the spec tests against PostgreSQL 11
           command: postgrest-with-postgresql-11 postgrest-test-spec
           when: always
       - run:
-          name: Run the spec tests against PostgreSQL 12
-          command: postgrest-with-postgresql-12 postgrest-test-spec
+          name: Run the spec tests against PostgreSQL 10
+          command: postgrest-with-postgresql-10 postgrest-test-spec
           when: always
       - run:
-          name: Check the spec tests for idempotence against PostgreSQL 13
+          name: Run the spec tests against PostgreSQL 9.6
+          command: postgrest-with-postgresql-9.6 postgrest-test-spec
+          when: always
+      - run:
+          name: Run the spec tests against PostgreSQL 9.5
+          command: postgrest-with-postgresql-9.5 postgrest-test-spec
+          when: always
+      - run:
+          name: Check the spec tests for idempotence
           command: postgrest-test-spec-idempotence
-          when: always
-      - run:
-          name: Run io tests
-          command: postgrest-test-io
           when: always
       - run:
           name: Run memory tests
           command: postgrest-test-memory
           when: always
-      - run:
-          name: Run coverage
-          command: postgrest-coverage
-      - run:
-          name: Upload coverage to codecov
-          command: bash <(curl -s https://codecov.io/bash) -f coverage/codecov.json
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,8 +156,8 @@ jobs:
               postgrest-release-dockerhubdescription
             fi
 
-  # Build everything in default.nix, push to the Cachix binary cache and run tests
-  nix-build-test:
+  # Build everything in default.nix and push to the Cachix binary cache if running on main
+  nix-build:
     machine: true
     steps:
       - checkout
@@ -191,6 +191,22 @@ jobs:
               echo "Building all derivations (caching skipped for outside pull requests)..."
               nix-build
             fi
+
+  # Run tests
+  nix-test:
+    machine: true
+    steps:
+      - checkout
+      - run:
+          name: Install Nix
+          command: |
+            curl -L https://nixos.org/nix/install | sh
+            echo "source $HOME/.nix-profile/etc/profile.d/nix.sh" >> $BASH_ENV
+      - run:
+          name: Install and use the Cachix binary cache
+          command: |
+            nix-env -iA cachix -f https://cachix.org/api/v1/install
+            cachix use postgrest
       - run:
           name: Install testing scripts
           command: nix-env -f default.nix -iA tests tests.memoryTests
@@ -261,7 +277,15 @@ workflows:
               only:
                 - /v[0-9]+(\.[0-9]+)*/
                 - nightly
-      - nix-build-test:
+      - nix-build:
+          filters:
+            tags:
+              only:
+                - /v[0-9]+(\.[0-9]+)*/
+                - nightly
+          context:
+            - cachix
+      - nix-test:
           filters:
             tags:
               only:
@@ -272,7 +296,8 @@ workflows:
             - style-check
             - stack-test
             - stack-test-memory
-            - nix-build-test
+            - nix-build
+            - nix-test
           filters:
             tags:
               only:
@@ -280,3 +305,6 @@ workflows:
                 - nightly
             branches:
               ignore: /.*/
+          context:
+            - docker
+            - github


### PR DESCRIPTION
As discussed via email. This is to secure our cachix, docker and github tokens better. Contexts will still have to be filled with environment variables.

The split in `nix-build` and `nix-test` should also make our pipeline faster, because they can both run in parallel. @monacoremo Did I miss anything in there? I don't think the `nix-build` step will have any problems, but will that be OK for `nix-test`? Or is it missing anything that I removed in that step?