### PR TITLE
Refactor: Remove (mis)uses of GHC.Show instances

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -76,7 +76,8 @@ import PostgREST.Request.ApiRequest      (Action (..),
                                           Target (..))
 import PostgREST.Request.Preferences     (PreferCount (..),
                                           PreferParameters (..),
-                                          PreferRepresentation (..))
+                                          PreferRepresentation (..),
+                                          toAppliedHeader)
 import PostgREST.Request.Types           (ReadRequest, fstFieldNames)
 import PostgREST.Version                 (prettyVersion)
 import PostgREST.Workers                 (connectionWorker, listener)
@@ -322,7 +323,7 @@ handleCreate identifier@QualifiedIdentifier{..} context@RequestContext{..} = do
         , if null pkCols && isNothing iOnConflict then
             Nothing
           else
-            (\x -> ("Preference-Applied", BS.pack $ show x)) <$> iPreferResolution
+            toAppliedHeader <$> iPreferResolution
         ]
 
   failNotSingular iAcceptContentType resQueryTotal $

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -50,7 +50,7 @@ import System.Environment      (getEnvironment)
 import System.Posix.Types      (FileMode)
 
 import PostgREST.Config.JSPath           (JSPath, JSPathExp (..),
-                                          pRoleClaimKey)
+                                          dumpJSPath, pRoleClaimKey)
 import PostgREST.Config.Proxy            (Proxy (..),
                                           isMalformedProxyUri, toURI)
 import PostgREST.DbStructure.Identifiers (QualifiedIdentifier, dumpQi,
@@ -100,10 +100,10 @@ data LogLevel = LogCrit | LogError | LogWarn | LogInfo
 
 dumpLogLevel :: LogLevel -> Text
 dumpLogLevel = \case
-  LogCrit -> "crit"
+  LogCrit  -> "crit"
   LogError -> "error"
-  LogWarn -> "warn"
-  LogInfo -> "info"
+  LogWarn  -> "warn"
+  LogInfo  -> "info"
 
 data OpenAPIMode = OAFollowPriv | OAIgnorePriv | OADisabled
   deriving Eq
@@ -138,7 +138,7 @@ toText conf =
       ,("db-embed-default-join",     q . dumpJoin . configDbEmbedDefaultJoin)
       ,("db-use-legacy-gucs",            T.toLower . show . configDbUseLegacyGucs)
       ,("jwt-aud",                       toS . encode . maybe "" toJSON . configJwtAudience)
-      ,("jwt-role-claim-key",        q . T.intercalate mempty . fmap show . configJwtRoleClaimKey)
+      ,("jwt-role-claim-key",        q . T.intercalate mempty . fmap dumpJSPath . configJwtRoleClaimKey)
       ,("jwt-secret",                q . toS . showJwtSecret)
       ,("jwt-secret-is-base64",          T.toLower . show . configJwtSecretIsBase64)
       ,("log-level",                 q . dumpLogLevel . configLogLevel)

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -134,7 +134,7 @@ toText conf =
       ,("db-config",                 q . T.toLower . show . configDbConfig)
       ,("db-tx-end",                 q . showTxEnd)
       ,("db-uri",                    q . configDbUri)
-      ,("db-embed-default-join",     q . show . configDbEmbedDefaultJoin)
+      ,("db-embed-default-join",     q . innerJoin . configDbEmbedDefaultJoin)
       ,("db-use-legacy-gucs",            T.toLower . show . configDbUseLegacyGucs)
       ,("jwt-aud",                       toS . encode . maybe "" toJSON . configJwtAudience)
       ,("jwt-role-claim-key",        q . T.intercalate mempty . fmap show . configJwtRoleClaimKey)
@@ -167,6 +167,9 @@ toText conf =
       where
         secret = fromMaybe mempty $ configJwtSecret c
     showSocketMode c = showOct (configServerUnixSocketMode c) mempty
+
+    innerJoin JTInner = "inner"
+    innerJoin JTLeft = "left"
 
 -- This class is needed for the polymorphism of overrideFromDbOrEnvironment
 -- because C.required and C.optional have different signatures

--- a/src/PostgREST/Config/JSPath.hs
+++ b/src/PostgREST/Config/JSPath.hs
@@ -1,12 +1,7 @@
-{-|
-Module      : PostgREST.Types
-Description : PostgREST common types and functions used by the rest of the modules
--}
-{-# LANGUAGE DuplicateRecordFields #-}
-
 module PostgREST.Config.JSPath
   ( JSPath
   , JSPathExp(..)
+  , dumpJSPath
   , pRoleClaimKey
   ) where
 
@@ -15,8 +10,6 @@ import qualified Text.ParserCombinators.Parsec as P
 import Data.Either.Combinators       (mapLeft)
 import Text.ParserCombinators.Parsec ((<?>))
 import Text.Read                     (read)
-
-import qualified GHC.Show (show)
 
 import Protolude      hiding (toS)
 import Protolude.Conv (toS)
@@ -30,10 +23,10 @@ data JSPathExp
   = JSPKey Text
   | JSPIdx Int
 
-instance Show JSPathExp where
-  -- TODO: this needs to be quoted properly for special chars
-  show (JSPKey k) = "." <> show k
-  show (JSPIdx i) = "[" <> show i <> "]"
+dumpJSPath :: JSPathExp -> Text
+-- TODO: this needs to be quoted properly for special chars
+dumpJSPath (JSPKey k) = "." <> show k
+dumpJSPath (JSPIdx i) = "[" <> show i <> "]"
 
 -- Used for the config value "role-claim-key"
 pRoleClaimKey :: Text -> Either Text JSPath

--- a/src/PostgREST/DbStructure/Identifiers.hs
+++ b/src/PostgREST/DbStructure/Identifiers.hs
@@ -6,12 +6,12 @@ module PostgREST.DbStructure.Identifiers
   , Schema
   , TableName
   , FieldName
+  , dumpQi
   , toQi
   ) where
 
 import qualified Data.Aeson as JSON
 import qualified Data.Text  as T
-import qualified GHC.Show
 
 import Protolude
 
@@ -26,9 +26,9 @@ data QualifiedIdentifier = QualifiedIdentifier
 
 instance Hashable QualifiedIdentifier
 
-instance Show QualifiedIdentifier where
-  show (QualifiedIdentifier s i) =
-    (if T.null s then mempty else toS s <> ".") <> toS i
+dumpQi :: QualifiedIdentifier -> Text
+dumpQi (QualifiedIdentifier s i) =
+  (if T.null s then mempty else s <> ".") <> i
 
 -- TODO: Handle a case where the QI comes like this: "my.fav.schema"."my.identifier"
 -- Right now it only handles the schema.identifier case

--- a/src/PostgREST/Middleware.hs
+++ b/src/PostgREST/Middleware.hs
@@ -23,7 +23,6 @@ import qualified Hasql.DynamicStatements.Snippet      as SQL hiding
                                                              (sql)
 import qualified Hasql.DynamicStatements.Statement    as SQL
 import qualified Hasql.Transaction                    as SQL
-import qualified Network.HTTP.Types.Header            as HTTP
 import qualified Network.Wai                          as Wai
 import qualified Network.Wai.Logger                   as Wai
 import qualified Network.Wai.Middleware.Cors          as Wai
@@ -182,10 +181,10 @@ optionalRollback AppConfig{..} ApiRequest{..} transaction = do
     preferenceApplied
       | shouldCommit =
           addHeadersIfNotIncluded
-            [(HTTP.hPreferenceApplied, BS.pack (show Commit))]
+            [toAppliedHeader Commit]
       | shouldRollback =
           addHeadersIfNotIncluded
-            [(HTTP.hPreferenceApplied, BS.pack (show Rollback))]
+            [toAppliedHeader Rollback]
       | otherwise =
           identity
 

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -52,12 +52,15 @@ import PostgREST.DbStructure.Identifiers (FieldName,
 import PostgREST.RangeQuery              (NonnegRange, allRange,
                                           rangeLimit, rangeOffset)
 import PostgREST.Request.Types           (Alias, Field, Filter (..),
-                                          OrderNulls(..), OrderDirection(..), LogicOperator(..),
                                           JoinCondition (..),
                                           JsonOperand (..),
                                           JsonOperation (..),
-                                          JsonPath, LogicTree (..),
-                                          OpExpr (..), Operation (..),
+                                          JsonPath,
+                                          LogicOperator (..),
+                                          LogicTree (..), OpExpr (..),
+                                          Operation (..),
+                                          OrderDirection (..),
+                                          OrderNulls (..),
                                           OrderTerm (..), SelectItem)
 
 import Protolude      hiding (cast, toS)
@@ -268,7 +271,7 @@ pgFmtLogicTree qi (Expr hasNot op forest) = SQL.sql notOp <> " (" <> intercalate
     notOp =  if hasNot then "NOT" else mempty
 
     opSql And = " AND "
-    opSql Or = " OR "
+    opSql Or  = " OR "
 pgFmtLogicTree qi (Stmnt flt) = pgFmtFilter qi flt
 
 pgFmtJsonPath :: JsonPath -> SQL.Snippet

--- a/src/PostgREST/Request/ApiRequest.hs
+++ b/src/PostgREST/Request/ApiRequest.hs
@@ -65,7 +65,7 @@ import PostgREST.Request.Preferences     (PreferCount (..),
                                           PreferResolution (..),
                                           PreferTransaction (..))
 
-import qualified PostgREST.ContentType as ContentType
+import qualified PostgREST.ContentType         as ContentType
 import qualified PostgREST.Request.Preferences as Preferences
 
 import Protolude      hiding (head, toS)

--- a/src/PostgREST/Request/Preferences.hs
+++ b/src/PostgREST/Request/Preferences.hs
@@ -9,20 +9,20 @@ module PostgREST.Request.Preferences
   , ToAppliedHeader(..)
   ) where
 
-import qualified Data.ByteString as BS
+import qualified Data.ByteString           as BS
+import qualified Data.Map                  as Map
 import qualified Network.HTTP.Types.Header as HTTP
-import qualified Data.Map as Map
 
 import Protolude
 
 
 data Preferences
   = Preferences
-    { preferResolution :: Maybe PreferResolution
+    { preferResolution     :: Maybe PreferResolution
     , preferRepresentation :: PreferRepresentation
-    , preferParameters :: Maybe PreferParameters
-    , preferCount :: Maybe PreferCount
-    , preferTransaction :: Maybe PreferTransaction
+    , preferParameters     :: Maybe PreferParameters
+    , preferCount          :: Maybe PreferCount
+    , preferTransaction    :: Maybe PreferTransaction
     }
 
 fromHeaders :: [HTTP.Header] -> Preferences

--- a/src/PostgREST/Request/Preferences.hs
+++ b/src/PostgREST/Request/Preferences.hs
@@ -1,16 +1,69 @@
-module PostgREST.Request.Preferences where
+module PostgREST.Request.Preferences
+  ( Preferences(..)
+  , PreferCount(..)
+  , PreferParameters(..)
+  , PreferRepresentation(..)
+  , PreferResolution(..)
+  , PreferTransaction(..)
+  , fromHeaders
+  , ToAppliedHeader(..)
+  ) where
 
-import GHC.Show
+import qualified Data.ByteString as BS
+import qualified Network.HTTP.Types.Header as HTTP
+import qualified Data.Map as Map
+
 import Protolude
 
+
+data Preferences
+  = Preferences
+    { preferResolution :: Maybe PreferResolution
+    , preferRepresentation :: PreferRepresentation
+    , preferParameters :: Maybe PreferParameters
+    , preferCount :: Maybe PreferCount
+    , preferTransaction :: Maybe PreferTransaction
+    }
+
+fromHeaders :: [HTTP.Header] -> Preferences
+fromHeaders headers =
+  Preferences
+    { preferResolution = parsePrefs [MergeDuplicates, IgnoreDuplicates]
+    , preferRepresentation = fromMaybe None $ parsePrefs [Full, None, HeadersOnly]
+    , preferParameters = parsePrefs [SingleObject, MultipleObjects]
+    , preferCount = parsePrefs [ExactCount, PlannedCount, EstimatedCount]
+    , preferTransaction = parsePrefs [Commit, Rollback]
+    }
+  where
+    prefHeaders = filter ((==) HTTP.hPrefer . fst) headers
+    prefs = fmap strip . concatMap (BS.split comma . snd) $ prefHeaders
+    comma = fromIntegral (ord ',')
+    strip = BS.dropWhile (space ==) . BS.dropWhileEnd (space ==)
+    space = fromIntegral (ord ' ')
+
+    parsePrefs :: ToHeaderValue a => [a] -> Maybe a
+    parsePrefs vals =
+      head $ mapMaybe (flip Map.lookup $ prefMap vals) prefs
+
+    prefMap :: ToHeaderValue a => [a] -> Map.Map ByteString a
+    prefMap = Map.fromList . fmap (\pref -> (toHeaderValue pref, pref))
+
+class ToHeaderValue a where
+  toHeaderValue :: a -> ByteString
+
+class ToHeaderValue a => ToAppliedHeader a where
+  toAppliedHeader :: a -> HTTP.Header
+  toAppliedHeader x = (HTTP.hPreferenceApplied, toHeaderValue x)
 
 data PreferResolution
   = MergeDuplicates
   | IgnoreDuplicates
 
-instance Show PreferResolution where
-  show MergeDuplicates  = "resolution=merge-duplicates"
-  show IgnoreDuplicates = "resolution=ignore-duplicates"
+instance ToHeaderValue PreferResolution where
+  toHeaderValue MergeDuplicates  = "resolution=merge-duplicates"
+  toHeaderValue IgnoreDuplicates = "resolution=ignore-duplicates"
+
+instance ToAppliedHeader PreferResolution
 
 -- | How to return the mutated data. From https://tools.ietf.org/html/rfc7240#section-4.2
 data PreferRepresentation
@@ -19,36 +72,38 @@ data PreferRepresentation
   | None        -- ^ Return nothing from the mutated data.
   deriving Eq
 
-instance Show PreferRepresentation where
-  show Full        = "return=representation"
-  show None        = "return=minimal"
-  show HeadersOnly = "return=headers-only"
+instance ToHeaderValue PreferRepresentation where
+  toHeaderValue Full        = "return=representation"
+  toHeaderValue None        = "return=minimal"
+  toHeaderValue HeadersOnly = "return=headers-only"
 
 data PreferParameters
   = SingleObject    -- ^ Pass all parameters as a single json object to a stored procedure
   | MultipleObjects -- ^ Pass an array of json objects as params to a stored procedure
   deriving Eq
 
-instance Show PreferParameters where
-  show SingleObject    = "params=single-object"
-  show MultipleObjects = "params=multiple-objects"
+instance ToHeaderValue PreferParameters where
+  toHeaderValue SingleObject    = "params=single-object"
+  toHeaderValue MultipleObjects = "params=multiple-objects"
 
 data PreferCount
   = ExactCount     -- ^ exact count(slower)
   | PlannedCount   -- ^ PostgreSQL query planner rows count guess. Done by using EXPLAIN {query}.
   | EstimatedCount -- ^ use the query planner rows if the count is superior to max-rows, otherwise get the exact count.
-  deriving Eq
+ deriving Eq
 
-instance Show PreferCount where
-  show ExactCount     = "count=exact"
-  show PlannedCount   = "count=planned"
-  show EstimatedCount = "count=estimated"
+instance ToHeaderValue PreferCount where
+  toHeaderValue ExactCount     = "count=exact"
+  toHeaderValue PlannedCount   = "count=planned"
+  toHeaderValue EstimatedCount = "count=estimated"
 
 data PreferTransaction
-  = Commit   -- Commit transaction - the default.
-  | Rollback -- Rollback transaction after sending the response - does not persist changes, e.g. for running tests.
+  = Commit   -- ^ Commit transaction - the default.
+  | Rollback -- ^ Rollback transaction after sending the response - does not persist changes, e.g. for running tests.
   deriving Eq
 
-instance Show PreferTransaction where
-  show Commit   = "tx=commit"
-  show Rollback = "tx=rollback"
+instance ToHeaderValue PreferTransaction where
+  toHeaderValue Commit   = "tx=commit"
+  toHeaderValue Rollback = "tx=rollback"
+
+instance ToAppliedHeader PreferTransaction

--- a/src/PostgREST/Request/Types.hs
+++ b/src/PostgREST/Request/Types.hs
@@ -39,8 +39,6 @@ import qualified Data.Set             as S
 
 import Data.Tree (Tree (..))
 
-import qualified GHC.Show (show)
-
 import PostgREST.DbStructure.Identifiers  (FieldName,
                                            QualifiedIdentifier)
 import PostgREST.DbStructure.Proc         (ProcParam (..))
@@ -93,18 +91,10 @@ data OrderDirection
   | OrderDesc
   deriving (Eq)
 
-instance Show OrderDirection where
-  show OrderAsc  = "ASC"
-  show OrderDesc = "DESC"
-
 data OrderNulls
   = OrderNullsFirst
   | OrderNullsLast
   deriving (Eq)
-
-instance Show OrderNulls where
-  show OrderNullsFirst = "NULLS FIRST"
-  show OrderNullsLast  = "NULLS LAST"
 
 data MutateQuery
   = Insert
@@ -160,9 +150,6 @@ data JoinType
   = JTInner
   | JTLeft
   deriving Eq
-instance Show JoinType where
-  show JTInner = "inner"
-  show JTLeft  = "left"
 
 -- | Path of the embedded levels, e.g "clients.projects.name=eq.." gives Path
 -- ["clients", "projects"]
@@ -208,10 +195,6 @@ data LogicOperator
   = And
   | Or
   deriving Eq
-
-instance Show LogicOperator where
-  show And = "AND"
-  show Or  = "OR"
 
 data Filter = Filter
   { field  :: Field


### PR DESCRIPTION
This is an item on our refactoring roadmap #1804 

Using `GHC.Show` to pretty-print or serialize data is an [anti-pattern](https://www.stephendiehl.com/posts/strings.html), show is meant to create a Haskell expression that can be parsed by `read`, see https://hackage.haskell.org/package/base-4.16.0.0/docs/GHC-Show.html

This PR removes all uses of `GHC.Show` instances in the codebase. As a side effect, this avoids several string conversions, especially when parsing preference headers, for what is likely a small performance gain.