### PR TITLE
Add pool stats to `/metrics` admin endpoint

### DIFF
--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -50,6 +50,15 @@ let
           }
           { };
 
+      resource-pool-fork-avanov =
+        prev.callHackageDirect
+          {
+            pkg = "resource-pool-fork-avanov";
+            ver = "0.2.4.0";
+            sha256 = "0y5hk4wi2n5xzdb11jvb9f8mh3lmycjfyxii81kl6s412ir5gpm5";
+          }
+          { };
+
       hasql-dynamic-statements =
         lib.dontCheck (lib.unmarkBroken prev.hasql-dynamic-statements);
 

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -56,6 +56,7 @@ library
                       PostgREST.Logger
                       PostgREST.Middleware
                       PostgREST.OpenAPI
+                      PostgREST.Pool
                       PostgREST.Query.QueryBuilder
                       PostgREST.Query.SqlFragment
                       PostgREST.Query.Statements
@@ -86,7 +87,6 @@ library
                     , hasql                     >= 1.4 && < 1.5
                     , hasql-dynamic-statements  == 0.3.1
                     , hasql-notifications       >= 0.1 && < 0.3
-                    , hasql-pool                >= 0.5 && < 0.6
                     , hasql-transaction         >= 1.0.1 && < 1.1
                     , heredoc                   >= 0.2 && < 0.3
                     , http-types                >= 0.12.2 && < 0.13
@@ -103,6 +103,7 @@ library
                     , protolude                 >= 0.3 && < 0.4
                     , regex-tdfa                >= 1.2.2 && < 1.4
                     , retry                     >= 0.7.4 && < 0.10
+                    , resource-pool-fork-avanov >= 0.2.4 && < 0.2.5
                     , scientific                >= 0.3.4 && < 0.4
                     , swagger2                  >= 2.4 && < 2.7
                     , text                      >= 1.2.2 && < 1.3

--- a/src/PostgREST/Admin.hs
+++ b/src/PostgREST/Admin.hs
@@ -10,7 +10,7 @@ import Network.Socket.ByteString
 import qualified Network.HTTP.Types.Status as HTTP
 import qualified Network.Wai               as Wai
 
-import qualified Hasql.Pool    as SQL
+import qualified PostgREST.Pool    as SQL
 import qualified Hasql.Session as SQL
 
 import qualified PostgREST.AppState as AppState

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -31,7 +31,6 @@ import qualified Data.ByteString.Lazy            as LBS
 import qualified Data.HashMap.Strict             as M
 import qualified Data.Set                        as S
 import qualified Hasql.DynamicStatements.Snippet as SQL (Snippet)
-import qualified PostgREST.Pool                  as SQL
 import qualified Hasql.Transaction               as SQL
 import qualified Hasql.Transaction.Sessions      as SQL
 import qualified Network.HTTP.Types.Header       as HTTP
@@ -39,6 +38,7 @@ import qualified Network.HTTP.Types.Status       as HTTP
 import qualified Network.HTTP.Types.URI          as HTTP
 import qualified Network.Wai                     as Wai
 import qualified Network.Wai.Handler.Warp        as Warp
+import qualified PostgREST.Pool                  as SQL
 
 import qualified PostgREST.Admin                    as Admin
 import qualified PostgREST.AppState                 as AppState

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -31,7 +31,7 @@ import qualified Data.ByteString.Lazy            as LBS
 import qualified Data.HashMap.Strict             as M
 import qualified Data.Set                        as S
 import qualified Hasql.DynamicStatements.Snippet as SQL (Snippet)
-import qualified Hasql.Pool                      as SQL
+import qualified PostgREST.Pool                  as SQL
 import qualified Hasql.Transaction               as SQL
 import qualified Hasql.Transaction.Sessions      as SQL
 import qualified Network.HTTP.Types.Header       as HTTP

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -27,7 +27,7 @@ module PostgREST.AppState
   , waitListener
   ) where
 
-import qualified Hasql.Pool as SQL
+import qualified PostgREST.Pool as SQL
 
 import Control.AutoUpdate (defaultUpdateSettings, mkAutoUpdate,
                            updateAction)

