### PR TITLE
Add stack support to nix environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,19 +24,10 @@ jobs:
 
   # Run tests based on stack
   stack-test:
-    machine: true
+    docker:
+      - image: technowledgy/nix:latest
     steps:
       - checkout
-      - run:
-          name: Install Nix
-          command: |
-            curl -L https://nixos.org/nix/install | sh
-            echo "source $HOME/.nix-profile/etc/profile.d/nix.sh" >> $BASH_ENV
-      - run:
-          name: Install and use the Cachix binary cache
-          command: |
-            nix-env -iA cachix -f https://cachix.org/api/v1/install
-            cachix use postgrest
       - run:
           name: Install testing scripts
           command: nix-env -f default.nix --arg stack true -iA buildTools tests withTools
@@ -55,8 +46,37 @@ jobs:
           name: Build src and tests
           command: postgrest-build -j1
       - run:
-          name: Run spec tests
-          command: postgrest-test-spec
+          name: Skip tests on build or primary test failure
+          command: circleci-agent step halt
+          when: on_fail
+      - run:
+          name: Run coverage (io tests and spec tests against PostgreSQL 13)
+          command: postgrest-coverage
+          when: always
+      - run:
+          name: Run the spec tests against PostgreSQL 12
+          command: postgrest-with-postgresql-12 postgrest-test-spec
+          when: always
+      - run:
+          name: Run the spec tests against PostgreSQL 11
+          command: postgrest-with-postgresql-11 postgrest-test-spec
+          when: always
+      - run:
+          name: Run the spec tests against PostgreSQL 10
+          command: postgrest-with-postgresql-10 postgrest-test-spec
+          when: always
+      - run:
+          name: Run the spec tests against PostgreSQL 9.6
+          command: postgrest-with-postgresql-9.6 postgrest-test-spec
+          when: always
+      - run:
+          name: Run the spec tests against PostgreSQL 9.5
+          command: postgrest-with-postgresql-9.5 postgrest-test-spec
+          when: always
+      - run:
+          name: Check the spec tests for idempotence
+          command: postgrest-test-spec-idempotence
+          when: always
       - store_artifacts:
           path: /tmp/postgrest
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,51 +22,41 @@ jobs:
             # 'Note: For checking this locally, use `nix-shell --run postgrest-style`
             postgrest-style-check
 
-  # Run tests based on stack and docker against the oldest PostgreSQL version
-  # that we support.
+  # Run tests based on stack
   stack-test:
-    docker:
-      - image: cimg/base:2021.03
-        environment:
-          - PGHOST=localhost
-      - image: circleci/postgres:9.5
-        environment:
-          - POSTGRES_USER=circleci
-          - POSTGRES_DB=circleci
-          - POSTGRES_HOST_AUTH_METHOD=trust
+    machine: true
     steps:
       - checkout
+      - run:
+          name: Install Nix
+          command: |
+            curl -L https://nixos.org/nix/install | sh
+            echo "source $HOME/.nix-profile/etc/profile.d/nix.sh" >> $BASH_ENV
+      - run:
+          name: Install and use the Cachix binary cache
+          command: |
+            nix-env -iA cachix -f https://cachix.org/api/v1/install
+            cachix use postgrest
+      - run:
+          name: Install testing scripts
+          command: nix-env -f default.nix --arg stack true -iA buildTools tests withTools
       - restore_cache:
           keys:
           - v1-stack-dependencies-{{ checksum "postgrest.cabal" }}-{{ checksum "stack.yaml" }}
       - run:
-          name: install stack & dependencies
-          command: |
-            curl -L https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz | tar zx -C /tmp
-            sudo mv /tmp/stack-2.3.1-linux-x86_64/stack /usr/bin
-            sudo apt-get update
-            sudo apt-get install -y libgmp-dev postgresql-client
-            sudo apt-get install -y --only-upgrade binutils
-            stack setup
-      - run:
-          name: build src and tests dependencies
-          command: |
-            stack build --fast -j1 --only-dependencies
-            stack build --fast --test --no-run-tests --only-dependencies
+          name: Build all dependencies
+          command: postgrest-build -j1 --only-dependencies
       - save_cache:
           paths:
             - "~/.stack"
             - ".stack-work"
           key: v1-stack-dependencies-{{ checksum "postgrest.cabal" }}-{{ checksum "stack.yaml" }}
       - run:
