### PR TITLE
Refactor: Make import aliases consistent

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -138,7 +138,7 @@ rec {
 
   # Linting and styling tools.
   style =
-    pkgs.callPackage nix/tools/style.nix { };
+    pkgs.callPackage nix/tools/style.nix { inherit hsie; };
 
   # Scripts for running tests.
   tests =

--- a/nix/tools/style.nix
+++ b/nix/tools/style.nix
@@ -3,6 +3,7 @@
 , checkedShellScript
 , git
 , hlint
+, hsie
 , nixpkgs-fmt
 , shellcheck
 , silver-searcher
@@ -53,12 +54,16 @@ let
         inRootDir = true;
       }
       ''
-        # Lint Haskell files
+        echo "Checking consistency of import aliases in Haskell code..."
+        ${hsie} check-aliases main src
+
+
+        echo "Linting Haskell files..."
         # --vimgrep fixes a bug in ag: https://github.com/ggreer/the_silver_searcher/issues/753
         ${silver-searcher}/bin/ag -l --vimgrep -g '\.l?hs$' . \
           | xargs ${hlint}/bin/hlint -X QuasiQuotes -X NoPatternSynonyms
 
-        # Lint bash scripts
+        echo "Linting bash scripts..."
         ${shellcheck}/bin/shellcheck test/with_tmp_db
       '';
 

--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -8,10 +8,10 @@ module PostgREST.CLI
   , readCLIShowHelp
   ) where
 
-import qualified Data.Aeson                 as Aeson
+import qualified Data.Aeson                 as JSON
 import qualified Data.ByteString.Lazy       as LBS
-import qualified Hasql.Pool                 as P
-import qualified Hasql.Transaction.Sessions as HT
+import qualified Hasql.Pool                 as SQL
+import qualified Hasql.Transaction.Sessions as SQL
 import qualified Options.Applicative        as O
 import qualified Protolude.Conv             as Conv
 
@@ -54,19 +54,19 @@ dumpSchema :: AppState -> IO LBS.ByteString
 dumpSchema appState = do
   AppConfig{..} <- AppState.getConfig appState
   result <-
-    let transaction = if configDbPreparedStatements then HT.transaction else HT.unpreparedTransaction in
-    P.use (AppState.getPool appState) $
-      transaction HT.ReadCommitted HT.Read $
+    let transaction = if configDbPreparedStatements then SQL.transaction else SQL.unpreparedTransaction in
+    SQL.use (AppState.getPool appState) $
+      transaction SQL.ReadCommitted SQL.Read $
         queryDbStructure
           (toList configDbSchemas)
           configDbExtraSearchPath
           configDbPreparedStatements
-  P.release $ AppState.getPool appState
+  SQL.release $ AppState.getPool appState
   case result of
     Left e -> do
       hPutStrLn stderr $ "An error ocurred when loading the schema cache:\n" <> show e
       exitFailure
-    Right dbStructure -> return $ Aeson.encode dbStructure
+    Right dbStructure -> return $ JSON.encode dbStructure
 
 -- | Command line interface options
 data CLI = CLI

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -29,9 +29,8 @@ module PostgREST.Config
 import qualified Crypto.JOSE.Types      as JOSE
 import qualified Crypto.JWT             as JWT
 import qualified Data.Aeson             as JSON
-import qualified Data.ByteString        as B
+import qualified Data.ByteString        as BS
 import qualified Data.ByteString.Base64 as B64
-import qualified Data.ByteString.Char8  as BS
 import qualified Data.Configurator      as C
 import qualified Data.Map.Strict        as M
 import qualified Data.Text              as T
@@ -86,12 +85,12 @@ data AppConfig = AppConfig
   , configJWKS                  :: Maybe JWKSet
   , configJwtAudience           :: Maybe StringOrURI
   , configJwtRoleClaimKey       :: JSPath
-  , configJwtSecret             :: Maybe B.ByteString
+  , configJwtSecret             :: Maybe BS.ByteString
   , configJwtSecretIsBase64     :: Bool
   , configLogLevel              :: LogLevel
   , configOpenApiMode           :: OpenAPIMode
   , configOpenApiServerProxyUri :: Maybe Text
-  , configRawMediaTypes         :: [B.ByteString]
+  , configRawMediaTypes         :: [BS.ByteString]
   , configServerHost            :: Text
   , configServerPort            :: Int
   , configServerUnixSocket      :: Maybe FilePath
