### PR TITLE
Some refactoring and fixes in the nix development environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,8 @@ jobs:
           name: run spec tests
           command: |
             test/create_test_db "postgres://circleci@localhost" postgrest_test stack test
+      - store_artifacts:
+          path: /tmp/postgrest
 
   # Publish a new release. This only runs when a release is tagged (see
   # workflow below).
@@ -111,6 +113,8 @@ jobs:
             then
               postgrest-release-dockerhub-description
             fi
+      - store_artifacts:
+          path: /tmp/postgrest
 
   # Build everything in default.nix and push to the Cachix binary cache if running on main
   nix-build:
@@ -154,6 +158,8 @@ jobs:
               echo "Building all derivations (caching skipped for outside pull requests)..."
               nix-build
             fi
+      - store_artifacts:
+          path: /tmp/postgrest
 
   # Run tests
   nix-test:
@@ -218,7 +224,8 @@ jobs:
           name: Run memory tests
           command: postgrest-test-memory
           when: always
-
+      - store_artifacts:
+          path: /tmp/postgrest
 
 workflows:
   version: 2

--- a/default.nix
+++ b/default.nix
@@ -113,9 +113,12 @@ rec {
 
   ### Tools
 
+  cabalTools =
+    pkgs.callPackage nix/tools/cabalTools.nix { inherit devCabalOptions postgrest; };
+
   # Development tools.
-  devtools =
-    pkgs.callPackage nix/tools/devtools.nix { inherit tests style devCabalOptions hsie; };
+  devTools =
+    pkgs.callPackage nix/tools/devTools.nix { inherit tests style devCabalOptions hsie; };
 
   # Docker images and loading script.
   docker =
@@ -127,7 +130,7 @@ rec {
 
   # Utility for updating the pinned version of Nixpkgs.
   nixpkgsTools =
-    pkgs.callPackage nix/tools/nixpkgstools.nix { };
+    pkgs.callPackage nix/tools/nixpkgsTools.nix { };
 
   # Scripts for publishing new releases.
   release =
@@ -149,5 +152,5 @@ rec {
     };
 
   withTools =
-    pkgs.callPackage nix/tools/withtools.nix { inherit postgresqlVersions; };
+    pkgs.callPackage nix/tools/withTools.nix { inherit postgresqlVersions; };
 }

--- a/default.nix
+++ b/default.nix
@@ -102,19 +102,43 @@ rec {
       )
     );
 
+  env =
+    postgrest.env;
+
+  # Tooling for analyzing Haskell imports and exports.
+  hsie =
+    pkgs.callPackage nix/hsie {
+      ghcWithPackages = pkgs.haskell.packages."${compiler}".ghcWithPackages;
+    };
+
+  ### Tools
+
+  # Development tools.
+  devtools =
+    pkgs.callPackage nix/tools/devtools.nix { inherit tests style devCabalOptions hsie; };
+
   # Docker images and loading script.
   docker =
     pkgs.callPackage nix/tools/docker { postgrest = postgrestStatic; };
 
-  env =
-    postgrest.env;
+  # Script for running memory tests.
+  memory =
+    pkgs.callPackage nix/tools/memory.nix { inherit postgrestProfiled withTools; };
 
   # Utility for updating the pinned version of Nixpkgs.
   nixpkgsTools =
     pkgs.callPackage nix/tools/nixpkgstools.nix { };
 
-  withTools =
-    pkgs.callPackage nix/tools/withtools.nix { inherit postgresqlVersions; };
+  # Scripts for publishing new releases.
+  release =
+    pkgs.callPackage nix/tools/release {
+      inherit docker;
+      postgrest = postgrestStatic;
+    };
+
+  # Linting and styling tools.
+  style =
+    pkgs.callPackage nix/tools/style.nix { };
 
   # Scripts for running tests.
   tests =
@@ -124,28 +148,6 @@ rec {
       hpc-codecov = pkgs.haskell.packages."${compiler}".hpc-codecov;
     };
 
