### PR TITLE
Treat plpgsql assert as invalid input

### DIFF
--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -241,6 +241,7 @@ pgErrorStatus authed (SQL.SessionError (SQL.QueryError _ _ (SQL.ResultError rErr
         'F':'0':_ -> HTTP.status500 -- conf file error
         'H':'V':_ -> HTTP.status500 -- foreign data wrapper error
         "P0001"   -> HTTP.status400 -- default code for "raise"
+        "P0004"   -> HTTP.status400 -- assert failure
         'P':'0':_ -> HTTP.status500 -- PL/pgSQL Error
         'X':'X':_ -> HTTP.status500 -- internal Error
         "42883"   -> HTTP.status404 -- undefined function

--- a/test/Feature/RpcSpec.hs
+++ b/test/Feature/RpcSpec.hs
@@ -494,6 +494,11 @@ spec actualPgVersion =
         liftIO $ do
           simpleStatus p `shouldBe` badRequest400
           isErrorFormat (simpleBody p) `shouldBe` True
+      it "treats plpgsql assert as invalid input" $ do
+        p <- post "/rpc/assert" "{}"
+        liftIO $ do
+          simpleStatus p `shouldBe` badRequest400
+          isErrorFormat (simpleBody p) `shouldBe` True
 
     context "unsupported verbs" $ do
       it "DELETE fails" $

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -366,6 +366,19 @@ $$;
 
 
 --
+-- Name: assert(); Type: FUNCTION; Schema: test; Owner: -
+--
+
+CREATE FUNCTION assert() RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+      ASSERT false, 'bad thing';
+END;
+$$;
+
+
+--
 -- Name: problem(); Type: FUNCTION; Schema: test; Owner: -
 --
 


### PR DESCRIPTION
IMHO: [PL/pgSQL assertions](https://www.postgresql.org/docs/14/plpgsql-errors-and-messages.html#PLPGSQL-STATEMENTS-ASSERT) is invalid input (HTTP 400 Bad request).

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs     - https://github.com/PostgREST/postgrest-docs
-->