@@ -144,7 +143,7 @@ toText conf =
       ,("log-level",                 q . show . configLogLevel)
       ,("openapi-mode",              q . show . configOpenApiMode)
       ,("openapi-server-proxy-uri",  q . fromMaybe mempty . configOpenApiServerProxyUri)
-      ,("raw-media-types",           q . toS . B.intercalate "," . configRawMediaTypes)
+      ,("raw-media-types",           q . toS . BS.intercalate "," . configRawMediaTypes)
       ,("server-host",               q . configServerHost)
       ,("server-port",                   show . configServerPort)
       ,("server-unix-socket",        q . maybe mempty T.pack . configServerUnixSocket)

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -17,9 +17,9 @@ module PostgREST.Error
 
 import qualified Data.Aeson                as JSON
 import qualified Data.Text                 as T
-import qualified Hasql.Pool                as P
-import qualified Hasql.Session             as H
-import qualified Network.HTTP.Types.Status as HT
+import qualified Hasql.Pool                as SQL
+import qualified Hasql.Session             as SQL
+import qualified Network.HTTP.Types.Status as HTTP
 
 import Data.Aeson  ((.=))
 import Network.Wai (Response, responseLBS)
@@ -41,7 +41,7 @@ import Protolude.Conv (toS, toSL)
 
 
 class (JSON.ToJSON a) => PgrstError a where
-  status   :: a -> HT.Status
+  status   :: a -> HTTP.Status
   headers  :: a -> [Header]
 
   errorPayload :: a -> LByteString
@@ -67,18 +67,18 @@ data ApiRequestError
   | UnsupportedVerb                -- Unreachable?
 
 instance PgrstError ApiRequestError where
-  status InvalidRange            = HT.status416
-  status InvalidFilters          = HT.status405
-  status (InvalidBody _)         = HT.status400
-  status UnsupportedVerb         = HT.status405
-  status ActionInappropriate     = HT.status405
-  status (ParseRequestError _ _) = HT.status400
-  status (NoRelBetween _ _)      = HT.status400
-  status AmbiguousRelBetween{}   = HT.status300
-  status (AmbiguousRpc _)        = HT.status300
-  status NoRpc{}                 = HT.status404
-  status (UnacceptableSchema _)  = HT.status406
-  status (ContentTypeError _)    = HT.status415
+  status InvalidRange            = HTTP.status416
+  status InvalidFilters          = HTTP.status405
+  status (InvalidBody _)         = HTTP.status400
+  status UnsupportedVerb         = HTTP.status405
+  status ActionInappropriate     = HTTP.status405
+  status (ParseRequestError _ _) = HTTP.status400
+  status (NoRelBetween _ _)      = HTTP.status400
+  status AmbiguousRelBetween{}   = HTTP.status300
+  status (AmbiguousRpc _)        = HTTP.status300
+  status NoRpc{}                 = HTTP.status404
+  status (UnacceptableSchema _)  = HTTP.status406
+  status (ContentTypeError _)    = HTTP.status415
 
   headers _ = [ContentType.toHeader CTApplicationJSON]
 
@@ -145,32 +145,32 @@ compressedRel Relationship{..} =
       , "relationship" .= (cons <> fmtEls (colName <$> relColumns) <> fmtEls (colName <$> relForeignColumns))
       ]
 
-data PgError = PgError Authenticated P.UsageError
+data PgError = PgError Authenticated SQL.UsageError
 type Authenticated = Bool
 
 instance PgrstError PgError where
   status (PgError authed usageError) = pgErrorStatus authed usageError
 
   headers err =
-    if status err == HT.status401
+    if status err == HTTP.status401
        then [ContentType.toHeader CTApplicationJSON, ("WWW-Authenticate", "Bearer") :: Header]
        else [ContentType.toHeader CTApplicationJSON]
 
 instance JSON.ToJSON PgError where
   toJSON (PgError _ usageError) = JSON.toJSON usageError
 
