### PR TITLE
Detecting space leaks (stack size) in CI

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -152,6 +152,8 @@ executable postgrest
 
   if flag(dev)
     ghc-options: -O0 -fwrite-ide-info
+                 -- https://github.com/PostgREST/postgrest/issues/387
+                 -with-rtsopts=-K1K
     if flag(hpc)
       ghc-options: -fhpc -hpcdir .hpc
   else
@@ -233,6 +235,8 @@ test-suite spec
                       -fno-spec-constr -optP-Wno-nonportable-include-path
                       -fno-warn-missing-signatures
                       -fwrite-ide-info
+                      -- https://github.com/PostgREST/postgrest/issues/387
+                      -with-rtsopts=-K33K
 
 test-suite querycost
   type:               exitcode-stdio-1.0
@@ -268,6 +272,8 @@ test-suite querycost
   ghc-options:        -O0 -Werror -Wall -fwarn-identities
                       -fno-spec-constr -optP-Wno-nonportable-include-path
                       -fwrite-ide-info
+                      -- https://github.com/PostgREST/postgrest/issues/387
+                      -with-rtsopts=-K1K
 
 test-suite doctests
   type:               exitcode-stdio-1.0

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -235,51 +235,51 @@ test-suite spec
                       -fwrite-ide-info
 
 test-suite querycost
-  type:                exitcode-stdio-1.0
-  default-language:    Haskell2010
-  default-extensions:  OverloadedStrings
-                       QuasiQuotes
-                       NoImplicitPrelude
-  hs-source-dirs:      test/spec
-  main-is:             QueryCost.hs
-  other-modules:       SpecHelper
-  build-depends:       base              >= 4.9 && < 4.16
-                     , aeson             >= 1.4.7 && < 1.6
-                     , base64-bytestring >= 1 && < 1.3
-                     , bytestring        >= 0.10.8 && < 0.11
-                     , case-insensitive  >= 1.2 && < 1.3
-                     , containers        >= 0.5.7 && < 0.7
-                     , contravariant     >= 1.4 && < 1.6
-                     , hasql             >= 1.4 && < 1.5
-                     , hasql-dynamic-statements  == 0.3.1
-                     , hasql-pool        >= 0.5 && < 0.6
-                     , hasql-transaction >= 1.0.1 && < 1.1
-                     , heredoc           >= 0.2 && < 0.3
-                     , hspec             >= 2.3 && < 2.9
-                     , hspec-wai         >= 0.10 && < 0.12
-                     , http-types        >= 0.12.3 && < 0.13
-                     , lens              >= 4.14 && < 5.1
-                     , lens-aeson        >= 1.0.1 && < 1.2
-                     , postgrest
-                     , process           >= 1.4.2 && < 1.7
-                     , protolude         >= 0.3 && < 0.4
-                     , regex-tdfa        >= 1.2.2 && < 1.4
-                     , wai-extra         >= 3.0.19 && < 3.2
-  ghc-options:         -O0 -Werror -Wall -fwarn-identities
-                       -fno-spec-constr -optP-Wno-nonportable-include-path
-                       -fwrite-ide-info
+  type:               exitcode-stdio-1.0
+  default-language:   Haskell2010
+  default-extensions: OverloadedStrings
+                      QuasiQuotes
+                      NoImplicitPrelude
+  hs-source-dirs:     test/spec
+  main-is:            QueryCost.hs
+  other-modules:      SpecHelper
+  build-depends:      base              >= 4.9 && < 4.16
+                    , aeson             >= 1.4.7 && < 1.6
+                    , base64-bytestring >= 1 && < 1.3
+                    , bytestring        >= 0.10.8 && < 0.11
+                    , case-insensitive  >= 1.2 && < 1.3
+                    , containers        >= 0.5.7 && < 0.7
+                    , contravariant     >= 1.4 && < 1.6
+                    , hasql             >= 1.4 && < 1.5
+                    , hasql-dynamic-statements  == 0.3.1
+                    , hasql-pool        >= 0.5 && < 0.6
+                    , hasql-transaction >= 1.0.1 && < 1.1
+                    , heredoc           >= 0.2 && < 0.3
+                    , hspec             >= 2.3 && < 2.9
+                    , hspec-wai         >= 0.10 && < 0.12
+                    , http-types        >= 0.12.3 && < 0.13
+                    , lens              >= 4.14 && < 5.1
+                    , lens-aeson        >= 1.0.1 && < 1.2
+                    , postgrest
+                    , process           >= 1.4.2 && < 1.7
+                    , protolude         >= 0.3 && < 0.4
+                    , regex-tdfa        >= 1.2.2 && < 1.4
+                    , wai-extra         >= 3.0.19 && < 3.2
+  ghc-options:        -O0 -Werror -Wall -fwarn-identities
+                      -fno-spec-constr -optP-Wno-nonportable-include-path
+                      -fwrite-ide-info
 
 test-suite doctests
-  type:                exitcode-stdio-1.0
-  default-language:    Haskell2010
-  default-extensions:  OverloadedStrings
-                       NoImplicitPrelude
-  hs-source-dirs:      test/doc
-  main-is:             Main.hs
-  build-depends:       base              >= 4.9 && < 4.16
-                     , doctest           >= 0.8
-                     , postgrest
-                     , pretty-simple
-                     , protolude         >= 0.3 && < 0.4
-  ghc-options:         -threaded -O0 -Werror -Wall -fwarn-identities
-                       -fno-spec-constr -optP-Wno-nonportable-include-path
+  type:               exitcode-stdio-1.0
+  default-language:   Haskell2010
+  default-extensions: OverloadedStrings
+                      NoImplicitPrelude
+  hs-source-dirs:     test/doc
+  main-is:            Main.hs
+  build-depends:      base              >= 4.9 && < 4.16
+                    , doctest           >= 0.8
+                    , postgrest
+                    , pretty-simple
+                    , protolude         >= 0.3 && < 0.4
+  ghc-options:        -threaded -O0 -Werror -Wall -fwarn-identities
+                      -fno-spec-constr -optP-Wno-nonportable-include-path


### PR DESCRIPTION
Resolves #387.

Related:
- https://neilmitchell.blogspot.com/2015/09/detecting-space-leaks.html?m=1
- https://downloads.haskell.org/~ghc/9.0.1/docs/html/users_guide/runtime_control.html#rts-flag--K%20%E2%9F%A8size%E2%9F%A9

`-K1K` will make the spec tests fail - the OpenAPI output causing the stack overflow here. I raised it up to `-K33K` to make it pass. This is just added to prevent things from using more stack than right now. Maybe we can lower it to `-K1K` at some point in the future.