### PR TITLE
Values with double quotes on the "in" operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + Enables calling a function with a single json parameter without using `Prefer: params=single-object`
    + Enables uploading bytea to a function with `Content-Type: application/octet-stream`
    + Enables uploading raw text to a function with `Content-Type: text/plain`
+- #1938, Allow escaping inside double quotes with a backslash, e.g. `?col=in.("Double\"Quote")`, `?col=in.("Back\\slash")` - @steve-chavez
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
  - #1871, Fix OpenAPI missing default values for String types and identify Array types as "array" instead of "string" - @laurenceisla
  - #1930, Fix RPC return type handling for `RETURNS TABLE` with a single column. Regression of #1615. - @wolfgangwalther
+ - #1938, Fix using single double quotes(`"`) and backslashes(`/`) as values on the "in" operator - @steve-chavez
 
 ### Changed
 

--- a/src/PostgREST/Request/Parsers.hs
+++ b/src/PostgREST/Request/Parsers.hs
@@ -207,7 +207,9 @@ pListElement :: Parser Text
 pListElement = try (pQuotedValue <* notFollowedBy (noneOf ",)")) <|> (toS <$> many (noneOf ",)"))
 
 pQuotedValue :: Parser Text
-pQuotedValue = toS <$> (char '"' *> many (noneOf "\"") <* char '"')
+pQuotedValue = toS <$> (char '"' *> many pCharsOrSlashed <* char '"')
+  where
+    pCharsOrSlashed = noneOf "\\\"" <|> (char '\\' *> anyChar)
 
 pDelimiter :: Parser Char
 pDelimiter = char '.' <?> "delimiter (.)"

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -953,6 +953,25 @@ spec actualPgVersion = do
         [json| [{"name":"Double O Seven(007)"}] |]
         { matchHeaders = [matchContentTypeJson] }
 
+    context "escaped chars" $ do
+      it "accepts escaped double quotes" $
+        get "/w_or_wo_comma_names?name=in.(\"Double\\\"Quote\\\"McGraw\\\"\")" `shouldRespondWith`
+          [json| [ { "name": "Double\"Quote\"McGraw\"" } ] |]
+          { matchHeaders = [matchContentTypeJson] }
+
+      it "accepts escaped backslashes" $ do
+        get "/w_or_wo_comma_names?name=in.(\"\\\\\")" `shouldRespondWith`
+          [json| [{ "name": "\\" }] |]
+          { matchHeaders = [matchContentTypeJson] }
+        get "/w_or_wo_comma_names?name=in.(\"/\\\\Slash/\\\\Beast/\\\\\")" `shouldRespondWith`
+          [json| [ { "name": "/\\Slash/\\Beast/\\" } ] |]
+          { matchHeaders = [matchContentTypeJson] }
+
+      it "passes any escaped char as the same char" $
+        get "/w_or_wo_comma_names?name=in.(\"D\\a\\vid W\\h\\ite\")" `shouldRespondWith`
+          [json| [{ "name": "David White" }] |]
+          { matchHeaders = [matchContentTypeJson] }
+
   describe "IN values without quotes" $ do
     it "accepts single double quotes as values" $ do
       get "/w_or_wo_comma_names?name=in.(\")" `shouldRespondWith`

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -938,25 +938,37 @@ spec actualPgVersion = do
       get "/w_or_wo_comma_names?name=in.(\"Hebdon, John\",\"Williams, Mary\",\"Smith, Joseph\")" `shouldRespondWith`
         [json| [{"name":"Hebdon, John"},{"name":"Williams, Mary"},{"name":"Smith, Joseph"}] |]
         { matchHeaders = [matchContentTypeJson] }
-      get "/w_or_wo_comma_names?name=not.in.(\"Hebdon, John\",\"Williams, Mary\",\"Smith, Joseph\")" `shouldRespondWith`
-        [json| [{"name":"David White"},{"name":"Larry Thompson"},{"name":"Double O Seven(007)"}] |]
+      get "/w_or_wo_comma_names?name=not.in.(\"Hebdon, John\",\"Williams, Mary\",\"Smith, Joseph\")&limit=3" `shouldRespondWith`
+        [json| [ { "name": "David White" }, { "name": "Larry Thompson" }, { "name": "Double O Seven(007)" }] |]
         { matchHeaders = [matchContentTypeJson] }
 
     it "succeeds w/ and w/o quoted values" $ do
       get "/w_or_wo_comma_names?name=in.(David White,\"Hebdon, John\")" `shouldRespondWith`
         [json| [{"name":"Hebdon, John"},{"name":"David White"}] |]
         { matchHeaders = [matchContentTypeJson] }
