### PR TITLE
fix: Make POST and PATCH with keys longer than PostgreSQL's NAMEDATALEN work as expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
  - #2020, Execute deferred constraint triggers when using `Prefer: tx=rollback` - @wolfgangwalther
+ - #1937, Make POST and PATCH with keys longer than PostgreSQL's NAMEDATALEN work as expected - @wolfgangwalther
 
 ## [9.0.0] - 2021-11-25
 

--- a/src/PostgREST/Query/QueryBuilder.hs
+++ b/src/PostgREST/Query/QueryBuilder.hs
@@ -88,7 +88,7 @@ mutateRequestToQuery (Insert mainQi iCols body onConflct putConditions returning
   "FROM (" <>
     "SELECT rec.* " <>
     "FROM json_array_elements(" <> SQL.sql selectBody <> ") AS elem, " <>
-         "json_populate_record(null::" <> SQL.sql (fromQi mainQi) <> ", elem) AS rec) _ " <>
+         "json_populate_record(null::" <> SQL.sql (fromQi mainQi) <> ", " <> (SQL.sql $ truncateJsonKeysF "elem") <> ") AS rec) _ " <>
   -- Only used for PUT
   (if null putConditions then mempty else "WHERE " <> intercalateSnippet " AND " (pgFmtLogicTree (QualifiedIdentifier mempty "_") <$> putConditions)) <>
   SQL.sql (BS.unwords [
@@ -120,7 +120,7 @@ mutateRequestToQuery (Update mainQi uCols body logicForest returnings) =
       "FROM (" <>
         "SELECT rec.* " <>
         "FROM json_array_elements(" <> SQL.sql selectBody <> ") AS elem, " <>
-             "json_populate_record(null::" <> SQL.sql (fromQi mainQi) <> ", elem) AS rec) _ " <>
+             "json_populate_record(null::" <> SQL.sql (fromQi mainQi) <> ", " <> (SQL.sql $ truncateJsonKeysF "elem") <> ") AS rec) _ " <>
       (if null logicForest then mempty else "WHERE " <> intercalateSnippet " AND " (pgFmtLogicTree mainQi <$> logicForest)) <> " " <>
       SQL.sql (returningF mainQi returnings)
   where

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -32,6 +32,7 @@ module PostgREST.Query.SqlFragment
   , selectBody
   , singleParameter
   , sourceCTEName
+  , truncateJsonKeysF
   , unknownEncoder
   , intercalateSnippet
   ) where
@@ -179,6 +180,9 @@ asJsonSingleF returnsScalar
 
 asBinaryF :: FieldName -> SqlFragment
 asBinaryF fieldName = "coalesce(string_agg(_postgrest_t." <> pgFmtIdent fieldName <> ", ''), '')"
+
+truncateJsonKeysF :: FieldName -> SqlFragment
+truncateJsonKeysF fieldName = "(SELECT  json_object_agg(substr(key, 0, 64), value) FROM json_each(" <> pgFmtIdent fieldName <> "))"
 
 locationF :: [Text] -> SqlFragment
 locationF pKeys = [qc|(

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -79,6 +79,15 @@ spec actualPgVersion = do
              , matchHeaders = [matchContentTypeJson]
              }
 
+    context "with keys longer than NAMEDATALEN" $
+      it "inserts successfully" $
+        request methodPost "/wow"
+            [("Prefer", "return=representation")]
+            [json|{"VeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongName": "haha"}|]
+          `shouldRespondWith`
+            [json|[{"VeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVer": "haha"}]|]
+            { matchStatus = 201 }
+
     context "requesting full representation" $ do
       it "includes related data after insert" $
         request methodPost "/projects?select=id,name,clients(id,name)"
@@ -379,7 +388,7 @@ spec actualPgVersion = do
               "code": "22023",
               "details": null,
               "hint": null,
-              "message": "cannot call populate_composite on a scalar"}|]
+              "message": "cannot deconstruct a scalar"}|]
           { matchStatus  = 400
           , matchHeaders = []
           }

--- a/test/Feature/InsertSpec.hs
+++ b/test/Feature/InsertSpec.hs
@@ -379,7 +379,7 @@ spec actualPgVersion = do
               "code": "22023",
               "details": null,
               "hint": null,
-              "message": "argument of json_populate_recordset must be an array of objects"}|]
+              "message": "cannot call populate_composite on a scalar"}|]
           { matchStatus  = 400
           , matchHeaders = []
           }

--- a/test/Feature/UpdateSpec.hs
+++ b/test/Feature/UpdateSpec.hs
@@ -37,6 +37,14 @@ spec = do
             matchHeaders = [matchContentTypeJson]
           }
 
+    context "with keys longer than NAMEDATALEN" $
+      it "inserts successfully" $
+        request methodPatch "/wow"
+            [("Prefer", "return=representation")]
+            [json|{"VeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongName": "haha"}|]
+          `shouldRespondWith`
+            [json|[{"VeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVer": "haha"}]|]
+
     context "with no payload" $
       it "fails with 400 and error" $
         request methodPatch "/items" [] ""

--- a/test/fixtures/data.sql
+++ b/test/fixtures/data.sql
@@ -730,3 +730,6 @@ INSERT INTO test.clientinfo (id,clientid, other) values (1,1,'123 Main St'),(2,2
 
 TRUNCATE TABLE test.chores CASCADE;
 INSERT INTO test.chores (id, name, done) values (1, 'take out the garbage', true), (2, 'do the laundry', false), (3, 'wash the dishes', null);
+
+TRUNCATE TABLE test.wow CASCADE;
+INSERT INTO test.wow VALUES ('hello');

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -161,6 +161,7 @@ GRANT ALL ON TABLE
     , clientinfo
     , contact
     , chores
+    , wow
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -2462,3 +2462,7 @@ BEGIN
 
   INSERT INTO deferrable_unique_constraint VALUES (1), (1);
 END$$;
+
+CREATE TABLE wow(
+  "VeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongName" TEXT
+);


### PR DESCRIPTION
This is my attempt at #1937, with the approach of truncating keys to 64 chars length.

The query is significantly more complex and I think I am seeing a slight regression in performance when testing this locally with `postgrest-loadtest`. Not sure whether that shows in CI. Unfortunately we don't separate the loadtest results by request type, yet, and this would only slow down the `POST` and `PATCH` requests.

At the same time, this leads to a problem, when you have a payload with two keys that will be truncated to the same shorter key:
```json
{
  "VeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongName": "haha",
  "VeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLong": "hehe"
}
```

This results in:

```json
{
  "hint":null,
  "details":null,
  "code":"42701",
  "message":"column \"VeryLongNameVeryLongNameVeryLongNameVeryLongNameVeryLongNameVer\" specified more than once"
}
```

That's probably the same reason, why the `json_populate_recordset` function behaves as it does, and is not fixed.

Note, that this does not happen, when you add two equal keys that are shorter than `NAMEDATALEN` to the json body: The earlier keys will be discarded by the json parsing already.

Overall, I think, we should just consider the fact that some operations seem to work with column names longer than `NAMEDATALEN` a conincidence and maybe even point out in the docs, that we are not supporting those. Let's close #1937 as "won't fix".