### PR TITLE
refactor: make Junction non-recursive

### DIFF
--- a/src/PostgREST/DbStructure/Relation.hs
+++ b/src/PostgREST/DbStructure/Relation.hs
@@ -25,11 +25,11 @@ import Protolude
 --
 -- TODO merge relColumns and relFColumns to a tuple or Data.Bimap
 data Relation = Relation
-  { relTable    :: Table
-  , relColumns  :: [Column]
-  , relFTable   :: Table
-  , relFColumns :: [Column]
-  , relCard     :: Cardinality
+  { relTable          :: Table
+  , relColumns        :: [Column]
+  , relForeignTable   :: Table
+  , relForeignColumns :: [Column]
+  , relCardinality    :: Cardinality
   }
   deriving (Eq, Generic, JSON.ToJSON)
 
@@ -37,25 +37,25 @@ data Relation = Relation
 -- | https://en.wikipedia.org/wiki/Cardinality_(data_modeling)
 -- TODO: missing one-to-one
 data Cardinality
-  = O2M ConstraintName -- ^ one-to-many cardinality
-  | M2O ConstraintName -- ^ many-to-one cardinality
-  | M2M Junction       -- ^ many-to-many cardinality
+  = O2M FKConstraint -- ^ one-to-many cardinality
+  | M2O FKConstraint -- ^ many-to-one cardinality
+  | M2M Junction     -- ^ many-to-many cardinality
   deriving (Eq, Generic, JSON.ToJSON)
 
-type ConstraintName = Text
+type FKConstraint = Text
 
 -- | Junction table on an M2M relationship
 data Junction = Junction
   { junTable       :: Table
-  , junConstraint1 :: ConstraintName
+  , junConstraint1 :: FKConstraint
   , junColumns1    :: [Column]
-  , junConstraint2 :: ConstraintName
+  , junConstraint2 :: FKConstraint
   , junColumns2    :: [Column]
   }
   deriving (Eq, Generic, JSON.ToJSON)
 
 isSelfReference :: Relation -> Bool
-isSelfReference r = relTable r == relFTable r
+isSelfReference r = relTable r == relForeignTable r
 
 data PrimaryKey = PrimaryKey
   { pkTable :: Table

--- a/src/PostgREST/DbStructure/Relation.hs
+++ b/src/PostgREST/DbStructure/Relation.hs
@@ -46,11 +46,11 @@ type ConstraintName = Text
 
 -- | Junction table on an M2M relationship
 data Junction = Junction
-  { junTable :: Table
-  , junCons1 :: ConstraintName
-  , junCols1 :: [Column]
-  , junCons2 :: ConstraintName
-  , junCols2 :: [Column]
+  { junTable       :: Table
+  , junConstraint1 :: ConstraintName
+  , junColumns1    :: [Column]
+  , junConstraint2 :: ConstraintName
+  , junColumns2    :: [Column]
   }
   deriving (Eq, Generic, JSON.ToJSON)
 

--- a/src/PostgREST/DbStructure/Relation.hs
+++ b/src/PostgREST/DbStructure/Relation.hs
@@ -3,11 +3,10 @@
 
 module PostgREST.DbStructure.Relation
   ( Cardinality(..)
-  , Constraint
   , ForeignKey(..)
-  , Link(..)
   , PrimaryKey(..)
   , Relation(..)
+  , Junction(..)
   , isSelfReference
   ) where
 
@@ -15,8 +14,6 @@ import qualified Data.Aeson as JSON
 
 import PostgREST.DbStructure.Table (Column (..), ForeignKey (..),
                                     Table (..))
-
-import qualified GHC.Show (show)
 
 import Protolude
 
@@ -32,45 +29,36 @@ data Relation = Relation
   , relColumns  :: [Column]
   , relFTable   :: Table
   , relFColumns :: [Column]
-  , relType     :: Cardinality
-  , relLink     :: Link -- ^ Constraint on O2M/M2O, Junction for M2M Cardinality
+  , relCard     :: Cardinality
   }
+  deriving (Eq, Generic, JSON.ToJSON)
+
+-- | The relationship cardinality
+-- | https://en.wikipedia.org/wiki/Cardinality_(data_modeling)
+-- TODO: missing one-to-one
+data Cardinality
+  = O2M ConstraintName -- ^ one-to-many cardinality
+  | M2O ConstraintName -- ^ many-to-one cardinality
+  | M2M Junction       -- ^ many-to-many cardinality
   deriving (Eq, Generic, JSON.ToJSON)
 
 type ConstraintName = Text
 
 -- | Junction table on an M2M relationship
-data Link
-  = Constraint
-      { constName :: ConstraintName }
-  | Junction
-      { junTable :: Table
-      , junLink1 :: Link
-      , junCols1 :: [Column]
-      , junLink2 :: Link
-      , junCols2 :: [Column]
-      }
+data Junction = Junction
+  { junTable :: Table
+  , junCons1 :: ConstraintName
+  , junCols1 :: [Column]
+  , junCons2 :: ConstraintName
+  , junCols2 :: [Column]
+  }
   deriving (Eq, Generic, JSON.ToJSON)
+
+isSelfReference :: Relation -> Bool
+isSelfReference r = relTable r == relFTable r
 
 data PrimaryKey = PrimaryKey
   { pkTable :: Table
   , pkName  :: Text
   }
   deriving (Generic, JSON.ToJSON)
-
--- | The relationship
--- [cardinality](https://en.wikipedia.org/wiki/Cardinality_(data_modeling)).
--- TODO: missing one-to-one
-data Cardinality
-  = O2M -- ^ one-to-many,  previously known as Parent
-  | M2O -- ^ many-to-one,  previously known as Child
-  | M2M -- ^ many-to-many, previously known as Many
-  deriving (Eq, Generic, JSON.ToJSON)
-
-instance Show Cardinality where
-  show O2M = "o2m"
-  show M2O = "m2o"
-  show M2M = "m2m"
-
-isSelfReference :: Relation -> Bool
-isSelfReference r = relTable r == relFTable r

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -112,7 +112,7 @@ compressedRel Relation{..} =
   case relCard of
     M2M Junction{..} -> [
         "cardinality" .= ("m2m" :: Text)
-      , "relationship" .= (fmtTbl junTable <> fmtEls [junCons1] <> fmtEls [junCons2])
+      , "relationship" .= (fmtTbl junTable <> fmtEls [junConstraint1] <> fmtEls [junConstraint2])
       ]
     M2O cons -> [
         "cardinality" .= ("m2o" :: Text)

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -107,20 +107,20 @@ compressedRel Relation{..} =
   in
   JSON.object $ [
     "origin"      .= fmtTbl relTable
-  , "target"      .= fmtTbl relFTable
+  , "target"      .= fmtTbl relForeignTable
   ] ++
-  case relCard of
+  case relCardinality of
     M2M Junction{..} -> [
         "cardinality" .= ("m2m" :: Text)
       , "relationship" .= (fmtTbl junTable <> fmtEls [junConstraint1] <> fmtEls [junConstraint2])
       ]
     M2O cons -> [
         "cardinality" .= ("m2o" :: Text)
-      , "relationship" .= (cons <> fmtEls (colName <$> relColumns) <> fmtEls (colName <$> relFColumns))
+      , "relationship" .= (cons <> fmtEls (colName <$> relColumns) <> fmtEls (colName <$> relForeignColumns))
       ]
     O2M cons -> [
         "cardinality" .= ("o2m" :: Text)
-      , "relationship" .= (cons <> fmtEls (colName <$> relColumns) <> fmtEls (colName <$> relFColumns))
+      , "relationship" .= (cons <> fmtEls (colName <$> relColumns) <> fmtEls (colName <$> relForeignColumns))
       ]
 
 data PgError = PgError Authenticated P.UsageError

--- a/src/PostgREST/Query/QueryBuilder.hs
+++ b/src/PostgREST/Query/QueryBuilder.hs
@@ -53,7 +53,7 @@ readRequestToQuery (Node (Select colSelects mainQi tblAlias implJoins logicFores
     (joins, selects) = foldr getJoinsSelects ([],[]) forest
 
 getJoinsSelects :: ReadRequest -> ([H.Snippet], [H.Snippet]) -> ([H.Snippet], [H.Snippet])
-getJoinsSelects rr@(Node (_, (name, Just Relation{relCard=card,relTable=Table{tableName=table}}, alias, _, _)) _) (j,s) =
+getJoinsSelects rr@(Node (_, (name, Just Relation{relCardinality=card,relTable=Table{tableName=table}}, alias, _, _)) _) (j,s) =
   let subquery = readRequestToQuery rr in
   case card of
     M2O _ ->

--- a/src/PostgREST/Query/QueryBuilder.hs
+++ b/src/PostgREST/Query/QueryBuilder.hs
@@ -53,10 +53,10 @@ readRequestToQuery (Node (Select colSelects mainQi tblAlias implJoins logicFores
     (joins, selects) = foldr getJoinsSelects ([],[]) forest
 
 getJoinsSelects :: ReadRequest -> ([H.Snippet], [H.Snippet]) -> ([H.Snippet], [H.Snippet])
-getJoinsSelects rr@(Node (_, (name, Just Relation{relType=relTyp,relTable=Table{tableName=table}}, alias, _, _)) _) (j,s) =
+getJoinsSelects rr@(Node (_, (name, Just Relation{relCard=card,relTable=Table{tableName=table}}, alias, _, _)) _) (j,s) =
   let subquery = readRequestToQuery rr in
-  case relTyp of
-    M2O ->
+  case card of
+    M2O _ ->
       let aliasOrName = fromMaybe name alias
           localTableName = pgFmtIdent $ table <> "_" <> aliasOrName
           sel = H.sql ("row_to_json(" <> localTableName <> ".*) AS " <> pgFmtIdent aliasOrName)

--- a/src/PostgREST/Request/DbRequestBuilder.hs
+++ b/src/PostgREST/Request/DbRequestBuilder.hs
@@ -33,7 +33,8 @@ import Data.Tree               (Tree (..))
 import PostgREST.DbStructure.Identifiers (FieldName,
                                           QualifiedIdentifier (..),
                                           Schema, TableName)
-import PostgREST.DbStructure.Relation    (Cardinality (..), Link (..),
+import PostgREST.DbStructure.Relation    (Cardinality (..),
+                                          Junction (..),
                                           Relation (..))
 import PostgREST.DbStructure.Table       (Column (..), Table (..),
                                           tableQi)
@@ -152,21 +153,25 @@ findRel schema allRels origin target hint =
   case rel of
     []  -> Left $ NoRelBetween origin target
     [r] -> Right r
-    rs  ->
-      -- Return error if more than one relationship is found, unless we're in a
-      -- self reference case.
-      --
-      -- Here we handle a self reference relationship to not cause a breaking
-      -- change: In a self reference we get two relationships with the same
-      -- foreign key and relTable/relFtable but with different
-      -- cardinalities(m2o/o2m) We output the O2M rel, the M2O rel can be
-      -- obtained by using the origin column as an embed hint.
-      let [rel0, rel1] = take 2 rs in
-      if length rs == 2 && relLink rel0 == relLink rel1 && relTable rel0 == relTable rel1 && relFTable rel0 == relFTable rel1
-        then note (NoRelBetween origin target) (find (\r -> relType r == O2M) rs)
-        else Left $ AmbiguousRelBetween origin target rs
+    -- Here we handle a self reference relationship to not cause a breaking
+    -- change: In a self reference we get two relationships with the same
+    -- foreign key and relTable/relFtable but with different
+    -- cardinalities(m2o/o2m) We output the O2M rel, the M2O rel can be
+    -- obtained by using the origin column as an embed hint.
+    rs@[rel0, rel1]  -> case (relCard rel0, relCard rel1, relTable rel0 == relTable rel1 && relFTable rel0 == relFTable rel1) of
+      (O2M cons1, M2O cons2, True) -> if cons1 == cons2 then Right rel0 else Left $ AmbiguousRelBetween origin target rs
+      (M2O cons1, O2M cons2, True) -> if cons1 == cons2 then Right rel1 else Left $ AmbiguousRelBetween origin target rs
+      _                            -> Left $ AmbiguousRelBetween origin target rs
+    rs -> Left $ AmbiguousRelBetween origin target rs
   where
     matchFKSingleCol hint_ cols = length cols == 1 && hint_ == (colName <$> head cols)
+    matchConstraint tar card = case card of
+      O2M cons -> tar == Just cons
+      M2O cons -> tar == Just cons
+      _        -> False
+    matchJunction hint_ card = case card of
+      M2M Junction{junTable} -> hint_ == Just (tableName junTable)
+      _                      -> False
     rel = filter (
       \Relation{..} ->
         -- Both relationship ends need to be on the exposed schema
@@ -178,8 +183,8 @@ findRel schema allRels origin target hint =
 
           -- /projects?select=projects_client_id_fkey(*)
           (
-            origin == tableName relTable && -- projects
-            Constraint target == relLink    -- projects_client_id_fkey
+            origin == tableName relTable &&       -- projects
+            matchConstraint (Just target) relCard -- projects_client_id_fkey
           ) ||
           -- /projects?select=client_id(*)
           (
@@ -190,20 +195,14 @@ findRel schema allRels origin target hint =
           isNothing hint || -- hint is optional
 
           -- /projects?select=clients!projects_client_id_fkey(*)
-          (
-            relType /= M2M &&
-            hint == Just (constName relLink) -- projects_client_id_fkey
-          ) ||
+          matchConstraint hint relCard || -- projects_client_id_fkey
 
           -- /projects?select=clients!client_id(*) or /projects?select=clients!id(*)
           matchFKSingleCol hint relColumns  || -- client_id
           matchFKSingleCol hint relFColumns || -- id
 
-          -- /users?select=tasks!users_tasks(*)
-          (
-            relType == M2M &&                           -- many-to-many between users and tasks
-            hint == Just (tableName $ junTable relLink) -- users_tasks
-          )
+          -- /users?select=tasks!users_tasks(*) many-to-many between users and tasks
+          matchJunction hint relCard -- users_tasks
         )
       ) allRels
 
@@ -211,7 +210,7 @@ findRel schema allRels origin target hint =
 addJoinConditions :: Maybe Alias -> ReadRequest -> Either ApiRequestError ReadRequest
 addJoinConditions previousAlias (Node node@(query@Select{from=tbl}, nodeProps@(_, rel, _, _, depth)) forest) =
   case rel of
-    Just r@Relation{relType=M2M, relLink=Junction{junTable}} ->
+    Just r@Relation{relCard=M2M Junction{junTable}} ->
       let rq = augmentQuery r in
       Node (rq{implicitJoins=tableQi junTable:implicitJoins rq}, nodeProps) <$> updatedForest
     Just r -> Node (augmentQuery r, nodeProps) <$> updatedForest
@@ -231,11 +230,11 @@ addJoinConditions previousAlias (Node node@(query@Select{from=tbl}, nodeProps@(_
 
 -- previousAlias and newAlias are used in the case of self joins
 getJoinConditions :: Maybe Alias -> Maybe Alias -> Relation -> [JoinCondition]
-getJoinConditions previousAlias newAlias (Relation Table{tableSchema=tSchema, tableName=tN} cols Table{tableName=ftN} fCols _ lnk) =
-  case lnk of
-    Junction Table{tableName=jtn} _ jc1 _ jc2 ->
+getJoinConditions previousAlias newAlias (Relation Table{tableSchema=tSchema, tableName=tN} cols Table{tableName=ftN} fCols card) =
+  case card of
+    M2M (Junction Table{tableName=jtn} _ jc1 _ jc2) ->
       zipWith (toJoinCondition tN jtn) cols jc1 ++ zipWith (toJoinCondition ftN jtn) fCols jc2
-    Constraint _ ->
+    _ ->
       zipWith (toJoinCondition tN ftN) cols fCols
   where
     toJoinCondition :: Text -> Text -> Column -> Column -> JoinCondition
@@ -358,14 +357,10 @@ returningCols rr@(Node _ forest) pkCols
     -- be `RETURNING name`(see QueryBuilder).  This would make the embedding
     -- fail because the following JOIN would need the "client_id" column from
     -- projects.  So this adds the foreign key columns to ensure the embedding
-    -- succeeds, result would be `RETURNING name, client_id`.  This also works
-    -- for the other relType's.
+    -- succeeds, result would be `RETURNING name, client_id`.
     fkCols = concat $ mapMaybe (\case
-        Node (_, (_, Just Relation{relColumns=cols, relType=relTyp}, _, _, _)) _ -> case relTyp of
-          O2M -> Just cols
-          M2O -> Just cols
-          M2M -> Just cols
-        _ -> Nothing
+        Node (_, (_, Just Relation{relColumns=cols}, _, _, _)) _ -> Just cols
+        _                                                        -> Nothing
       ) forest
     -- However if the "client_id" is present, e.g. mutateRequest to
     -- /projects?select=client_id,name,clients(name) we would get `RETURNING


### PR DESCRIPTION
While working on https://github.com/PostgREST/postgrest/pull/1794, I noticed that we can have recursive Junctions:

https://github.com/PostgREST/postgrest/blob/4b46c4eff329c91dc13b26c78b266c7361ecace4/src/PostgREST/DbStructure/Relation.hs#L43-L53

Which didn't seem right, as discussed in https://github.com/PostgREST/postgrest/commit/522308217a03b912e858bdb3311641b6c65c1954#r49568150.

This PR fixes that, also Cardinality now contains the constraint or junction that defines it:

```haskell
data Cardinality
  = O2M ConstraintName -- ^ one-to-many cardinality
  | M2O ConstraintName -- ^ many-to-one cardinality
  | M2M Junction       -- ^ many-to-many cardinality
  deriving (Eq, Generic, JSON.ToJSON)
```

That makes sense IMO, it clears up the code in some parts.