### PR TITLE
Fix windows build in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -168,6 +168,8 @@ jobs:
               ~\AppData\Local\Programs\stack
               .stack-work
             deps: |
+              stack exec -- pacman -Syu --noconfirm
+              stack exec -- pacman -S msys2-keyring --noconfirm
               stack exec -- pacman -S mingw64/mingw-w64-x86_64-postgresql --noconfirm
             # We'd need to make test/with_tmp_db run on Windows first
             # test: true

--- a/nix/tools/tests.nix
+++ b/nix/tools/tests.nix
@@ -133,7 +133,10 @@ let
         # build once before running all the tests
         ${cabal-install}/bin/cabal v2-build ${devCabalOptions} exe:postgrest lib:postgrest test:spec test:querycost
 
-        ${haskellPackages.weeder}/bin/weeder --config=./test/weeder.dhall || echo Found dead code: Check file list above.
+        (
+          trap 'echo Found dead code: Check file list above.' ERR ;
+          ${haskellPackages.weeder}/bin/weeder --config=./test/weeder.dhall
+        )
 
         # collect all tests
         HPCTIXFILE="$tmpdir"/io.tix \

--- a/test/spec/SpecHelper.hs
+++ b/test/spec/SpecHelper.hs
@@ -5,14 +5,12 @@ import qualified Data.ByteString.Char8  as BS
 import qualified Data.ByteString.Lazy   as BL
 import qualified Data.Map.Strict        as M
 import qualified Data.Set               as S
-import qualified System.IO.Error        as E
 
 import Data.Aeson           (Value (..), decode, encode)
 import Data.CaseInsensitive (CI (..), original)
 import Data.List            (lookup)
 import Data.List.NonEmpty   (fromList)
 import Network.Wai.Test     (SResponse (simpleBody, simpleHeaders, simpleStatus))
-import System.Environment   (getEnv)
 import System.Process       (readProcess)
 import Text.Regex.TDFA      ((=~))
 
@@ -67,10 +65,6 @@ validateOpenApiResponse headers = do
       , matchHeaders = []
       }
 
-
-getEnvVarWithDefault :: Text -> Text -> IO Text
-getEnvVarWithDefault var def = toS <$>
-  getEnv (toS var) `E.catchIOError` const (return $ toS def)
 
 baseCfg :: AppConfig
 baseCfg = let secret = Just $ encodeUtf8 "reallyreallyreallyreallyverysafe" in


### PR DESCRIPTION
This updates the keyring on windows builds to remove the key failure when installing dependencies. This will have to rebuild everything, so this might take a while.

While at it, I also fixed `weeder` to find dead code. The non-zero exit code was swallowed, leading to no failures when there should have been some.