### PR TITLE
fix: Allow OPTIONS requests to RPC

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -387,9 +387,6 @@ handleInfoProc procedure RequestContext{..} = do
   case M.lookup (identifier procedure) (dbProcs ctxDbStructure) of
     Nothing ->
       throwError Error.NotFound
-    Just [proc] ->
-      return $ Wai.responseLBS HTTP.status200 [allOrigins, allowH $ isNotVolatile proc] mempty
-    -- TODO: Handle composite retType
     Just procs ->
       return $ Wai.responseLBS HTTP.status200 [allOrigins, allowH $ any procMatches procs] mempty
   where
@@ -401,10 +398,7 @@ handleInfoProc procedure RequestContext{..} = do
           ++ ["GET" | isNotVol]
           ++ ["HEAD,POST"]
       )
-    identifier proc =
-      QualifiedIdentifier
-        (pdSchema proc)
-        (fromMaybe (pdName proc) $ Proc.procTableName proc)
+    identifier proc = QualifiedIdentifier (pdSchema proc) (pdName proc)
     procMatches proc = isNotVolatile proc
     isNotVolatile proc =
       case pdVolatility proc of

--- a/src/PostgREST/Request/ApiRequest.hs
+++ b/src/PostgREST/Request/ApiRequest.hs
@@ -165,7 +165,7 @@ data ApiRequest = ApiRequest {
 userApiRequest :: AppConfig -> DbStructure -> Request -> RequestBody -> Either ApiRequestError ApiRequest
 userApiRequest conf@AppConfig{..} dbStructure req reqBody
   | isJust profile && fromJust profile `notElem` configDbSchemas = Left $ UnacceptableSchema $ toList configDbSchemas
-  | isTargetingProc && method `notElem` ["HEAD", "GET", "POST"] = Left ActionInappropriate
+  | isTargetingProc && method `notElem` ["HEAD", "GET", "POST", "OPTIONS"] = Left ActionInappropriate
   | topLevelRange == emptyRange = Left InvalidRange
   | shouldParsePayload && isLeft payload = either (Left . InvalidBody . toS) witness payload
   | isLeft parsedColumns = either Left witness parsedColumns

--- a/test/Feature/OptionsSpec.hs
+++ b/test/Feature/OptionsSpec.hs
@@ -69,3 +69,36 @@ spec = describe "Allow header" $ do
         liftIO $
           simpleHeaders r `shouldSatisfy`
             matchHeader "Allow" "OPTIONS,GET,HEAD,DELETE"
+
+  context "a function" $ do
+    context "non overloaded" $ do
+      it "does not include GET verb for volatile functions" $ do
+        r <- request methodOptions "/rpc/options_test_volatile" [] ""
+        liftIO $
+          simpleHeaders r `shouldSatisfy`
+            matchHeader "Allow" "OPTIONS,HEAD,POST"
+
+      it "includes GET verb for stable functions" $ do
+        r <- request methodOptions "/rpc/options_test_stable" [] ""
+        liftIO $
+          simpleHeaders r `shouldSatisfy`
+            matchHeader "Allow" "OPTIONS,GET,HEAD,POST"
+
+      it "includes POST verb for immutable functions" $ do
+        r <- request methodOptions "/rpc/options_test_immutable" [] ""
+        liftIO $
+          simpleHeaders r `shouldSatisfy`
+            matchHeader "Allow" "OPTIONS,GET,HEAD,POST"
+
+    context "overloaded" $ do
+      it "does not include GET verb for volatile only overloaded functions" $ do
+        r <- request methodOptions "/rpc/options_test_overloaded_all_volatile" [] ""
+        liftIO $
+          simpleHeaders r `shouldSatisfy`
+            matchHeader "Allow" "OPTIONS,HEAD,POST"
+
+      it "includes GET verb for at lest one non volatile overloaded functions" $ do
+        r <- request methodOptions "/rpc/options_test_overloaded_at_least_one_non_volatile" [] ""
+        liftIO $
+          simpleHeaders r `shouldSatisfy`
+            matchHeader "Allow" "OPTIONS,GET,HEAD,POST"

--- a/test/Feature/OptionsSpec.hs
+++ b/test/Feature/OptionsSpec.hs
@@ -84,7 +84,7 @@ spec = describe "Allow header" $ do
           simpleHeaders r `shouldSatisfy`
             matchHeader "Allow" "OPTIONS,GET,HEAD,POST"
 
-      it "includes POST verb for immutable functions" $ do
+      it "includes GET verb for immutable functions" $ do
         r <- request methodOptions "/rpc/options_test_immutable" [] ""
         liftIO $
           simpleHeaders r `shouldSatisfy`
@@ -97,7 +97,7 @@ spec = describe "Allow header" $ do
           simpleHeaders r `shouldSatisfy`
             matchHeader "Allow" "OPTIONS,HEAD,POST"
 
-      it "includes GET verb for at lest one non volatile overloaded functions" $ do
+      it "includes GET verb for at lest one non volatile overloaded function" $ do
         r <- request methodOptions "/rpc/options_test_overloaded_at_least_one_non_volatile" [] ""
         liftIO $
           simpleHeaders r `shouldSatisfy`

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -466,10 +466,6 @@ spec actualPgVersion =
       it "PATCH fails" $
         request methodPatch "/rpc/sayhello" [] ""
           `shouldRespondWith` 405
-      it "OPTIONS fails" $
-        -- TODO: should return info about the function
-        request methodOptions "/rpc/sayhello" [] ""
-          `shouldRespondWith` 405
 
     it "executes the proc exactly once per request" $ do
       -- callcounter is persistent even with rollback, because it uses a sequence

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1611,6 +1611,34 @@ create trigger projects_view_with_delete_trigger_delete
     instead of delete on test.projects_view_with_delete_trigger
     for each row execute procedure test_for_views_with_triggers();
 
+create or replace function test.options_test_volatile(num int) returns int AS $$
+select num;
+$$ language sql volatile;
+
+create or replace function test.options_test_stable(num int) returns int AS $$
+select num;
+$$ language sql stable;
+
+create or replace function test.options_test_immutable(num int) returns int AS $$
+select num;
+$$ language sql immutable;
+
+create or replace function test.options_test_overloaded_all_volatile(num int) returns int AS $$
+select num;
+$$ language sql volatile ;
+
+create or replace function test.options_test_overloaded_all_volatile(num1 int, num2 int) returns int AS $$
+select num1 + num2;
+$$ language sql volatile ;
+
+create or replace function test.options_test_overloaded_at_least_one_non_volatile(num int) returns int AS $$
+select num;
+$$ language sql stable ;
+
+create or replace function test.options_test_overloaded_at_least_one_non_volatile(num1 int, num2 int) returns int AS $$
+select num1 + num2;
+$$ language sql volatile;
+
 create or replace function test."quotedFunction"("user" text, "fullName" text, "SSN" text)
 returns jsonb AS $$
   select format('{"user": "%s", "fullName": "%s", "SSN": "%s"}', "user", "fullName", "SSN")::jsonb;


### PR DESCRIPTION
This PR handles OPTIONS requests to functions, mentioned here: #1826

Won't add the 405 response to a GET for a volatile function feature due to the routing refactor as discussed [here ](https://github.com/PostgREST/postgrest/pull/1824#discussion_r616857705)