### PR TITLE
fix: disregard internal junction when embedding

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -45,7 +45,7 @@ library
                       PostgREST.DbStructure.Identifiers
                       PostgREST.DbStructure.PgVersion
                       PostgREST.DbStructure.Proc
-                      PostgREST.DbStructure.Relation
+                      PostgREST.DbStructure.Relationship
                       PostgREST.DbStructure.Table
                       PostgREST.Error
                       PostgREST.GucHeader

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -518,7 +518,7 @@ readRequest :: Monad m => QualifiedIdentifier -> RequestContext -> Handler m Rea
 readRequest QualifiedIdentifier{..} (RequestContext AppConfig{..} dbStructure apiRequest _) =
   liftEither $
     ReqBuilder.readRequest qiSchema qiName configDbMaxRows
-      (dbRelations dbStructure)
+      (dbRelationships dbStructure)
       apiRequest
 
 contentTypeHeaders :: RequestContext -> [HTTP.Header]

--- a/src/PostgREST/DbStructure/Relationship.hs
+++ b/src/PostgREST/DbStructure/Relationship.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric  #-}
 
-module PostgREST.DbStructure.Relation
+module PostgREST.DbStructure.Relationship
   ( Cardinality(..)
   , ForeignKey(..)
   , PrimaryKey(..)
-  , Relation(..)
+  , Relationship(..)
   , Junction(..)
   , isSelfReference
   ) where
