### PR TITLE
Add tests for embedding on overloaded functions with a default param

### DIFF
--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -739,7 +739,7 @@ spec actualPgVersion =
             [json|"123"|]
 
       -- https://github.com/PostgREST/postgrest/issues/1672
-      context "embedding overloaded functions with the same quantity of args and one has a default value" $ do
+      context "embedding overloaded functions with the same signature except for the last param with a default value" $ do
         it "overloaded_default(text default)" $ do
           request methodPost "/rpc/overloaded_default?select=id,name,users(name)"
               [("Content-Type", "application/json")]

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -738,6 +738,36 @@ spec actualPgVersion =
           `shouldRespondWith`
             [json|"123"|]
 
+      -- https://github.com/PostgREST/postgrest/issues/1672
+      context "embedding overloaded functions with the same quantity of args and one has a default value" $ do
+        it "overloaded_default(text default)" $ do
+          request methodPost "/rpc/overloaded_default?select=id,name,users(name)"
+              [("Content-Type", "application/json")]
+              [json|{}|]
+            `shouldRespondWith`
+              [json|[{"id": 2, "name": "Code w7", "users": [{"name": "Angela Martin"}]}] |]
+
+        it "overloaded_default(int)" $
+          request methodPost "/rpc/overloaded_default"
+              [("Content-Type", "application/json")]
+              [json|{"must_param":1}|]
+            `shouldRespondWith`
+              [json|{"val":1}|]
+
+        it "overloaded_default(int, text default)" $ do
+          request methodPost "/rpc/overloaded_default?select=id,name,users(name)"
+              [("Content-Type", "application/json")]
+              [json|{"a":4}|]
+            `shouldRespondWith`
+              [json|[{"id": 5, "name": "Design IOS", "users": [{"name": "Michael Scott"}, {"name": "Dwight Schrute"}]}] |]
+
+        it "overloaded_default(int, int)" $
+          request methodPost "/rpc/overloaded_default"
+              [("Content-Type", "application/json")]
+              [json|{"a":2,"must_param":4}|]
+            `shouldRespondWith`
+              [json|{"a":2,"val":4}|]
+
     context "only for POST rpc" $ do
       it "gives a parse filter error if GET style proc args are specified" $
         post "/rpc/sayhello?name=John" [json|{name: "John"}|] `shouldRespondWith` 400

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1328,7 +1328,7 @@ select * from test.tasks where name like opt_param;
 $$ language sql;
 
 create or replace function test.overloaded_default(must_param int) returns jsonb as $$
-select row_to_json(r) from (select must_param as val) as r;
+select row_to_json(r)::jsonb from (select must_param as val) as r;
 $$ language sql;
 
 create or replace function test.overloaded_default(a int, opt_param text default 'Design IOS') returns setof test.tasks as $$
@@ -1336,7 +1336,7 @@ select * from test.tasks where name like opt_param and id > a;
 $$ language sql;
 
 create or replace function test.overloaded_default(a int, must_param int) returns jsonb as $$
-select row_to_json(r) from (select a, must_param as val) as r;
+select row_to_json(r)::jsonb from (select a, must_param as val) as r;
 $$ language sql;
 
 create or replace function test.overloaded_html_form() returns setof int as $$

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -1323,6 +1323,22 @@ create or replace function test.overloaded(a text, b text, c text) returns text 
   select a || b || c
 $$ language sql;
 
+create or replace function test.overloaded_default(opt_param text default 'Code w7') returns setof test.tasks as $$
+select * from test.tasks where name like opt_param;
+$$ language sql;
+
+create or replace function test.overloaded_default(must_param int) returns jsonb as $$
+select row_to_json(r) from (select must_param as val) as r;
+$$ language sql;
+
+create or replace function test.overloaded_default(a int, opt_param text default 'Design IOS') returns setof test.tasks as $$
+select * from test.tasks where name like opt_param and id > a;
+$$ language sql;
+
+create or replace function test.overloaded_default(a int, must_param int) returns jsonb as $$
+select row_to_json(r) from (select a, must_param as val) as r;
+$$ language sql;
+
 create or replace function test.overloaded_html_form() returns setof int as $$
 values (1), (2), (3);
 $$ language sql;


### PR DESCRIPTION
Closes #1672 

As mentioned in https://github.com/PostgREST/postgrest/issues/1672#issuecomment-971005376, looks like the changes made in the `findProc` function solved the issue with embedding on overloaded functions with the same signature except for the last parameter, which has a default value.

This PR adds tests to confirm the resolution.