### PR TITLE
refactor: Move accept content type code from App into ApiRequest

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -160,7 +160,7 @@ postgrestResponse
   -> UTCTime
   -> Wai.Request
   -> Handler IO Wai.Response
-postgrestResponse conf@AppConfig{..} maybeDbStructure pool time req = do
+postgrestResponse conf maybeDbStructure pool time req = do
   body <- lift $ Wai.strictRequestBody req
 
   dbStructure <-


### PR DESCRIPTION
This is a smaller intermediate step to carving out a small API to `Request`. This moves the code that finds an acceptable response content type into ApiRequest. 