--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -11,9 +11,9 @@ module PostgREST.CLI
 import qualified Data.Aeson                 as JSON
 import qualified Data.ByteString.Char8      as BS
 import qualified Data.ByteString.Lazy       as LBS
-import qualified PostgREST.Pool                 as SQL
 import qualified Hasql.Transaction.Sessions as SQL
 import qualified Options.Applicative        as O
+import qualified PostgREST.Pool             as SQL
 
 import Data.Text.IO (hPutStrLn)
 import Text.Heredoc (str)

--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -11,7 +11,7 @@ module PostgREST.CLI
 import qualified Data.Aeson                 as JSON
 import qualified Data.ByteString.Char8      as BS
 import qualified Data.ByteString.Lazy       as LBS
-import qualified Hasql.Pool                 as SQL
+import qualified PostgREST.Pool                 as SQL
 import qualified Hasql.Transaction.Sessions as SQL
 import qualified Options.Applicative        as O
 

--- a/src/PostgREST/Config/Database.hs
+++ b/src/PostgREST/Config/Database.hs
@@ -9,11 +9,11 @@ import PostgREST.Config.PgVersion (PgVersion (..))
 
 import qualified Hasql.Decoders             as HD
 import qualified Hasql.Encoders             as HE
-import qualified PostgREST.Pool             as SQL
 import           Hasql.Session              (Session, statement)
 import qualified Hasql.Statement            as SQL
 import qualified Hasql.Transaction          as SQL
 import qualified Hasql.Transaction.Sessions as SQL
+import qualified PostgREST.Pool             as SQL
 
 import Text.InterpolatedString.Perl6 (q)
 

--- a/src/PostgREST/Config/Database.hs
+++ b/src/PostgREST/Config/Database.hs
@@ -9,7 +9,7 @@ import PostgREST.Config.PgVersion (PgVersion (..))
 
 import qualified Hasql.Decoders             as HD
 import qualified Hasql.Encoders             as HE
-import qualified Hasql.Pool                 as SQL
+import qualified PostgREST.Pool             as SQL
 import           Hasql.Session              (Session, statement)
 import qualified Hasql.Statement            as SQL
 import qualified Hasql.Transaction          as SQL

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -20,9 +20,9 @@ import qualified Data.ByteString.Char8     as BS
 import qualified Data.Text                 as T
 import qualified Data.Text.Encoding        as T
 import qualified Data.Text.Encoding.Error  as T
-import qualified PostgREST.Pool                as SQL
 import qualified Hasql.Session             as SQL
 import qualified Network.HTTP.Types.Status as HTTP
+import qualified PostgREST.Pool            as SQL
 
 import Data.Aeson  ((.=))
 import Network.Wai (Response, responseLBS)

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -20,7 +20,7 @@ import qualified Data.ByteString.Char8     as BS
 import qualified Data.Text                 as T
 import qualified Data.Text.Encoding        as T
 import qualified Data.Text.Encoding.Error  as T
-import qualified Hasql.Pool                as SQL
+import qualified PostgREST.Pool                as SQL
 import qualified Hasql.Session             as SQL
 import qualified Network.HTTP.Types.Status as HTTP
 

