### PR TITLE
ci: Refactor workflows

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -1,0 +1,21 @@
+name: Setup Nix
+
+description: Installs nix, sets up cachix and installs a subset of tooling.
+
+inputs:
+  authToken:
+    description: Token to pass to cachix
+  tools:
+    description: Tools to install with nix-env -iA <tools>
+
+runs:
+  using: composite
+  steps:
+    - uses: cachix/install-nix-action@v13
+    - uses: cachix/cachix-action@v10
+      with:
+        name: postgrest
+        authToken: ${{ inputs.authToken }}
+    - if: ${{ inputs.tools }}
+      run: nix-env -f default.nix -iA ${{ inputs.tools }}
+      shell: bash

--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -11,7 +11,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: cachix/install-nix-action@v13
+    - uses: cachix/install-nix-action@v16
     - uses: cachix/cachix-action@v10
       with:
         name: postgrest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,7 +90,7 @@ jobs:
       - name: Run memory tests
         run: postgrest-test-memory
 
-  Build-Linux-Nix:
+  Build-Nix:
     name: Build Linux static (Nix)
     runs-on: ubuntu-latest
     steps:
@@ -125,80 +125,67 @@ jobs:
           nix-env -f default.nix -iA devTools
           postgrest-push-cachix
 
-  Build-Linux-Stack:
-    name: Build Ubuntu & test (Stack)
-    runs-on: ubuntu-latest
+  Build-Stack:
+    strategy:
+      matrix:
+        os:
+          - name: Linux & test
+            runs-on: ubuntu-latest
+            cache: |
+              ~/.stack
+              .stack-work
+            test: true
+            pgdir: /usr/lib/postgresql
+            artifact: postgrest-ubuntu-x64
+
+          - name: MacOS & test
+            runs-on: macos-latest
+            cache: |
+              ~/.stack
+              .stack-work
+            test: true
+            pgdir: /usr/local/Cellar/postgresql
+            artifact: postgrest-macos-x64
+
+          - name: Windows
+            runs-on: windows-latest
+            cache: |
+              ~\AppData\Roaming\stack
+              ~\AppData\Local\Programs\stack
+              .stack-work
+            deps: |
+              stack exec -- pacman -S mingw64/mingw-w64-x86_64-postgresql --noconfirm
+            # We'd need to make test/with_tmp_db run on Windows first
+            # test: true
+            artifact: postgrest-windows-x64
+
+    name: Build ${{ matrix.os.name }} (Stack)
+    runs-on: ${{ matrix.os.runs-on }}
     steps:
       - uses: actions/checkout@v2.4.0
       - name: Stack working files cache
         uses: actions/cache@v2.1.6
         with:
-          path: |
-            ~/.stack
-            .stack-work
+          path: ${{ matrix.os.cache }}
           key: ${{ runner.os }}-${{ hashFiles('stack.yaml.lock') }}
+      - name: Install dependencies
+        if: ${{ matrix.os.deps }}
+        run: ${{ matrix.os.deps }}
       - name: Build with Stack
         run: stack build --local-bin-path result --copy-bins
       - name: Run Spec tests with Stack
+        if: ${{ matrix.os.test }}
         run: |
-          postgresql_bin="$(find /usr/lib/postgresql -maxdepth 2 -type d -name bin | head -n 1)"
+          postgresql_bin="$(find ${{ matrix.os.pgdir }} -maxdepth 2 -type d -name bin | head -n 1)"
           echo "Using PostgreSQL binaries at $postgresql_bin ..."
           PATH="$postgresql_bin:$PATH" test/with_tmp_db stack test
       - name: Save built executable as artifact
         uses: actions/upload-artifact@v2.2.4
         with:
-          name: postgrest-ubuntu-x64
-          path: result/postgrest
-          if-no-files-found: error
-
-  Build-MacOS-Stack:
-    name: Build MacOS & test (Stack)
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Stack working files cache
-        uses: actions/cache@v2
-        with:
+          name: ${{ matrix.os.artifact }}
           path: |
-            ~/.stack
-            .stack-work
-          key: ${{ runner.os }}-${{ hashFiles('stack.yaml.lock') }}
-      - name: Build with Stack
-        run: stack build --local-bin-path result --copy-bins
-      - name: Run Spec tests with Stack
-        run: |
-          postgresql_bin="$(find /usr/local/Cellar/postgresql -maxdepth 2 -type d -name bin | head -n 1)"
-          echo "Using PostgreSQL binaries at $postgresql_bin ..."
-          PATH="$postgresql_bin:$PATH" test/with_tmp_db stack test
-      - name: Save built executable as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: postgrest-macos-x64
-          path: result/postgrest
-          if-no-files-found: error
-
-  Build-Windows-Stack:
-    name: Build Windows (Stack)
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Stack working files cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~\AppData\Roaming\stack
-            ~\AppData\Local\Programs\stack
-            .stack-work
-          key: ${{ runner.os }}-${{ hashFiles('stack.yaml.lock') }}
-      - name: Install dependencies
-        run: stack exec -- pacman -S mingw64/mingw-w64-x86_64-postgresql --noconfirm
-      - name: Build with Stack
-        run: stack build --local-bin-path result --copy-bins
-      - name: Save built executable as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: postgrest-windows-x64
-          path: result/postgrest.exe
+            result/postgrest
+            result/postgrest.exe
           if-no-files-found: error
 
   Get-FreeBSD-CirrusCI:
@@ -226,10 +213,8 @@ jobs:
       - Lint-Style
       - Test-Nix
       - Test-Memory-Nix
-      - Build-Linux-Nix
-      - Build-Linux-Stack
-      - Build-MacOS-Stack
-      - Build-Windows-Stack
+      - Build-Nix
+      - Build-Stack
       - Get-FreeBSD-CirrusCI
     outputs:
       version: ${{ steps.Identify-Version.outputs.version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Lint & check code style
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.4.0
       - name: Setup Nix Environment
         uses: ./.github/actions/setup-nix
         with:
@@ -34,7 +34,7 @@ jobs:
         # https://github.com/actions/runner/issues/241#issuecomment-842566950
         shell: script -qec "bash --noprofile --norc -eo pipefail {0}"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.4.0
       - name: Setup Nix Environment
         uses: ./.github/actions/setup-nix
         with:
@@ -43,7 +43,7 @@ jobs:
       - name: Run coverage (IO tests and Spec tests against PostgreSQL 14)
         run: postgrest-coverage
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v2.1.0
         with:
           files: ./coverage/codecov.json
 
@@ -82,7 +82,7 @@ jobs:
     name: Test memory (Nix)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.4.0
       - name: Setup Nix Environment
         uses: ./.github/actions/setup-nix
         with:
@@ -94,7 +94,7 @@ jobs:
     name: Build Linux static (Nix)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.4.0
       - name: Setup Nix Environment
         uses: ./.github/actions/setup-nix
         with:
@@ -103,7 +103,7 @@ jobs:
       - name: Build static executable
         run: nix-build -A postgrestStatic
       - name: Save built executable as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.4
         with:
           name: postgrest-linux-static-x64
           path: result/bin/postgrest
@@ -112,7 +112,7 @@ jobs:
       - name: Build Docker image
         run: nix-build -A docker.image --out-link postgrest-docker.tar.gz
       - name: Save built Docker image as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.4
         with:
           name: postgrest-docker-x64
           path: postgrest-docker.tar.gz
@@ -129,9 +129,9 @@ jobs:
     name: Build Ubuntu & test (Stack)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.4.0
       - name: Stack working files cache
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.6
         with:
           path: |
             ~/.stack
@@ -145,7 +145,7 @@ jobs:
           echo "Using PostgreSQL binaries at $postgresql_bin ..."
           PATH="$postgresql_bin:$PATH" test/with_tmp_db stack test
       - name: Save built executable as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.4
         with:
           name: postgrest-ubuntu-x64
           path: result/postgrest
@@ -205,14 +205,14 @@ jobs:
     name: Get FreeBSD build from CirrusCI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.4.0
       - name: Get FreeBSD executable from CirrusCI
         env:
           # GITHUB_SHA does weird things for pull request, so we roll our own:
           GITHUB_COMMIT: ${{github.event.pull_request.head.sha || github.sha}}
         run: .github/get_cirrusci_freebsd
       - name: Save executable as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.4
         with:
           name: postgrest-freebsd-x64
           path: postgrest
@@ -235,7 +235,7 @@ jobs:
       version: ${{ steps.Identify-Version.outputs.version }}
       isprerelease: ${{ steps.Identify-Version.outputs.isprerelease }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.4.0
       - id: Identify-Version
         name: Identify the version to be released
         run: |
@@ -272,7 +272,7 @@ jobs:
           echo "Relevant extract from CHANGELOG.md:"
           cat CHANGES.md
       - name: Save CHANGES.md as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.4
         with:
           name: release-changes
           path: CHANGES.md
@@ -287,9 +287,9 @@ jobs:
     env:
       VERSION: ${{ needs.Prepare-Release.outputs.version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.4.0
       - name: Download all artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v2.0.10
         with:
           path: artifacts
       - name: Create release bundle with archives for all builds
@@ -316,7 +316,7 @@ jobs:
             artifacts/postgrest-windows-x64/postgrest.exe
 
       - name: Save release bundle
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.4
         with:
           name: release-bundle
           path: release-bundle
@@ -345,13 +345,13 @@ jobs:
       VERSION: ${{ needs.Prepare-Release.outputs.version }}
       ISPRERELEASE: ${{ needs.Prepare-Release.outputs.isprerelease }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.4.0
       - name: Setup Nix Environment
         uses: ./.github/actions/setup-nix
         with:
           tools: release
       - name: Download Docker image
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v2.0.10
         with:
           name: postgrest-docker-x64
       - name: Publish images on Docker Hub

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v13
-      - name: Install linting and styling scripts
-        run: nix-env -f default.nix -iA style
+      - name: Setup Nix Environment
+        uses: ./.github/actions/setup-nix
+        with:
+          tools: style
       - name: Run linter (check locally with `nix-shell --run postgrest-lint`)
         run: postgrest-lint
       - name: Run style check (auto-format with `nix-shell --run postgrest-style`)
@@ -34,12 +35,10 @@ jobs:
         shell: script -qec "bash --noprofile --norc -eo pipefail {0}"
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v13
-      - uses: cachix/cachix-action@v10
+      - name: Setup Nix Environment
+        uses: ./.github/actions/setup-nix
         with:
-          name: postgrest
-      - name: Install testing scripts
-        run: nix-env -f default.nix -iA tests withTools
+          tools: tests withTools
 
       - name: Run coverage (IO tests and Spec tests against PostgreSQL 14)
         run: postgrest-coverage
@@ -84,12 +83,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v13
-      - uses: cachix/cachix-action@v10
+      - name: Setup Nix Environment
+        uses: ./.github/actions/setup-nix
         with:
-          name: postgrest
-      - name: Install testing script
-        run: nix-env -f default.nix -iA memory
+          tools: memory
       - name: Run memory tests
         run: postgrest-test-memory
 
@@ -98,10 +95,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v13
-      - uses: cachix/cachix-action@v10
+      - name: Setup Nix Environment
+        uses: ./.github/actions/setup-nix
         with:
-          name: postgrest
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Build static executable
@@ -350,9 +346,10 @@ jobs:
       ISPRERELEASE: ${{ needs.Prepare-Release.outputs.isprerelease }}
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v13
-      - name: Install release scripts
-        run: nix-env -f default.nix -iA release
+      - name: Setup Nix Environment
+        uses: ./.github/actions/setup-nix
+        with:
+          tools: release
       - name: Download Docker image
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -284,7 +284,8 @@ jobs:
 
   Release-GitHub:
     name: Release on GitHub
-    permissions: write-all
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: Prepare-Release
     env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,7 @@ jobs:
       - name: Run style check (auto-format with `nix-shell --run postgrest-style`)
         run: postgrest-style-check
 
+
   Test-Nix:
     name: Test (Nix)
     runs-on: ubuntu-latest
@@ -78,6 +79,7 @@ jobs:
         if: always()
         run: postgrest-test-spec-idempotence
 
+
   Test-Memory-Nix:
     name: Test memory (Nix)
     runs-on: ubuntu-latest
@@ -89,6 +91,7 @@ jobs:
           tools: memory
       - name: Run memory tests
         run: postgrest-test-memory
+
 
   Build-Nix:
     name: Build Linux static (Nix)
@@ -124,6 +127,7 @@ jobs:
           nix-build
           nix-env -f default.nix -iA devTools
           postgrest-push-cachix
+
 
   Build-Stack:
     strategy:
@@ -188,6 +192,7 @@ jobs:
             result/postgrest.exe
           if-no-files-found: error
 
+
   Get-FreeBSD-CirrusCI:
     name: Get FreeBSD build from CirrusCI
     runs-on: ubuntu-latest
@@ -204,6 +209,7 @@ jobs:
           name: postgrest-freebsd-x64
           path: postgrest
           if-no-files-found: error
+
 
   Prepare-Release:
     name: Prepare release
@@ -263,6 +269,7 @@ jobs:
           path: CHANGES.md
           if-no-files-found: error
 
+
   Release-GitHub:
     name: Release on GitHub
     permissions:
@@ -319,6 +326,7 @@ jobs:
             -F artifacts/release-changes/CHANGES.md \
             ${isprerelease:+"--prerelease"} \
             release-bundle/*
+
 
   Release-Docker:
     name: Release on Docker Hub

--- a/nix/tools/style.nix
+++ b/nix/tools/style.nix
@@ -65,7 +65,10 @@ let
           | xargs ${hlint}/bin/hlint -X QuasiQuotes -X NoPatternSynonyms
 
         echo "Linting bash scripts..."
-        ${shellcheck}/bin/shellcheck test/with_tmp_db
+        ${shellcheck}/bin/shellcheck \
+          .github/get_cirrusci_freebsd \
+          .github/release \
+          test/with_tmp_db
 
         echo "Linting workflows..."
         ${actionlint}/bin/actionlint


### PR DESCRIPTION
I wanted to get used to GitHub Actions a bit more and played with our workflow. To reduce some of the repetition we currently have, I added a `setup-nix` action and used a matrix strategy to build with stack on different OS. This doesn't really reduce the amount of code, but I feel it's a bit quicker to see which parts are the same between different jobs and which parts are varied.

I also tried two more things, but failed so far:
- Reorganizing the big workflow into multiple files with the "reusable workflows" feature, doesn't really work, yet, because this does not support calling workflow files in the same repository, yet. This might be possible in the future.
- Running the spec tests on Windows requires to have `with_tmp_db` run on Windows. I can see that as a possibility and also made a bit of progress, but gave up on it for now.