### PR TITLE
ci: Add dependabot config for auto updates of github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly


### PR DESCRIPTION
Now, that we have switched to GitHub Actions and are using actions from other sources, it would make life easier if dependabot gave us automatic PRs for updates to those actions.

This is the config for that - but dependabot needs to be enabled at the same time in the repo settings, for which I don't have access. @steve-chavez