### PR TITLE
Update nixpkgs and stackage to use GHC 8.10.7

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@ let
     "postgrest";
 
   compiler =
-    "ghc8104";
+    "ghc8107";
 
   # PostgREST source files, filtered based on the rules in the .gitignore files
   # and file extensions. We want to include as litte as possible, as the files

--- a/default.nix
+++ b/default.nix
@@ -110,7 +110,7 @@ rec {
   # Tooling for analyzing Haskell imports and exports.
   hsie =
     pkgs.callPackage nix/hsie {
-      ghcWithPackages = pkgs.haskell.packages.ghc884.ghcWithPackages;
+      ghcWithPackages = pkgs.haskell.packages."${compiler}".ghcWithPackages;
     };
 
   ### Tools

--- a/nix/nixpkgs-version.nix
+++ b/nix/nixpkgs-version.nix
@@ -1,6 +1,6 @@
 # Pinned version of Nixpkgs, generated with postgrest-nixpkgs-upgrade.
 {
-  date = "2021-07-17";
-  rev = "d00b5a5fa6fe8bdf7005abb06c46ae0245aec8b5";
-  tarballHash = "08497wbpnf3w5dalcasqzymw3fmcn8qrnbkf8rxxwwvyjdnczxdv";
+  date = "2021-10-31";
+  rev = "9303cc044586dd40599233454f1fd79176584c0f";
+  tarballHash = "0bgdk4zw9m42i3cva55a2bp2z16kd6xchz08vl0zg8d0mr3kk0q3";
 }

--- a/nix/overlays/postgresql-future.nix
+++ b/nix/overlays/postgresql-future.nix
@@ -2,16 +2,18 @@ self: super:
 # Overlay that adds future versions of PostgreSQL that are supported by
 # PostgREST.
 {
-  postgresql_14 =
-    let
-      rev = "76b1e16c6659ccef7187ca69b287525fea133244";
-      tarballHash = "1vsahpcx80k2bgslspb0sa6j4bmhdx77sw6la455drqcrqhdqj6a";
-
-      pinnedPkgs =
-        builtins.fetchTarball {
-          url = "https://github.com/nixos/nixpkgs/archive/${rev}.tar.gz";
-          sha256 = tarballHash;
-        };
-    in
-    (import pinnedPkgs { }).pkgs.postgresql_14;
+  ## Example for including a postgresql version from a specific nixpks commit:
+  ##
+  #  postgresql_14 =
+  #    let
+  #      rev = "76b1e16c6659ccef7187ca69b287525fea133244";
+  #      tarballHash = "1vsahpcx80k2bgslspb0sa6j4bmhdx77sw6la455drqcrqhdqj6a";
+  #
+  #      pinnedPkgs =
+  #        builtins.fetchTarball {
+  #          url = "https://github.com/nixos/nixpkgs/archive/${rev}.tar.gz";
+  #          sha256 = tarballHash;
+  #        };
+  #    in
+  #    (import pinnedPkgs { }).pkgs.postgresql_14;
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.2 # 2021-07-10, GHC 8.10.4
+resolver: lts-18.14 # 2021-10-24, GHC 8.10.7
 
 nix:
   packages:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -27,7 +27,7 @@ packages:
     hackage: ptr-0.16.8.1@sha256:525219ec5f5da5c699725f7efcef91b00a7d44120fc019878b85c09440bf51d6,2686
 snapshots:
 - completed:
-    size: 585392
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/2.yaml
-    sha256: 7abb45c0cc5eb349448b66d8753655542d45d387ad26970419282eab3d860724
-  original: lts-18.2
+    size: 586069
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/14.yaml
+    sha256: 87842ecbaa8ca9cee59a7e6be52369dbed82ed075cb4e0d152614a627e8fd488
+  original: lts-18.14


### PR DESCRIPTION
* Update to latest nixpkgs and stackage
  * Building postgresql with musl yields two failing regression tests that should not impact the libpq library that we link; will investigate ans report to nixpkgs
* Upgrade hsie tooling to same compiler version