### PR TITLE
Allow unknown for is operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #1075, Allow filtering top-level resource based on embedded resources filters - @steve-chavez, @Iced-Sun
    + This is enabled by adding `!inner` to the embedded resource, e.g. `/projects?select=*,clients!inner(*)&clients.id=eq.12`
    + This behavior can be enabled by default with the `db-embed-default-join='inner'` config option, which saves the need for specifying `!inner` on every request. In this case, you can go back to the previous behavior per request by specifying `!left`  on the embedded resource, e.g `/projects?select=*,clients!left(*)&clients.id=eq.12`
+- #1988, Allow specifying `unknown` for the `is` operator - @steve-chavez
 
 ### Fixed
 

--- a/src/PostgREST/Request/Types.hs
+++ b/src/PostgREST/Request/Types.hs
@@ -31,6 +31,7 @@ module PostgREST.Request.Types
   , ReadRequest
   , SelectItem
   , SingleVal
+  , TrileanVal(..)
   , fstFieldNames
   ) where
 
@@ -209,6 +210,7 @@ data OpExpr =
 data Operation
   = Op Operator SingleVal
   | In ListVal
+  | Is TrileanVal
   | Fts Operator (Maybe Language) SingleVal
   deriving (Eq)
 
@@ -220,3 +222,11 @@ type SingleVal = Text
 
 -- | Represents a list value in a filter, e.g. id=in.(val1,val2,val3)
 type ListVal = [Text]
+
+-- | Three-valued logic values
+data TrileanVal
+  = TriTrue
+  | TriFalse
+  | TriNull
+  | TriUnknown
+  deriving Eq

--- a/test/Feature/QuerySpec.hs
+++ b/test/Feature/QuerySpec.hs
@@ -73,6 +73,23 @@ spec actualPgVersion = do
 
       get "/nullable_integer?a=is.null" `shouldRespondWith` [json|[{"a":null}]|]
 
+    it "matches with trilean values" $ do
+      get "/chores?done=is.true" `shouldRespondWith`
+        [json| [{"id": 1, "name": "take out the garbage", "done": true }] |]
+        { matchHeaders = [matchContentTypeJson] }
+
+      get "/chores?done=is.false" `shouldRespondWith`
+        [json| [{"id": 2, "name": "do the laundry", "done": false }] |]
+        { matchHeaders = [matchContentTypeJson] }
+
+      get "/chores?done=is.unknown" `shouldRespondWith`
+        [json| [{"id": 3, "name": "wash the dishes", "done": null }] |]
+        { matchHeaders = [matchContentTypeJson] }
+
+    it "fails if 'is' used and there's no null or trilean value" $ do
+      get "/chores?done=is.nil" `shouldRespondWith` 400
+      get "/chores?done=is.ok"  `shouldRespondWith` 400
+
     it "matches with like" $ do
       get "/simple_pk?k=like.*yx" `shouldRespondWith`
         [json|[{"k":"xyyx","extra":"u"}]|]

--- a/test/fixtures/data.sql
+++ b/test/fixtures/data.sql
@@ -716,3 +716,6 @@ INSERT INTO test.contact (id,name, clientid) values (1,'Wally Walton',1),(2,'Wil
 
 TRUNCATE TABLE test.clientinfo CASCADE;
 INSERT INTO test.clientinfo (id,clientid, other) values (1,1,'123 Main St'),(2,2,'456 South 3rd St'),(3,3,'789 Palm Tree Ln');
+
+TRUNCATE TABLE test.chores CASCADE;
+INSERT INTO test.chores (id, name, done) values (1, 'take out the garbage', true), (2, 'do the laundry', false), (3, 'wash the dishes', null);

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -159,6 +159,7 @@ GRANT ALL ON TABLE
     , client
     , clientinfo
     , contact
+    , chores
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -2390,3 +2390,9 @@ CREATE TABLE clientinfo (
 , clientid int unique references client(id)
 , other text
 );
+
+CREATE TABLE chores (
+  id int primary key
+, name text
+, done bool
+);


### PR DESCRIPTION
Closes https://github.com/PostgREST/postgrest/issues/1998.

- feat: allow unknown on the is operator 

  Also make the IS values strict at the Parser level since IS cannot be parametrized.

- refactor: remove pgFmtLit

  This is so there's no more logic related to escaping in the codebase.