### PR TITLE
fix: Make pfkSourceColumns query work with standard_conforming_strings = off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #1871, Fix OpenAPI missing default values for String types and identify Array types as "array" instead of "string" - @laurenceisla
  - #1930, Fix RPC return type handling for `RETURNS TABLE` with a single column. Regression of #1615. - @wolfgangwalther
  - #1938, Fix using single double quotes(`"`) and backslashes(`/`) as values on the "in" operator - @steve-chavez
+ - #1992, Fix schema cache query failing with standard_conforming_strings = off - @wolfgangwalther
 
 ### Changed
 

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -814,8 +814,8 @@ pfkSourceColumns cols =
                ','               , ''
             -- The same applies for `{` and `}`, although those are used a lot in pg_node_tree.
             -- We remove the escaped ones, which might be part of column names again.
-            ), '\{'              , ''
-            ), '\}'              , ''
+            ), E'\\{'            , ''
+            ), E'\\}'            , ''
             -- The fields we need are formatted as json manually to protect them from the regex.
             ), ' :targetList '   , ',"targetList":'
             ), ' :resno '        , ',"resno":'


### PR DESCRIPTION
Resolves #1992.

Tested by adding `standard_conforming_strings = off` to the `postgrest_test_authenticator` role. This made a lot of spec tests fail. The fix made them turn green again.

Didn't commit the config change, as we should probably add some kind of different machinery to test different postgresql configurations.