### PR TITLE
fix: Make recursive view parsing work with XMLTABLE + DEFAULT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2020, Execute deferred constraint triggers when using `Prefer: tx=rollback` - @wolfgangwalther
  - #2058, Return 204 No Content without Content-Type for PUT - @wolfgangwalther
  - #2077, Fix `is` not working with upper or mixed case values like `NULL, TrUe, FaLsE` - @steve-chavez
+ - #2024, Fix schema cache loading when views with XMLTABLE and DEFAULT are present - @wolfgangwalther
 
 ## [9.0.0] - 2021-11-25
 

--- a/test/fixtures/schema.sql
+++ b/test/fixtures/schema.sql
@@ -2462,3 +2462,21 @@ BEGIN
 
   INSERT INTO deferrable_unique_constraint VALUES (1), (1);
 END$$;
+
+-- This view is not used in any requests but just parsed by the pfkSourceColumns query.
+-- XMLTABLE is only supported from PG 10 on
+DO $do$
+BEGIN
+  IF current_setting('server_version_num')::INT >= 100000 THEN
+    CREATE VIEW test.xml AS
+    SELECT *
+      FROM (SELECT ''::xml AS data) _,
+           XMLTABLE(
+             ''
+             PASSING data
+             COLUMNS id int PATH '@id',
+                     premier_name text PATH 'PREMIER_NAME' DEFAULT 'not specified'
+           );
+  END IF;
+END
+$do$;

--- a/test/io-tests/test_io.py
+++ b/test/io-tests/test_io.py
@@ -741,7 +741,9 @@ def test_admin_healthy_w_channel(defaultenv):
     }
 
     with run(env=env) as postgrest:
-        response = requests.get(f"http://localhost:{env['PGRST_ADMIN_SERVER_PORT']}/health")
+        response = requests.get(
+            f"http://localhost:{env['PGRST_ADMIN_SERVER_PORT']}/health"
+        )
         assert response.status_code == 200
 
 
@@ -755,7 +757,9 @@ def test_admin_healthy_wo_channel(defaultenv):
     }
 
     with run(env=env) as postgrest:
-        response = requests.get(f"http://localhost:{env['PGRST_ADMIN_SERVER_PORT']}/health")
+        response = requests.get(
+            f"http://localhost:{env['PGRST_ADMIN_SERVER_PORT']}/health"
+        )
         assert response.status_code == 200
 
 
@@ -768,5 +772,7 @@ def test_admin_not_found(defaultenv):
     }
 
     with run(env=env) as postgrest:
-        response = requests.get(f"http://localhost:{env['PGRST_ADMIN_SERVER_PORT']}/notfound")
+        response = requests.get(
+            f"http://localhost:{env['PGRST_ADMIN_SERVER_PORT']}/notfound"
+        )
         assert response.status_code == 404


### PR DESCRIPTION
Resolves #2024.

Using `XMLTABLE` in a view with a column that has a `DEFAULT` when the first column does not have a default, currently breaks our recursive view parsing query `pfkSourceColumns`.

This is because in this case the node tree has an expression of the form `:coldefexprs (<> {CONST ... })` for the default values. The column does not have a default value, so it's set as `<>`, which means null in the node tree. One step of parsing is "protecting node lists from the greedy regex", which is run later. This protection assumes that node lists always start with either `((` or `({` - only that in this case, the list starts with `(<`.

By moving the replacement of `<>` with an empty array, that was happening as the last step before, to the beginning, this case will now look like a `((` list, too - and makes the parsing in JSON succeed.