-instance JSON.ToJSON P.UsageError where
-  toJSON (P.ConnectionError e) = JSON.object [
+instance JSON.ToJSON SQL.UsageError where
+  toJSON (SQL.ConnectionError e) = JSON.object [
     "code"    .= ("" :: Text),
     "message" .= ("Database connection error. Retrying the connection." :: Text),
     "details" .= (toSL $ fromMaybe "" e :: Text)]
-  toJSON (P.SessionError e) = JSON.toJSON e -- H.Error
+  toJSON (SQL.SessionError e) = JSON.toJSON e -- SQL.Error
 
-instance JSON.ToJSON H.QueryError where
-  toJSON (H.QueryError _ _ e) = JSON.toJSON e
+instance JSON.ToJSON SQL.QueryError where
+  toJSON (SQL.QueryError _ _ e) = JSON.toJSON e
 
-instance JSON.ToJSON H.CommandError where
-  toJSON (H.ResultError (H.ServerError c m d h)) = case toS c of
+instance JSON.ToJSON SQL.CommandError where
+  toJSON (SQL.ResultError (SQL.ServerError c m d h)) = case toS c of
     'P':'T':_ -> JSON.object [
         "details" .= (fmap toS d :: Maybe Text),
         "hint"    .= (fmap toS h :: Maybe Text)]
@@ -181,86 +181,86 @@ instance JSON.ToJSON H.CommandError where
         "details" .= (fmap toS d :: Maybe Text),
         "hint"    .= (fmap toS h :: Maybe Text)]
 
