### PR TITLE
Make JWT authorization a middleware

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -107,6 +107,7 @@ library
                     , text                      >= 1.2.2 && < 1.3
                     , time                      >= 1.6 && < 1.11
                     , unordered-containers      >= 0.2.8 && < 0.3
+                    , vault                     >= 0.3.1.5 && < 0.4
                     , vector                    >= 0.11 && < 0.13
                     , wai                       >= 3.2.1 && < 3.3
                     , wai-cors                  >= 0.2.5 && < 0.3

--- a/src/PostgREST/Auth.hs
+++ b/src/PostgREST/Auth.hs
@@ -12,8 +12,7 @@ very simple authentication system inside the PostgreSQL database.
 -}
 {-# LANGUAGE RecordWildCards #-}
 module PostgREST.Auth
-  ( containsRole
-  , jwtClaims
+  ( jwtClaims
   , JWTClaims
   ) where
 
@@ -76,7 +75,3 @@ claimsMap jspath claims =
     walkJSPath (Just (JSON.Object o)) (JSPKey key:rest) = walkJSPath (M.lookup key o) rest
     walkJSPath (Just (JSON.Array ar)) (JSPIdx idx:rest) = walkJSPath (ar V.!? idx) rest
     walkJSPath _                      _                 = Nothing
-
--- | Whether a response from jwtClaims contains a role claim
-containsRole :: JWTClaims -> Bool
-containsRole = M.member "role"


### PR DESCRIPTION
I found myself switching the log level on my Postgres server a lot when needing to debug permissions because I wanted to see what role the query ran as. This PR moves the JWT parsing to a middleware such that it is now available for the logging middleware.

Example of new access log output (e.g the `api_user` value)

```
127.0.0.1 api_user - [23/Oct/2021:22:58:32 +0200] "GET /todos HTTP/1.1" 200 - "" "curl/7.64.1"
```

This follows the style of wai-middleware-auth package and makes the JWT claims available anywhere we have a `Request` value through the `vault` mechanism in Wai. 

The existing JWT handling is not yet replaced as I wanted to get some feedback if this is interesting for anyone else.