### PR TITLE
Include valid examples in the hint for ambiguous embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + This is enabled by adding `!inner` to the embedded resource, e.g. `/projects?select=*,clients!inner(*)&clients.id=eq.12`
    + This behavior can be enabled by default with the `db-embed-default-join='inner'` config option, which saves the need for specifying `!inner` on every request. In this case, you can go back to the previous behavior per request by specifying `!left`  on the embedded resource, e.g `/projects?select=*,clients!left(*)&clients.id=eq.12`
 - #1988, Allow specifying `unknown` for the `is` operator - @steve-chavez
+- #2031, Add clarification and relevant hint examples to the ambiguous embedding error - @laurenceisla
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + This is enabled by adding `!inner` to the embedded resource, e.g. `/projects?select=*,clients!inner(*)&clients.id=eq.12`
    + This behavior can be enabled by default with the `db-embed-default-join='inner'` config option, which saves the need for specifying `!inner` on every request. In this case, you can go back to the previous behavior per request by specifying `!left`  on the embedded resource, e.g `/projects?select=*,clients!left(*)&clients.id=eq.12`
 - #1988, Allow specifying `unknown` for the `is` operator - @steve-chavez
-- #2031, Add clarification and relevant hint examples to the ambiguous embedding error - @laurenceisla
+- #2031, Improve error message for ambiguous embedding and add a relevant hint that includes unambiguous embedding suggestions - @laurenceisla
 
 ### Fixed
 

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -98,7 +98,7 @@ instance JSON.ToJSON ApiRequestError where
     "message" .= ("Could not find a relationship between " <> parent <> " and " <> child <> " in the schema cache" :: Text)]
   toJSON (AmbiguousRelBetween parent child rels) = JSON.object [
     "hint"    .= ("Try changing '" <> child <> "' to one of the following: " <> relHint rels <> ". Find the desired relationship in the 'details' key." :: Text),
-    "message" .= ("Could not embed because more than one relationship was found for " <> parent <> " and " <> child :: Text),
+    "message" .= ("Could not embed because more than one relationship was found for '" <> parent <> "' and '" <> child <> "'" :: Text),
     "details" .= (compressedRel <$> rels) ]
   toJSON (AmbiguousRpc procs)  = JSON.object [
     "hint"    .= ("Try renaming the parameters or the function itself in the database so function overloading can be resolved" :: Text),
@@ -149,7 +149,7 @@ relHint :: [Relationship] -> Text
 relHint rels = T.intercalate ", " (hintList <$> rels)
   where
     hintList Relationship{..} =
-      let buildHint rel = tableName relForeignTable <> "!" <> rel in
+      let buildHint rel = "'" <> tableName relForeignTable <> "!" <> rel <> "'" in
       case relCardinality of
         M2M Junction{..} -> buildHint (tableName junTable)
         M2O cons         -> buildHint cons

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -97,7 +97,7 @@ instance JSON.ToJSON ApiRequestError where
     "hint"    .= ("If a new foreign key between these entities was created in the database, try reloading the schema cache." :: Text),
     "message" .= ("Could not find a relationship between " <> parent <> " and " <> child <> " in the schema cache" :: Text)]
   toJSON (AmbiguousRelBetween parent child rels) = JSON.object [
-    "hint"    .= ("According to the relationship needed, try changing the query string to one of the following: " <> relHint rels :: Text),
+    "hint"    .= ("According to the relationship needed, try changing the value in the query string to one of the following: " <> relHint rels :: Text),
     "message" .= ("More than one relationship was found for " <> parent <> " and " <> child :: Text),
     "details" .= (compressedRel <$> rels) ]
   toJSON (AmbiguousRpc procs)  = JSON.object [

--- a/test/Feature/EmbedDisambiguationSpec.hs
+++ b/test/Feature/EmbedDisambiguationSpec.hs
@@ -31,7 +31,7 @@ spec =
                     "target": "test.person_detail"
                 }
               ],
-              "hint": "By following the 'details' key, disambiguate the request by changing the url to /origin?select=relationship(*) or /origin?select=target!relationship(*)",
+              "hint": "According to the relationship needed, try changing the value in the query string to one of the following: person!message_sender_fkey(*), person_detail!message_sender_fkey(*)",
               "message": "More than one relationship was found for message and sender"
             }
           |]