-  toJSON (H.ResultError (H.UnexpectedResult m)) = JSON.object [
+  toJSON (SQL.ResultError (SQL.UnexpectedResult m)) = JSON.object [
     "message" .= (m :: Text)]
-  toJSON (H.ResultError (H.RowError i H.EndOfInput)) = JSON.object [
+  toJSON (SQL.ResultError (SQL.RowError i SQL.EndOfInput)) = JSON.object [
     "message" .= ("Row error: end of input" :: Text),
     "details" .= ("Attempt to parse more columns than there are in the result" :: Text),
     "hint"    .= (("Row number " <> show i) :: Text)]
-  toJSON (H.ResultError (H.RowError i H.UnexpectedNull)) = JSON.object [
+  toJSON (SQL.ResultError (SQL.RowError i SQL.UnexpectedNull)) = JSON.object [
     "message" .= ("Row error: unexpected null" :: Text),
     "details" .= ("Attempt to parse a NULL as some value." :: Text),
     "hint"    .= (("Row number " <> show i) :: Text)]
-  toJSON (H.ResultError (H.RowError i (H.ValueError d))) = JSON.object [
+  toJSON (SQL.ResultError (SQL.RowError i (SQL.ValueError d))) = JSON.object [
     "message" .= ("Row error: Wrong value parser used" :: Text),
     "details" .= d,
     "hint"    .= (("Row number " <> show i) :: Text)]
-  toJSON (H.ResultError (H.UnexpectedAmountOfRows i)) = JSON.object [
+  toJSON (SQL.ResultError (SQL.UnexpectedAmountOfRows i)) = JSON.object [
     "message" .= ("Unexpected amount of rows" :: Text),
     "details" .= i]
-  toJSON (H.ClientError d) = JSON.object [
+  toJSON (SQL.ClientError d) = JSON.object [
     "message" .= ("Database client error. Retrying the connection." :: Text),
     "details" .= (fmap toS d :: Maybe Text)]
 
-pgErrorStatus :: Bool -> P.UsageError -> HT.Status
-pgErrorStatus _      (P.ConnectionError _)                                      = HT.status503
-pgErrorStatus _      (P.SessionError (H.QueryError _ _ (H.ClientError _)))      = HT.status503
-pgErrorStatus authed (P.SessionError (H.QueryError _ _ (H.ResultError rError))) =
+pgErrorStatus :: Bool -> SQL.UsageError -> HTTP.Status
+pgErrorStatus _      (SQL.ConnectionError _)                                      = HTTP.status503
+pgErrorStatus _      (SQL.SessionError (SQL.QueryError _ _ (SQL.ClientError _)))      = HTTP.status503
+pgErrorStatus authed (SQL.SessionError (SQL.QueryError _ _ (SQL.ResultError rError))) =
   case rError of
-    (H.ServerError c m _ _) ->
+    (SQL.ServerError c m _ _) ->
       case toS c of
-        '0':'8':_ -> HT.status503 -- pg connection err
-        '0':'9':_ -> HT.status500 -- triggered action exception
-        '0':'L':_ -> HT.status403 -- invalid grantor
-        '0':'P':_ -> HT.status403 -- invalid role specification
-        "23503"   -> HT.status409 -- foreign_key_violation
-        "23505"   -> HT.status409 -- unique_violation
-        "25006"   -> HT.status405 -- read_only_sql_transaction
-        '2':'5':_ -> HT.status500 -- invalid tx state
-        '2':'8':_ -> HT.status403 -- invalid auth specification
-        '2':'D':_ -> HT.status500 -- invalid tx termination
-        '3':'8':_ -> HT.status500 -- external routine exception
-        '3':'9':_ -> HT.status500 -- external routine invocation
-        '3':'B':_ -> HT.status500 -- savepoint exception
-        '4':'0':_ -> HT.status500 -- tx rollback
-        '5':'3':_ -> HT.status503 -- insufficient resources
-        '5':'4':_ -> HT.status413 -- too complex
-        '5':'5':_ -> HT.status500 -- obj not on prereq state
-        '5':'7':_ -> HT.status500 -- operator intervention
-        '5':'8':_ -> HT.status500 -- system error
-        'F':'0':_ -> HT.status500 -- conf file error
-        'H':'V':_ -> HT.status500 -- foreign data wrapper error
-        "P0001"   -> HT.status400 -- default code for "raise"
-        'P':'0':_ -> HT.status500 -- PL/pgSQL Error
-        'X':'X':_ -> HT.status500 -- internal Error
-        "42883"   -> HT.status404 -- undefined function
-        "42P01"   -> HT.status404 -- undefined table
-        "42501"   -> if authed then HT.status403 else HT.status401 -- insufficient privilege
-        'P':'T':n -> fromMaybe HT.status500 (HT.mkStatus <$> readMaybe n <*> pure m)
-        _         -> HT.status400
+        '0':'8':_ -> HTTP.status503 -- pg connection err
+        '0':'9':_ -> HTTP.status500 -- triggered action exception
+        '0':'L':_ -> HTTP.status403 -- invalid grantor
+        '0':'P':_ -> HTTP.status403 -- invalid role specification
+        "23503"   -> HTTP.status409 -- foreign_key_violation
+        "23505"   -> HTTP.status409 -- unique_violation
+        "25006"   -> HTTP.status405 -- read_only_sql_transaction
+        '2':'5':_ -> HTTP.status500 -- invalid tx state
+        '2':'8':_ -> HTTP.status403 -- invalid auth specification
+        '2':'D':_ -> HTTP.status500 -- invalid tx termination
+        '3':'8':_ -> HTTP.status500 -- external routine exception
+        '3':'9':_ -> HTTP.status500 -- external routine invocation
+        '3':'B':_ -> HTTP.status500 -- savepoint exception
+        '4':'0':_ -> HTTP.status500 -- tx rollback
+        '5':'3':_ -> HTTP.status503 -- insufficient resources
+        '5':'4':_ -> HTTP.status413 -- too complex
+        '5':'5':_ -> HTTP.status500 -- obj not on prereq state
+        '5':'7':_ -> HTTP.status500 -- operator intervention
+        '5':'8':_ -> HTTP.status500 -- system error
+        'F':'0':_ -> HTTP.status500 -- conf file error
+        'H':'V':_ -> HTTP.status500 -- foreign data wrapper error
+        "P0001"   -> HTTP.status400 -- default code for "raise"
+        'P':'0':_ -> HTTP.status500 -- PL/pgSQL Error
+        'X':'X':_ -> HTTP.status500 -- internal Error
+        "42883"   -> HTTP.status404 -- undefined function
+        "42P01"   -> HTTP.status404 -- undefined table
+        "42501"   -> if authed then HTTP.status403 else HTTP.status401 -- insufficient privilege
+        'P':'T':n -> fromMaybe HTTP.status500 (HTTP.mkStatus <$> readMaybe n <*> pure m)
+        _         -> HTTP.status400
 
-    _                       -> HT.status500
+    _                       -> HTTP.status500
 
 checkIsFatal :: PgError -> Maybe Text
-checkIsFatal (PgError _ (P.ConnectionError e))
+checkIsFatal (PgError _ (SQL.ConnectionError e))
   | isAuthFailureMessage = Just $ toS failureMessage
   | otherwise = Nothing
   where isAuthFailureMessage = "FATAL:  password authentication failed" `isPrefixOf` toS failureMessage
         failureMessage = fromMaybe mempty e
-checkIsFatal (PgError _ (P.SessionError (H.QueryError _ _ (H.ResultError serverError))))
+checkIsFatal (PgError _ (SQL.SessionError (SQL.QueryError _ _ (SQL.ResultError serverError))))
   = case serverError of
       -- Check for a syntax error (42601 is the pg code). This would mean the error is on our part somehow, so we treat it as fatal.
-      H.ServerError "42601" _ _ _
+      SQL.ServerError "42601" _ _ _
         -> Just "Hint: This is probably a bug in PostgREST, please report it at https://github.com/PostgREST/postgrest/issues"
       -- Check for a "prepared statement <name> already exists" error (Code 42P05: duplicate_prepared_statement).
       -- This would mean that a connection pooler in transaction mode is being used
       -- while prepared statements are enabled in the PostgREST configuration,
       -- both of which are incompatible with each other.
-      H.ServerError "42P05" _ _ _
+      SQL.ServerError "42P05" _ _ _
         -> Just "Hint: If you are using connection poolers in transaction mode, try setting db-prepared-statements to false."
       -- Check for a "transaction blocks not allowed in statement pooling mode" error (Code 08P01: protocol_violation).
       -- This would mean that a connection pooler in statement mode is being used which is not supported in PostgREST.
-      H.ServerError "08P01" "transaction blocks not allowed in statement pooling mode" _ _
+      SQL.ServerError "08P01" "transaction blocks not allowed in statement pooling mode" _ _
         -> Just "Hint: Connection poolers in statement mode are not supported."
       _ -> Nothing
 checkIsFatal _ = Nothing
@@ -281,16 +281,16 @@ data Error
   | PgErr PgError
 
 instance PgrstError Error where
-  status GucHeadersError         = HT.status500
-  status GucStatusError          = HT.status500
-  status (BinaryFieldError _)    = HT.status406
-  status ConnectionLostError     = HT.status503
-  status PutMatchingPkError      = HT.status400
-  status PutRangeNotAllowedError = HT.status400
-  status JwtTokenMissing         = HT.status500
-  status (JwtTokenInvalid _)     = HT.unauthorized401
-  status (SingularityError _)    = HT.status406
-  status NotFound                = HT.status404
+  status GucHeadersError         = HTTP.status500
+  status GucStatusError          = HTTP.status500
+  status (BinaryFieldError _)    = HTTP.status406
+  status ConnectionLostError     = HTTP.status503
+  status PutMatchingPkError      = HTTP.status400
+  status PutRangeNotAllowedError = HTTP.status400
+  status JwtTokenMissing         = HTTP.status500
+  status (JwtTokenInvalid _)     = HTTP.unauthorized401
+  status (SingularityError _)    = HTTP.status406
+  status NotFound                = HTTP.status404
   status (PgErr err)             = status err
   status (ApiRequestError err)   = status err
 

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -9,7 +9,7 @@ module PostgREST.OpenAPI (encode) where
 
 import qualified Data.Aeson           as JSON
 import qualified Data.ByteString.Lazy as LBS
-import qualified Data.HashMap.Strict  as HashMap
+import qualified Data.HashMap.Strict  as M
 import qualified Data.HashSet.InsOrd  as Set
 import qualified Data.Text            as T
 
@@ -40,12 +40,12 @@ import PostgREST.ContentType
 import Protolude      hiding (Proxy, get, toS)
 import Protolude.Conv (toS)
 
-encode :: AppConfig -> DbStructure -> [Table] -> HashMap.HashMap k [ProcDescription] -> Maybe Text -> LBS.ByteString
+encode :: AppConfig -> DbStructure -> [Table] -> M.HashMap k [ProcDescription] -> Maybe Text -> LBS.ByteString
 encode conf dbStructure tables procs schemaDescription =
   JSON.encode $
     postgrestSpec
       (dbRelationships dbStructure)
-      (concat $ HashMap.elems procs)
+      (concat $ M.elems procs)
       (openApiTableInfo dbStructure <$> tables)
       (proxyUri conf)
       schemaDescription

--- a/src/PostgREST/Request/ApiRequest.hs
+++ b/src/PostgREST/Request/ApiRequest.hs
@@ -19,7 +19,7 @@ module PostgREST.Request.ApiRequest
 
 import qualified Data.Aeson           as JSON
 import qualified Data.ByteString      as BS
-import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString.Lazy as LBS
 import qualified Data.CaseInsensitive as CI
 import qualified Data.Csv             as CSV
 import qualified Data.HashMap.Strict  as M
@@ -72,11 +72,11 @@ import Protolude      hiding (head, toS)
 import Protolude.Conv (toS)
 
 
-type RequestBody = BL.ByteString
+type RequestBody = LBS.ByteString
 
 data Payload
   = ProcessedJSON -- ^ Cached attributes of a JSON payload
-      { payRaw  :: BL.ByteString
+      { payRaw  :: LBS.ByteString
       -- ^ This is the raw ByteString that comes from the request body.  We
       -- cache this instead of an Aeson Value because it was detected that for
       -- large payloads the encoding had high memory usage, see
@@ -85,8 +85,8 @@ data Payload
       -- ^ Keys of the object or if it's an array these keys are guaranteed to
       -- be the same across all its objects
       }
-  | RawJSON { payRaw  :: BL.ByteString }
-  | RawPay  { payRaw  :: BL.ByteString }
+  | RawJSON { payRaw  :: LBS.ByteString }
+  | RawPay  { payRaw  :: LBS.ByteString }
 
 data InvokeMethod = InvHead | InvGet | InvPost deriving Eq
 -- | Types of things a user wants to do to tables/views/procs
@@ -273,7 +273,7 @@ userApiRequest conf@AppConfig{..} dbStructure req reqBody
       if isJust columns
         then Right $ RawJSON reqBody
         else note "All object keys must match" . payloadAttributes reqBody
-               =<< if BL.null reqBody && isTargetingProc
+               =<< if LBS.null reqBody && isTargetingProc
                      then Right emptyObject
                      else JSON.eitherDecode reqBody
     CTTextCSV -> do
@@ -406,7 +406,7 @@ mutuallyAgreeable sProduces cAccepts =
      then listToMaybe sProduces
      else exact
 
-type CsvData = V.Vector (M.HashMap Text BL.ByteString)
+type CsvData = V.Vector (M.HashMap Text LBS.ByteString)
 
 {-|
   Converts CSV like

--- a/src/PostgREST/Request/Types.hs
+++ b/src/PostgREST/Request/Types.hs
@@ -34,7 +34,7 @@ module PostgREST.Request.Types
   , fstFieldNames
   ) where
 
-import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Set             as S
 
 import Data.Tree (Tree (..))
@@ -110,7 +110,7 @@ data MutateQuery
   = Insert
       { in_        :: QualifiedIdentifier
       , insCols    :: S.Set FieldName
-      , insBody    :: Maybe BL.ByteString
+      , insBody    :: Maybe LBS.ByteString
       , onConflict :: Maybe (PreferResolution, [FieldName])
       , where_     :: [LogicTree]
       , returning  :: [FieldName]
@@ -118,7 +118,7 @@ data MutateQuery
   | Update
       { in_       :: QualifiedIdentifier
       , updCols   :: S.Set FieldName
-      , updBody   :: Maybe BL.ByteString
+      , updBody   :: Maybe LBS.ByteString
       , where_    :: [LogicTree]
       , returning :: [FieldName]
       }
@@ -131,7 +131,7 @@ data MutateQuery
 data CallQuery = FunctionCall
   { funCQi           :: QualifiedIdentifier
   , funCParams       :: CallParams
-  , funCArgs         :: Maybe BL.ByteString
+  , funCArgs         :: Maybe LBS.ByteString
   , funCScalar       :: Bool
   , funCMultipleCall :: Bool
   , funCReturning    :: [FieldName]


### PR DESCRIPTION
This is an item on our refactoring roadmap: https://github.com/PostgREST/postgrest/issues/1804

Our Haskell Import/Export tool `hsie` is able to check whether we use consistent aliases when importing modules. Before this PR, when running `hsie check-aliases main src` we get:

```
The following imports have inconsistent aliases:               

Module 'Data.Aeson' has the aliases:
  'Aeson' in file:
    src/PostgREST/CLI.hs
  'JSON' in files:
    src/PostgREST/Auth.hs
    src/PostgREST/Config.hs
    src/PostgREST/Config/PgVersion.hs
    src/PostgREST/DbStructure.hs
    src/PostgREST/DbStructure/Identifiers.hs
    src/PostgREST/DbStructure/Proc.hs
    src/PostgREST/DbStructure/Relationship.hs
    src/PostgREST/DbStructure/Table.hs
    src/PostgREST/Error.hs
    src/PostgREST/GucHeader.hs
    src/PostgREST/Middleware.hs
    src/PostgREST/OpenAPI.hs
    src/PostgREST/Query/Statements.hs
    src/PostgREST/Request/ApiRequest.hs
    src/PostgREST/Workers.hs

Module 'Data.ByteString' has the aliases:
  'B' in file:
    src/PostgREST/Config.hs
  'BS' in files:
    src/PostgREST/ContentType.hs
    src/PostgREST/Request/ApiRequest.hs
    src/PostgREST/Workers.hs

Module 'Data.ByteString.Char8' has the aliases:
  'BS' in files:
    src/PostgREST/Config.hs
    src/PostgREST/Middleware.hs
    src/PostgREST/Query/QueryBuilder.hs
    src/PostgREST/Query/SqlFragment.hs
    src/PostgREST/Query/Statements.hs
    src/PostgREST/RangeQuery.hs
  'BS8' in file:
    src/PostgREST/App.hs

Module 'Data.ByteString.Lazy' has the aliases:
  'BL' in files:
    src/PostgREST/Query/SqlFragment.hs
    src/PostgREST/Request/ApiRequest.hs
    src/PostgREST/Request/Types.hs
  'LBS' in files:
    src/PostgREST/App.hs
    src/PostgREST/CLI.hs
    src/PostgREST/OpenAPI.hs

Module 'Data.HashMap.Strict' has the aliases:
  'HM' in file:
    src/PostgREST/Query/SqlFragment.hs
  'HashMap' in file:
    src/PostgREST/OpenAPI.hs
  'M' in files:
    src/PostgREST/Auth.hs
    src/PostgREST/DbStructure.hs
    src/PostgREST/DbStructure/Proc.hs
    src/PostgREST/GucHeader.hs
    src/PostgREST/Middleware.hs
    src/PostgREST/Request/ApiRequest.hs
    src/PostgREST/Request/DbRequestBuilder.hs
    src/PostgREST/Request/Parsers.hs
  'Map' in file:
    src/PostgREST/App.hs

Module 'Data.Set' has the aliases:
  'S' in files:
    src/PostgREST/DbStructure.hs
    src/PostgREST/Query/QueryBuilder.hs
    src/PostgREST/Request/ApiRequest.hs
    src/PostgREST/Request/DbRequestBuilder.hs
    src/PostgREST/Request/Parsers.hs
    src/PostgREST/Request/Types.hs
  'Set' in file:
    src/PostgREST/App.hs

Module 'Hasql.DynamicStatements.Snippet' has the aliases:
  'H' in files:
    src/PostgREST/Middleware.hs
    src/PostgREST/Query/QueryBuilder.hs
    src/PostgREST/Query/SqlFragment.hs
    src/PostgREST/Query/Statements.hs
  'SQL' in file:
    src/PostgREST/App.hs

Module 'Hasql.Pool' has the aliases:
  'P' in files:
    src/PostgREST/AppState.hs
    src/PostgREST/CLI.hs
    src/PostgREST/Config/Database.hs
    src/PostgREST/Error.hs
    src/PostgREST/Workers.hs
  'SQL' in file:
    src/PostgREST/App.hs

Module 'Hasql.Transaction' has the aliases:
  'H' in file:
    src/PostgREST/Middleware.hs
  'HT' in file:
    src/PostgREST/Config/Database.hs
    src/PostgREST/DbStructure.hs
  'SQL' in file:
    src/PostgREST/App.hs

Module 'Hasql.Transaction.Sessions' has the aliases:
  'HT' in files:
    src/PostgREST/CLI.hs
    src/PostgREST/Config/Database.hs
    src/PostgREST/Workers.hs
  'SQL' in file:
    src/PostgREST/App.hs

Module 'Network.HTTP.Types.Status' has the aliases:
  'HT' in file:
    src/PostgREST/Error.hs
  'HTTP' in file:
    src/PostgREST/App.hs

```

This PR hooks `hsie check-aliases` into `postgrest-lint`, and therefore our CI, and proposes fixes to make the import aliases consistent.

Note: In `Config.hs`, I replaced the functions `readFile` and `stripPrefix` from `Data.ByteString.Char8` with the ones from `Data.ByteString` - they are [identical](https://github.com/haskell/bytestring/blob/11af63eab5945d2ac5aa39bcadc5f8bfa17f3a6d/Data/ByteString/Char8.hs#L255-L259)