### PR TITLE
Upgrade Nix dependencies in preparation for new release

### DIFF
--- a/nix/nixpkgs-version.nix
+++ b/nix/nixpkgs-version.nix
@@ -1,6 +1,6 @@
 # Pinned version of Nixpkgs, generated with postgrest-nixpkgs-upgrade.
 {
-  date = "2021-07-12";
-  rev = "c114cd459e1bac0d05e4e27c9ea43c99799cbbd1";
-  tarballHash = "1hpspw8jbzq03k8a6izxnbqww42mihqaa6c8nszw30igiaqc98i2";
+  date = "2021-07-17";
+  rev = "d00b5a5fa6fe8bdf7005abb06c46ae0245aec8b5";
+  tarballHash = "08497wbpnf3w5dalcasqzymw3fmcn8qrnbkf8rxxwwvyjdnczxdv";
 }

--- a/nix/overlays/ghr/ghr.nix
+++ b/nix/overlays/ghr/ghr.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "ghr";
-  version = "0.13.0";
+  version = "0.14.0";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "tcnksm";
     repo = "ghr";
-    sha256 = "1nm5kdjkqayxh06j9nr5daic9sw9nx9w06y9gaqhdrw9byvjpr1a";
+    sha256 = "1jjc3bwmyw831r1ayic1f1ysh5ggm88aszbndm0swg8byhz56pd4";
   };
 
-  vendorSha256 = "14avsngzhl1b8a05i43ph6sxh9vj0jls0acxr9j7r0h3f0vpamcj";
+  vendorSha256 = "06cbhsnxv4gisnwrhw61af7rpv2a9slf9z2wbn79r91xzkh51vzr";
 
   # Disabling tests, as they require a GitHub API token
   doCheck = false;

--- a/nix/overlays/gitignore.nix
+++ b/nix/overlays/gitignore.nix
@@ -12,8 +12,8 @@ self: super:
       gitignoreSrc = super.fetchFromGitHub {
         owner = "hercules-ci";
         repo = "gitignore";
-        rev = "c4662e662462e7bf3c2a968483478a665d00e717";
-        sha256 = "1npnx0h6bd0d7ql93ka7azhj40zgjp815fw2r6smg8ch9p7mzdlx";
+        rev = "211907489e9f198594c0eb0ca9256a1949c9d412";
+        sha256 = "06j7wpvj54khw0z10fjyi31kpafkr6hi1k0di13k1xp8kywvfyx8";
       };
     in
     (super.callPackage gitignoreSrc { }).gitignoreSource;

--- a/nix/static-haskell-package.nix
+++ b/nix/static-haskell-package.nix
@@ -6,11 +6,11 @@ let
   # The nh2/static-haskell-nix project does all the hard work for us.
   static-haskell-nix =
     let
-      rev = "cdc1a9a36add24fac3b98e32b03e0e3c41bd17ee";
+      rev = "bd66b86b72cff4479e1c76d5916a853c38d09837";
     in
     builtins.fetchTarball {
       url = "https://github.com/nh2/static-haskell-nix/archive/${rev}.tar.gz";
-      sha256 = "0ba2jqi25p01jmd827xkw05wrv40pa46vh3j0dvyx6b6bsyj4xqx";
+      sha256 = "0rnsxaw7v27znsg9lgqk1i4007ydqrc8gfgimrmhf24lv6galbjh";
     };
 
   patched-static-haskell-nix =


### PR DESCRIPTION
Update dependencies once more now that https://github.com/NixOS/nixpkgs/pull/129606 and https://github.com/nh2/static-haskell-nix/pull/107 are merged. Also update `nix gitignore` and `ghr` to the latest versions.
