### PR TITLE
ci: Add report workflow ahead of #1812

### DIFF
--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -1,0 +1,29 @@
+name: Upload Reports
+
+on:
+  workflow_run:
+    workflows: ["Loadtest"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Download from Artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow.name }}
+          run_id: ${{github.event.workflow_run.id }}
+          name: loadtest.md
+          path: artifacts
+      - name: Upload to GitHub Checks
+        uses: LouisBrunner/checks-action@v1.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: Loadtest Results
+          conclusion: neutral
+          output: |
+            {"summary":""}
+          output_text_description_file: artifacts/loadtest.md

--- a/nix/tools/release/default.nix
+++ b/nix/tools/release/default.nix
@@ -1,7 +1,6 @@
 { buildToolbox
 , checkedShellScript
 , curl
-, ghr
 , jq
 }:
 let

--- a/nix/tools/release/default.nix
+++ b/nix/tools/release/default.nix
@@ -26,9 +26,9 @@ let
         # ARG_USE_ENV only adds defaults or docs for environment variables
         # We manually implement a required check here
         # See also: https://github.com/matejak/argbash/issues/80
-        DOCKER_USER="''${DOCKER_USER:?DOCKER_USER is required}"
-        DOCKER_PASS="''${DOCKER_PASS:?DOCKER_PASS is required}"
-        DOCKER_REPO="''${DOCKER_REPO:?DOCKER_REPO is required}"
+        : "''${DOCKER_USER:?DOCKER_USER is required}"
+        : "''${DOCKER_PASS:?DOCKER_PASS is required}"
+        : "''${DOCKER_REPO:?DOCKER_REPO is required}"
 
         echo "Logging in to Docker Hub to get an auth token..."
         token="$(


### PR DESCRIPTION
This takes two tiny nix fixes out of #1812 and adds the report workflow from there, too. The workflow needs to be merged ahead of #1812 to be able to upload coverage reports to the Actions/Checks page. This is because the workflow to do that must be trusted and as such must be from this repo and not from my fork through the PR.

I tested it in my own fork and it should work like that.