-  # Script for running memory tests.
-  memory =
-    pkgs.callPackage nix/tools/memory.nix { inherit postgrestProfiled withTools; };
-
-  # Linting and styling tools.
-  style =
-    pkgs.callPackage nix/tools/style.nix { };
-
-  # Tooling for analyzing Haskell imports and exports.
-  hsie =
-    pkgs.callPackage nix/hsie {
-      ghcWithPackages = pkgs.haskell.packages."${compiler}".ghcWithPackages;
-    };
-
-  # Development tools.
-  devtools =
-    pkgs.callPackage nix/tools/devtools.nix { inherit tests style devCabalOptions hsie; };
-
-  # Scripts for publishing new releases.
-  release =
-    pkgs.callPackage nix/tools/release {
-      inherit docker;
-      postgrest = postgrestStatic;
-    };
+  withTools =
+    pkgs.callPackage nix/tools/withtools.nix { inherit postgresqlVersions; };
 }

--- a/nix/overlays/checked-shell-script/checked-shell-script.nix
+++ b/nix/overlays/checked-shell-script/checked-shell-script.nix
@@ -3,6 +3,7 @@
 # to be used in a path for example.
 { argbash
 , bash_5
+, coreutils
 , git
 , lib
 , runCommand
@@ -83,7 +84,7 @@ let
 
         + lib.optionalString redirectTixFiles ''
           # storing tix files in a temporary throw away directory avoids mix/tix conflicts after changes
-          hpctixdir=$(mktemp -d)
+          hpctixdir=$(${coreutils}/bin/mktemp -d)
           export HPCTIXFILE="$hpctixdir"/postgrest.tix
           trap 'rm -rf $hpctixdir' EXIT
         ''
@@ -99,7 +100,8 @@ let
         ''
 
         + lib.optionalString withTmpDir ''
-          tmpdir="$(mktemp -d)"
+          mkdir -p "''${TMPDIR:-/tmp}/postgrest"
+          tmpdir="$(${coreutils}/bin/mktemp -d --tmpdir postgrest/${name}-XXX)"
 
           # we keep the tmpdir when an error occurs for debugging
           trap 'echo Temporary directory kept at: $tmpdir' ERR

--- a/nix/overlays/checked-shell-script/checked-shell-script.nix
+++ b/nix/overlays/checked-shell-script/checked-shell-script.nix
@@ -77,9 +77,8 @@ let
       text =
         ''
           #!${bash_5}/bin/bash
-          set -euo pipefail
-
           source ${argsParser}
+          set -euo pipefail
         ''
 
         + lib.optionalString redirectTixFiles ''

--- a/nix/tools/cabalTools.nix
+++ b/nix/tools/cabalTools.nix
@@ -1,0 +1,57 @@
+{ buildToolbox
+, cabal-install
+, checkedShellScript
+, devCabalOptions
+, postgrest
+}:
+let
+  build =
+    checkedShellScript
+      {
+        name = "postgrest-build";
+        docs = "Build PostgREST interactively using cabal-install.";
+        args = [ "ARG_LEFTOVERS([Cabal arguments])" ];
+        inRootDir = true;
+        withEnv = postgrest.env;
+      }
+      ''
+        exec ${cabal-install}/bin/cabal v2-build ${devCabalOptions} "''${_arg_leftovers[@]}"
+      '';
+
+  clean =
+    checkedShellScript
+      {
+        name = "postgrest-clean";
+        docs = "Clean the PostgREST project, including all cabal-install artifacts.";
+        inRootDir = true;
+      }
+      ''
+        # clean old coverage data, too
+        rm -rf .hpc coverage
+        exec ${cabal-install}/bin/cabal v2-clean
+      '';
+
+  run =
+    checkedShellScript
+      {
+        name = "postgrest-run";
+        docs = "Run PostgREST after buidling it interactively with cabal-install";
+        args = [ "ARG_LEFTOVERS([PostgREST arguments])" ];
+        inRootDir = true;
+        withEnv = postgrest.env;
+      }
+      ''
+        exec ${cabal-install}/bin/cabal v2-run ${devCabalOptions} --verbose=0 -- \
+          postgrest "''${_arg_leftovers[@]}"
+      '';
+
+in
+buildToolbox
+{
+  name = "postgrest-cabal";
+  tools = [
+    build
+    clean
+    run
+  ];
+}

--- a/nix/tools/devTools.nix
+++ b/nix/tools/devTools.nix
@@ -57,44 +57,6 @@ let
           | ${cachix}/bin/cachix push postgrest
       '';
 
-  build =
-    checkedShellScript
-      {
-        name = "postgrest-build";
-        docs = "Build PostgREST interactively using cabal-install.";
-        args = [ "ARG_LEFTOVERS([Cabal arguments])" ];
-        inRootDir = true;
-      }
-      ''
-        ${cabal-install}/bin/cabal v2-build ${devCabalOptions} "''${_arg_leftovers[@]}"
-      '';
-
-  run =
-    checkedShellScript
-      {
-        name = "postgrest-run";
-        docs = "Run PostgREST after buidling it interactively with cabal-install";
-        args = [ "ARG_LEFTOVERS([PostgREST arguments])" ];
-        inRootDir = true;
-      }
-      ''
-        ${cabal-install}/bin/cabal v2-run ${devCabalOptions} --verbose=0 -- \
-          postgrest "''${_arg_leftovers[@]}"
-      '';
-
-  clean =
-    checkedShellScript
-      {
-        name = "postgrest-clean";
-        docs = "Clean the PostgREST project, including all cabal-install artifacts.";
-        inRootDir = true;
-      }
-      ''
-        ${cabal-install}/bin/cabal v2-clean
-        # clean old coverage data, too
-        rm -rf .hpc coverage
-      '';
-
   check =
     checkedShellScript
       {
@@ -176,13 +138,10 @@ let
 in
 buildToolbox
 {
-  name = "postgrest-devtools";
+  name = "postgrest-dev";
   tools = [
     watch
     pushCachix
-    build
-    run
-    clean
     check
     dumpMinimalImports
     hsieMinimalImports

--- a/nix/tools/nixpkgsTools.nix
+++ b/nix/tools/nixpkgsTools.nix
@@ -48,6 +48,6 @@ let
 in
 buildToolbox
 {
-  name = "postgrest-nixpkgstools";
+  name = "postgrest-nixpkgs";
   tools = [ upgrade ];
 }

--- a/nix/tools/style.nix
+++ b/nix/tools/style.nix
@@ -57,7 +57,7 @@ let
           | xargs ${hlint}/bin/hlint -X QuasiQuotes -X NoPatternSynonyms
 
         # Lint bash scripts
-        ${shellcheck}/bin/shellcheck test/create_test_db test/memory-tests.sh test/with_tmp_db
+        ${shellcheck}/bin/shellcheck test/create_test_db test/memory-tests.sh
       '';
 
 in

--- a/nix/tools/tests.nix
+++ b/nix/tools/tests.nix
@@ -7,6 +7,7 @@
 , gnugrep
 , haskell
 , hpc-codecov
+, jq
 , postgrest
 , python3
 , runtimeShell
@@ -74,6 +75,8 @@ let
         withEnv = postgrest.env;
       }
       ''
+        export PATH="${jq}/bin:$PATH"
+        
         ${withTools.latest} \
             ${cabal-install}/bin/cabal v2-run ${devCabalOptions} --verbose=0 -- \
             postgrest --dump-schema \

--- a/nix/tools/tests.nix
+++ b/nix/tools/tests.nix
@@ -102,7 +102,7 @@ let
         rm -rf coverage/*
 
         # build once before running all the tests
-        ${cabal-install}/bin/cabal v2-build ${devCabalOptions} --enable-tests all
+        ${cabal-install}/bin/cabal v2-build ${devCabalOptions} exe:postgrest lib:postgrest test:spec test:spec-querycost
 
         # collect all tests
         HPCTIXFILE="$tmpdir"/io.tix \

--- a/nix/tools/withTools.nix
+++ b/nix/tools/withTools.nix
@@ -127,7 +127,7 @@ let
 in
 buildToolbox
 {
-  name = "postgrest-withtools";
+  name = "postgrest-with";
   tools = [ withAll ] ++ withVersions;
   extra = {
     # make withTools.latest available for other nix files

--- a/nix/tools/withTools.nix
+++ b/nix/tools/withTools.nix
@@ -41,6 +41,8 @@ let
         }
 
         mkdir -p "$tmpdir"/{db,socket}
+        # remove data dir, even if we keep tmpdir - no need to upload it to artifacts
+        trap 'rm -rf $tmpdir/db' EXIT
 
         export PGDATA="$tmpdir/db"
         export PGHOST="$tmpdir/socket"

--- a/nix/tools/withtools.nix
+++ b/nix/tools/withtools.nix
@@ -6,7 +6,6 @@
 , writeTextFile
 }:
 let
-  # Wrap the `test/with_tmp_db` script with the required dependencies from Nix.
   withTmpDb =
     { name, postgresql }:
     checkedShellScript
@@ -15,22 +14,70 @@ let
         docs = "Run the given command in a temporary database with ${name}";
         args =
           [
+            "ARG_OPTIONAL_SINGLE([fixtures], [f], [SQL file to load fixtures from], [test/fixtures/load.sql])"
             "ARG_POSITIONAL_SINGLE([command], [Command to run])"
             "ARG_LEFTOVERS([command arguments])"
+            "ARG_USE_ENV([PGUSER], [postgrest_test_authenticator], [Authenticator PG role])"
+            "ARG_USE_ENV([PGDATABASE], [postgres], [PG database name])"
+            "ARG_USE_ENV([PGRST_DB_SCHEMAS], [test], [Schema to expose])"
+            "ARG_USE_ENV([PGRST_DB_ANON_ROLE], [postgrest_test_anonymous], [Anonymous PG role])"
           ];
         addCommandCompletion = true;
         inRootDir = true;
         redirectTixFiles = false;
+        withTmpDir = true;
       }
       ''
-        # avoid starting multiple layers of with_tmp_db
-        if test ! -v PGRST_DB_URI; then
-          export PATH=${postgresql}/bin:"$PATH"
-
-          exec ${../../test/with_tmp_db} "$_arg_command" "''${_arg_leftovers[@]}"
-        else
-          "$@"
+        # avoid starting multiple layers of withTmpDb
+        if test -v PGRST_DB_URI; then
+          exec "$@"
         fi
+        
+        export PATH=${postgresql}/bin:"$PATH"
+        setuplog="$tmpdir/setup.log"
+
+        log () {
+          echo "$1" >> "$setuplog"
+        }
+
+        mkdir -p "$tmpdir"/{db,socket}
+
+        export PGDATA="$tmpdir/db"
+        export PGHOST="$tmpdir/socket"
+        export PGUSER
+        export PGDATABASE
+        export PGRST_DB_URI="postgresql:///$PGDATABASE?host=$PGHOST&user=$PGUSER"
+        export PGRST_DB_SCHEMAS
+        export PGRST_DB_ANON_ROLE
+
+        log "Initializing database cluster..."
+        # We try to make the database cluster as independent as possible from the host
+        # by specifying the timezone, locale and encoding.
+        PGTZ=UTC initdb --no-locale --encoding=UTF8 --nosync -U "$PGUSER" --auth=trust \
+          >> "$setuplog"
+
+        log "Starting the database cluster..."
+        # Instead of listening on a local port, we will listen on a unix domain socket.
+        pg_ctl -l "$tmpdir/db.log" start -o "-F -c listen_addresses=\"\" -k $PGHOST" \
+          >> "$setuplog"
+
+        log "Waiting for the database cluster to be ready..."
+        # Waiting is required for older versions of Postgres (< 10).
+        until pg_isready >> "$setuplog"; do
+          sleep 0.1
+        done
+
+        stop () {
+          log "Stopping the database cluster..."
+          pg_ctl stop -m i >> "$setuplog"
+        }
+        trap stop EXIT
+
+        log "Loading fixtures..."
+        psql -v ON_ERROR_STOP=1 -f "$_arg_fixtures" >> "$setuplog"
+
+        log "Done. Running command..."
+        ("$_arg_command" "''${_arg_leftovers[@]}")
       '';
 
   # Helper script for running a command against all PostgreSQL versions.

--- a/shell.nix
+++ b/shell.nix
@@ -25,7 +25,8 @@ let
 
   toolboxes =
     [
-      postgrest.devtools
+      postgrest.cabalTools
+      postgrest.devTools
       postgrest.nixpkgsTools
       postgrest.style
       postgrest.tests

--- a/test/create_test_db
+++ b/test/create_test_db
@@ -62,11 +62,6 @@ EOF
 #Remove database path from the connection uri--prevents setting up the new database name with PGDATABASE
 URI=$(echo "$URI" | cut -d'/' -f1-3)
 
-PGDATABASE=$DB PGOPTIONS='-c client_min_messages=WARNING' psql "$URI" --set=db="$DB" -Xq <<EOF
-  CREATE EXTENSION IF NOT EXISTS pgcrypto;
-  ALTER DATABASE ${DB} SET request.jwt.claim.id = '-1';
-EOF
-
 # Create a new connection string to use with the test runner
 export PGRST_DB_URI="postgres://${TEST_USER_NAME}:$TEST_USER_PASS@$HOST_PORT/$DB"
 export PGRST_DB_ANON_ROLE="postgrest_test_anonymous"

--- a/test/fixtures/database.sql
+++ b/test/fixtures/database.sql
@@ -1,3 +1,6 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+ALTER DATABASE :DBNAME SET request.jwt.claim.id = '-1';
+
 set client_min_messages to warning;
 DROP SCHEMA IF EXISTS test, private, postgrest, jwt, public, تست, extensions, v1, v2 CASCADE;
 DROP TYPE IF EXISTS jwt_token CASCADE;

--- a/test/with_tmp_db
+++ b/test/with_tmp_db
@@ -99,12 +99,7 @@ stop() {
 trap stop sigint sigterm exit
 
 log "Loading fixtures..."
-psql -v ON_ERROR_STOP=1 >> "$setuplog" << EOF
-  create extension pgcrypto;
-  alter database $PGDATABASE set request.jwt.claim.id = '-1';
-  alter role $PGUSER set default_text_search_config to english;
-  \i test/fixtures/load.sql
-EOF
+psql -v ON_ERROR_STOP=1 -f test/fixtures/load.sql >> "$setuplog"
 
 log "Done. Running command..."
 # Run the command that was given as an argument. The `exit` trap above will


### PR DESCRIPTION
There are a couple of things I needed to do for #1805, #1812 and while playing around with CI in #1822 - some of which I needed to have fixed in multiple of those PRs. To avoid juggling the same commits in the different PRs, I want to merge them ahead of time.

This PR does the following:
- Moves `default.nix` and `shell.nix` into the `nix/` subfolder. This is to have all nix-related files in one directory, which allows to set up the context for a ci-nix-Dockerfile much easier. This adds a convenience wrapper for `shell.nix` in the root directory, so that `nix-shell` can still be called the same way as before.
- Splits `cabalTools` from `devTools` to allow installing `postgrest-build` in CI without the overhead of many `devtools` dependencies.
- Fix `postgrest-dump-schema` currently not working `nix-shell --pure`. `yq` needs `jq` under the hood - but it seems like it currently doesn't import it properly in it's environment. Not sure if that's fixed already upstream, but just adding `jq` to the PATH fixes it for now.
- Fix `postgrest-coverage` needing a rebuild while running the tests, because of changed flags. The build step had `--enable-tests all`, but the test step did not and so started a rebuild. Now the build targets are listed explicitly and no rebuild is needed.
- A small improvement to the way we create our `withTmpDir` temporary directories. They are now created in a common directory `/tmp/postgrest/...` - this allows to upload all of the kept temp dirs as artifacts in CI in the case of a failed step. Also each individual temp directory is now prefixed with the name of the shell script that was run and not a generic `tmp.xxxx`. Makes it much easier to debug things.
- Makes `with_tmp_db` a true `checkedShellScript` as discussed in https://github.com/PostgREST/postgrest/pull/1812#issuecomment-822023148. This also helps with the Dockerfile context (see above). We still need to agree on how we handle the stack situation. The 3 suggestions we have so far are:
a) Auto-generate a checked-in copy of with_tmp_db
b) just keep the original file or
c) create `postgrest-stack-build` and `postgrest-stack-test` commands and keep everything in nix.