### PR TITLE
Refactor: Remove uses of Protolude.Conv.toS

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,11 +10,6 @@ build_task:
     fingerprint_script: cat postgrest.cabal stack.yaml.lock
     reupload_on_changes: false
 
-  stack_work_cache:
-    folders: .stack-work
-    fingerprint_script: cat postgrest.cabal stack.yaml.lock
-    reupload_on_changes: false
-
   build_script: stack build -j 1 --local-bin-path . --copy-bins
   bin_artifacts:
     path: postgrest

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -39,8 +39,7 @@ import PostgREST.Config           (AppConfig (..))
 import PostgREST.Config.PgVersion (PgVersion (..), minimumPgVersion)
 import PostgREST.DbStructure      (DbStructure)
 
-import Protolude      hiding (toS)
-import Protolude.Conv (toS)
+import Protolude
 
 
 data AppState = AppState
@@ -87,7 +86,7 @@ initWithPool newPool conf =
 
 initPool :: AppConfig -> IO SQL.Pool
 initPool AppConfig{..} =
-  SQL.acquire (configDbPoolSize, configDbPoolTimeout, toS configDbUri)
+  SQL.acquire (configDbPoolSize, configDbPoolTimeout, toUtf8 configDbUri)
 
 getPool :: AppState -> SQL.Pool
 getPool = statePool

--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -9,11 +9,11 @@ module PostgREST.CLI
   ) where
 
 import qualified Data.Aeson                 as JSON
+import qualified Data.ByteString.Char8      as BS
 import qualified Data.ByteString.Lazy       as LBS
 import qualified Hasql.Pool                 as SQL
 import qualified Hasql.Transaction.Sessions as SQL
 import qualified Options.Applicative        as O
-import qualified Protolude.Conv             as Conv
 
 import Data.Text.IO (hPutStrLn)
 import Text.Heredoc (str)
@@ -91,7 +91,7 @@ readCLIShowHelp hasEnvironment =
     progDesc =
       O.progDesc $
         "PostgREST "
-        <> Conv.toS prettyVersion
+        <> BS.unpack prettyVersion
         <> " / create a REST API to an existing Postgres database"
 
     footer =

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -30,8 +30,8 @@ import qualified Crypto.JOSE.Types      as JOSE
 import qualified Crypto.JWT             as JWT
 import qualified Data.Aeson             as JSON
 import qualified Data.ByteString        as BS
-import qualified Data.ByteString.Lazy   as LBS
 import qualified Data.ByteString.Base64 as B64
+import qualified Data.ByteString.Lazy   as LBS
 import qualified Data.Configurator      as C
 import qualified Data.Map.Strict        as M
 import qualified Data.Text              as T
@@ -59,7 +59,7 @@ import PostgREST.DbStructure.Identifiers (QualifiedIdentifier, dumpQi,
                                           toQi)
 import PostgREST.Request.Types           (JoinType (..))
 
-import Protolude      hiding (Proxy, toList)
+import Protolude hiding (Proxy, toList)
 
 
 data AppConfig = AppConfig

--- a/src/PostgREST/Config/JSPath.hs
+++ b/src/PostgREST/Config/JSPath.hs
@@ -11,8 +11,7 @@ import Data.Either.Combinators       (mapLeft)
 import Text.ParserCombinators.Parsec ((<?>))
 import Text.Read                     (read)
 
-import Protolude      hiding (toS)
-import Protolude.Conv (toS)
+import Protolude
 
 
 -- | full jspath, e.g. .property[0].attr.detail

--- a/src/PostgREST/Config/Proxy.hs
+++ b/src/PostgREST/Config/Proxy.hs
@@ -8,13 +8,12 @@ module PostgREST.Config.Proxy
   , toURI
   ) where
 
+import qualified Data.Text as T
+
 import Data.Maybe  (fromJust)
-import Data.Text   (pack, toLower)
 import Network.URI (URI (..), URIAuth (..), isAbsoluteURI, parseURI)
 
