### PR TITLE
feat: Add logging with time for worker

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -44,5 +44,4 @@ setBuffering = do
   -- output, the buffer overflows, a hFlush is issued or the handle is closed
   hSetBuffering stdout LineBuffering
   hSetBuffering stdin LineBuffering
-  -- NoBuffering: output is written immediately and never stored in the buffer
-  hSetBuffering stderr NoBuffering
+  hSetBuffering stderr LineBuffering

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -116,13 +116,14 @@ run installHandlers maybeRunWithSocket appState = do
     Just socket ->
       -- run the postgrest application with user defined socket. Only for UNIX systems
       case maybeRunWithSocket of
-        Just runWithSocket ->
+        Just runWithSocket -> do
+          AppState.logWithZTime appState stdout $ "Listening on unix socket " <> show socket
           runWithSocket (serverSettings conf) app configServerUnixSocketMode socket
         Nothing ->
           panic "Cannot run with socket on non-unix plattforms."
     Nothing ->
       do
-        putStrLn $ ("Listening on port " :: Text) <> show configServerPort
+        AppState.logWithZTime appState stdout $ "Listening on port " <> show configServerPort
         Warp.runSettings (serverSettings conf) app
 
 serverSettings :: AppConfig -> Warp.Settings

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -117,13 +117,13 @@ run installHandlers maybeRunWithSocket appState = do
       -- run the postgrest application with user defined socket. Only for UNIX systems
       case maybeRunWithSocket of
         Just runWithSocket -> do
-          AppState.logWithZTime appState stdout $ "Listening on unix socket " <> show socket
+          AppState.logWithZTime appState $ "Listening on unix socket " <> show socket
           runWithSocket (serverSettings conf) app configServerUnixSocketMode socket
         Nothing ->
           panic "Cannot run with socket on non-unix plattforms."
     Nothing ->
       do
-        AppState.logWithZTime appState stdout $ "Listening on port " <> show configServerPort
+        AppState.logWithZTime appState $ "Listening on port " <> show configServerPort
         Warp.runSettings (serverSettings conf) app
 
 serverSettings :: AppConfig -> Warp.Settings

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -124,11 +124,11 @@ putConfig = atomicWriteIORef . stateConf
 getTime :: AppState -> IO UTCTime
 getTime = stateGetTime
 
--- | Log with local time
-logWithZTime :: AppState -> Handle -> Text -> IO ()
-logWithZTime appState hdl txt = do
+-- | Log to stderr with local time
+logWithZTime :: AppState -> Text -> IO ()
+logWithZTime appState txt = do
   zTime <- stateGetZTime appState
-  hPutStrLn hdl $ toS (formatTime defaultTimeLocale "%d/%b/%Y:%T %z: " zTime) <> txt
+  hPutStrLn stderr $ toS (formatTime defaultTimeLocale "%d/%b/%Y:%T %z: " zTime) <> txt
 
 getMainThreadId :: AppState -> ThreadId
 getMainThreadId = stateMainThreadId

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -12,6 +12,7 @@ module PostgREST.AppState
   , getTime
   , init
   , initWithPool
+  , logWithZTime
   , putConfig
   , putDbStructure
   , putIsWorkerOn
@@ -28,6 +29,8 @@ import Control.AutoUpdate (defaultUpdateSettings, mkAutoUpdate,
                            updateAction)
 import Data.IORef         (IORef, atomicWriteIORef, newIORef,
                            readIORef)
+import Data.Time          (ZonedTime, defaultTimeLocale, formatTime,
+                           getZonedTime)
 import Data.Time.Clock    (UTCTime, getCurrentTime)
 
 import PostgREST.Config           (AppConfig (..))
@@ -51,7 +54,11 @@ data AppState = AppState
   , stateListener     :: MVar ()
   -- | Config that can change at runtime
   , stateConf         :: IORef AppConfig
+  -- | Time used for verifying JWT expiration
   , stateGetTime      :: IO UTCTime
+  -- | Time with time zone used for worker logs
+  , stateGetZTime     :: IO ZonedTime
+  -- | Used for killing the main thread in case a subthread fails
   , stateMainThreadId :: ThreadId
   }
 
@@ -63,14 +70,14 @@ init conf = do
 initWithPool :: P.Pool -> AppConfig -> IO AppState
 initWithPool newPool conf =
   AppState newPool
-    -- assume we're in a supported version when starting, this will be corrected on a later step
-    <$> newIORef minimumPgVersion
+    <$> newIORef minimumPgVersion -- assume we're in a supported version when starting, this will be corrected on a later step
     <*> newIORef Nothing
     <*> newIORef mempty
     <*> newIORef False
     <*> newEmptyMVar
     <*> newIORef conf
     <*> mkAutoUpdate defaultUpdateSettings { updateAction = getCurrentTime }
+    <*> mkAutoUpdate defaultUpdateSettings { updateAction = getZonedTime }
     <*> myThreadId
 
 initPool :: AppConfig -> IO P.Pool
