### PR TITLE
Allow overloaded functions if one has a single unnamed JSON param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
- - #1927, Overloaded Functions: If there's a function "my_func" having a single unnamed json param and other overloaded pairs(with any number of params), PostgREST won't be able to resolve a POST request to "my_func". For solving this, you can name the unnamed json param `my_func(json) -> my_func(prm json)`.
  - #1857, Make GUC names for headers, cookies and jwt claims compatible with PostgreSQL v14 - @laurenceisla, @robertsosinski
    + Getting the value for a header GUC on PostgreSQL 14 is done using `current_setting('request.headers')::json->>'name-of-header'` and in a similar way for `request.cookies` and `request.jwt.claims`
    + PostgreSQL versions below 14 can opt in to the new JSON GUCs by setting the `db-use-legacy-gucs` config option to false (true by default)

--- a/src/PostgREST/Request/ApiRequest.hs
+++ b/src/PostgREST/Request/ApiRequest.hs
@@ -491,10 +491,10 @@ findProc :: QualifiedIdentifier -> S.Set Text -> Bool -> ProcsMap -> ContentType
 findProc qi argumentsKeys paramsAsSingleObject allProcs contentType isInvPost =
   case matchProc of
     ([], [])     -> Left $ NoRpc (qiSchema qi) (qiName qi) (S.toList argumentsKeys) paramsAsSingleObject contentType isInvPost
-    -- If there are no procedures with named arguments, fallback to the single unnamed argument procedure
+    -- If there are no functions with named arguments, fallback to the single unnamed argument function
     ([], [proc]) -> Right proc
     ([], procs)  -> Left $ AmbiguousRpc (toList procs)
-    -- Matches the procedures with named arguments
+    -- Matches the functions with named arguments
     ([proc], _)  -> Right proc
     (procs, _)   -> Left $ AmbiguousRpc (toList procs)
   where

--- a/src/PostgREST/Request/ApiRequest.hs
+++ b/src/PostgREST/Request/ApiRequest.hs
@@ -522,7 +522,7 @@ findProc qi argumentsKeys paramsAsSingleObject allProcs contentType isInvPost =
         then length params == 1 && (ppType <$> headMay params) `elem` [Just "json", Just "jsonb"]
       -- If the function has no parameters, the arguments keys must be empty as well
       else if null params
-        then null argumentsKeys
+        then null argumentsKeys && contentType `notElem` [CTTextPlain, CTOctetStream]
       -- A function has optional and required parameters. Optional parameters have a default value and
       -- don't require arguments for the function to be executed, required parameters must have an argument present.
       else case L.partition ppReq params of

--- a/src/PostgREST/Request/ApiRequest.hs
+++ b/src/PostgREST/Request/ApiRequest.hs
@@ -492,7 +492,9 @@ findProc qi argumentsKeys paramsAsSingleObject allProcs contentType isInvPost =
   case matchProc of
     []     -> Left $ NoRpc (qiSchema qi) (qiName qi) (S.toList argumentsKeys) paramsAsSingleObject contentType isInvPost
     [proc] -> Right proc
-    procs  -> Left $ AmbiguousRpc (toList procs)
+    procs  -> case procs of  
+                [proc1,proc2] -> if length (pdParams proc1) == 1 && (ppType <$> headMay (pdParams proc1)) `elem` [Just "json", Just "jsonb"] && (ppName <$> headMay (pdParams proc1)) == Just mempty then Right proc2 else Left $ AmbiguousRpc (toList procs) 
+                _             -> Left $ AmbiguousRpc (toList procs)
   where
     matchProc = filter matchesParams $ M.lookupDefault mempty qi allProcs -- first find the proc by name
     matchesParams proc =

--- a/src/PostgREST/Request/ApiRequest.hs
+++ b/src/PostgREST/Request/ApiRequest.hs
@@ -504,11 +504,11 @@ findProc qi argumentsKeys paramsAsSingleObject allProcs contentType isInvPost =
     overloadedProcPartition procs = foldr select ([],[]) procs
     select proc ~(ts,fs)
       | matchesParams proc         = (proc:ts,fs)
-      | hasSinglaUnnamedParam proc = (ts,proc:fs)
+      | hasSingleUnnamedParam proc = (ts,proc:fs)
       | otherwise                  = (ts,fs)
     -- If the function is called with post and has a single unnamed parameter
     -- it can be called depending on content type and the parameter type
-    hasSinglaUnnamedParam proc = isInvPost && case pdParams proc of
+    hasSingleUnnamedParam proc = isInvPost && case pdParams proc of
       [ProcParam "" ppType _ _]
         | contentType == CTApplicationJSON -> ppType `elem` ["json", "jsonb"]
         | contentType == CTTextPlain       -> ppType == "text"

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -2304,25 +2304,33 @@ $$ language sql;
 
 create or replace function test.unnamed_text_param(text) returns text as $$
   select $1;
-$$ language sql ;
+$$ language sql;
 
 create or replace function test.unnamed_bytea_param(bytea) returns bytea as $$
   select $1::bytea;
-$$ language sql ;
+$$ language sql;
 
 create or replace function test.unnamed_int_param(int) returns int as $$
   select $1;
 $$ language sql;
 
-create or replace function test.overloaded_unnamed_json_param(json) returns json as $$
+create or replace function test.overloaded_unnamed_param(json) returns json as $$
   select $1;
 $$ language sql;
 
-create or replace function test.overloaded_unnamed_json_param() returns int as $$
+create or replace function test.overloaded_unnamed_param(bytea) returns bytea as $$
+select $1;
+$$ language sql;
+
+create or replace function test.overloaded_unnamed_param(text) returns text as $$
+select $1;
+$$ language sql;
+
+create or replace function test.overloaded_unnamed_param() returns int as $$
 select 1;
 $$ language sql;
 
-create or replace function test.overloaded_unnamed_json_param(x int, y int) returns int as $$
+create or replace function test.overloaded_unnamed_param(x int, y int) returns int as $$
   select x + y;
 $$ language sql;
 

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -2314,12 +2314,28 @@ create or replace function test.unnamed_int_param(int) returns int as $$
   select $1;
 $$ language sql;
 
-create or replace function test.overloaded_unnamed_param(json) returns int as $$
+create or replace function test.overloaded_unnamed_json_param(json) returns json as $$
   select $1;
 $$ language sql;
 
-create or replace function test.overloaded_unnamed_param(x int, y int) returns int as $$
+create or replace function test.overloaded_unnamed_json_param() returns int as $$
+select 1;
+$$ language sql;
+
+create or replace function test.overloaded_unnamed_json_param(x int, y int) returns int as $$
   select x + y;
+$$ language sql;
+
+create or replace function test.overloaded_unnamed_json_jsonb_param(json) returns json as $$
+select $1;
+$$ language sql;
+
+create or replace function test.overloaded_unnamed_json_jsonb_param(jsonb) returns jsonb as $$
+select $1;
+$$ language sql;
+
+create or replace function test.overloaded_unnamed_json_jsonb_param(x int, y int) returns int as $$
+select x + y;
 $$ language sql;
 
 create table products(


### PR DESCRIPTION
WIP

Implementing this idea https://github.com/PostgREST/postgrest/pull/1927#discussion_r737776638 to avoid responding with a `300 Multiple Choices` error when doing a POST request to overloaded functions if one has a single unnamed JSON parameter.

The first commit is an ugly attempt, which is working so far (only the test for the overloaded function is failing as expected).