@@ -63,7 +63,7 @@ spec =
                   "target": "test.big_projects"
                 }
               ],
-              "hint": "By following the 'details' key, disambiguate the request by changing the url to /origin?select=relationship(*) or /origin?select=target!relationship(*)",
+              "hint": "According to the relationship needed, try changing the value in the query string to one of the following: big_projects!main_project(*), big_projects!jobs(*), big_projects!main_jobs(*)",
               "message": "More than one relationship was found for sites and big_projects"
             }
           |]
@@ -89,7 +89,7 @@ spec =
                     "target": "test.departments"
                 }
               ],
-              "hint": "By following the 'details' key, disambiguate the request by changing the url to /origin?select=relationship(*) or /origin?select=target!relationship(*)",
+              "hint": "According to the relationship needed, try changing the value in the query string to one of the following: departments!agents_department_id_fkey(*), departments!departments_head_id_fkey(*)",
               "message": "More than one relationship was found for agents and departments"
             }
            |]
@@ -130,7 +130,7 @@ spec =
                   "target": "test.whatev_projects"
                 }
               ],
-              "hint": "By following the 'details' key, disambiguate the request by changing the url to /origin?select=relationship(*) or /origin?select=target!relationship(*)",
+              "hint": "According to the relationship needed, try changing the value in the query string to one of the following: whatev_projects!whatev_jobs(*), whatev_projects!whatev_jobs(*), whatev_projects!whatev_jobs(*), whatev_projects!whatev_jobs(*)",
               "message": "More than one relationship was found for whatev_sites and whatev_projects"
             }
           |]

--- a/test/Feature/EmbedDisambiguationSpec.hs
+++ b/test/Feature/EmbedDisambiguationSpec.hs
@@ -29,8 +29,8 @@ spec =
                     "embedding": "message with person_detail"
                 }
               ],
-              "hint": "Try changing 'sender' to one of the following: person!message_sender_fkey, person_detail!message_sender_fkey. Find the desired relationship in the 'details' key.",
-              "message": "Could not embed because more than one relationship was found for message and sender"
+              "hint": "Try changing 'sender' to one of the following: 'person!message_sender_fkey', 'person_detail!message_sender_fkey'. Find the desired relationship in the 'details' key.",
+              "message": "Could not embed because more than one relationship was found for 'message' and 'sender'"
             }
           |]
           { matchStatus  = 300
@@ -58,8 +58,8 @@ spec =
                   "embedding": "sites with big_projects"
                 }
               ],
-              "hint": "Try changing 'big_projects' to one of the following: big_projects!main_project, big_projects!jobs, big_projects!main_jobs. Find the desired relationship in the 'details' key.",
-              "message": "Could not embed because more than one relationship was found for sites and big_projects"
+              "hint": "Try changing 'big_projects' to one of the following: 'big_projects!main_project', 'big_projects!jobs', 'big_projects!main_jobs'. Find the desired relationship in the 'details' key.",
+              "message": "Could not embed because more than one relationship was found for 'sites' and 'big_projects'"
             }
           |]
           { matchStatus  = 300
@@ -82,8 +82,8 @@ spec =
                     "embedding": "agents with departments"
                 }
               ],
-              "hint": "Try changing 'departments' to one of the following: departments!agents_department_id_fkey, departments!departments_head_id_fkey. Find the desired relationship in the 'details' key.",
-              "message": "Could not embed because more than one relationship was found for agents and departments"
+              "hint": "Try changing 'departments' to one of the following: 'departments!agents_department_id_fkey', 'departments!departments_head_id_fkey'. Find the desired relationship in the 'details' key.",
+              "message": "Could not embed because more than one relationship was found for 'agents' and 'departments'"
             }
            |]
           { matchStatus  = 300
@@ -119,8 +119,8 @@ spec =
                   "embedding": "whatev_sites with whatev_projects"
                 }
               ],
