### PR TITLE
fix: Return array of objects for RPCs with single-column TABLE return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
  - #1871, Fix OpenAPI missing default values for String types and identify Array types as "array" instead of "string" - @laurenceisla
+ - #1930, Fix RPC return type handling for `RETURNS TABLE` with a single column. Regression of #1615. - @wolfgangwalther
+
 ### Changed
 
  - #1927, Overloaded Functions: If there's a function "my_func" having a single unnamed json param and other overloaded pairs(with any number of params), PostgREST won't be able to resolve a POST request to "my_func". For solving this, you can name the unnamed json param `my_func(json) -> my_func(prm json)`.

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -284,10 +284,8 @@ procsSqlQuery = [q|
     COALESCE(comp.relname, t.typname) AS name,
     p.proretset AS rettype_is_setof,
     (t.typtype = 'c'
-     -- Only pg pseudo type that is a row type is 'record'
-     or t.typtype = 'p' and t.typname = 'record'
-     -- if any INOUT or OUT arguments present, treat as composite
-     or COALESCE(proargmodes::text[] && '{b,o}', false)
+     -- if any TABLE, INOUT or OUT arguments present, treat as composite
+     or COALESCE(proargmodes::text[] && '{t,b,o}', false)
     ) AS rettype_is_composite,
     p.provolatile,
     p.provariadic > 0 as hasvariadic

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -572,6 +572,17 @@ spec actualPgVersion =
           `shouldRespondWith`
             [json|{"num":1,"str":"two","b":false}|]
 
+    context "procs with TABLE return" $ do
+      it "returns an object result when there is a single-column TABLE return type" $
+        get "/rpc/single_column_table_return"
+          `shouldRespondWith`
+            [json|[{"a": "A"}]|]
+
+      it "returns an object result when there is a multi-column TABLE return type" $
+        get "/rpc/multi_column_table_return"
+          `shouldRespondWith`
+            [json|[{"a": "A", "b": "B"}]|]
+
     context "procs with VARIADIC params" $ do
       when (actualPgVersion < pgVersion100) $
         it "works with POST (Postgres < 10)" $

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1203,6 +1203,14 @@ create function test.many_inout_params(INOUT num int, INOUT str text, INOUT b bo
   select num, str, b;
 $$ language sql;
 
+create function test.single_column_table_return () returns table (a text) AS $$
+  select 'A'::text;
+$$ language sql;
+
+create function test.multi_column_table_return () returns table (a text, b text) AS $$
+  select 'A'::text, 'B'::text;
+$$ language sql;
+
 CREATE FUNCTION test.variadic_param(VARIADIC v TEXT[] DEFAULT '{}') RETURNS text[]
 IMMUTABLE
 LANGUAGE SQL AS $$


### PR DESCRIPTION
This is a regression after changing responses for RPCs with INOUT or OUT arguments in #1615.

Resolves #1930.

The main idea of #1615 was "whenever any argument is given a name, we should return it in object style". We forgot about `RETURNS TABLE`, which has a special case when there is only one column given. With multiple columns in `RETURNS TABLE(...)`, PostgreSQL creates a record type behind the scenes, which we handle correctly. With only one column, this is not the case and we need to specifically check the existance of `TABLE`.

From the two tests I added the first one failed before my change, confirming #1930. The second one is working fine and is just added for completeness.

I added a second commit, too, which removes the check for the record pseudo type. I think we fully replaced that with the check for `TABLE` (and no test is failing), but it would be better to double check that one.