### PR TITLE
nix(feat): Add actionlint to postgrest-lint

### DIFF
--- a/nix/tools/style.nix
+++ b/nix/tools/style.nix
@@ -1,4 +1,5 @@
-{ black
+{ actionlint
+, black
 , buildToolbox
 , checkedShellScript
 , git
@@ -50,7 +51,7 @@ let
     checkedShellScript
       {
         name = "postgrest-lint";
-        docs = "Lint all Haskell files and bash scripts.";
+        docs = "Lint all Haskell files, bash scripts and github workflows.";
         inRootDir = true;
       }
       ''
@@ -65,6 +66,9 @@ let
 
         echo "Linting bash scripts..."
         ${shellcheck}/bin/shellcheck test/with_tmp_db
+
+        echo "Linting workflows..."
+        ${actionlint}/bin/actionlint
       '';
 
 in


### PR DESCRIPTION
I found `actionlint` yesterday. Thought we could add it. Of course, we have @remo, whose github workflows are flawless - actionlint reports no problems, so far! But just to make sure we don't make things worse in the future, we can still add it..