### PR TITLE
fix: Detect default values for String types in OpenAPI output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  
 ### Fixed
 
- - #1871, OpenAPI fix: Show missing default values for String types and identify Array types as "array" instead of "string" - @laurenceisla
+ - #1871, Fix OpenAPI missing default values for String types and identify Array types as "array" instead of "string" - @laurenceisla
 
 ## [8.0.0] - 2021-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  
 ### Fixed
 
- - #1871, Default values for String and Array types are now detected by OpenAPI - @laurenceisla
+ - #1871, OpenAPI fix: Show missing default values for String types and identify Array types as "array" instead of "string" - @laurenceisla
 
 ## [8.0.0] - 2021-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  
 ### Fixed
 
+ - #1871, Default values for String and Array types are now detected by OpenAPI - @laurenceisla
+
 ## [8.0.0] - 2021-07-25
 
 ### Added

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -71,11 +71,9 @@ toSwaggerType _                   = SwaggerString
 parseDefault :: Text -> Text -> Text
 parseDefault colType colDefault =
   case toSwaggerType colType of
-    -- TODO: Parse default values for json and jsonb types
     SwaggerString -> wrapInQuotations $ case T.stripSuffix ("::" <> colType) colDefault of
       Just def -> T.dropAround (=='\'')  def
       Nothing  -> colDefault
-    SwaggerArray -> wrapInQuotations $ fromMaybe colDefault (T.stripPrefix "ARRAY" colDefault)
     _ -> colDefault
   where
     wrapInQuotations text = "\"" <> text <> "\""

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -74,7 +74,7 @@ parseDefault colType colDefault =
     -- TODO: Parse default values for json and jsonb types
     SwaggerString -> wrapInQuotations $ case T.stripSuffix ("::" <> colType) colDefault of
       Just def -> T.dropAround (=='\'')  def
-      Nothing -> colDefault
+      Nothing  -> colDefault
     SwaggerArray -> wrapInQuotations $ fromMaybe colDefault (T.stripPrefix "ARRAY" colDefault)
     _ -> colDefault
   where

--- a/test/Feature/OpenApiSpec.hs
+++ b/test/Feature/OpenApiSpec.hs
@@ -425,6 +425,71 @@ spec actualPgVersion = describe "OpenAPI" $ do
             }
           |]
 
+  describe "Detects default values" $ do
+
+    it "text" $ do
+      r <- simpleBody <$> get "/"
+
+      let defaultValue = r ^? key "definitions" . key "openapi_defaults" . key "properties" . key "text" . key "default"
+
+      liftIO $
+
+        defaultValue `shouldBe` Just "default"
+
+    it "boolean" $ do
+      r <- simpleBody <$> get "/"
+
+      let types = r ^? key "definitions" . key "openapi_defaults" . key "properties" . key "boolean" . key "default"
+
+      liftIO $
+
+        types `shouldBe` Just (Bool False)
+
+    it "integer" $ do
+      r <- simpleBody <$> get "/"
+
+      let types = r ^? key "definitions" . key "openapi_defaults" . key "properties" . key "integer" . key "default"
+
+      liftIO $
+
+        types `shouldBe` Just (Number 42)
+
+    it "numeric" $ do
+      r <- simpleBody <$> get "/"
+
+      let types = r ^? key "definitions" . key "openapi_defaults" . key "properties" . key "numeric" . key "default"
+
+      liftIO $
+
+        types `shouldBe` Just (Number 42.2)
+
+    it "date" $ do
+      r <- simpleBody <$> get "/"
+
+      let types = r ^? key "definitions" . key "openapi_defaults" . key "properties" . key "date" . key "default"
+
+      liftIO $
+
+        types `shouldBe` Just "1900-01-01"
+
+    it "time" $ do
+      r <- simpleBody <$> get "/"
+
+      let types = r ^? key "definitions" . key "openapi_defaults" . key "properties" . key "time" . key "default"
+
+      liftIO $
+
+        types `shouldBe` Just "13:00:00"
+
+    it "array" $ do
+      r <- simpleBody <$> get "/"
+
+      let types = r ^? key "definitions" . key "openapi_defaults" . key "properties" . key "array" . key "default"
+
+      liftIO $
+
+        types `shouldBe` Just "['a'::character varying, 'b'::character varying]"
+
   describe "RPC" $ do
 
     it "includes function summary/description and body schema for arguments" $ do

--- a/test/Feature/OpenApiSpec.hs
+++ b/test/Feature/OpenApiSpec.hs
@@ -481,15 +481,6 @@ spec actualPgVersion = describe "OpenAPI" $ do
 
         types `shouldBe` Just "13:00:00"
 
-    it "array" $ do
-      r <- simpleBody <$> get "/"
-
-      let types = r ^? key "definitions" . key "openapi_defaults" . key "properties" . key "array" . key "default"
-
-      liftIO $
-
-        types `shouldBe` Just "['a'::character varying, 'b'::character varying]"
-
   describe "RPC" $ do
 
     it "includes function summary/description and body schema for arguments" $ do

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -115,6 +115,7 @@ GRANT ALL ON TABLE
     , pgrst_reserved_chars
     , authors_w_entities
     , openapi_types
+    , openapi_defaults
     , getallprojects_view
     , get_projects_above_view
     , web_content

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1757,8 +1757,7 @@ CREATE TABLE test.openapi_defaults(
   "integer" integer default 42,
   "numeric" numeric default 42.2,
   "date" date default '1900-01-01'::date,
-  "time" time default '13:00:00'::time without time zone,
-  "array" character varying[] DEFAULT array['a','b']::varchar[]
+  "time" time default '13:00:00'::time without time zone
 );
 
 create function add_them(a integer, b integer)

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1751,6 +1751,16 @@ CREATE TABLE test.openapi_types(
   "a_double_precision" double precision
 );
 
+CREATE TABLE test.openapi_defaults(
+  "text" text default 'default',
+  "boolean" boolean default false,
+  "integer" integer default 42,
+  "numeric" numeric default 42.2,
+  "date" date default '1900-01-01'::date,
+  "time" time default '13:00:00'::time without time zone,
+  "array" character varying[] DEFAULT array['a','b']::varchar[]
+);
+
 create function add_them(a integer, b integer)
 returns integer as $$
   select a + b;


### PR DESCRIPTION
Closes #1871

Detects most string formats excluding "json" and "jsonb".
Arrays are now detected as an "array" type instead of "string".