### PR TITLE
nix: Add weeder to postgrest-coverage

### DIFF
--- a/nix/tools/devTools.nix
+++ b/nix/tools/devTools.nix
@@ -5,6 +5,7 @@
 , devCabalOptions
 , entr
 , graphviz
+, haskellPackages
 , hsie
 , nix
 , silver-searcher

--- a/nix/tools/tests.nix
+++ b/nix/tools/tests.nix
@@ -5,7 +5,7 @@
 , ghc
 , glibcLocales
 , gnugrep
-, haskell
+, haskellPackages
 , hpc-codecov
 , jq
 , postgrest
@@ -116,7 +116,7 @@ let
     checkedShellScript
       {
         name = "postgrest-coverage";
-        docs = "Run spec and io tests while collecting hpc coverage data.";
+        docs = "Run spec and io tests while collecting hpc coverage data. First runs weeder to detect dead code.";
         args = [ "ARG_LEFTOVERS([hpc report arguments])" ];
         inRootDir = true;
         redirectTixFiles = false;
@@ -132,6 +132,8 @@ let
 
         # build once before running all the tests
         ${cabal-install}/bin/cabal v2-build ${devCabalOptions} exe:postgrest lib:postgrest test:spec test:querycost
+
+        ${haskellPackages.weeder}/bin/weeder --config=./test/weeder.dhall || echo Found dead code: Check file list above.
 
         # collect all tests
         HPCTIXFILE="$tmpdir"/io.tix \

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -123,7 +123,7 @@ library
                       -fno-spec-constr -optP-Wno-nonportable-include-path
 
   if flag(dev)
-    ghc-options: -O0
+    ghc-options: -O0 -fwrite-ide-info
     if flag(hpc)
       ghc-options: -fhpc -hpcdir .hpc
   else
@@ -152,7 +152,7 @@ executable postgrest
                       -fno-spec-constr -optP-Wno-nonportable-include-path
 
   if flag(dev)
-    ghc-options: -O0
+    ghc-options: -O0 -fwrite-ide-info
     if flag(hpc)
       ghc-options: -fhpc -hpcdir .hpc
   else
@@ -237,6 +237,7 @@ test-suite spec
   ghc-options:        -O0 -Werror -Wall -fwarn-identities
                       -fno-spec-constr -optP-Wno-nonportable-include-path
                       -fno-warn-missing-signatures
+                      -fwrite-ide-info
 
 test-suite querycost
   type:                exitcode-stdio-1.0
@@ -281,6 +282,7 @@ test-suite querycost
                      , wai-extra         >= 3.0.19 && < 3.2
   ghc-options:         -O0 -Werror -Wall -fwarn-identities
                        -fno-spec-constr -optP-Wno-nonportable-include-path
+                       -fwrite-ide-info
 
 test-suite doctests
   type:                exitcode-stdio-1.0

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -1,6 +1,6 @@
 module SpecHelper where
 
-import qualified Data.ByteString.Base64 as B64 (decodeLenient, encode)
+import qualified Data.ByteString.Base64 as B64 (decodeLenient)
 import qualified Data.ByteString.Char8  as BS
 import qualified Data.ByteString.Lazy   as BL
 import qualified Data.Map.Strict        as M
@@ -189,16 +189,9 @@ testMultipleSchemaCfg testDbConn = (testCfg testDbConn) { configDbSchemas = from
 testCfgLegacyGucs :: Text -> AppConfig
 testCfgLegacyGucs testDbConn = (testCfg testDbConn) { configDbUseLegacyGucs = False }
 
-resetDb :: Text -> IO ()
-resetDb dbConn = loadFixture dbConn "data"
-
 analyzeTable :: Text -> Text -> IO ()
 analyzeTable dbConn tableName =
   void $ readProcess "psql" ["--set", "ON_ERROR_STOP=1", toS dbConn, "-a", "-c", toS $ "ANALYZE test.\"" <> tableName <> "\""] []
-
-loadFixture :: Text -> FilePath -> IO()
-loadFixture dbConn name =
-  void $ readProcess "psql" ["--set", "ON_ERROR_STOP=1", toS dbConn, "-q", "-f", "test/fixtures/" ++ name ++ ".sql"] []
 
 rangeHdrs :: ByteRange -> [Header]
 rangeHdrs r = [rangeUnit, (hRange, renderByteRange r)]
@@ -225,10 +218,6 @@ noProfileHeader headers = isNothing $ find ((== "Content-Profile") . fst) header
 authHeader :: BS.ByteString -> BS.ByteString -> Header
 authHeader typ creds =
   (hAuthorization, typ <> " " <> creds)
-
-authHeaderBasic :: BS.ByteString -> BS.ByteString -> Header
-authHeaderBasic u p =
-  authHeader "Basic" $ toS . B64.encode . toS $ u <> ":" <> p
 
 authHeaderJWT :: BS.ByteString -> Header
 authHeaderJWT = authHeader "Bearer"

--- a/test/weeder.dhall
+++ b/test/weeder.dhall
@@ -1,0 +1,4 @@
+{
+  roots = [ "^Main.main$", "^Paths_" ],
+  type-class-roots = True
+}


### PR DESCRIPTION
Found [weeder](https://hackage.haskell.org/package/weeder) and gave it a try. It found some dead code in `SpecHelper.hs`. Removed that and added it to `postgrest-coverage`. `postgrest-coverage` instead of `postgrest-lint`, because it needs to have the whole project built to operate.