-import Protolude      hiding (Proxy, dropWhile, get, intercalate,
-                       toLower, toS, (&))
-import Protolude.Conv (toS)
+import Protolude hiding (Proxy)
 
 data Proxy = Proxy
   { proxyScheme :: Text
@@ -48,8 +47,8 @@ fAnd fs x = all ($ x) fs
 
 isSchemeValid :: URI -> Bool
 isSchemeValid URI {uriScheme = s}
-  | toLower (pack s) == "https:" = True
-  | toLower (pack s) == "http:" = True
+  | T.toLower (T.pack s) == "https:" = True
+  | T.toLower (T.pack s) == "http:" = True
   | otherwise = False
 
 isQueryValid :: URI -> Bool

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -54,8 +54,7 @@ import PostgREST.DbStructure.Relationship (Cardinality (..),
                                            Relationship (..))
 import PostgREST.DbStructure.Table        (Column (..), Table (..))
 
-import Protolude        hiding (toS)
-import Protolude.Conv   (toS)
+import Protolude
 import Protolude.Unsafe (unsafeHead)
 
 
@@ -225,12 +224,12 @@ decodeProcs =
                       | otherwise = Volatile -- only 'v' can happen here
 
 allProcs :: Bool -> SQL.Statement [Schema] ProcsMap
-allProcs = SQL.Statement (toS sql) (arrayParam HE.text) decodeProcs
+allProcs = SQL.Statement sql (arrayParam HE.text) decodeProcs
   where
     sql = procsSqlQuery <> " WHERE pn.nspname = ANY($1)"
 
 accessibleProcs :: Bool -> SQL.Statement Schema ProcsMap
-accessibleProcs = SQL.Statement (toS sql) (param HE.text) decodeProcs
+accessibleProcs = SQL.Statement sql (param HE.text) decodeProcs
   where
     sql = procsSqlQuery <> " WHERE pn.nspname = $1 AND has_function_privilege(p.oid, 'execute')"
 

--- a/src/PostgREST/GucHeader.hs
+++ b/src/PostgREST/GucHeader.hs
@@ -10,8 +10,7 @@ import qualified Data.HashMap.Strict  as M
 
 import Network.HTTP.Types.Header (Header)
 
-import Protolude      hiding (toS)
-import Protolude.Conv (toS)
+import Protolude
 
 
 {-|
@@ -21,11 +20,11 @@ import Protolude.Conv (toS)
 newtype GucHeader = GucHeader (CI.CI ByteString, ByteString)
 
 instance JSON.FromJSON GucHeader where
-  parseJSON (JSON.Object o) = case headMay (M.toList o) of
-    Just (k, JSON.String s) | M.size o == 1 -> pure $ GucHeader (CI.mk $ toS k, toS s)
-                            | otherwise     -> mzero
-    _ -> mzero
-  parseJSON _          = mzero
+  parseJSON (JSON.Object o) =
+    case M.toList o of
+      [(k, JSON.String s)] -> pure $ GucHeader (CI.mk $ toUtf8 k, toUtf8 s)
+      _ -> mzero
+  parseJSON _ = mzero
 
 unwrapGucHeader :: GucHeader -> Header
 unwrapGucHeader (GucHeader (k, v)) = (k, v)

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -7,12 +7,13 @@ Description : Generates the OpenAPI output
 {-# LANGUAGE RecordWildCards #-}
 module PostgREST.OpenAPI (encode) where
 
-import qualified Data.Aeson           as JSON
-import qualified Data.ByteString.Lazy as LBS
-import qualified Data.HashMap.Strict  as M
-import qualified Data.HashSet.InsOrd  as Set
-import qualified Data.Text            as T
-import qualified Data.Text.Encoding   as T
+import qualified Data.Aeson            as JSON
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy  as LBS
+import qualified Data.HashMap.Strict   as M
+import qualified Data.HashSet.InsOrd   as Set
+import qualified Data.Text             as T
+import qualified Data.Text.Encoding    as T
 
 import Control.Arrow              ((&&&))
 import Data.HashMap.Strict.InsOrd (InsOrdHashMap, fromList)
@@ -38,8 +39,7 @@ import PostgREST.Version                  (docsVersion, prettyVersion)
 
 import PostgREST.ContentType
 
-import Protolude      hiding (Proxy, get, toS)
-import Protolude.Conv (toS)
+import Protolude hiding (Proxy, get)
 
 encode :: AppConfig -> DbStructure -> [Table] -> M.HashMap k [ProcDescription] -> Maybe Text -> LBS.ByteString
 encode conf dbStructure tables procs schemaDescription =
@@ -53,7 +53,7 @@ encode conf dbStructure tables procs schemaDescription =
       (dbPrimaryKeys dbStructure)
 
 makeMimeList :: [ContentType] -> MimeList
-makeMimeList cs = MimeList $ fmap (fromString . toS . toMime) cs
+makeMimeList cs = MimeList $ fmap (fromString . BS.unpack . toMime) cs
 
 toSwaggerType :: Text -> SwaggerType t
 toSwaggerType "character varying" = SwaggerString
@@ -119,7 +119,7 @@ makeProperty rels pks c = (colName c, Inline s)
         colDescription c
     s =
       (mempty :: Schema)
-        & default_ .~ (JSON.decode . toS . parseDefault (colType c) =<< colDefault c)
+        & default_ .~ (JSON.decode . toUtf8Lazy . parseDefault (colType c) =<< colDefault c)
         & description .~ d
         & enum_ .~ e
         & format ?~ colType c

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -12,6 +12,7 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.HashMap.Strict  as M
 import qualified Data.HashSet.InsOrd  as Set
 import qualified Data.Text            as T
+import qualified Data.Text.Encoding   as T
 
 import Control.Arrow              ((&&&))
 import Data.HashMap.Strict.InsOrd (InsOrdHashMap, fromList)
@@ -324,7 +325,7 @@ postgrestSpec rels pds ti (s, h, p, b) sd pks = (mempty :: Swagger)
   & basePath ?~ T.unpack b
   & schemes ?~ [s']
   & info .~ ((mempty :: Info)
-      & version .~ prettyVersion
+      & version .~ T.decodeUtf8 prettyVersion
       & title .~ "PostgREST API"
       & description ?~ d)
   & externalDocs ?~ ((mempty :: ExternalDocs)

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -63,8 +63,7 @@ import PostgREST.Request.Types           (Alias, Field, Filter (..),
                                           OrderNulls (..),
                                           OrderTerm (..), SelectItem)
 
-import Protolude      hiding (cast, toS)
-import Protolude.Conv (toS)
+import Protolude hiding (cast)
 
 
 -- | A part of a SQL query that cannot be executed independently
@@ -122,14 +121,14 @@ normalizedBody body =
         "END AS val",
       "FROM pgrst_payload)"])
   where
-    jsonPlaceHolder = SQL.encoderAndParam (HE.nullable HE.unknown) (toS <$> body) <> "::json"
+    jsonPlaceHolder = SQL.encoderAndParam (HE.nullable HE.unknown) (LBS.toStrict <$> body) <> "::json"
 
 singleParameter :: Maybe LBS.ByteString -> ByteString -> SQL.Snippet
 singleParameter body typ =
   if typ == "bytea"
     -- TODO: Hasql fails when using HE.unknown with bytea(pg tries to utf8 encode).
-    then SQL.encoderAndParam (HE.nullable HE.bytea) (toS <$> body)
-    else SQL.encoderAndParam (HE.nullable HE.unknown) (toS <$> body) <> "::" <> SQL.sql typ
+    then SQL.encoderAndParam (HE.nullable HE.bytea) (LBS.toStrict <$> body)
+    else SQL.encoderAndParam (HE.nullable HE.unknown) (LBS.toStrict <$> body) <> "::" <> SQL.sql typ
 
 selectBody :: SqlFragment
 selectBody = "(SELECT val FROM pgrst_body)"

--- a/src/PostgREST/Query/Statements.hs
+++ b/src/PostgREST/Query/Statements.hs
@@ -19,6 +19,7 @@ module PostgREST.Query.Statements
 import qualified Data.Aeson                        as JSON
 import qualified Data.Aeson.Lens                   as L
 import qualified Data.ByteString.Char8             as BS
+import qualified Data.ByteString.Lazy              as LBS
 import qualified Hasql.Decoders                    as HD
 import qualified Hasql.DynamicStatements.Snippet   as SQL
 import qualified Hasql.DynamicStatements.Statement as SQL
@@ -37,8 +38,7 @@ import PostgREST.DbStructure.Identifiers (FieldName)
 import PostgREST.Query.SqlFragment
 import PostgREST.Request.Preferences
 
-import Protolude      hiding (toS)
-import Protolude.Conv (toS)
+import Protolude
 
 {-| The generic query result format used by API responses. The location header
     is represented as a list of strings containing variable bindings like
@@ -189,7 +189,7 @@ createExplainStatement countQuery =
       (^? L.nth 0 . L.key "Plan" .  L.key "Plan Rows" . L._Integral) <$> row
 
 decodeGucHeaders :: HD.Value (Either Error [GucHeader])
-decodeGucHeaders = first (const GucHeadersError) . JSON.eitherDecode . toS <$> HD.bytea
+decodeGucHeaders = first (const GucHeadersError) . JSON.eitherDecode . LBS.fromStrict <$> HD.bytea
 
 decodeGucStatus :: HD.Value (Either Error (Maybe Status))
 decodeGucStatus = first (const GucStatusError) . fmap (Just . toEnum . fst) . decimal <$> HD.text

--- a/src/PostgREST/RangeQuery.hs
+++ b/src/PostgREST/RangeQuery.hs
@@ -26,8 +26,7 @@ import Data.Ranged.Ranges
 import Network.HTTP.Types.Header
 import Network.HTTP.Types.Status
 
-import Protolude      hiding (toS)
-import Protolude.Conv (toS)
+import Protolude
 
 type NonnegRange = Range Integer
 
@@ -37,7 +36,7 @@ rangeParse range = do
 
   case listToMaybe (range =~ rangeRegex :: [[BS.ByteString]]) of
     Just parsedRange ->
-      let [_, mLower, mUpper] = readMaybe . toS <$> parsedRange
+      let [_, mLower, mUpper] = readMaybe . BS.unpack <$> parsedRange
           lower         = maybe emptyRange rangeGeq mLower
           upper         = maybe allRange rangeLeq mUpper in
       rangeIntersection lower upper

--- a/src/PostgREST/Request/ApiRequest.hs
+++ b/src/PostgREST/Request/ApiRequest.hs
@@ -16,18 +16,18 @@ module PostgREST.Request.ApiRequest
   , userApiRequest
   ) where
 
-import qualified Data.Aeson           as JSON
-import qualified Data.ByteString.Char8      as BS
-import qualified Data.ByteString.Lazy as LBS
-import qualified Data.CaseInsensitive as CI
-import qualified Data.Csv             as CSV
-import qualified Data.HashMap.Strict  as M
-import qualified Data.List            as L
-import qualified Data.Set             as S
-import qualified Data.Text            as T
-import qualified Data.Text.Encoding   as T
-import qualified Data.Vector          as V
-import qualified Data.List.NonEmpty   as NonEmptyList
+import qualified Data.Aeson            as JSON
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy  as LBS
+import qualified Data.CaseInsensitive  as CI
+import qualified Data.Csv              as CSV
+import qualified Data.HashMap.Strict   as M
+import qualified Data.List             as L
+import qualified Data.List.NonEmpty    as NonEmptyList
+import qualified Data.Set              as S
+import qualified Data.Text             as T
+import qualified Data.Text.Encoding    as T
+import qualified Data.Vector           as V
 
 import Control.Arrow             ((***))
 import Data.Aeson.Types          (emptyArray, emptyObject)

--- a/src/PostgREST/Request/ApiRequest.hs
+++ b/src/PostgREST/Request/ApiRequest.hs
@@ -152,7 +152,7 @@ targetToJsonRpcParams target params =
 -}
 data ApiRequest = ApiRequest {
     iAction               :: Action                           -- ^ Similar but not identical to HTTP verb, e.g. Create/Invoke both POST
-  , iRange                :: M.HashMap ByteString NonnegRange -- ^ Requested range of rows within response
+  , iRange                :: M.HashMap Text NonnegRange -- ^ Requested range of rows within response
   , iTopLevelRange        :: NonnegRange                      -- ^ Requested range of rows from the top level
   , iTarget               :: Target                           -- ^ The target, be it calling a proc or accessing a table
   , iPayload              :: Maybe Payload                    -- ^ Data sent by client and used for mutation actions
@@ -362,9 +362,9 @@ userApiRequest conf@AppConfig{..} dbStructure req reqBody
 
   headerRange = rangeRequested hdrs
   replaceLast x s = T.intercalate "." $ L.init (T.split (=='.') s) ++ [x]
-  limitParams :: M.HashMap ByteString NonnegRange
+  limitParams :: M.HashMap Text NonnegRange
   limitParams  = M.fromList [(toS (replaceLast "limit" k), restrictRange (readMaybe . toS =<< v) allRange) | (k,v) <- qParams, isJust v, endingIn ["limit"] k]
-  offsetParams :: M.HashMap ByteString NonnegRange
+  offsetParams :: M.HashMap Text NonnegRange
   offsetParams = M.fromList [(toS (replaceLast "limit" k), maybe allRange rangeGeq (readMaybe . toS =<< v)) | (k,v) <- qParams, isJust v, endingIn ["offset"] k]
 
   urlRange = M.unionWith f limitParams offsetParams

--- a/src/PostgREST/Request/Parsers.hs
+++ b/src/PostgREST/Request/Parsers.hs
@@ -47,8 +47,7 @@ import PostgREST.RangeQuery              (NonnegRange)
 
 import PostgREST.Request.Types
 
-import Protolude      hiding (intercalate, option, replace, toS, try)
-import Protolude.Conv (toS)
+import Protolude hiding (intercalate, option, replace, try)
 
 pRequestSelect :: Text -> Either ApiRequestError [Tree SelectItem]
 pRequestSelect selStr =
@@ -73,7 +72,7 @@ pRequestOrder (k, v) = mapError $ (,) <$> path <*> ord'
     path = fst <$> treePath
     ord' = parse pOrder ("failed to parse order (" ++ toS v ++ ")") $ toS v
 
-pRequestRange :: (ByteString, NonnegRange) -> Either ApiRequestError (EmbedPath, NonnegRange)
+pRequestRange :: (Text, NonnegRange) -> Either ApiRequestError (EmbedPath, NonnegRange)
 pRequestRange (k, v) = mapError $ (,) <$> path <*> pure v
   where
     treePath = parse pTreePath ("failed to parser tree path (" ++ toS k ++ ")") $ toS k
@@ -117,7 +116,7 @@ pFieldForest = pFieldTree `sepBy1` lexeme (char ',')
                   Node <$> pFieldSelect <*> pure []
 
 pStar :: Parser Text
-pStar = toS <$> (string "*" $> ("*"::ByteString))
+pStar = string "*" $> "*"
 
 pFieldName :: Parser Text
 pFieldName =

--- a/src/PostgREST/Version.hs
+++ b/src/PostgREST/Version.hs
@@ -4,7 +4,8 @@ module PostgREST.Version
   , prettyVersion
   ) where
 
-import qualified Data.Text as T
+import qualified Data.ByteString as BS
+import qualified Data.Text       as T
 
 import Data.Version       (showVersion, versionBranch)
 import Development.GitRev (gitHash)
@@ -16,15 +17,15 @@ import Protolude
 -- | User friendly version number such as '1.1.1'.
 -- Pre-release versions are tagged as such, e.g., '1.1.1.1 (pre-release)'.
 -- If a git hash is available, it's added to the version, e.g., '1.1.1 (abcdef0)'.
-prettyVersion :: Text
+prettyVersion :: ByteString
 prettyVersion =
-  T.pack (showVersion version) <> preRelease <> gitRev
+  toUtf8 (showVersion version) <> preRelease <> gitRev
   where
     gitRev =
       if $(gitHash) == ("UNKNOWN" :: Text) then
         mempty
       else
-        " (" <> T.take 7 $(gitHash) <> ")"
+        " (" <> BS.take 7 $(gitHash) <> ")"
     preRelease = if isPreRelease then " (pre-release)" else mempty
 
 


### PR DESCRIPTION
This is another item on our refactoring roadmap #1804 and builds on top of the commits in #2016

Currently, we use `toS` from [`Protolude.Conv`](https://hackage.haskell.org/package/protolude-0.3.0/docs/Protolude-Conv.html) in almost all modules. `toS` contains partial functions and expensive transformations, which is why it is not exported by Protolude by default. For example, converting `ByteString` to `Text` involves [`T.decodeUtf8`](https://hackage.haskell.org/package/text-1.2.5.0/docs/Data-Text-Encoding.html#v:decodeUtf8) (see: https://hackage.haskell.org/package/protolude-0.3.0/docs/src/Protolude.Conv.html#StringConv) which will raise an uncatchable exception if the input is not valid utf-8.

This PR replaces all uses of `Protolude.Conv.toS` with the respective explicit transformations that are needed, making transparent where we are doing expensive (e.g., `BS.unpack`), performance critical (`LBS.toStrict`) or unsafe (`T.decodeUtf8`) ones, as a basis for further fixes.