### PR TITLE
feat: Support accessing array items and fields of composite types through json operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + A `<host>:<admin_server_port>/live` endpoint is available for checking if postgrest is running on its port/socket. 200 OK = alive, 503 = dead.
    + A `<host>:<admin_server_port>/ready` endpoint is available for checking a correct internal state(the database connection plus the schema cache). 200 OK = ready, 503 = not ready.
  - #1988, Add the current user to the request log on stdout - @DavidLindbom, @wolfgangwalther
- - #1823, Add the ability to run postgrest without any configuration. @wolfgangwalther
-   + #1991, Add the ability to run without `db-uri` using libpq's PG environment variables to connect. @wolfgangwalther
-   + #1769, Add the ability to run without `db-schemas`, defaulting to `db-schemas=public`. @wolfgangwalther
-   + #1689, Add the ability to run without `db-anon-role` disabling anonymous access. @wolfgangwalther
+ - #1823, Add the ability to run postgrest without any configuration. - @wolfgangwalther
+   + #1991, Add the ability to run without `db-uri` using libpq's PG environment variables to connect. - @wolfgangwalther
+   + #1769, Add the ability to run without `db-schemas`, defaulting to `db-schemas=public`. - @wolfgangwalther
+   + #1689, Add the ability to run without `db-anon-role` disabling anonymous access. - @wolfgangwalther
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + #1991, Add the ability to run without `db-uri` using libpq's PG environment variables to connect. - @wolfgangwalther
    + #1769, Add the ability to run without `db-schemas`, defaulting to `db-schemas=public`. - @wolfgangwalther
    + #1689, Add the ability to run without `db-anon-role` disabling anonymous access. - @wolfgangwalther
+ - #1543, Allow access to fields of composite types in select=, order= and filters through JSON operators -> and ->>. - @wolfgangwalther
+ - #2075, Allow access to array items in ?select=, ?order= and filters through JSON operators -> and ->>. - @wolfgangwalther
 
 ### Fixed
 
@@ -29,6 +31,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2120, Fix reading database configuration properly when `=` is present in value - @wolfgangwalther
  - #1771, Fix silently ignoring filter on a non-existent embedded resource - @steve-chavez
  - #2135, Remove trigger functions from schema cache and OpenAPI output, because they can't be called directly anyway. - @wolfgangwalther
+ - #2145, Fix accessing json array fields with -> and ->> in ?select= and ?order=. - @wolfgangwalther
 
 ## [9.0.0] - 2021-11-25
 

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -197,7 +197,10 @@ pgFmtColumn table "*" = fromQi table <> ".*"
 pgFmtColumn table c   = fromQi table <> "." <> pgFmtIdent c
 
 pgFmtField :: QualifiedIdentifier -> Field -> SQL.Snippet
-pgFmtField table (c, jp) = SQL.sql (pgFmtColumn table c) <> pgFmtJsonPath jp
+pgFmtField table (c, []) = SQL.sql (pgFmtColumn table c)
+-- Using to_jsonb instead of to_json to avoid missing operator errors when filtering:
+-- "operator does not exist: json = unknown"
+pgFmtField table (c, jp) = SQL.sql ("to_jsonb(" <> pgFmtColumn table c <> ")") <> pgFmtJsonPath jp
 
 pgFmtSelectItem :: QualifiedIdentifier -> SelectItem -> SQL.Snippet
 pgFmtSelectItem table (f@(fName, jp), Nothing, alias, _, _) = pgFmtField table f <> SQL.sql (pgFmtAs fName jp alias)

--- a/src/PostgREST/Request/QueryParams.hs
+++ b/src/PostgREST/Request/QueryParams.hs
@@ -318,6 +318,26 @@ pFieldName =
     dash :: Parser Char
     dash = isDash $> '-'
 
+-- |
+-- Parse json operators in select, order and filters
+--
+-- >>> P.parse pJsonPath "" "->text"
+-- Right [JArrow {jOp = JKey {jVal = "text"}}]
+--
+-- >>> P.parse pJsonPath "" "->1"
+-- Right [JArrow {jOp = JIdx {jVal = "+1"}}]
+--
+-- >>> P.parse pJsonPath "" "->>text"
+-- Right [J2Arrow {jOp = JKey {jVal = "text"}}]
+--
+-- >>> P.parse pJsonPath "" "->>1"
+-- Right [J2Arrow {jOp = JIdx {jVal = "+1"}}]
+--
+-- >>> P.parse pJsonPath "" "->0,other"
+-- Right [JArrow {jOp = JIdx {jVal = "+0"}}]
+--
+-- >>> P.parse pJsonPath "" "->0.desc"
+-- Right [JArrow {jOp = JIdx {jVal = "+0"}}]
 pJsonPath :: Parser JsonPath
 pJsonPath = many pJsonOperation
   where