-          name: build src and tests
-          command: |
-            stack build --fast -j1
-            stack build --fast --test --no-run-tests
+          name: Build src and tests
+          command: postgrest-build -j1
       - run:
-          name: run spec tests
-          command: |
-            test/create_test_db "postgres://circleci@localhost" postgrest_test stack test
+          name: Run spec tests
+          command: postgrest-test-spec
       - store_artifacts:
           path: /tmp/postgrest
 
@@ -161,7 +151,7 @@ jobs:
       - store_artifacts:
           path: /tmp/postgrest
 
-  # Run tests
+  # Run tests based on cabal
   nix-test:
     machine: true
     steps:

--- a/default.nix
+++ b/default.nix
@@ -65,10 +65,6 @@ let
   staticHaskellPackage =
     import nix/static-haskell-package.nix { inherit nixpkgs compiler patches allOverlays; };
 
-  # Options passed to cabal in dev tools and tests
-  devCabalOptions =
-    "-f dev --test-show-detail=direct";
-
   profiledHaskellPackages =
     pkgs.haskell.packages."${compiler}".extend (self: super:
       {
@@ -114,11 +110,11 @@ rec {
   ### Tools
 
   cabalTools =
-    pkgs.callPackage nix/tools/cabalTools.nix { inherit devCabalOptions postgrest; };
+    pkgs.callPackage nix/tools/cabalTools.nix { inherit postgrest; };
 
   # Development tools.
   devTools =
-    pkgs.callPackage nix/tools/devTools.nix { inherit tests style devCabalOptions hsie; };
+    pkgs.callPackage nix/tools/devTools.nix { inherit cabalTools hsie style tests; };
 
   # Docker images and loading script.
   docker =
@@ -146,7 +142,7 @@ rec {
   # Scripts for running tests.
   tests =
     pkgs.callPackage nix/tools/tests.nix {
-      inherit postgrest devCabalOptions withTools;
+      inherit cabalTools withTools;
       ghc = pkgs.haskell.compiler."${compiler}";
       hpc-codecov = pkgs.haskell.packages."${compiler}".hpc-codecov;
     };

--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,4 @@
+{ stack ? false }:
 let
   name =
     "postgrest";
@@ -109,12 +110,15 @@ rec {
 
   ### Tools
 
+  buildTools =
+    if stack then stackTools else cabalTools;
+
   cabalTools =
     pkgs.callPackage nix/tools/cabalTools.nix { inherit postgrest; };
 
   # Development tools.
   devTools =
-    pkgs.callPackage nix/tools/devTools.nix { inherit cabalTools hsie style tests; };
+    pkgs.callPackage nix/tools/devTools.nix { inherit buildTools cabalTools hsie style tests; };
 
   # Docker images and loading script.
   docker =
@@ -135,6 +139,9 @@ rec {
       postgrest = postgrestStatic;
     };
 
+  stackTools =
+    pkgs.callPackage nix/tools/stackTools.nix { };
+
   # Linting and styling tools.
   style =
     pkgs.callPackage nix/tools/style.nix { };
@@ -142,7 +149,7 @@ rec {
   # Scripts for running tests.
   tests =
     pkgs.callPackage nix/tools/tests.nix {
-      inherit cabalTools withTools;
+      inherit buildTools withTools;
       ghc = pkgs.haskell.compiler."${compiler}";
       hpc-codecov = pkgs.haskell.packages."${compiler}".hpc-codecov;
     };

--- a/default.nix
+++ b/default.nix
@@ -116,6 +116,9 @@ rec {
   cabalTools =
     pkgs.callPackage nix/tools/cabalTools.nix { inherit postgrest; };
 
+  ciTools =
+    pkgs.callPackage nix/tools/ciTools.nix { };
+
   # Development tools.
   devTools =
     pkgs.callPackage nix/tools/devTools.nix { inherit buildTools cabalTools hsie style tests; };

--- a/nix/overlays/checked-shell-script/checked-shell-script.nix
+++ b/nix/overlays/checked-shell-script/checked-shell-script.nix
@@ -18,6 +18,7 @@
 , inRootDir ? false
 , redirectTixFiles ? true
 , withEnv ? null
+, withPath ? [ ]
 , withTmpDir ? false
 }: text:
 let
@@ -114,6 +115,10 @@ let
         + lib.optionalString (withEnv != null) ''
           env="$(cat ${withEnv})"
           export PATH="$env/bin:$PATH"
+        ''
+
+        + lib.optionalString (lib.length withPath > 0) ''
+          export PATH="${lib.concatMapStrings (p: p + "/bin:") withPath}$PATH"
         ''
 
         + "(${text})"

--- a/nix/overlays/checked-shell-script/checked-shell-script.nix
+++ b/nix/overlays/checked-shell-script/checked-shell-script.nix
@@ -83,10 +83,12 @@ let
         ''
 
         + lib.optionalString redirectTixFiles ''
-          # storing tix files in a temporary throw away directory avoids mix/tix conflicts after changes
-          hpctixdir=$(${coreutils}/bin/mktemp -d)
-          export HPCTIXFILE="$hpctixdir"/postgrest.tix
-          trap 'rm -rf $hpctixdir' EXIT
+          if ! test -v HPCTIXFILE; then
+            # storing tix files in a temporary throw away directory avoids mix/tix conflicts after changes
+            hpctixdir=$(${coreutils}/bin/mktemp -d)
+            export HPCTIXFILE="$hpctixdir"/postgrest.tix
+            trap 'rm -rf $hpctixdir' EXIT
+          fi
         ''
 
         + lib.optionalString inRootDir ''

--- a/nix/tools/cabalTools.nix
+++ b/nix/tools/cabalTools.nix
@@ -1,21 +1,25 @@
 { buildToolbox
 , cabal-install
 , checkedShellScript
-, devCabalOptions
 , postgrest
 }:
 let
+  devCabalOptions =
+    "-f dev --test-show-detail=direct";
+
   build =
     checkedShellScript
       {
         name = "postgrest-build";
-        docs = "Build PostgREST interactively using cabal-install.";
+        docs = "Build PostgREST using cabal-install.";
         args = [ "ARG_LEFTOVERS([Cabal arguments])" ];
         inRootDir = true;
         withEnv = postgrest.env;
       }
       ''
-        exec ${cabal-install}/bin/cabal v2-build ${devCabalOptions} "''${_arg_leftovers[@]}"
+        exec ${cabal-install}/bin/cabal v2-build ${devCabalOptions} \
+          exe:postgrest lib:postgrest test:spec test:spec-querycost \
+          "''${_arg_leftovers[@]}"
       '';
 
   clean =
@@ -31,11 +35,30 @@ let
         exec ${cabal-install}/bin/cabal v2-clean
       '';
 
+  exec =
+    checkedShellScript
+      {
+        name = "postgrest-exec";
+        docs = "Execute <command> after building PostgREST with cabal-install.";
+        args =
+          [
+            "ARG_POSITIONAL_SINGLE([command], [Command to run])"
+            "ARG_LEFTOVERS([command arguments])"
+          ];
+        inRootDir = true;
+        withEnv = postgrest.env;
+      }
+      ''
+        ${build} --verbose=0
+        exec ${cabal-install}/bin/cabal v2-exec ${devCabalOptions} --verbose=0 -- \
+          "$_arg_command" "''${_arg_leftovers[@]}"
+      '';
+
   run =
     checkedShellScript
       {
         name = "postgrest-run";
-        docs = "Run PostgREST after buidling it interactively with cabal-install";
+        docs = "Run PostgREST after building it with cabal-install.";
         args = [ "ARG_LEFTOVERS([PostgREST arguments])" ];
         inRootDir = true;
         withEnv = postgrest.env;
@@ -43,6 +66,19 @@ let
       ''
         exec ${cabal-install}/bin/cabal v2-run ${devCabalOptions} --verbose=0 -- \
           postgrest "''${_arg_leftovers[@]}"
+      '';
+
+  test =
+    checkedShellScript
+      {
+        name = "postgrest-test";
+        docs = "Run tests using cabal-install.";
+        args = [ "ARG_LEFTOVERS([Cabal arguments])" ];
+        inRootDir = true;
+        withEnv = postgrest.env;
+      }
+      ''
+        exec ${cabal-install}/bin/cabal v2-test ${devCabalOptions} "''${_arg_leftovers[@]}"
       '';
 
 in
@@ -54,4 +90,7 @@ buildToolbox
     clean
     run
   ];
+  extra = {
+    inherit build exec run test;
+  };
 }

--- a/nix/tools/ciTools.nix
+++ b/nix/tools/ciTools.nix
@@ -1,0 +1,48 @@
+{ buildToolbox
+, checkedShellScript
+, circleci-cli
+, docker
+}:
+let
+  execute =
+    checkedShellScript
+      {
+        name = "postgrest-ci-execute";
+        docs = "Execute CircleCI job locally.";
+        args =
+          [
+            "ARG_POSITIONAL_SINGLE([job], [Job to execute], [nix-test])"
+          ];
+        inRootDir = true;
+        withPath = [ docker ];
+        withTmpDir = true;
+      }
+      ''
+        # We override the circle checkout step, because this causes problems with non-root docker images.
+        sed -r 's|^(\s*)- checkout$|\1- run: { name: "checkout", command: "cp -rT /tmp/_circleci_local_build_repo ." }|g' \
+          .circleci/config.yml > "$tmpdir/config.yml"
+        ${circleci-cli}/bin/circleci-cli local execute \
+          --config "$tmpdir/config.yml" \
+          --job "$_arg_job" 
+      '';
+
+  validate =
+    checkedShellScript
+      {
+        name = "postgrest-ci-validate";
+        docs = "Validate CI config files.";
+        inRootDir = true;
+      }
+      ''
+        ${circleci-cli}/bin/circleci-cli config validate
+        # TODO: Make "travis/bin/travis lint" work.
+        # TODO: Add cirrus-cli: https://github.com/cirruslabs/cirrus-cli
+      '';
+
+in
+buildToolbox
+{
+  name = "postgrest-ci";
+  tools = [ execute validate ];
+}
+

--- a/nix/tools/devTools.nix
+++ b/nix/tools/devTools.nix
@@ -1,6 +1,7 @@
 { buildToolbox
-, cabalTools
+, buildTools
 , cachix
+, cabalTools
 , checkedShellScript
 , entr
 , graphviz
@@ -88,6 +89,8 @@ let
       }
       ''
         mkdir -p "$_arg_dumpdir"
+        # Running cabalTools instead of buildTools on purpose,
+        # because the cabal arguments don't work with stack
         ${cabalTools.build} \
           --builddir="$tmpdir" \
           --ghc-option=-ddump-minimal-imports \

--- a/nix/tools/devTools.nix
+++ b/nix/tools/devTools.nix
@@ -1,8 +1,7 @@
 { buildToolbox
-, cabal-install
+, cabalTools
 , cachix
 , checkedShellScript
-, devCabalOptions
 , entr
 , graphviz
 , hsie
@@ -89,7 +88,7 @@ let
       }
       ''
         mkdir -p "$_arg_dumpdir"
-        ${cabal-install}/bin/cabal v2-build ${devCabalOptions} \
+        ${cabalTools.build} \
           --builddir="$tmpdir" \
           --ghc-option=-ddump-minimal-imports \
           --ghc-option=-dumpdir="$_arg_dumpdir" \

--- a/nix/tools/memory.nix
+++ b/nix/tools/memory.nix
@@ -14,10 +14,9 @@ let
         name = "postgrest-test-memory";
         docs = "Run the memory tests.";
         inRootDir = true;
+        withPath = [ postgrestProfiled curl ];
       }
       ''
-        export PATH="${postgrestProfiled}/bin:${curl}/bin:$PATH"
-
         ${withTools.latest} test/memory-tests.sh
       '';
 

--- a/nix/tools/stackTools.nix
+++ b/nix/tools/stackTools.nix
@@ -1,0 +1,91 @@
+{ buildToolbox
+, checkedShellScript
+, stack
+}:
+let
+  devStackOptions =
+    "--flag 'postgrest:dev'";
+
+  build =
+    checkedShellScript
+      {
+        name = "postgrest-build";
+        docs = "Build PostgREST using stack.";
+        args = [ "ARG_LEFTOVERS([Stack arguments])" ];
+        inRootDir = true;
+      }
+      ''
+        exec ${stack}/bin/stack --nix build ${devStackOptions} --no-run-tests \
+          postgrest:exe:postgrest postgrest:lib postgrest:test:spec postgrest:test:spec-querycost \
+          "''${_arg_leftovers[@]}"
+      '';
+
+  clean =
+    checkedShellScript
+      {
+        name = "postgrest-clean";
+        docs = "Clean the PostgREST project, including all stack artifacts.";
+        args = [ "ARG_LEFTOVERS([Stack arguments])" ];
+        inRootDir = true;
+      }
+      ''
+        # clean old coverage data, too
+        rm -rf .hpc coverage
+        exec ${stack}/bin/stack clean "''${_arg_leftovers[@]}"
+      '';
+
+  exec =
+    checkedShellScript
+      {
+        name = "postgrest-exec";
+        docs = "Execute <command> after building PostgREST with stack.";
+        args =
+          [
+            "ARG_POSITIONAL_SINGLE([command], [Command to run])"
+            "ARG_LEFTOVERS([command arguments])"
+          ];
+        inRootDir = true;
+      }
+      ''
+        ${build} --silent
+        exec ${stack}/bin/stack --nix --silent exec -- \
+          "$_arg_command" "''${_arg_leftovers[@]}"
+      '';
+
+  run =
+    checkedShellScript
+      {
+        name = "postgrest-run";
+        docs = "Run PostgREST after building it with stack.";
+        args = [ "ARG_LEFTOVERS([PostgREST arguments])" ];
+        inRootDir = true;
+      }
+      ''
+        exec ${exec} postgrest "''${_arg_leftovers[@]}"
+      '';
+
+  test =
+    checkedShellScript
+      {
+        name = "postgrest-test";
+        docs = "Run tests using stack.";
+        args = [ "ARG_LEFTOVERS([Stack arguments])" ];
+        inRootDir = true;
+      }
+      ''
+        exec ${stack}/bin/stack --nix test ${devStackOptions} "''${_arg_leftovers[@]}"
+      '';
+
+in
+buildToolbox
+{
+  name = "postgrest-stack";
+  tools = [
+    build
+    clean
+    run
+  ];
+  extra = {
+    inherit build exec run test;
+  };
+}

--- a/nix/tools/style.nix
+++ b/nix/tools/style.nix
@@ -1,6 +1,7 @@
 { black
 , buildToolbox
 , checkedShellScript
+, circleci-cli
 , git
 , hlint
 , nixpkgs-fmt
@@ -58,6 +59,9 @@ let
 
         # Lint bash scripts
         ${shellcheck}/bin/shellcheck test/create_test_db test/memory-tests.sh
+
+        # Validate circleci config
+        ${circleci-cli}/bin/circleci-cli config validate
       '';
 
 in

--- a/nix/tools/tests.nix
+++ b/nix/tools/tests.nix
@@ -1,5 +1,5 @@
 { buildToolbox
-, cabalTools
+, buildTools
 , checkedShellScript
 , ghc
 , glibcLocales
@@ -21,7 +21,7 @@ let
         inRootDir = true;
       }
       ''
-        ${withTools.latest} ${cabalTools.test}
+        ${withTools.latest} ${buildTools.test}
       '';
 
   testSpecIdempotence =
@@ -33,8 +33,8 @@ let
       }
       ''
         ${withTools.latest} ${runtimeShell} -c " \
-          ${cabalTools.test} && \
-          ${cabalTools.test}"
+          ${buildTools.test} && \
+          ${buildTools.test}"
       '';
 
   ioTestPython =
@@ -56,7 +56,7 @@ let
         inRootDir = true;
       }
       ''
-        ${withTools.latest} ${cabalTools.exec} \
+        ${withTools.latest} ${buildTools.exec} \
           ${ioTestPython}/bin/pytest -v test/io-tests "''${_arg_leftovers[@]}"
       '';
 
@@ -70,7 +70,7 @@ let
       ''
         export PATH="${jq}/bin:$PATH"
         
-        ${withTools.latest} ${cabalTools.run} --dump-schema \
+        ${withTools.latest} ${buildTools.run} --dump-schema \
           | ${yq}/bin/yq -y .
       '';
 
@@ -96,7 +96,7 @@ let
         ${testIO}
           
         HPCTIXFILE="$tmpdir"/spec.tix \
-        ${withTools.latest} ${cabalTools.test}
+        ${withTools.latest} ${buildTools.test}
 
         # collect all the tix files
         ${ghc}/bin/hpc sum  --union --exclude=Paths_postgrest --output="$tmpdir"/tests.tix "$tmpdir"/io*.tix "$tmpdir"/spec.tix

--- a/nix/tools/tests.nix
+++ b/nix/tools/tests.nix
@@ -66,10 +66,9 @@ let
         name = "postgrest-dump-schema";
         docs = "Dump the loaded schema's DbStructure as a yaml file.";
         inRootDir = true;
+        withPath = [ jq ];
       }
       ''
-        export PATH="${jq}/bin:$PATH"
-        
         ${withTools.latest} ${buildTools.run} --dump-schema \
           | ${yq}/bin/yq -y .
       '';

--- a/nix/tools/withTools.nix
+++ b/nix/tools/withTools.nix
@@ -72,6 +72,7 @@ let
         stop () {
           log "Stopping the database cluster..."
           pg_ctl stop -m i >> "$setuplog"
+          rm -rf "$tmpdir/db"
         }
         trap stop EXIT
 

--- a/nix/tools/withTools.nix
+++ b/nix/tools/withTools.nix
@@ -25,6 +25,7 @@ let
         addCommandCompletion = true;
         inRootDir = true;
         redirectTixFiles = false;
+        withPath = [ postgresql ];
         withTmpDir = true;
       }
       ''
@@ -32,8 +33,7 @@ let
         if test -v PGRST_DB_URI; then
           exec "$@"
         fi
-        
-        export PATH=${postgresql}/bin:"$PATH"
+
         setuplog="$tmpdir/setup.log"
 
         log () {

--- a/shell.nix
+++ b/shell.nix
@@ -27,6 +27,7 @@ let
   toolboxes =
     [
       postgrest.buildTools
+      postgrest.ciTools
       postgrest.devTools
       postgrest.nixpkgsTools
       postgrest.style

--- a/shell.nix
+++ b/shell.nix
@@ -12,10 +12,11 @@
 { docker ? false
 , memory ? false
 , release ? false
+, stack ? false
 }:
 let
   postgrest =
-    import ./default.nix;
+    import ./default.nix { inherit stack; };
 
   pkgs =
     postgrest.pkgs;
@@ -25,7 +26,7 @@ let
 
   toolboxes =
     [
-      postgrest.cabalTools
+      postgrest.buildTools
       postgrest.devTools
       postgrest.nixpkgsTools
       postgrest.style
@@ -44,6 +45,7 @@ lib.overrideDerivation postgrest.env (
         pkgs.cabal-install
         pkgs.cabal2nix
         pkgs.postgresql
+        pkgs.stack
         postgrest.hsie.bin
       ]
       ++ toolboxes;

--- a/shell.nix
+++ b/shell.nix
@@ -44,6 +44,7 @@ lib.overrideDerivation postgrest.env (
       base.buildInputs ++ [
         pkgs.cabal-install
         pkgs.cabal2nix
+        pkgs.circleci-cli
         pkgs.postgresql
         pkgs.stack
         postgrest.hsie.bin


### PR DESCRIPTION
https://github.com/PostgREST/postgrest/pull/1812#issuecomment-822247012 got me thinking... and primarily out of curiosity I wanted to try to make our nix dev tools "build tool agnostic" by:
- making all tests and devtools use `cabalTools` instead of `cabal-install` directly
- adding `stackTools` similar to `cabalTools`
- make all tests use `buildTools`, which are either `cabalTools` or `stackTools` depending on command line argument `stack` (boolean, default false)

Some things that I am not sure about:
- The dynamic derivation `postgrest` is built with `cabal2nix` - I am using it right now through `postgrest.env` in `stackTools`, too. I don't really have an idea what `postgrest.env` contains. I guess I only need GHC.
- I understand that `postgrest` is about creating the haskell dependencies via nix packages - and loading them via cachix, right? I guess this doesn't work with `cabal2nix` and stack. I found https://input-output-hk.github.io/haskell.nix/, which seems to support something like `stack2nix`, but... I don't really have a clue.

Unfortunately I couldn't test locally, yet, because I get this when building with stack:
```
cassava > error: #error **INVARIANT BROKEN** Detected invalid combination of `text-short` and
`bytestring` versions. Please verify the `pre-bytestring-0.10-4` flag-logic in the .cabal file wasn't elided.
```
And I have no idea what to do :).

I have a small hope that dependencies are already built in CI and cached, and `postgrest-build` might go through.

Happy about any feedback regarding the idea in general, and the specifics, too.