-              "hint": "Try changing 'whatev_projects' to one of the following: whatev_projects!whatev_jobs, whatev_projects!whatev_jobs, whatev_projects!whatev_jobs, whatev_projects!whatev_jobs. Find the desired relationship in the 'details' key.",
-              "message": "Could not embed because more than one relationship was found for whatev_sites and whatev_projects"
+              "hint": "Try changing 'whatev_projects' to one of the following: 'whatev_projects!whatev_jobs', 'whatev_projects!whatev_jobs', 'whatev_projects!whatev_jobs', 'whatev_projects!whatev_jobs'. Find the desired relationship in the 'details' key.",
+              "message": "Could not embed because more than one relationship was found for 'whatev_sites' and 'whatev_projects'"
             }
           |]
           { matchStatus  = 300

--- a/test/Feature/EmbedDisambiguationSpec.hs
+++ b/test/Feature/EmbedDisambiguationSpec.hs
@@ -19,18 +19,18 @@ spec =
             {
               "details": [
                 {
-                    "cardinality": "many to one",
+                    "cardinality": "many-to-one",
                     "relationship": "message_sender_fkey[sender][id]",
                     "embedding": "message with person"
                 },
                 {
-                    "cardinality": "many to one",
+                    "cardinality": "many-to-one",
                     "relationship": "message_sender_fkey[sender][id]",
                     "embedding": "message with person_detail"
                 }
               ],
-              "hint": "Try changing 'sender' to one of the following: person!message_sender_fkey(*), person_detail!message_sender_fkey(*). Find your desired relationship in the 'details' key.",
-              "message": "More than one relationship was found for message and sender"
+              "hint": "Try changing 'sender' to one of the following: person!message_sender_fkey, person_detail!message_sender_fkey. Find the desired relationship in the 'details' key.",
+              "message": "Could not embed because more than one relationship was found for message and sender"
             }
           |]
           { matchStatus  = 300
@@ -43,23 +43,23 @@ spec =
             {
               "details": [
                 {
-                  "cardinality": "many to one",
+                  "cardinality": "many-to-one",
                   "relationship": "main_project[main_project_id][big_project_id]",
                   "embedding": "sites with big_projects"
                 },
                 {
-                  "cardinality": "many to many",
+                  "cardinality": "many-to-many",
                   "relationship": "test.jobs[jobs_site_id_fkey][jobs_big_project_id_fkey]",
                   "embedding": "sites with big_projects"
                 },
                 {
-                  "cardinality": "many to many",
+                  "cardinality": "many-to-many",
                   "relationship": "test.main_jobs[jobs_site_id_fkey][jobs_big_project_id_fkey]",
                   "embedding": "sites with big_projects"
                 }
               ],
-              "hint": "Try changing 'big_projects' to one of the following: big_projects!main_project(*), big_projects!jobs(*), big_projects!main_jobs(*). Find your desired relationship in the 'details' key.",
-              "message": "More than one relationship was found for sites and big_projects"
+              "hint": "Try changing 'big_projects' to one of the following: big_projects!main_project, big_projects!jobs, big_projects!main_jobs. Find the desired relationship in the 'details' key.",
+              "message": "Could not embed because more than one relationship was found for sites and big_projects"
             }
           |]
           { matchStatus  = 300
@@ -72,18 +72,18 @@ spec =
             {
               "details": [
                 {
-                    "cardinality": "many to one",
+                    "cardinality": "many-to-one",
                     "relationship": "agents_department_id_fkey[department_id][id]",
                     "embedding": "agents with departments"
                 },
                 {
-                    "cardinality": "one to many",
+                    "cardinality": "one-to-many",
                     "relationship": "departments_head_id_fkey[id][head_id]",
                     "embedding": "agents with departments"
                 }
               ],
-              "hint": "Try changing 'departments' to one of the following: departments!agents_department_id_fkey(*), departments!departments_head_id_fkey(*). Find your desired relationship in the 'details' key.",
-              "message": "More than one relationship was found for agents and departments"
+              "hint": "Try changing 'departments' to one of the following: departments!agents_department_id_fkey, departments!departments_head_id_fkey. Find the desired relationship in the 'details' key.",
+              "message": "Could not embed because more than one relationship was found for agents and departments"
             }
            |]
           { matchStatus  = 300
@@ -99,28 +99,28 @@ spec =
             {
               "details": [
                 {
-                  "cardinality": "many to many",
+                  "cardinality": "many-to-many",
                   "relationship": "test.whatev_jobs[whatev_jobs_site_id_1_fkey][whatev_jobs_project_id_1_fkey]",
                   "embedding": "whatev_sites with whatev_projects"
                 },
                 {
-                  "cardinality": "many to many",
+                  "cardinality": "many-to-many",
                   "relationship": "test.whatev_jobs[whatev_jobs_site_id_1_fkey][whatev_jobs_project_id_2_fkey]",
                   "embedding": "whatev_sites with whatev_projects"
                 },
                 {
-                  "cardinality": "many to many",
+                  "cardinality": "many-to-many",
                   "relationship": "test.whatev_jobs[whatev_jobs_site_id_2_fkey][whatev_jobs_project_id_1_fkey]",
                   "embedding": "whatev_sites with whatev_projects"
                 },
                 {
-                  "cardinality": "many to many",
+                  "cardinality": "many-to-many",
                   "relationship": "test.whatev_jobs[whatev_jobs_site_id_2_fkey][whatev_jobs_project_id_2_fkey]",
                   "embedding": "whatev_sites with whatev_projects"
                 }
               ],
-              "hint": "Try changing 'whatev_projects' to one of the following: whatev_projects!whatev_jobs(*), whatev_projects!whatev_jobs(*), whatev_projects!whatev_jobs(*), whatev_projects!whatev_jobs(*). Find your desired relationship in the 'details' key.",
-              "message": "More than one relationship was found for whatev_sites and whatev_projects"
+              "hint": "Try changing 'whatev_projects' to one of the following: whatev_projects!whatev_jobs, whatev_projects!whatev_jobs, whatev_projects!whatev_jobs, whatev_projects!whatev_jobs. Find the desired relationship in the 'details' key.",
+              "message": "Could not embed because more than one relationship was found for whatev_sites and whatev_projects"
             }
           |]
           { matchStatus  = 300

--- a/test/Feature/EmbedDisambiguationSpec.hs
+++ b/test/Feature/EmbedDisambiguationSpec.hs
@@ -19,19 +19,17 @@ spec =
             {
               "details": [
                 {
-                    "cardinality": "m2o",
+                    "cardinality": "many to one",
                     "relationship": "message_sender_fkey[sender][id]",
-                    "origin": "test.message",
-                    "target": "test.person"
+                    "embedding": "message with person"
                 },
                 {
-                    "cardinality": "m2o",
+                    "cardinality": "many to one",
                     "relationship": "message_sender_fkey[sender][id]",
-                    "origin": "test.message",
-                    "target": "test.person_detail"
+                    "embedding": "message with person_detail"
                 }
               ],
-              "hint": "According to the relationship needed, try changing the value in the query string to one of the following: person!message_sender_fkey(*), person_detail!message_sender_fkey(*)",
+              "hint": "Try changing 'sender' to one of the following: person!message_sender_fkey(*), person_detail!message_sender_fkey(*). Find your desired relationship in the 'details' key.",
               "message": "More than one relationship was found for message and sender"
             }
           |]
