### PR TITLE
fix: Remove trigger functions from schema cache and OpenAPI output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + From `Database connection lost. Retrying the connection` to `Could not query the database for the schema cache. Retrying.`
  - #2120, Fix reading database configuration properly when `=` is present in value - @wolfgangwalther
  - #1771, Fix silently ignoring filter on a non-existent embedded resource - @steve-chavez
+ - #2135, Remove trigger functions from schema cache and OpenAPI output, because they can't be called directly anyway. - @wolfgangwalther
 
 ## [9.0.0] - 2021-11-25
 

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -227,12 +227,12 @@ decodeProcs =
 allProcs :: Bool -> SQL.Statement [Schema] ProcsMap
 allProcs = SQL.Statement sql (arrayParam HE.text) decodeProcs
   where
-    sql = procsSqlQuery <> " WHERE pn.nspname = ANY($1)"
+    sql = procsSqlQuery <> " AND pn.nspname = ANY($1)"
 
 accessibleProcs :: Bool -> SQL.Statement Schema ProcsMap
 accessibleProcs = SQL.Statement sql (param HE.text) decodeProcs
   where
-    sql = procsSqlQuery <> " WHERE pn.nspname = $1 AND has_function_privilege(p.oid, 'execute')"
+    sql = procsSqlQuery <> " AND pn.nspname = $1 AND has_function_privilege(p.oid, 'execute')"
 
 procsSqlQuery :: SqlQuery
 procsSqlQuery = [q|
@@ -297,6 +297,7 @@ procsSqlQuery = [q|
   JOIN pg_namespace tn ON tn.oid = t.typnamespace
   LEFT JOIN pg_class comp ON comp.oid = t.typrelid
   LEFT JOIN pg_catalog.pg_description as d ON d.objoid = p.oid
+  WHERE t.oid <> 'pg_catalog.trigger'::regtype
 |]
 
 schemaDescription :: Bool -> SQL.Statement Schema (Maybe Text)


### PR DESCRIPTION
Trigger functions can't be called directly from SQL and can't be called
via the /rpc prefix either - it makes no sense to expose them in the
OpenAPI output. And we don't need to cache them in the schema cache
either.

Best practice would be to keep the trigger functions in a non-exposed
schema anyway.