### PR TITLE
nix(fix): Fix missed devtools->devTools renaming

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
               nix-build | cachix push postgrest
 
               # Make sure that everything, including .drv files, is pushed
-              nix-env -f default.nix -iA devtools
+              nix-env -f default.nix -iA devTools
               postgrest-push-cachix
             else
               echo "Building all derivations (caching skipped for outside pull requests)..."

--- a/nix/README.md
+++ b/nix/README.md
@@ -130,7 +130,7 @@ $ nix-shell --run "postgrest-foo --bar"
 A third option is to install utilities that you use very often locally:
 
 ```bash
-$ nix-env -f default.nix -iA devtools
+$ nix-env -f default.nix -iA devTools
 
 # `postgrest-style` can now be run directly:
 $ postgrest-style


### PR DESCRIPTION
After merging #1827 this came up in `nix-build` running on main. Double checked all ci jobs that only run on main, should be fine now.

Since this path will not be taken on a PR CI, I will merge this right away.