### PR TITLE
nix: Simplify with_tmp_db

### DIFF
--- a/nix/tools/withTools.nix
+++ b/nix/tools/withTools.nix
@@ -60,14 +60,8 @@ let
 
         log "Starting the database cluster..."
         # Instead of listening on a local port, we will listen on a unix domain socket.
-        pg_ctl -l "$tmpdir/db.log" start -o "-F -c listen_addresses=\"\" -k $PGHOST" \
+        pg_ctl -l "$tmpdir/db.log" -w start -o "-F -c listen_addresses=\"\" -k $PGHOST" \
           >> "$setuplog"
-
-        log "Waiting for the database cluster to be ready..."
-        # Waiting is required for older versions of Postgres (< 10).
-        until pg_isready >> "$setuplog"; do
-          sleep 0.1
-        done
 
         stop () {
           log "Stopping the database cluster..."

--- a/test/with_tmp_db
+++ b/test/with_tmp_db
@@ -69,23 +69,10 @@ PGTZ=UTC initdb --no-locale --encoding=UTF8 --nosync -U "$PGUSER" --auth=trust \
 
 log "Starting the database cluster..."
 # Instead of listening on a local port, we will listen on a unix domain socket.
-pg_ctl -l "$dblog" start -o "-F -c listen_addresses=\"\" -k $PGHOST" \
+pg_ctl -l "$dblog" -w start -o "-F -c listen_addresses=\"\" -k $PGHOST" \
   >> "$setuplog"
 
-log "Waiting for the database cluster to be ready..."
-# Waiting is required for older versions of Postgres (< 10).
-until pg_isready >> "$setuplog"; do
-  sleep 0.1
-done
-
-stopped=0
 stop() {
-  # cleaning up once is enough; otherwise we get some errors
-  if [ $stopped -eq 1 ]; then
-    return
-  fi
-  stopped=1
-
   log "Stopping the database cluster..."
   pg_ctl stop -m i >> "$setuplog"
 
@@ -96,7 +83,7 @@ stop() {
   fi
 }
 
-trap stop sigint sigterm exit
+trap stop EXIT
 
 log "Loading fixtures..."
 psql -v ON_ERROR_STOP=1 -f test/fixtures/load.sql >> "$setuplog"
@@ -106,4 +93,4 @@ log "Done. Running command..."
 # make sure that the database is shut down and the temporary directory is
 # deleted when the command is done. This is also why we don't `exec` the
 # command - our trap would be lost if we did that.
-"$@"
+("$@")


### PR DESCRIPTION
Three changes here:
- For one, `pg_ctl` has a `-w` option, that will make it wait until startup is completed. This option is enabled by default from PG 10 onwards - but can be enabled with this flag for older versions. No need for the loop anymore.
- the nix-checked `withTmpDb` and `test/with_tmp_db` have deviated a bit by now. We can do the same simplifications regarding error handling we did for the nix version in the standalone version, too. If we only trap `EXIT`, we will only have `stop()` called once automatically, but still clean up all the time properly.
- Finally, running the actual command in a subshell in `with_tmp_db`, too, makes it a bit more robust in case somebody runs it with a shell script that sets up other traps - we'd want to make sure we're not losing our exit trap in that case.