### PR TITLE
refactor: more DbStructure cleaning

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -60,6 +60,7 @@ import PostgREST.DbStructure             (DbStructure (..),
 import PostgREST.DbStructure.Identifiers (FieldName,
                                           QualifiedIdentifier (..),
                                           Schema)
+import PostgREST.DbStructure.PgVersion   (PgVersion (..))
 import PostgREST.DbStructure.Proc        (ProcDescription (..),
                                           ProcVolatility (..))
 import PostgREST.DbStructure.Table       (Table (..))
@@ -89,6 +90,7 @@ data RequestContext = RequestContext
   { ctxConfig      :: AppConfig
   , ctxDbStructure :: DbStructure
   , ctxApiRequest  :: ApiRequest
+  , ctxPgVersion   :: PgVersion
   }
 
 type Handler = ExceptT Error
@@ -138,11 +140,12 @@ postgrest logLev appState connWorker =
       time <- AppState.getTime appState
       conf <- AppState.getConfig appState
       maybeDbStructure <- AppState.getDbStructure appState
+      pgVer <- AppState.getPgVersion appState
 
       let
         eitherResponse :: IO (Either Error Wai.Response)
         eitherResponse =
-          runExceptT $ postgrestResponse conf maybeDbStructure (AppState.getPool appState) time req
+          runExceptT $ postgrestResponse conf maybeDbStructure pgVer (AppState.getPool appState) time req
 
       response <- either Error.errorResponseFor identity <$> eitherResponse
 
@@ -156,11 +159,12 @@ postgrest logLev appState connWorker =
 postgrestResponse
   :: AppConfig
   -> Maybe DbStructure
+  -> PgVersion
   -> SQL.Pool
   -> UTCTime
   -> Wai.Request
   -> Handler IO Wai.Response
-postgrestResponse conf maybeDbStructure pool time req = do
+postgrestResponse conf maybeDbStructure pgVer pool time req = do
   body <- lift $ Wai.strictRequestBody req
 
   dbStructure <-
@@ -179,7 +183,7 @@ postgrestResponse conf maybeDbStructure pool time req = do
 
   let
     handleReq apiReq =
-      handleRequest $ RequestContext conf dbStructure apiReq
+      handleRequest $ RequestContext conf dbStructure apiReq pgVer
 
   runDbHandler pool (txMode apiRequest) jwtClaims .
     Middleware.optionalRollback conf apiRequest $
@@ -197,7 +201,7 @@ runDbHandler pool mode jwtClaims handler = do
   liftEither resp
 
 handleRequest :: RequestContext -> DbHandler Wai.Response
-handleRequest context@(RequestContext _ _ ApiRequest{..}) =
+handleRequest context@(RequestContext _ _ ApiRequest{..} _) =
   case (iAction, iTarget) of
     (ActionRead headersOnly, TargetIdent identifier) ->
       handleRead headersOnly identifier context
@@ -242,7 +246,7 @@ handleRead headersOnly identifier context@RequestContext{..} = do
         (shouldCount iPreferCount)
         (iAcceptContentType == CTTextCSV)
         bField
-        (pgVersion ctxDbStructure)
+        ctxPgVersion
         configDbPreparedStatements
 
   total <- readTotal ctxConfig ctxApiRequest tableTotal countQuery
@@ -316,7 +320,7 @@ handleCreate identifier@QualifiedIdentifier{..} context@RequestContext{..} = do
       response HTTP.status201 headers mempty
 
 handleUpdate :: QualifiedIdentifier -> RequestContext -> DbHandler Wai.Response
-handleUpdate identifier context@(RequestContext _ _ ApiRequest{..}) = do
+handleUpdate identifier context@(RequestContext _ _ ApiRequest{..} _) = do
   WriteQueryResult{..} <- writeQuery identifier False mempty context
 
   let
@@ -338,7 +342,7 @@ handleUpdate identifier context@(RequestContext _ _ ApiRequest{..}) = do
       response status [contentRangeHeader] mempty
 
 handleSingleUpsert :: QualifiedIdentifier -> RequestContext-> DbHandler Wai.Response
-handleSingleUpsert identifier context@(RequestContext _ _ ApiRequest{..}) = do
+handleSingleUpsert identifier context@(RequestContext _ _ ApiRequest{..} _) = do
   when (iTopLevelRange /= RangeQuery.allRange) $
     throwError Error.PutRangeNotAllowedError
 
@@ -362,7 +366,7 @@ handleSingleUpsert identifier context@(RequestContext _ _ ApiRequest{..}) = do
       response HTTP.status204 (contentTypeHeaders context) mempty
 
 handleDelete :: QualifiedIdentifier -> RequestContext -> DbHandler Wai.Response
-handleDelete identifier context@(RequestContext _ _ ApiRequest{..}) = do
+handleDelete identifier context@(RequestContext _ _ ApiRequest{..} _) = do
   WriteQueryResult{..} <- writeQuery identifier False mempty context
 
   let
@@ -439,7 +443,7 @@ handleInvoke invMethod proc context@RequestContext{..} = do
         (iAcceptContentType == CTTextCSV)
         (iPreferParameters == Just MultipleObjects)
         bField
-        (pgVersion ctxDbStructure)
+        ctxPgVersion
         (configDbPreparedStatements ctxConfig)
 
   response <- liftEither $ gucResponse <$> gucStatus <*> gucHeaders
@@ -454,7 +458,7 @@ handleInvoke invMethod proc context@RequestContext{..} = do
       (if invMethod == InvHead then mempty else toS body)
 
 handleOpenApi :: Bool -> Schema -> RequestContext -> DbHandler Wai.Response
-handleOpenApi headersOnly tSchema (RequestContext conf@AppConfig{..} dbStructure apiRequest) = do
+handleOpenApi headersOnly tSchema (RequestContext conf@AppConfig{..} dbStructure apiRequest _) = do
   body <-
     lift $
       OpenAPI.encode conf dbStructure
@@ -516,7 +520,7 @@ writeQuery identifier@QualifiedIdentifier{..} isInsert pkCols context@RequestCon
         (iAcceptContentType ctxApiRequest == CTTextCSV)
         (iPreferRepresentation ctxApiRequest)
         pkCols
-        (pgVersion ctxDbStructure)
+        ctxPgVersion
         (configDbPreparedStatements ctxConfig)
 
   liftEither $ WriteQueryResult queryTotal fields body <$> gucStatus <*> gucHeaders
@@ -554,7 +558,7 @@ returnsScalar (TargetProc proc _) = Proc.procReturnsScalar proc
 returnsScalar _                   = False
 
 readRequest :: Monad m => QualifiedIdentifier -> RequestContext -> Handler m ReadRequest
-readRequest QualifiedIdentifier{..} (RequestContext AppConfig{..} dbStructure apiRequest) =
+readRequest QualifiedIdentifier{..} (RequestContext AppConfig{..} dbStructure apiRequest _) =
   liftEither $
     ReqBuilder.readRequest qiSchema qiName configDbMaxRows
       (dbRelationships dbStructure)

--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -20,7 +20,7 @@ import Text.Heredoc (str)
 
 import PostgREST.AppState    (AppState)
 import PostgREST.Config      (AppConfig (..))
-import PostgREST.DbStructure (getDbStructure, getPgVersion)
+import PostgREST.DbStructure (getDbStructure)
 import PostgREST.Version     (prettyVersion)
 import PostgREST.Workers     (reReadConfig)
 
@@ -54,13 +54,11 @@ dumpSchema :: AppState -> IO LBS.ByteString
 dumpSchema appState = do
   AppConfig{..} <- AppState.getConfig appState
   result <-
-    P.use (AppState.getPool appState) $ do
-      pgVersion <- getPgVersion
+    P.use (AppState.getPool appState) $
       HT.transaction HT.ReadCommitted HT.Read $
         getDbStructure
           (toList configDbSchemas)
           configDbExtraSearchPath
-          pgVersion
           configDbPreparedStatements
   P.release $ AppState.getPool appState
   case result of

--- a/src/PostgREST/DbStructure/Relationship.hs
+++ b/src/PostgREST/DbStructure/Relationship.hs
@@ -3,7 +3,6 @@
 
 module PostgREST.DbStructure.Relationship
   ( Cardinality(..)
-  , ForeignKey(..)
   , PrimaryKey(..)
   , Relationship(..)
   , Junction(..)
@@ -12,8 +11,7 @@ module PostgREST.DbStructure.Relationship
 
 import qualified Data.Aeson as JSON
 
-import PostgREST.DbStructure.Table (Column (..), ForeignKey (..),
-                                    Table (..))
+import PostgREST.DbStructure.Table (Column (..), Table (..))
 
 import Protolude
 

--- a/src/PostgREST/DbStructure/Table.hs
+++ b/src/PostgREST/DbStructure/Table.hs
@@ -3,7 +3,6 @@
 
 module PostgREST.DbStructure.Table
   ( Column(..)
-  , ForeignKey(..)
   , Table(..)
   , tableQi
   ) where
@@ -34,10 +33,6 @@ instance Eq Table where
 tableQi :: Table -> QualifiedIdentifier
 tableQi Table{tableSchema=s, tableName=n} = QualifiedIdentifier s n
 
-newtype ForeignKey = ForeignKey
-  { fkCol :: Column }
-  deriving (Eq, Ord, Generic, JSON.ToJSON)
-
 data Column = Column
   { colTable       :: Table
   , colName        :: FieldName
@@ -47,7 +42,6 @@ data Column = Column
   , colMaxLen      :: Maybe Int32
   , colDefault     :: Maybe Text
   , colEnum        :: [Text]
-  , colFK          :: Maybe ForeignKey
   }
   deriving (Ord, Generic, JSON.ToJSON)
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -63,12 +63,12 @@ main = do
     loadDbStructure pool
       (configDbSchemas $ testCfg testDbConn)
       (configDbExtraSearchPath $ testCfg testDbConn)
-      actualPgVersion
 
   let
     -- For tests that run with the same refDbStructure
     app cfg = do
       appState <- AppState.initWithPool pool $ cfg testDbConn
+      AppState.putPgVersion appState actualPgVersion
       AppState.putDbStructure appState baseDbStructure
       return ((), postgrest LogCrit appState $ pure ())
 
@@ -78,7 +78,6 @@ main = do
         loadDbStructure pool
           (configDbSchemas $ cfg testDbConn)
           (configDbExtraSearchPath $ cfg testDbConn)
-          actualPgVersion
       appState <- AppState.initWithPool pool $ cfg testDbConn
       AppState.putDbStructure appState customDbStructure
       return ((), postgrest LogCrit appState $ pure ())
@@ -204,5 +203,5 @@ main = do
       describe "Feature.RollbackForcedSpec" Feature.RollbackSpec.forced
 
   where
-    loadDbStructure pool schemas extraSearchPath ver =
-      either (panic.show) id <$> P.use pool (HT.transaction HT.ReadCommitted HT.Read $ getDbStructure (toList schemas) extraSearchPath ver True)
+    loadDbStructure pool schemas extraSearchPath =
+      either (panic.show) id <$> P.use pool (HT.transaction HT.ReadCommitted HT.Read $ getDbStructure (toList schemas) extraSearchPath True)


### PR DESCRIPTION
As noted on https://github.com/PostgREST/postgrest/pull/1794#issuecomment-826048398, having a foreign key attached to the Column type doesn't make sense(a single column can have multiple FKs defined). So I've removed `colFK` from our `Column` type, without breaking the current OpenAPI output.

The advantage of this is that filtering internal `colFKs`(as mentioned on https://github.com/PostgREST/postgrest/pull/1794#issuecomment-826001841) is no longer needed.

TODO:

- [x] Remove pgVersion from DbStructure, maybe put it on AppState.