-      get "/w_or_wo_comma_names?name=not.in.(\"Hebdon, John\",Larry Thompson,\"Smith, Joseph\")" `shouldRespondWith`
-        [json| [{"name":"Williams, Mary"},{"name":"David White"},{"name":"Double O Seven(007)"}] |]
+      get "/w_or_wo_comma_names?name=not.in.(\"Hebdon, John\",Larry Thompson,\"Smith, Joseph\")&limit=3" `shouldRespondWith`
+        [json| [ { "name": "Williams, Mary" }, { "name": "David White" }, { "name": "Double O Seven(007)" }] |]
         { matchHeaders = [matchContentTypeJson] }
       get "/w_or_wo_comma_names?name=in.(\"Double O Seven(007)\")" `shouldRespondWith`
         [json| [{"name":"Double O Seven(007)"}] |]
         { matchHeaders = [matchContentTypeJson] }
 
-    it "fails on malformed quoted values" $ do
-      get "/w_or_wo_comma_names?name=in.(\"\"Hebdon, John\")" `shouldRespondWith` 400
-      get "/w_or_wo_comma_names?name=in.(\"\"Hebdon, John\"\"Mary)" `shouldRespondWith` 400
-      get "/w_or_wo_comma_names?name=in.(Williams\"Hebdon, John\")" `shouldRespondWith` 400
+  describe "IN values without quotes" $ do
+    it "accepts single double quotes as values" $ do
+      get "/w_or_wo_comma_names?name=in.(\")" `shouldRespondWith`
+        [json| [{ "name": "\"" }] |]
+        { matchHeaders = [matchContentTypeJson] }
+      get "/w_or_wo_comma_names?name=in.(Double\"Quote\"McGraw\")" `shouldRespondWith`
+        [json| [ { "name": "Double\"Quote\"McGraw\"" } ] |]
+        { matchHeaders = [matchContentTypeJson] }
+
+    it "accepts backslashes as values" $ do
+      get "/w_or_wo_comma_names?name=in.(\\)" `shouldRespondWith`
+        [json| [{ "name": "\\" }] |]
+        { matchHeaders = [matchContentTypeJson] }
+      get "/w_or_wo_comma_names?name=in.(/\\Slash/\\Beast/\\)" `shouldRespondWith`
+        [json| [ { "name": "/\\Slash/\\Beast/\\" } ] |]
+        { matchHeaders = [matchContentTypeJson] }
 
   describe "IN and NOT IN empty set" $ do
     context "returns an empty result for IN when no value is present" $ do

--- a/test/fixtures/data.sql
+++ b/test/fixtures/data.sql
@@ -345,6 +345,10 @@ INSERT INTO w_or_wo_comma_names VALUES ('Smith, Joseph');
 INSERT INTO w_or_wo_comma_names VALUES ('David White');
 INSERT INTO w_or_wo_comma_names VALUES ('Larry Thompson');
 INSERT INTO w_or_wo_comma_names VALUES ('Double O Seven(007)');
+INSERT INTO w_or_wo_comma_names VALUES ('"');
+INSERT INTO w_or_wo_comma_names VALUES ('Double"Quote"McGraw"');
+INSERT INTO w_or_wo_comma_names VALUES ('\');
+INSERT INTO w_or_wo_comma_names VALUES ('/\Slash/\Beast/\');
 
 TRUNCATE TABLE items_with_different_col_types CASCADE;
 INSERT INTO items_with_different_col_types VALUES (1, null, null, null, null, null, null, null);


### PR DESCRIPTION
Closes #1938.

- **fix**: using `"` and `\` as values on the `in` filter.
- **feat**: Allow backslash escaping inside double quotes.
 
Examples:

  + `?col=in.("Double\"Quote")`
  + `?col=in.("Back\\slash")`

Backslashed chars get passed as is

   + `?col=in.("\a\b\c")` = `?col=in.(abc)`