@@ -116,6 +123,12 @@ putConfig = atomicWriteIORef . stateConf
 
 getTime :: AppState -> IO UTCTime
 getTime = stateGetTime
+
+-- | Log with local time
+logWithZTime :: AppState -> Handle -> Text -> IO ()
+logWithZTime appState hdl txt = do
+  zTime <- stateGetZTime appState
+  hPutStrLn hdl $ toS (formatTime defaultTimeLocale "%d/%b/%Y:%T %z: " zTime) <> txt
 
 getMainThreadId :: AppState -> ThreadId
 getMainThreadId = stateMainThreadId

--- a/src/PostgREST/Unix.hs
+++ b/src/PostgREST/Unix.hs
@@ -23,7 +23,6 @@ import Protolude
 runAppWithSocket :: Warp.Settings -> Application -> FileMode -> FilePath -> IO ()
 runAppWithSocket settings app socketFileMode socketFilePath =
   bracket createAndBindSocket Socket.close $ \socket -> do
-    putStrLn $ ("Listening on unix socket " :: Text) <> show socketFilePath
     Socket.listen socket Socket.maxListenQueue
     Warp.runSettingsSocket settings socket app
   where

--- a/test/io-tests/test_io.py
+++ b/test/io-tests/test_io.py
@@ -684,6 +684,10 @@ def test_invalid_role_claim_key_notify_reload(defaultenv):
     with run(env=env) as postgrest:
         postgrest.session.post("/rpc/invalid_role_claim_key_reload")
 
+        # skips the first lines from stderr, the "Attempting to connect to database", "Connection successful", etc.
+        # this is a hack to avoid readline() from locking up the test
+        for _ in range(6):
+            postgrest.process.stderr.readline()
         assert "failed to parse role-claim-key value" in str(
             postgrest.process.stderr.readline()
         )


### PR DESCRIPTION
Fixes #1850. Now the recovery and startup logs include the time:

```
12/Jun/2021:17:47:39 -0500: Attempting to connect to the database...
12/Jun/2021:17:47:39 -0500: Listening on port 3000
12/Jun/2021:17:47:39 -0500: Connection successful
12/Jun/2021:17:47:39 -0500: Config re-loaded
12/Jun/2021:17:47:40 -0500: Schema cache loaded
12/Jun/2021:17:47:51 -0500: Attempting to connect to the database...
12/Jun/2021:17:47:51 -0500: {"details":"could not connect to server: Connection refused\n\tIs the serv127.0.0.1 - - [12/Jun/2021:17:47:51 -0500] "GET /x HTTP/1.1" 503 - "" "curl/7.64.0"
er running on host \"localhost\" (::1) and accepting\n\tTCP/IP connections on port 5432?\ncould not connect to server: Connection refused\n\tIs the server running on host \"localhost\" (127.0.0.1) and accepting\n\tTCP/IP connections on port 5432?\n","code":"","message":"Database connection error. Retrying the connection."}
12/Jun/2021:17:47:51 -0500: Attempting to reconnect to the database in 0 seconds...
12/Jun/2021:17:47:52 -0500: {"details":"could not connect to server: Connection refused\n\tIs the server running on host \"localhost\" (::1) and accepting\n\tTCP/IP connections on port 5432?\ncould not connect to server: Connection refused\n\tIs the server running on host \"localhost\" (127.0.0.1) and accepting\n\tTCP/IP connections on port 5432?\n","code":"","message":"Database connection error. Retrying the connection."}
12/Jun/2021:17:47:52 -0500: Attempting to reconnect to the database in 1 seconds...
12/Jun/2021:17:47:54 -0500: {"details":"could not connect to server: Connection refused\n\tIs the server running on host \"localhost\" (::1) and accepting\n\tTCP/IP connections on port 5432?\ncould not connect to server: Connection refused\n\tIs the server running on host \"localhost\" (127.0.0.1) and accepting\n\tTCP/IP connections on port 5432?\n","code":"","message":"Database connection error. Retrying the connection."}
12/Jun/2021:17:47:54 -0500: Attempting to reconnect to the database in 2 seconds...
12/Jun/2021:17:47:59 -0500: Connection successful
```

### Implementation details

I got the logs format from Nginx logs. They don't use the apache format(`ip - - date - path status`) for error logs, instead they do it like:

```
2021/06/08 10:02:47 [notice] 1356#0: getrlimit(RLIMIT_NOFILE): 65536:65536
2021/06/08 10:02:47 [notice] 1404#0: start worker processes
2021/06/08 10:02:47 [notice] 1404#0: start worker process 1405
2021/06/08 10:02:47 [notice] 1404#0: start worker process 1406
2021/06/08 10:02:47 [notice] 1405#0: *1 [lua] cache.lua:374: purge(): [DB cache] purging (local) cache, context: init_worker_by_lua*
```

I think that's good for differentiating between access logs and other logs.

---

Hm, maybe all workers logs should go to `stderr` since they're in a different format, that way they can be parsed if needed.