@@ -45,25 +43,22 @@ spec =
             {
               "details": [
                 {
-                  "cardinality": "m2o",
+                  "cardinality": "many to one",
                   "relationship": "main_project[main_project_id][big_project_id]",
-                  "origin": "test.sites",
-                  "target": "test.big_projects"
+                  "embedding": "sites with big_projects"
                 },
                 {
-                  "cardinality": "m2m",
+                  "cardinality": "many to many",
                   "relationship": "test.jobs[jobs_site_id_fkey][jobs_big_project_id_fkey]",
-                  "origin": "test.sites",
-                  "target": "test.big_projects"
+                  "embedding": "sites with big_projects"
                 },
                 {
-                  "cardinality": "m2m",
+                  "cardinality": "many to many",
                   "relationship": "test.main_jobs[jobs_site_id_fkey][jobs_big_project_id_fkey]",
-                  "origin": "test.sites",
-                  "target": "test.big_projects"
+                  "embedding": "sites with big_projects"
                 }
               ],
-              "hint": "According to the relationship needed, try changing the value in the query string to one of the following: big_projects!main_project(*), big_projects!jobs(*), big_projects!main_jobs(*)",
+              "hint": "Try changing 'big_projects' to one of the following: big_projects!main_project(*), big_projects!jobs(*), big_projects!main_jobs(*). Find your desired relationship in the 'details' key.",
               "message": "More than one relationship was found for sites and big_projects"
             }
           |]