@@ -333,6 +353,8 @@ pJsonPath = many pJsonOperation
           pJIdx = JIdx . toS <$> ((:) <$> P.option '+' (char '-') <*> many1 digit) <* pEnd
           pEnd = try (void $ lookAhead (string "->")) <|>
                  try (void $ lookAhead (string "::")) <|>
+                 try (void $ lookAhead (string ".")) <|>
+                 try (void $ lookAhead (string ",")) <|>
                  try eof in
       try pJIdx <|> try pJKey
 

--- a/test/spec/fixtures/data.sql
+++ b/test/spec/fixtures/data.sql
@@ -730,3 +730,9 @@ INSERT INTO test.clientinfo (id,clientid, other) values (1,1,'123 Main St'),(2,2
 
 TRUNCATE TABLE test.chores CASCADE;
 INSERT INTO test.chores (id, name, done) values (1, 'take out the garbage', true), (2, 'do the laundry', false), (3, 'wash the dishes', null);
+
+TRUNCATE TABLE test.fav_numbers CASCADE;
+INSERT INTO test.fav_numbers VALUES (ROW(0.5, 0.5), 'A'),  (ROW(0.6, 0.6), 'B');
+
+TRUNCATE TABLE test.arrays CASCADE;
+INSERT INTO test.arrays VALUES (0, '{1,2,3}', '{{1,2,3},{4,5,6},{7,8,9}}'), (1, '{11,12,13}', '{{11,12,13},{14,15,16},{17,18,19}}');

--- a/test/spec/fixtures/privileges.sql
+++ b/test/spec/fixtures/privileges.sql
@@ -19,6 +19,7 @@ GRANT ALL ON TABLE
     , items3
     , "articleStars"
     , articles
+    , arrays
     , auto_incrementing_pk
     , clients
     , comments
@@ -27,6 +28,7 @@ GRANT ALL ON TABLE
     , compound_pk_view
     , deferrable_unique_constraint
     , empty_table
+    , fav_numbers
     , has_count_column
     , has_fk
     , insertable_view_with_join

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -2427,3 +2427,21 @@ BEGIN
   END IF;
 END
 $do$;
+
+-- https://github.com/PostgREST/postgrest/issues/1543
+CREATE TYPE complex AS (
+ r double precision,
+ i double precision
+);
+
+CREATE TABLE test.fav_numbers (
+ num    complex,
+ person text
+);
+
+-- https://github.com/PostgREST/postgrest/issues/2075
+create table test.arrays (
+  id int primary key,
+  numbers int[],
+  numbers_mult int[][]
+);


### PR DESCRIPTION
As discussed in https://github.com/PostgREST/postgrest/issues/1543#issuecomment-1028162880.

Works fine... almost.

---

The array part is failing two tests. Filtering works, but select and order do not - and I don't understand why.

The following request (the combination of both failing tests):
```http
GET /arrays?select=a:numbers->0,b:numbers->1,c:numbers_mult->1->1,d:numbers_mult->2->3&order=numbers->0.desc
```
results in the following query:

```sql
WITH pgrst_source AS (
  SELECT
    to_jsonb("test"."arrays"."numbers")->$1 AS "a",
    to_jsonb("test"."arrays"."numbers")->$2 AS "b",
    to_jsonb("test"."arrays"."numbers_mult")->$3::int->$4 AS "c",
    to_jsonb("test"."arrays"."numbers_mult")->$5::int->$6::int AS "d"
  FROM "test"."arrays"
  ORDER BY to_jsonb("test"."arrays"."numbers")->$7 DESC
)
-- [...]
```

Note the missing `::int` for some of those query parameters. This will cause the unknown literal to be interpreted as `text` - and the `->` and `->>` operators to fail accessing the array properly.

I just have no idea why the parser does that. And it looks random, too, because some of the `::int` are there...