### PR TITLE
Nix: Add statix linting for nix code

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -80,8 +80,7 @@ let
       }
     );
 
-  lib =
-    pkgs.haskell.lib;
+  inherit (pkgs.haskell) lib;
 in
 rec {
   inherit nixpkgs pkgs;
@@ -104,13 +103,12 @@ rec {
       )
     );
 
-  env =
-    postgrest.env;
+  inherit (postgrest) env;
 
   # Tooling for analyzing Haskell imports and exports.
   hsie =
     pkgs.callPackage nix/hsie {
-      ghcWithPackages = pkgs.haskell.packages."${compiler}".ghcWithPackages;
+      inherit (pkgs.haskell.packages."${compiler}") ghcWithPackages;
     };
 
   ### Tools
@@ -147,7 +145,7 @@ rec {
     pkgs.callPackage nix/tools/tests.nix {
       inherit postgrest devCabalOptions withTools;
       ghc = pkgs.haskell.compiler."${compiler}";
-      hpc-codecov = pkgs.haskell.packages."${compiler}".hpc-codecov;
+      inherit (pkgs.haskell.packages."${compiler}") hpc-codecov;
     };
 
   withTools =

--- a/nix/nixpkgs-version.nix
+++ b/nix/nixpkgs-version.nix
@@ -1,6 +1,6 @@
 # Pinned version of Nixpkgs, generated with postgrest-nixpkgs-upgrade.
 {
-  date = "2021-10-31";
-  rev = "9303cc044586dd40599233454f1fd79176584c0f";
-  tarballHash = "0bgdk4zw9m42i3cva55a2bp2z16kd6xchz08vl0zg8d0mr3kk0q3";
+  date = "2021-11-02";
+  rev = "7053541084bf5ce2921ef307e5585d39d7ba8b3f";
+  tarballHash = "1flhh5d4zy43x6060hvzjb5hi5cmc51ivc0nwmija9n8d35kcc4x";
 }

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -2,8 +2,7 @@
 
 self: super:
 let
-  lib =
-    self.haskell.lib;
+  inherit (self.haskell) lib;
 
   overrides =
     final: prev:

--- a/nix/tools/nixpkgsTools.nix
+++ b/nix/tools/nixpkgsTools.nix
@@ -14,13 +14,13 @@ let
     "postgrest-nixpkgs-upgrade";
 
   refUrl =
-    https://api.github.com/repos/nixos/nixpkgs/git/ref/heads/nixpkgs-unstable;
+    "https://api.github.com/repos/nixos/nixpkgs/git/ref/heads/nixpkgs-unstable";
 
   githubV3Header =
     "Accept: application/vnd.github.v3+json";
 
   tarballUrlBase =
-    https://github.com/nixos/nixpkgs/archive/;
+    "https://github.com/nixos/nixpkgs/archive/";
 
   upgrade =
     checkedShellScript

--- a/nix/tools/style.nix
+++ b/nix/tools/style.nix
@@ -6,6 +6,7 @@
 , nixpkgs-fmt
 , shellcheck
 , silver-searcher
+, statix
 , stylish-haskell
 }:
 let
@@ -18,6 +19,7 @@ let
       }
       ''
         # Format Nix files
+        ${statix}/bin/statix fix
         ${nixpkgs-fmt}/bin/nixpkgs-fmt . > /dev/null 2> /dev/null
 
         # Format Haskell files

--- a/shell.nix
+++ b/shell.nix
@@ -13,11 +13,9 @@ let
   postgrest =
     import ./default.nix;
 
-  pkgs =
-    postgrest.pkgs;
+  inherit (postgrest) pkgs;
 
-  lib =
-    pkgs.lib;
+  inherit (pkgs) lib;
 
   toolboxes =
     [


### PR DESCRIPTION
https://github.com/nerdypepper/statix is a very promising new linting tool for nix code, it already identified and automatically fixed several improvements in our codebase. Hooked into `postgrest-style`
