### PR TITLE
refactor: Carve out QueryParams module

### DIFF
--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -59,7 +59,7 @@ import PostgREST.Request.Types           (Alias, Field, Filter (..),
                                           OrderDirection (..),
                                           OrderNulls (..),
                                           OrderTerm (..), SelectItem,
-                                          SimpleOperator (..),
+                                          SingleValOperator (..),
                                           TrileanVal (..))
 
 import Protolude hiding (cast)
@@ -74,7 +74,7 @@ noLocationF = "array[]::text[]"
 sourceCTEName :: SqlFragment
 sourceCTEName = "pgrst_source"
 
-singleValOperator :: SimpleOperator -> SqlFragment
+singleValOperator :: SingleValOperator -> SqlFragment
 singleValOperator = \case
   OpEqual            -> "="
   OpGreaterThanEqual -> ">="

--- a/src/PostgREST/Request/QueryParams.hs
+++ b/src/PostgREST/Request/QueryParams.hs
@@ -52,8 +52,9 @@ import PostgREST.Request.Types (EmbedParam (..), EmbedPath, Field,
                                 OpExpr (..), Operation (..),
                                 OrderDirection (..), OrderNulls (..),
                                 OrderTerm (..), QPError (..),
-                                SelectItem, SimpleOperator (..),
-                                SingleVal, TrileanVal (..))
+                                SelectItem, SingleVal,
+                                SingleValOperator (..),
+                                TrileanVal (..))
 
 import Protolude hiding (try)
 
@@ -64,7 +65,7 @@ import Protolude hiding (try)
 -- >>> deriving instance Show QPError
 -- >>> deriving instance Show TrileanVal
 -- >>> deriving instance Show FtsOperator
--- >>> deriving instance Show SimpleOperator
+-- >>> deriving instance Show SingleValOperator
 -- >>> deriving instance Show Operation
 -- >>> deriving instance Show OpExpr
 -- >>> deriving instance Show JsonOperand
@@ -206,7 +207,7 @@ parse qs =
         offsetParams =
           M.fromList [(k, maybe allRange rangeGeq (readMaybe $ toS v)) | (k,v) <- offsets]
 
-operator :: Text -> Maybe SimpleOperator
+operator :: Text -> Maybe SingleValOperator
 operator = \case
   "eq"    -> Just OpEqual
   "gte"   -> Just OpGreaterThanEqual

--- a/src/PostgREST/Request/Types.hs
+++ b/src/PostgREST/Request/Types.hs
@@ -35,7 +35,7 @@ module PostgREST.Request.Types
   , SingleVal
   , TrileanVal(..)
   , fstFieldNames
-  , SimpleOperator(..)
+  , SingleValOperator(..)
   , FtsOperator(..)
   ) where
 
@@ -232,7 +232,7 @@ data OpExpr =
   deriving (Eq)
 
 data Operation
-  = Op SimpleOperator SingleVal
+  = Op SingleValOperator SingleVal
   | In ListVal
   | Is TrileanVal
   | Fts FtsOperator (Maybe Language) SingleVal
@@ -254,7 +254,7 @@ data TrileanVal
   | TriUnknown
   deriving Eq
 
-data SimpleOperator
+data SingleValOperator
   = OpEqual
   | OpGreaterThanEqual
   | OpGreaterThan


### PR DESCRIPTION
What module is in charge of parsing the query string `?id=eq.1&select=name`? Currently, that concern is spread across many modules, including:

* `ApiRequest`
* `Parsers`
* `DbRequestBuilder`
* `SqlFragment`

This PR carves out one coherent module that is in charge of parsing the query string. It exposes one function `parse` that is also easy to use interactively. Additional type safety is introduced by defining types for the filter operators, which also decouples the query string parsing from SqlFragment.