### PR TITLE
Fix `--example` configuration file

### DIFF
--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -150,10 +150,6 @@ exampleConfigFile =
       |## Stored proc to exec immediately after auth
       |# db-pre-request = "stored_proc_name"
       |
-      |## stored proc that overrides the root "/" spec
-      |## it must be inside the db-schema
-      |# db-root-spec = "stored_proc_name"
-      |
       |## Notification channel for reloading the schema cache
       |db-channel = "pgrst"
       |

--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -125,30 +125,11 @@ readCLIShowHelp =
 
 exampleConfigFile :: [Char]
 exampleConfigFile =
-  [str|## The standard connection URI format, documented at
-      |## https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-      |db-uri = "postgresql://"
-      |
-      |## The name of which database schema to expose to REST clients
-      |db-schemas = "public"
+  [str|## Admin server used for checks. It's disabled by default unless a port is specified.
+      |# admin-server-port = 3001
       |
       |## The database role to use when no client authentication is provided
       |# db-anon-role = "anon"
-      |
-      |## Number of open connections in the pool
-      |db-pool = 10
-      |
-      |## Time to live, in seconds, for an idle database pool connection
-      |db-pool-timeout = 10
-      |
-      |## Extra schemas to add to the search_path of every request
-      |db-extra-search-path = "public"
-      |
-      |## Limit rows in response
-      |# db-max-rows = 1000
-      |
-      |## Stored proc to exec immediately after auth
-      |# db-pre-request = "stored_proc_name"
       |
       |## Notification channel for reloading the schema cache
       |db-channel = "pgrst"
@@ -159,9 +140,27 @@ exampleConfigFile =
       |## Enable in-database configuration
       |db-config = true
       |
-      |## Determine if GUC request settings for headers, cookies and jwt claims use the legacy names (string with dashes, invalid starting from PostgreSQL v14) with text values instead of the new names (string without dashes, valid on all PostgreSQL versions) with json values.
-      |## For PostgreSQL v14 and up, this setting will be ignored.
-      |db-use-legacy-gucs = true
+      |## Extra schemas to add to the search_path of every request
+      |db-extra-search-path = "public"
+      |
+      |## Limit rows in response
+      |# db-max-rows = 1000
+      |
+      |## Number of open connections in the pool
+      |db-pool = 10
+      |
+      |## Time to live, in seconds, for an idle database pool connection
+      |db-pool-timeout = 10
+      |
+      |## Stored proc to exec immediately after auth
+      |# db-pre-request = "stored_proc_name"
+      |
+      |## Enable or disable prepared statements. disabling is only necessary when behind a connection pooler.
+      |## When disabled, statements will be parametrized but won't be prepared.
+      |db-prepared-statements = true
+      |
+      |## The name of which database schema to expose to REST clients
+      |db-schemas = "public"
       |
       |## How to terminate database transactions
       |## Possible values are:
@@ -175,9 +174,36 @@ exampleConfigFile =
       |##   Transaction is rolled back, but can be overriden with Prefer tx=commit header
       |db-tx-end = "commit"
       |
-      |## Enable or disable prepared statements. disabling is only necessary when behind a connection pooler.
-      |## When disabled, statements will be parametrized but won't be prepared.
-      |db-prepared-statements = true
+      |## The standard connection URI format, documented at
+      |## https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+      |db-uri = "postgresql://"
+      |
+      |## Determine if GUC request settings for headers, cookies and jwt claims use the legacy names (string with dashes, invalid starting from PostgreSQL v14) with text values instead of the new names (string without dashes, valid on all PostgreSQL versions) with json values.
+      |## For PostgreSQL v14 and up, this setting will be ignored.
+      |db-use-legacy-gucs = true
+      |
+      |# jwt-aud = "your_audience_claim"
+      |
+      |## Jspath to the role claim key
+      |jwt-role-claim-key = ".role"
+      |
+      |## Choose a secret, JSON Web Key (or set) to enable JWT auth
+      |## (use "@filename" to load from separate file)
+      |# jwt-secret = "secret_with_at_least_32_characters"
+      |jwt-secret-is-base64 = false
+      |
+      |## Logging level, the admitted values are: crit, error, warn and info.
+      |log-level = "error"
+      |
+      |## Determine if the OpenAPI output should follow or ignore role privileges or be disabled entirely.
+      |## Admitted values: follow-privileges, ignore-privileges, disabled
+      |openapi-mode = "follow-privileges"
+      |
+      |## Base url for the OpenAPI output
+      |openapi-server-proxy-uri = ""
+      |
+      |## Content types to produce raw output
+      |# raw-media-types="image/png, image/jpg"
       |
       |server-host = "!4"
       |server-port = 3000
@@ -189,29 +215,4 @@ exampleConfigFile =
       |## Unix socket file mode
       |## When none is provided, 660 is applied by default
       |# server-unix-socket-mode = "660"
-      |
-      |## Admin server used for checks. It's disabled by default unless a port is specified.
-      |# admin-server-port = 3001
-      |
-      |## Determine if the OpenAPI output should follow or ignore role privileges or be disabled entirely.
-      |## Admitted values: follow-privileges, ignore-privileges, disabled
-      |openapi-mode = "follow-privileges"
-      |
-      |## Base url for the OpenAPI output
-      |openapi-server-proxy-uri = ""
-      |
-      |## Choose a secret, JSON Web Key (or set) to enable JWT auth
-      |## (use "@filename" to load from separate file)
-      |# jwt-secret = "secret_with_at_least_32_characters"
-      |# jwt-aud = "your_audience_claim"
-      |jwt-secret-is-base64 = false
-      |
-      |## Jspath to the role claim key
-      |jwt-role-claim-key = ".role"
-      |
-      |## Content types to produce raw output
-      |# raw-media-types="image/png, image/jpg"
-      |
-      |## Logging level, the admitted values are: crit, error, warn and info.
-      |log-level = "error"
       |]

--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -131,19 +131,19 @@ exampleConfigFile =
       |db-anon-role = "postgres"
       |
       |### OPTIONAL:
-      |## number of open connections in the pool
+      |## Number of open connections in the pool
       |db-pool = 10
       |
-      |## Time to live, in seconds, for an idle database pool connection.
+      |## Time to live, in seconds, for an idle database pool connection
       |db-pool-timeout = 10
       |
-      |## extra schemas to add to the search_path of every request
+      |## Extra schemas to add to the search_path of every request
       |db-extra-search-path = "public"
       |
-      |## limit rows in response
+      |## Limit rows in response
       |# db-max-rows = 1000
       |
-      |## stored proc to exec immediately after auth
+      |## Stored proc to exec immediately after auth
       |# db-pre-request = "stored_proc_name"
       |
       |## stored proc that overrides the root "/" spec
@@ -163,55 +163,55 @@ exampleConfigFile =
       |## For PostgreSQL v14 and up, this setting will be ignored.
       |db-use-legacy-gucs = true
       |
-      |## how to terminate database transactions
-      |## possible values are:
+      |## How to terminate database transactions
+      |## Possible values are:
       |## commit (default)
-      |##   transaction is always committed, this can not be overriden
+      |##   Transaction is always committed, this can not be overriden
       |## commit-allow-override
-      |##   transaction is committed, but can be overriden with Prefer tx=rollback header
+      |##   Transaction is committed, but can be overriden with Prefer tx=rollback header
       |## rollback
-      |##   transaction is always rolled back, this can not be overriden
+      |##   Transaction is always rolled back, this can not be overriden
       |## rollback-allow-override
-      |##   transaction is rolled back, but can be overriden with Prefer tx=commit header
+      |##   Transaction is rolled back, but can be overriden with Prefer tx=commit header
       |db-tx-end = "commit"
       |
-      |## enable or disable prepared statements. disabling is only necessary when behind a connection pooler.
-      |## when disabled, statements will be parametrized but won't be prepared.
+      |## Enable or disable prepared statements. disabling is only necessary when behind a connection pooler.
+      |## When disabled, statements will be parametrized but won't be prepared.
       |db-prepared-statements = true
       |
       |server-host = "!4"
       |server-port = 3000
       |
-      |## unix socket location
+      |## Unix socket location
       |## if specified it takes precedence over server-port
       |# server-unix-socket = "/tmp/pgrst.sock"
       |
-      |## unix socket file mode
-      |## when none is provided, 660 is applied by default
+      |## Unix socket file mode
+      |## When none is provided, 660 is applied by default
       |# server-unix-socket-mode = "660"
       |
-      |## admin server used for checks, it's disabled by default unless a port is specified
+      |## Admin server used for checks. It's disabled by default unless a port is specified.
       |# admin-server-port = 3001
       |
-      |## determine if the OpenAPI output should follow or ignore role privileges or be disabled entirely
-      |## admitted values: follow-privileges, ignore-privileges, disabled
+      |## Determine if the OpenAPI output should follow or ignore role privileges or be disabled entirely.
+      |## Admitted values: follow-privileges, ignore-privileges, disabled
       |openapi-mode = "follow-privileges"
       |
-      |## base url for the OpenAPI output
+      |## Base url for the OpenAPI output
       |openapi-server-proxy-uri = ""
       |
-      |## choose a secret, JSON Web Key (or set) to enable JWT auth
+      |## Choose a secret, JSON Web Key (or set) to enable JWT auth
       |## (use "@filename" to load from separate file)
       |# jwt-secret = "secret_with_at_least_32_characters"
       |# jwt-aud = "your_audience_claim"
       |jwt-secret-is-base64 = false
       |
-      |## jspath to the role claim key
+      |## Jspath to the role claim key
       |jwt-role-claim-key = ".role"
       |
-      |## content types to produce raw output
+      |## Content types to produce raw output
       |# raw-media-types="image/png, image/jpg"
       |
-      |## logging level, the admitted values are: crit, error, warn and info.
+      |## Logging level, the admitted values are: crit, error, warn and info.
       |log-level = "error"
       |]