@@ -18,13 +18,13 @@ import PostgREST.DbStructure.Table (Column (..), ForeignKey (..),
 import Protolude
 
 
--- | "Relation"ship between two tables.
+-- | Relationship between two tables.
 --
--- The order of the relColumns and relFColumns should be maintained to get the
+-- The order of the relColumns and relForeignColumns should be maintained to get the
 -- join conditions right.
 --
--- TODO merge relColumns and relFColumns to a tuple or Data.Bimap
-data Relation = Relation
+-- TODO merge relColumns and relForeignColumns to a tuple or Data.Bimap
+data Relationship = Relationship
   { relTable          :: Table
   , relColumns        :: [Column]
   , relForeignTable   :: Table
@@ -54,7 +54,7 @@ data Junction = Junction
   }
   deriving (Eq, Generic, JSON.ToJSON)
 
-isSelfReference :: Relation -> Bool
+isSelfReference :: Relationship -> Bool
 isSelfReference r = relTable r == relForeignTable r
 
 data PrimaryKey = PrimaryKey

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -21,16 +21,17 @@ import Control.Lens (at, (.~), (?~))
 
 import Data.Swagger
 
-import PostgREST.Config               (AppConfig (..), Proxy (..),
-                                       isMalformedProxyUri, toURI)
-import PostgREST.DbStructure          (DbStructure (..), tableCols,
-                                       tablePKCols)
-import PostgREST.DbStructure.Proc     (PgArg (..),
-                                       ProcDescription (..))
-import PostgREST.DbStructure.Relation (PrimaryKey (..))
-import PostgREST.DbStructure.Table    (Column (..), ForeignKey (..),
-                                       Table (..))
-import PostgREST.Version              (docsVersion, prettyVersion)
+import PostgREST.Config                   (AppConfig (..), Proxy (..),
+                                           isMalformedProxyUri, toURI)
+import PostgREST.DbStructure              (DbStructure (..),
+                                           tableCols, tablePKCols)
+import PostgREST.DbStructure.Proc         (PgArg (..),
+                                           ProcDescription (..))
+import PostgREST.DbStructure.Relationship (PrimaryKey (..))
+import PostgREST.DbStructure.Table        (Column (..),
+                                           ForeignKey (..),
+                                           Table (..))
+import PostgREST.Version                  (docsVersion, prettyVersion)
 
 import PostgREST.ContentType
 

--- a/src/PostgREST/Query/QueryBuilder.hs
+++ b/src/PostgREST/Query/QueryBuilder.hs
@@ -21,15 +21,15 @@ import qualified Hasql.DynamicStatements.Snippet as H
 
 import Data.Tree (Tree (..))
 
-import PostgREST.DbStructure.Identifiers (FieldName,
-                                          QualifiedIdentifier (..))
-import PostgREST.DbStructure.Proc        (PgArg (..))
-import PostgREST.DbStructure.Relation    (Cardinality (..),
-                                          Relation (..))
-import PostgREST.DbStructure.Table       (Table (..))
-import PostgREST.Request.ApiRequest      (PayloadJSON (..))
-import PostgREST.Request.Preferences     (PreferParameters (..),
-                                          PreferResolution (..))
+import PostgREST.DbStructure.Identifiers  (FieldName,
+                                           QualifiedIdentifier (..))
+import PostgREST.DbStructure.Proc         (PgArg (..))
+import PostgREST.DbStructure.Relationship (Cardinality (..),
+                                           Relationship (..))
+import PostgREST.DbStructure.Table        (Table (..))
+import PostgREST.Request.ApiRequest       (PayloadJSON (..))
+import PostgREST.Request.Preferences      (PreferParameters (..),
+                                           PreferResolution (..))
 
 import PostgREST.Query.SqlFragment
 import PostgREST.Request.Types
@@ -53,7 +53,7 @@ readRequestToQuery (Node (Select colSelects mainQi tblAlias implJoins logicFores
     (joins, selects) = foldr getJoinsSelects ([],[]) forest
 
 getJoinsSelects :: ReadRequest -> ([H.Snippet], [H.Snippet]) -> ([H.Snippet], [H.Snippet])
-getJoinsSelects rr@(Node (_, (name, Just Relation{relCardinality=card,relTable=Table{tableName=table}}, alias, _, _)) _) (j,s) =
+getJoinsSelects rr@(Node (_, (name, Just Relationship{relCardinality=card,relTable=Table{tableName=table}}, alias, _, _)) _) (j,s) =
   let subquery = readRequestToQuery rr in
   case card of
     M2O _ ->

--- a/src/PostgREST/Request/Types.hs
+++ b/src/PostgREST/Request/Types.hs
@@ -36,11 +36,11 @@ import Data.Tree (Tree (..))
 
 import qualified GHC.Show (show)
 
-import PostgREST.DbStructure.Identifiers (FieldName,
-                                          QualifiedIdentifier)
-import PostgREST.DbStructure.Relation    (Relation)
-import PostgREST.RangeQuery              (NonnegRange)
-import PostgREST.Request.Preferences     (PreferResolution)
+import PostgREST.DbStructure.Identifiers  (FieldName,
+                                           QualifiedIdentifier)
+import PostgREST.DbStructure.Relationship (Relationship)
+import PostgREST.RangeQuery               (NonnegRange)
+import PostgREST.Request.Preferences      (PreferResolution)
 
 import Protolude
 
@@ -49,7 +49,7 @@ type ReadRequest = Tree ReadNode
 type MutateRequest = MutateQuery
 
 type ReadNode =
-  (ReadQuery, (NodeName, Maybe Relation, Maybe Alias, Maybe EmbedHint, Depth))
+  (ReadQuery, (NodeName, Maybe Relationship, Maybe Alias, Maybe EmbedHint, Depth))
 
 type NodeName = Text
 type Depth = Integer
@@ -121,10 +121,7 @@ data MutateQuery
       , returning :: [FieldName]
       }
 
--- | This type will hold information about which particular 'Relation' between
--- two tables to choose when there are multiple ones.
--- Specifically, it will contain the name of the foreign key or the join table
--- in many to many relations.
+-- | The select value in `/tbl?select=alias:field::cast`
 type SelectItem = (Field, Maybe Cast, Maybe Alias, Maybe EmbedHint)
 
 type Field = (FieldName, JsonPath)

--- a/test/fixtures/data.sql
+++ b/test/fixtures/data.sql
@@ -643,3 +643,23 @@ INSERT INTO v2.another_table VALUES(5, 'value 5'), (6, 'value 6');
 
 TRUNCATE TABLE private.stuff CASCADE;
 INSERT INTO private.stuff (id, name) VALUES (1, 'stuff 1');
+
+TRUNCATE TABLE private.screens CASCADE;
+INSERT INTO private.screens(name) VALUES ('banana'), ('helicopter'), ('formula 1 banana');
+
+INSERT INTO private.labels(name) VALUES ('vehicles'), ('fruit');
+
+INSERT INTO private.label_screen(label_id, screen_id) VALUES
+    ((SELECT id FROM labels WHERE name='vehicles'), (SELECT id FROM screens WHERE name='helicopter')),
+    ((SELECT id FROM labels WHERE name='vehicles'), (SELECT id FROM screens WHERE name='formula 1 banana')),
+    ((SELECT id FROM labels WHERE name='fruit'), (SELECT id FROM screens WHERE name='banana')),
+    ((SELECT id FROM labels WHERE name='fruit'), (SELECT id FROM screens WHERE name='formula 1 banana'));
+
+TRUNCATE TABLE private.actors CASCADE;
+INSERT INTO private.actors (id, name) VALUES (1,'john'), (2,'mary');
+
+TRUNCATE TABLE private.films CASCADE;
+INSERT INTO private.films (id, title) VALUES (12,'douze commandements'), (2001,'odyssée de l''espace');
+
+TRUNCATE TABLE private.personnages CASCADE;
+INSERT INTO private.personnages (film_id, role_id, character) VALUES (12,1,'méchant'), (2001,2,'astronaute');

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -138,6 +138,17 @@ GRANT ALL ON TABLE
     , v2.another_table
     , v1.children
     , v2.children
+    , screens
+    , labels
+    , label_screen
+    , actors
+    , films
+    , personnages
+    , end_1
+    , end_2
+    , schauspieler
+    , filme
+    , rollen
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1976,3 +1976,95 @@ create or replace function test.reload_pgrst_config() returns void as $_$
 begin
   perform pg_notify('pgrst', 'reload config');
 end $_$ language plpgsql ;
+
+create table private.screens (
+  id serial primary key,
+  name text not null default 'new screen'
+);
+
+create table private.labels (
+  id serial primary key,
+  name text not null default 'new label'
+);
+
+create table private.label_screen (
+  label_id int not null references private.labels(id) on update cascade on delete cascade,
+  screen_id int not null references private.screens(id) on update cascade on delete cascade,
+  constraint label_screen_pkey primary key (label_id, screen_id)
+);
+
+create view test.labels as
+select * from private.labels;
+
+create view test.screens as
+select * from private.screens;
+
+create view test.label_screen as
+select * from private.label_screen;
+
+create table private.actors (
+  id int,
+  name text,
+  constraint actors_id primary key (id)
+);
+
+create table private.films (
+  id integer,
+  title text,
+  constraint films_id primary key (id)
+);
+
+create table private.personnages (
+  film_id int not null,
+  role_id int not null,
+  character text not null,
+  constraint personnages_film_id_role_id primary key (film_id, role_id),
+  constraint personnages_film_id_fkey foreign key (film_id) references private.films(id) not deferrable,
+  constraint personnages_role_id_fkey foreign key (role_id) references private.actors(id) not deferrable
+);
+
+create view test.actors as
+select * from private.actors;
+
+create view test.films as
+select * from private.films;
+
+create view test.personnages as
+select * from private.personnages;
+
+create table test.end_1(
+  id int primary key,
+  name text
+);
+
+create table test.end_2(
+  id int primary key,
+  name text
+);
+
+create table private.junction(
+  end_1_id int not null references test.end_1(id) on update cascade on delete cascade,
+  end_2_id int not null references test.end_2(id) on update cascade on delete cascade,
+  primary key (end_1_id, end_2_id)
+);
+
+create table test.schauspieler (
+  id int primary key,
+  name text
+);
+
+create table test.filme (
+  id int primary key,
+  titel text
+);
+
+create table test.rollen ();
+
+create table private.rollen (
+  film_id int not null,
+  rolle_id int not null,
+  charakter text not null,
+  primary key (film_id, rolle_id),
+  foreign key (film_id) references test.filme(id),
+  foreign key (rolle_id) references test.schauspieler(id)
+);


### PR DESCRIPTION
Fixes https://github.com/PostgREST/postgrest/issues/1736. Also fixes https://github.com/PostgREST/postgrest/issues/1587.

While working on the pure json schema cache, we noticed that the schema cache contains private db objects: https://github.com/PostgREST/postgrest/pull/1794#issuecomment-815264688.

The solution was to filter the private objects from the json output https://github.com/PostgREST/postgrest/pull/1794#issuecomment-815264688. However, I noticed that this fix would be better applied at a lower level(DbStructure), and thus also solve other issues, like #1736.

It should also increase embedding speed, since there are less relationships to search.

#### Pending

- [x] Add a test case for solving https://github.com/PostgREST/postgrest/issues/1587 as well.
- [x] Quick test on the big schema to see if there's a noticeable perf loss on startup.