@@ -77,19 +72,17 @@ spec =
             {
               "details": [
                 {
-                    "cardinality": "m2o",
+                    "cardinality": "many to one",
                     "relationship": "agents_department_id_fkey[department_id][id]",
-                    "origin": "test.agents",
-                    "target": "test.departments"
+                    "embedding": "agents with departments"
                 },
                 {
-                    "cardinality": "o2m",
+                    "cardinality": "one to many",
                     "relationship": "departments_head_id_fkey[id][head_id]",
-                    "origin": "test.agents",
-                    "target": "test.departments"
+                    "embedding": "agents with departments"
                 }
               ],
-              "hint": "According to the relationship needed, try changing the value in the query string to one of the following: departments!agents_department_id_fkey(*), departments!departments_head_id_fkey(*)",
+              "hint": "Try changing 'departments' to one of the following: departments!agents_department_id_fkey(*), departments!departments_head_id_fkey(*). Find your desired relationship in the 'details' key.",
               "message": "More than one relationship was found for agents and departments"
             }
            |]
@@ -106,31 +99,27 @@ spec =
             {
               "details": [
                 {
-                  "cardinality": "m2m",
+                  "cardinality": "many to many",
                   "relationship": "test.whatev_jobs[whatev_jobs_site_id_1_fkey][whatev_jobs_project_id_1_fkey]",
-                  "origin": "test.whatev_sites",
-                  "target": "test.whatev_projects"
+                  "embedding": "whatev_sites with whatev_projects"
                 },
                 {
-                  "cardinality": "m2m",
+                  "cardinality": "many to many",
                   "relationship": "test.whatev_jobs[whatev_jobs_site_id_1_fkey][whatev_jobs_project_id_2_fkey]",
-                  "origin": "test.whatev_sites",
-                  "target": "test.whatev_projects"
+                  "embedding": "whatev_sites with whatev_projects"
                 },
                 {
-                  "cardinality": "m2m",
+                  "cardinality": "many to many",
                   "relationship": "test.whatev_jobs[whatev_jobs_site_id_2_fkey][whatev_jobs_project_id_1_fkey]",
-                  "origin": "test.whatev_sites",
-                  "target": "test.whatev_projects"
+                  "embedding": "whatev_sites with whatev_projects"
                 },
                 {
-                  "cardinality": "m2m",
+                  "cardinality": "many to many",
                   "relationship": "test.whatev_jobs[whatev_jobs_site_id_2_fkey][whatev_jobs_project_id_2_fkey]",
-                  "origin": "test.whatev_sites",
-                  "target": "test.whatev_projects"
+                  "embedding": "whatev_sites with whatev_projects"
                 }
               ],
-              "hint": "According to the relationship needed, try changing the value in the query string to one of the following: whatev_projects!whatev_jobs(*), whatev_projects!whatev_jobs(*), whatev_projects!whatev_jobs(*), whatev_projects!whatev_jobs(*)",
+              "hint": "Try changing 'whatev_projects' to one of the following: whatev_projects!whatev_jobs(*), whatev_projects!whatev_jobs(*), whatev_projects!whatev_jobs(*), whatev_projects!whatev_jobs(*). Find your desired relationship in the 'details' key.",
               "message": "More than one relationship was found for whatev_sites and whatev_projects"
             }
           |]


### PR DESCRIPTION
The example given when an Ambiguous Embedding error is thrown shows a generic example `/origin?select=relationship(*)` or `/origin?select=target!relationship(*)`.

This PR adds examples with the real  `target!relationship` names relevant to the query, omitting the `origin` and the `select` clause. 

Edit: Also adds changes to other parts of the error to make it clearer to the user.