### PR TITLE
Consider schema cache state on the health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
  - #1933, #2109, Add a minimal health check endpoint - @steve-chavez
    + For enabling this, the `admin-server-port` config must be set explictly
-   + The check is at the `<host>:<admin_server_port>/live` endpoint. A 200 OK status will be returned if postgrest is alive, otherwise a 503 will be returned.
+   + A `<host>:<admin_server_port>/live` endpoint is available for checking if postgrest is running on its port/socket. 200 OK = alive, 503 = dead.
    + A `<host>:<admin_server_port>/ready` endpoint is available for checking a correct internal state(the database connection plus the schema cache). 200 OK = ready, 503 = not ready.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2077, Fix `is` not working with upper or mixed case values like `NULL, TrUe, FaLsE` - @steve-chavez
  - #2024, Fix schema cache loading when views with XMLTABLE and DEFAULT are present - @wolfgangwalther
  - #1724, Fix wrong CORS header Authentication -> Authorization - @wolfgangwalther
+ - #2107, Clarify error for failed schema cache load. - @steve-chavez
+   + From `Database connection lost. Retrying the connection` to `Could not query the database for the schema cache. Retrying.`
 
 ## [9.0.0] - 2021-11-25
 

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -191,7 +191,7 @@ postgrestResponse conf maybeDbStructure jsonDbS pgVer pool time req = do
       Just dbStructure ->
         return dbStructure
       Nothing ->
-        throwError Error.ConnectionLostError
+        throwError Error.NoSchemaCacheError
 
   apiRequest@ApiRequest{..} <-
     liftEither . mapLeft Error.ApiRequestError $

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -108,9 +108,8 @@ putPgVersion = atomicWriteIORef . statePgVersion
 getDbStructure :: AppState -> IO (Maybe DbStructure)
 getDbStructure = readIORef . stateDbStructure
 
-putDbStructure :: AppState -> DbStructure -> IO ()
-putDbStructure appState structure =
-  atomicWriteIORef (stateDbStructure appState) $ Just structure
+putDbStructure :: AppState -> Maybe DbStructure -> IO ()
+putDbStructure appState = atomicWriteIORef (stateDbStructure appState)
 
 getJsonDbS :: AppState -> IO ByteString
 getJsonDbS = readIORef . stateJsonDbS

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -280,7 +280,7 @@ data Error
   = GucHeadersError
   | GucStatusError
   | BinaryFieldError ContentType
-  | ConnectionLostError
+  | NoSchemaCacheError
   | PutMatchingPkError
   | PutRangeNotAllowedError
   | JwtTokenMissing
@@ -294,7 +294,7 @@ instance PgrstError Error where
   status GucHeadersError         = HTTP.status500
   status GucStatusError          = HTTP.status500
   status (BinaryFieldError _)    = HTTP.status406
-  status ConnectionLostError     = HTTP.status503
+  status NoSchemaCacheError      = HTTP.status503
   status PutMatchingPkError      = HTTP.status400
   status PutRangeNotAllowedError = HTTP.status400
   status JwtTokenMissing         = HTTP.status500
@@ -317,8 +317,8 @@ instance JSON.ToJSON Error where
     "message" .= ("response.status guc must be a valid status code" :: Text)]
   toJSON (BinaryFieldError ct)          = JSON.object [
     "message" .= ((T.decodeUtf8 (ContentType.toMime ct) <> " requested but more than one column was selected") :: Text)]
-  toJSON ConnectionLostError       = JSON.object [
-    "message" .= ("Database connection lost. Retrying the connection." :: Text)]
+  toJSON NoSchemaCacheError       = JSON.object [
+    "message" .= ("Could not query the database for the schema cache. Retrying." :: Text)]
 
   toJSON PutRangeNotAllowedError   = JSON.object [
     "message" .= ("Range header and limit/offset querystring parameters are not allowed for PUT" :: Text)]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -76,7 +76,7 @@ main = do
       let config = cfg testDbConn
       appState <- AppState.initWithPool pool config
       AppState.putPgVersion appState actualPgVersion
-      AppState.putDbStructure appState baseDbStructure
+      AppState.putDbStructure appState (Just baseDbStructure)
       when (isJust $ configDbRootSpec config) $
         AppState.putJsonDbS appState $ toS $ JSON.encode baseDbStructure
       return ((), postgrest LogCrit appState $ pure ())
@@ -91,7 +91,7 @@ main = do
           actualPgVersion
       appState <- AppState.initWithPool pool config
       AppState.putPgVersion appState actualPgVersion
-      AppState.putDbStructure appState customDbStructure
+      AppState.putDbStructure appState (Just customDbStructure)
       when (isJust $ configDbRootSpec config) $
         AppState.putJsonDbS appState $ toS $ JSON.encode baseDbStructure
       return ((), postgrest LogCrit appState $ pure ())

--- a/test/io-tests/db_config.sql
+++ b/test/io-tests/db_config.sql
@@ -53,3 +53,11 @@ ALTER ROLE other_authenticator SET pgrst.db_pre_request = 'test.other_custom_hea
 ALTER ROLE other_authenticator SET pgrst.db_max_rows = '100';
 ALTER ROLE other_authenticator SET pgrst.db_extra_search_path = 'public, extensions, other';
 ALTER ROLE other_authenticator SET pgrst.openapi_mode = 'disabled';
+
+-- limited authenticator used for failed schema cache loads
+CREATE ROLE limited_authenticator LOGIN NOINHERIT;
+
+create or replace function no_schema_cache_for_limited_authenticator() returns void as $_$
+begin
+  ALTER ROLE limited_authenticator SET statement_timeout to 1;
+end $_$ volatile security definer language plpgsql ;

--- a/test/io-tests/test_io.py
+++ b/test/io-tests/test_io.py
@@ -787,10 +787,15 @@ def test_admin_ready_includes_schema_cache_state(defaultenv):
             "/rpc/no_schema_cache_for_limited_authenticator"
         )
         assert response.status_code == 200
+
         # force a reconnection so the new role setting is picked up
         postgrest.process.send_signal(signal.SIGUSR1)
         time.sleep(0.1)
+
         response = postgrest.admin.get("/ready")
+        assert response.status_code == 503
+
+        response = postgrest.session.get("/projects")
         assert response.status_code == 503
 
 


### PR DESCRIPTION
As suggested in https://github.com/PostgREST/postgrest/pull/2092#issuecomment-1000776098

> However, what we can and should do is: Keep track of the status of the last schema cache refresh - and if that fails, e.g. because of something like #2024, we should return 503. Currently we are still returning 200, when the schema cache fails.

This change does prevent a healthy response in case something like #2024 happens, but only at startup. If the schema cache fails to load after startup, the main app will continue working and the health check will respond accordingly.

The main app failure happens at startup because of:

https://github.com/PostgREST/postgrest/blob/4f7ee6f36aae6ed36ecfec4ac3c1aa0b656bdddb/src/PostgREST/App.hs#L203-L208

Should we turn the schema cache to Nothing if it fails loading? That would make the main app fail for all requests, I think it's better to leave the schema cache stale in that case, as it happens currently.

**Edit**: On second thought, I think it'd be better to void the schema cache, otherwise the app will continue running with a stale schema cache and the developers won't know about it.