--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -125,12 +125,16 @@ readCLIShowHelp =
 
 exampleConfigFile :: [Char]
 exampleConfigFile =
-  [str|### REQUIRED:
-      |db-uri = "postgres://user:pass@localhost:5432/dbname"
-      |db-schema = "public"
-      |db-anon-role = "postgres"
+  [str|## The standard connection URI format, documented at
+      |## https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+      |db-uri = "postgresql://"
       |
-      |### OPTIONAL:
+      |## The name of which database schema to expose to REST clients
+      |db-schemas = "public"
+      |
+      |## The database role to use when no client authentication is provided
+      |# db-anon-role = "anon"
+      |
       |## Number of open connections in the pool
       |db-pool = 10
       |

--- a/test/memory/memory-tests.sh
+++ b/test/memory/memory-tests.sh
@@ -1,13 +1,13 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 # This test script expects that a `postgrest` executable with profiling enabled
 # is on the PATH.
 
-set -eu
+set -Eeuo pipefail
 
 pgrPort=49421
 
-# PGRST_DB_URI, PGRST_DB_ANON_ROLE and PGRST_DB_SCHEMAS are expected to be set by with_tmp_db
+export PGRST_DB_ANON_ROLE="postgrest_test_anonymous"
 export PGRST_DB_POOL="1"
 export PGRST_SERVER_HOST="127.0.0.1"
 export PGRST_SERVER_PORT="$pgrPort"
@@ -22,7 +22,7 @@ result(){ echo "$1 $currentTest $2"; currentTest=$(( currentTest + 1 )); }
 ok(){ result 'ok' "- $1"; }
 ko(){ result 'not ok' "- $1"; failedTests=$(( failedTests + 1 )); }
 
-pgrStart(){ postgrest +RTS -p -h > /dev/null & pgrPID="$!"; }
+pgrStart(){ postgrest +RTS -p -h > /dev/null 2>&1 & pgrPID="$!"; }
 pgrStop(){ kill "$pgrPID" 2>/dev/null; }
 
 checkPgrStarted(){


### PR DESCRIPTION
I mentioned `postgrest --example` in https://github.com/PostgREST/postgrest-docs/pull/493 - and then realized that I forgot to update the example config file in #2112. This PR does that - and improves the example file a bit more.