### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,14 @@
 name: CI
+
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - main
 
 jobs:
   Lint-Style:
@@ -236,10 +243,10 @@ jobs:
             echo "::set-output name=version::$cabal_version"
           fi
 
-          if [[ "$cabal_version" != *-* ]]; then
-            echo "Version is for a full release (no '-' in version)"
+          if [[ "$cabal_version" != *.*.*.* ]]; then
+            echo "Version is for a full release (version does not have four components)"
           else
-            echo "Version is for a pre-release (version contains a '-', as in v1.0.0-a2)"
+            echo "Version is for a pre-release (version has four components, e.g., 1.1.1.1)"
             echo "::set-output name=isprerelease::1"
           fi
       - name: Identify changes from CHANGELOG.md
@@ -279,22 +286,24 @@ jobs:
           path: artifacts
       - name: Create release bundle with archives for all builds
         run: |
+          find artifacts -type f -iname postgrest -exec chmod +x {} \; 
+
           mkdir -p release-bundle
-          
-          tar cfvz "release-bundle/postgrest-v$VERSION-linux-static-x64.tar.gz" \
+
+          tar cJvf "release-bundle/postgrest-v$VERSION-linux-static-x64.tar.xz" \
             -C artifacts/postgrest-linux-static-x64 postgrest
 
           # No need to release Ubuntu, as the static Linux binary built with Nix
           # covers all Linux use-cases
-          #tar cfvz "release-bundle/postgrest-v$VERSION-ubuntu-x64.tar.gz" \
+          #tar cfJv "release-bundle/postgrest-v$VERSION-ubuntu-x64.tar.xz" \
           #  -C artifacts/postgrest-ubuntu-x64 postgrest
-          
-          tar cfvz "release-bundle/postgrest-v$VERSION-macos-x64.tar.gz" \
+
+          tar cJvf "release-bundle/postgrest-v$VERSION-macos-x64.tar.xz" \
             -C artifacts/postgrest-macos-x64 postgrest
-          
-          tar cfvz "release-bundle/postgrest-v$VERSION-freebsd-x64.tar.gz" \
+
+          tar cJvf "release-bundle/postgrest-v$VERSION-freebsd-x64.tar.xz" \
             -C artifacts/postgrest-freebsd-x64 postgrest
-          
+
           zip "release-bundle/postgrest-v$VERSION-windows-x64.zip" \
             artifacts/postgrest-windows-x64/postgrest.exe
 
@@ -317,7 +326,7 @@ jobs:
             -F artifacts/release-changes/CHANGES.md \
             ${isprerelease:+"--prerelease"} \
             release-bundle/*
-  
+
   Release-Docker:
     name: Release on Docker Hub
     runs-on: ubuntu-latest
@@ -355,4 +364,10 @@ jobs:
       - name: Update descriptions on Docker Hub
         env:
           DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
-        run: postgrest-release-dockerhub-description
+        run: |
+          if [[ -z "$ISPRERELEASE" ]]; then
+            echo "Updating description on Docker Hub..."
+            postgrest-release-dockerhub-description
+          else
+            echo "Skipping updating description for pre-release..."
+          fi

--- a/default.nix
+++ b/default.nix
@@ -118,7 +118,7 @@ rec {
 
   # Development tools.
   devTools =
-    pkgs.callPackage nix/tools/devTools.nix { inherit tests style devCabalOptions hsie; };
+    pkgs.callPackage nix/tools/devTools.nix { inherit tests style devCabalOptions hsie withTools; };
 
   # Docker images and loading script.
   docker =

--- a/nix/tools/devTools.nix
+++ b/nix/tools/devTools.nix
@@ -10,6 +10,7 @@
 , silver-searcher
 , style
 , tests
+, withTools
 }:
 let
   watch =
@@ -71,7 +72,7 @@ let
         inRootDir = true;
       }
       ''
-        ${tests}/bin/postgrest-with-all ${tests}/bin/postgrest-test-spec
+        ${withTools}/bin/postgrest-with-all ${tests}/bin/postgrest-test-spec
         ${tests}/bin/postgrest-test-spec-idempotence
         ${tests}/bin/postgrest-test-io
         ${style}/bin/postgrest-lint

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -1,5 +1,5 @@
 name:               postgrest
-version:            9.0.0-a1
+version:            8.0.0.20210921
 synopsis:           REST API for any Postgres database
 description:        Reads the schema of a PostgreSQL database and creates RESTful routes
                     for the tables and views, supporting all HTTP verbs that security

--- a/src/PostgREST/Version.hs
+++ b/src/PostgREST/Version.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -fno-warn-type-defaults #-}
 module PostgREST.Version
   ( docsVersion
   , prettyVersion
@@ -7,23 +6,36 @@ module PostgREST.Version
 
 import qualified Data.Text as T
 
-import Data.Version       (versionBranch)
+import Data.Version       (showVersion, versionBranch)
 import Development.GitRev (gitHash)
 import Paths_postgrest    (version)
 
 import Protolude
 
 
--- | User friendly version number
+-- | User friendly version number such as '1.1.1'.
+-- Pre-release versions are tagged as such, e.g., '1.1.1.1 (pre-release)'.
+-- If a git hash is available, it's added to the version, e.g., '1.1.1 (abcdef0)'.
 prettyVersion :: Text
 prettyVersion =
-  T.intercalate "." (map show $ versionBranch version) <> gitRev
+  T.pack (showVersion version) <> preRelease <> gitRev
   where
     gitRev =
-      if $(gitHash) == "UNKNOWN"
-        then mempty
-        else " (" <> T.take 7 $(gitHash) <> ")"
+      if $(gitHash) == ("UNKNOWN" :: Text) then
+        mempty
+      else
+        " (" <> T.take 7 $(gitHash) <> ")"
+    preRelease = if isPreRelease then " (pre-release)" else mempty
 
--- | Version number used in docs
+
+-- | Version number used in docs.
+-- Uses only the two first components of the version. Example: 'v1.1'
 docsVersion :: Text
-docsVersion = "v" <> T.dropEnd 1 (T.dropWhileEnd (/= '.') prettyVersion)
+docsVersion =
+  "v" <> (T.intercalate "." . map show . take 2 $ versionBranch version)
+
+
+-- | Versions with four components (e.g., '1.1.1.1') are treated as pre-releases.
+isPreRelease :: Bool
+isPreRelease =
+  length (versionBranch version) == 4


### PR DESCRIPTION
Fix issues noted in https://github.com/PostgREST/postgrest/pull/1948#issuecomment-919547558

According to https://pvp.haskell.org/#version-tags, tags in the package version are not supported anymore. Cabal silently swallows them, which is why the earlier CI hack for pre-releases worked somehow.

I propose that we use version numbers with 4 components (e.g., 1.1.1.1) to identify pre-releases.