### PR TITLE
Ignore impossible disambiguations examples in error hint

### DIFF
--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -156,7 +156,9 @@ relHint =  T.intercalate ", " . unique . foldr hint []
           -- TODO: Omit this conditional when aliases are implemented in the query builder
           | isSelfM2M = hintList
           -- Special self reference case
-          | isSelfM2O = ("'" <> maybe rel colName (headMay relColumns) <> "'"):hintList
+          | isSelfM2O = case relColumns of
+                          [col] -> ("'" <> colName col <> "'"):hintList
+                          _     -> hintList
           | otherwise = ("'" <> tableName relForeignTable <> "!" <> rel <> "'"):hintList
       in
       case relCardinality of

--- a/test/Feature/EmbedDisambiguationSpec.hs
+++ b/test/Feature/EmbedDisambiguationSpec.hs
@@ -119,7 +119,7 @@ spec =
                   "embedding": "whatev_sites with whatev_projects"
                 }
               ],
-              "hint": "Try changing 'whatev_projects' to one of the following: 'whatev_projects!whatev_jobs', 'whatev_projects!whatev_jobs', 'whatev_projects!whatev_jobs', 'whatev_projects!whatev_jobs'. Find the desired relationship in the 'details' key.",
+              "hint": "The embedding cannot be disambiguated.",
               "message": "Could not embed because more than one relationship was found for 'whatev_sites' and 'whatev_projects'"
             }
           |]

--- a/test/fixtures/data.sql
+++ b/test/fixtures/data.sql
@@ -730,3 +730,13 @@ INSERT INTO test.clientinfo (id,clientid, other) values (1,1,'123 Main St'),(2,2
 
 TRUNCATE TABLE test.chores CASCADE;
 INSERT INTO test.chores (id, name, done) values (1, 'take out the garbage', true), (2, 'do the laundry', false), (3, 'wash the dishes', null);
+
+
+TRUNCATE TABLE test.locations CASCADE;
+INSERT INTO test.locations (id, name) values (1,'North'),(2,'South');
+
+TRUNCATE TABLE test.dependencies CASCADE;
+INSERT INTO test.dependencies (id, name, parent_id, location_id) values (1,'Main Kingdom',null,null),(2,'New Kingdom',1,1),(3,'Old Kingdom',1,2);
+
+TRUNCATE TABLE test.dependency_trade CASCADE;
+INSERT INTO test.dependency_trade (from_dependency_id, to_dependency_id, date) values (2,3,'20210101'),(3,2,'20210102');

--- a/test/fixtures/privileges.sql
+++ b/test/fixtures/privileges.sql
@@ -161,6 +161,9 @@ GRANT ALL ON TABLE
     , clientinfo
     , contact
     , chores
+    , locations
+    , dependencies
+    , dependency_trade
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -2462,3 +2462,27 @@ BEGIN
 
   INSERT INTO deferrable_unique_constraint VALUES (1), (1);
 END$$;
+
+-- Tables and views used for testing special cases of embedding disambiguation involving self referenced tables
+
+CREATE TABLE locations (
+  id INT PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE dependencies (
+  id INT PRIMARY KEY,
+  name TEXT NOT NULL,
+  parent_id INT,
+  location_id INT,
+  CONSTRAINT dependencies_parent_fk FOREIGN KEY (parent_id) REFERENCES dependencies(id),
+  CONSTRAINT dependencies_locations_fk FOREIGN KEY (location_id) REFERENCES locations(id)
+);
+
+CREATE TABLE dependency_trade (
+  from_dependency_id INT NOT NULL,
+  to_dependency_id INT NOT NULL,
+  date date,
+  CONSTRAINT dependency_trade_from_fk FOREIGN KEY (from_dependency_id) REFERENCES  dependencies(id),
+  CONSTRAINT dependency_trade_to_fk FOREIGN KEY (to_dependency_id) REFERENCES  dependencies(id)
+);


### PR DESCRIPTION
* Ignores m2m relationships where the target and hint are the same table (self reference)
* Ignores m2m relationships where an extra hint is needed to disambiguate

Resolves part of #2070