### PR TITLE
New: drop gzip support, improve performance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #1560, Volatile RPC called with GET now returns 405 Method not Allowed instead of 500 - @wolfgangwalther
  - #1604, Change the default logging level to `log-level=error`. Only requests with a status greater or equal than 500 will be logged. If you wish to go back to the previous behaviour and log all the requests, use `log-level=info` - @steve-chavez
  - #1617, Dropped support for PostgreSQL 9.4 - @wolfgangwalther
-
+ - #1854, Dropped undocumented support for gzip compression (which was surprisingly slow and easily enabled by mistake). In some use-cases this makes Postgres up to 3x faster - @aljungberg
+ 
 ## [7.0.1] - 2020-05-18
 
 ### Fixed

--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -114,7 +114,6 @@ pgrstFormat minStatus date req status responseSize =
 pgrstMiddleware :: LogLevel -> Wai.Application -> Wai.Application
 pgrstMiddleware logLevel =
     logger
-  . Wai.gzip Wai.def
   . Wai.cors corsPolicy
   . Wai.staticPolicy (Wai.only [("favicon.ico", "static/favicon.ico")])
   where


### PR DESCRIPTION
Postgrest's gzip support was surprisingly slow, lacked in configurability, was undocumented and untested. This pull request drops that support entirely.

## Why?

Not gzipping the output more than triples the throughput for a simple no database access RPC function.

Most browsers do send this header, and while it's possible to drop the header in the proxy if you're aware, it's a bit of an undocumented gotcha.

Better then not support gzip at all, further focusing on ensuring Postgrest is a minimal layer over Postgres. Postgrest essentially requires a proxy in production (to set rate limits for example) and chances are that proxy will be much better suited for the job. Nginx, for instance, provides critical options such as min length, vary headers and so forth, and is much faster at it in my testing.

There are no unit test changes for this pull request. It seems futile to test a negative (there's an infinite number of unsupported features) and there was never a test to verify compression support to begin with.

## Before

These tests were run inside an otherwise idle 8 core, 96 GB RAM machine, with postgres and postgrest in separate Docker containers. The first is without accept encoding, serving as a baseline, the second is with `Accept-Encoding: gzip`.

```
> echo "GET http://10.0.1.205:3000/rpc/add_them?a=1&b=2" | vegeta attack -duration=30s -workers=16 -max-workers=16 -rate 5000 -header "Accept-Encoding: identity" >results.bin && vegeta report <results.bin
Requests      [total, rate, throughput]         135038, 4500.35, 4500.26
Duration      [total, attack, wait]             30.007s, 30.006s, 536.81µs
Latencies     [min, mean, 50, 90, 95, 99, max]  501.142µs, 3.517ms, 1.525ms, 8.631ms, 10.731ms, 22.263ms, 47.847ms
Bytes In      [total, mean]                     135038, 1.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:135038
Error Set:

> echo "GET http://10.0.1.205:3000/rpc/add_them?a=1&b=2" | vegeta attack -duration=30s -workers=16 -max-workers=16 -rate 5000 -header "Accept-Encoding: gzip" >results.bin && vegeta report <results.bin
Requests      [total, rate, throughput]         41699, 1389.96, 1389.75
Duration      [total, attack, wait]             30.005s, 30s, 4.498ms
Latencies     [min, mean, 50, 90, 95, 99, max]  642.107µs, 11.482ms, 9.587ms, 21.521ms, 27.463ms, 39.246ms, 61.252ms
Bytes In      [total, mean]                     875679, 21.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:41699
Error Set:
```

Note the tremendous drop in throughput with gzip enabled (and again, it's easy to have this enabled without even knowing). 

In this particular case, gzip actually leads to *more* bytes being written in response since you can't compress a single byte response, visible in "Bytes In". This is a problem that's easy to solve in nginx (set `gzip_min_length`), but not in Postgrest.

## After

Same test after merging this patch:

```
echo "GET http://10.0.1.205:3000/rpc/add_them?a=1&b=2" | vegeta attack -duration=30s -workers=16 -max-workers=16 -rate 5000 -header "Accept-Encoding: gzip" >results.bin && vegeta report <results.bin
Requests      [total, rate, throughput]         134910, 4495.78, 4495.68
Duration      [total, attack, wait]             30.009s, 30.008s, 694.065µs
Latencies     [min, mean, 50, 90, 95, 99, max]  403.378µs, 3.51ms, 1.513ms, 8.591ms, 10.827ms, 21.99ms, 55.013ms
Bytes In      [total, mean]                     134910, 1.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:134910
Error Set:
```

So the data is clear: running without gzip is over 3x faster and latency is lower too.

In fact `nginx -> postgrest` is faster than postgrest by itself with compression. In this test there's a very simple nginx setup listening on port 80 and forwarding to postgres, configured with the gzip module.

```
echo "GET http://10.0.1.205:80/rpc/add_them?a=1&b=2" | vegeta attack -duration=30s -workers=16 -max-workers=16 -rate 5000 -header "Accept-Encoding: gzip" >results.bin && vegeta report <results.bin
Requests      [total, rate, throughput]         75222, 2507.41, 2507.32
Duration      [total, attack, wait]             30.001s, 30s, 1.122ms
Latencies     [min, mean, 50, 90, 95, 99, max]  717.27µs, 6.36ms, 4.956ms, 12.193ms, 17.289ms, 28.881ms, 54.161ms
Bytes In      [total, mean]                     1579662, 21.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:75222
Error Set:
```

When postgrest did the gziping it only got 1400 RPS -- nginx doing the compression gives 2500 RPS *even that it also has to do a bunch of other work to do a layer 7 shuffle of data*.

## Summary

I strongly believe the gzip feature is an unintentional one in Postgrest (given it's undocumented and has no options), but it still has a huge performance penalty in common usage. So let's drop it.



<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs     - https://github.com/PostgREST/postgrest-docs
-->