--- a/src/PostgREST/Pool.hs
+++ b/src/PostgREST/Pool.hs
@@ -1,0 +1,88 @@
+module PostgREST.Pool
+(
+  Pool,
+  Settings,
+  acquire,
+  release,
+  UsageError(..),
+  use,
+)
+where
+
+import Data.Time (NominalDiffTime)
+import qualified Data.Pool as ResourcePool
+
+import qualified Hasql.Connection
+import qualified Hasql.Session
+
+import Protolude
+
+-- |
+-- A pool of connections to DB.
+newtype Pool =
+  Pool (ResourcePool.Pool (Either Hasql.Connection.ConnectionError Hasql.Connection.Connection))
+  deriving (Show)
+
+-- |
+-- Settings of the connection pool. Consist of:
+--
+-- * Pool-size.
+--
+-- * Timeout.
+-- An amount of time for which an unused resource is kept open.
+-- The smallest acceptable value is 0.5 seconds.
+--
+-- * Connection settings.
+--
+type Settings =
+  (Int, NominalDiffTime, Hasql.Connection.Settings)
+
+-- |
+-- Given the pool-size, timeout and connection settings
+-- create a connection-pool.
+acquire :: Settings -> IO Pool
+acquire (size, timeout, connectionSettings) =
+  fmap Pool $
+  ResourcePool.createPool acq rel stripes timeout size
+  where
+    acq =
+      Hasql.Connection.acquire connectionSettings
+    rel =
+      either (const (pure ())) Hasql.Connection.release
+    stripes =
+      1
+
+-- |
+-- Release the connection-pool.
+release :: Pool -> IO ()
+release (Pool pool) =
+  ResourcePool.destroyAllResources pool
+
+-- |
+-- A union over the connection establishment error and the session error.
+data UsageError =
+  ConnectionError Hasql.Connection.ConnectionError |
+  SessionError Hasql.Session.QueryError
+  deriving (Show, Eq)
+
+-- |
+-- Use a connection from the pool to run a session and
+-- return the connection to the pool, when finished.
+use :: Pool -> Hasql.Session.Session a -> IO (Either UsageError a)
+use (Pool pool) session =
+  fmap (either (Left . ConnectionError) (either (Left . SessionError) Right)) $
+  withResourceOnEither pool $
+  traverse $
+  Hasql.Session.run session
+
+withResourceOnEither :: ResourcePool.Pool resource -> (resource -> IO (Either failure success)) -> IO (Either failure success)
+withResourceOnEither pool act = mask_ $ do
+  (resource, localPool) <- ResourcePool.takeResource pool
+  failureOrSuccess <- act resource `onException` ResourcePool.destroyResource pool localPool resource
+  case failureOrSuccess of
+    Right success -> do
+      ResourcePool.putResource localPool resource
+      return (Right success)
+    Left failure -> do
+      ResourcePool.destroyResource pool localPool resource
+      return (Left failure)

--- a/src/PostgREST/Workers.hs
+++ b/src/PostgREST/Workers.hs
@@ -12,8 +12,8 @@ import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Lazy       as LBS
 import qualified Data.Text.Encoding         as T
 import qualified Hasql.Notifications        as SQL
-import qualified PostgREST.Pool             as SQL
 import qualified Hasql.Transaction.Sessions as SQL
+import qualified PostgREST.Pool             as SQL
 
 import Control.Retry    (RetryStatus, capDelay, exponentialBackoff,
                          retrying, rsPreviousDelay)

--- a/src/PostgREST/Workers.hs
+++ b/src/PostgREST/Workers.hs
@@ -12,7 +12,7 @@ import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Lazy       as LBS
 import qualified Data.Text.Encoding         as T
 import qualified Hasql.Notifications        as SQL
-import qualified Hasql.Pool                 as SQL
+import qualified PostgREST.Pool             as SQL
 import qualified Hasql.Transaction.Sessions as SQL
 
 import Control.Retry    (RetryStatus, capDelay, exponentialBackoff,


### PR DESCRIPTION
As mentioned on https://github.com/PostgREST/postgrest/issues/2042#issuecomment-1012703514, this adds a `/metrics` endpoint on the admin server.

For now, it contains the database pool stats:

```http
GET /metrics

{"dbPoolStats":{"currentUsage":20,"creates":43,"highwaterUsage":20,"createFailures":0,"takes":102097}}
```

New metrics would be namespaced on their own json field.

With the addition of https://github.com/avanov/pool/pull/3 we'd also get the waiters in the queue (discussed on https://github.com/PostgREST/postgrest/issues/2042#issuecomment-1027621704)

```js
{ 
  "dbPoolStats": {
    "currentUsage":10,"creates":421,
    "highwaterUsage":10,"createFailures":0,
    "totalWaiters":483,"takes":190445
  }
}
```