### PR TITLE
fix: Using GET with certain Content-Type headers now correctly calls the no parameter function if it exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2145, Fix accessing json array fields with -> and ->> in ?select= and ?order=. - @wolfgangwalther
  - #2153, Fix --dump-schema running with a wrong PG version. - @wolfgangwalther
  - #2042, Keep working when EMFILE(Too many open files) is reached. - @steve-chavez
+ - #2147, Using GET with `text/plain` or `application/octet-stream` as `Content-Type` headers no longer returns "Not Found" when the requested function with no parameters exists
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2145, Fix accessing json array fields with -> and ->> in ?select= and ?order=. - @wolfgangwalther
  - #2153, Fix --dump-schema running with a wrong PG version. - @wolfgangwalther
  - #2042, Keep working when EMFILE(Too many open files) is reached. - @steve-chavez
- - #2147, Using GET with `text/plain` or `application/octet-stream` as `Content-Type` headers no longer returns "Not Found" when the requested function with no parameters exists
+ - #2147, Ignore `Content-Type` headers for `GET` requests when calling RPCs. Previously, `GET` without parameters, but with `Content-Type: text/plain` or `Content-Type: application/octet-stream` would fail with `404 Not Found`, even if a function without arguments was available.
+ - ```
 
 ### Changed
 

--- a/src/PostgREST/Request/ApiRequest.hs
+++ b/src/PostgREST/Request/ApiRequest.hs
@@ -465,7 +465,7 @@ findProc qi argumentsKeys paramsAsSingleObject allProcs contentType isInvPost =
         then length params == 1 && (firstType == Just "json" || firstType == Just "jsonb")
       -- If the function has no parameters, the arguments keys must be empty as well
       else if null params
-        then null argumentsKeys && contentType `notElem` [CTTextPlain, CTOctetStream]
+        then null argumentsKeys && not (isInvPost && contentType `elem` [CTTextPlain, CTOctetStream])
       -- A function has optional and required parameters. Optional parameters have a default value and
       -- don't require arguments for the function to be executed, required parameters must have an argument present.
       else case L.partition ppReq params of

--- a/test/spec/Feature/Query/RpcSpec.hs
+++ b/test/spec/Feature/Query/RpcSpec.hs
@@ -1245,10 +1245,6 @@ spec actualPgVersion =
             respBody `shouldBe` file
 
         it "should call the function with no parameters and not fallback to the single unnamed parameter function when using GET with Content-Type headers" $ do
-          request methodGet "/rpc/overloaded_unnamed_param" [("Content-Type", "application/json")] ""
-            `shouldRespondWith`
-              [json| 1|]
-              { matchStatus  = 200 }
           request methodGet "/rpc/overloaded_unnamed_param" [("Content-Type", "text/plain")] ""
             `shouldRespondWith`
               [json| 1|]

--- a/test/spec/Feature/Query/RpcSpec.hs
+++ b/test/spec/Feature/Query/RpcSpec.hs
@@ -1244,6 +1244,20 @@ spec actualPgVersion =
             let respBody = simpleBody r
             respBody `shouldBe` file
 
+        it "should call the function with no parameters and not fallback to the single unnamed parameter function when using GET with Content-Type headers" $ do
+          request methodGet "/rpc/overloaded_unnamed_param" [("Content-Type", "application/json")] ""
+            `shouldRespondWith`
+              [json| 1|]
+              { matchStatus  = 200 }
+          request methodGet "/rpc/overloaded_unnamed_param" [("Content-Type", "text/plain")] ""
+            `shouldRespondWith`
+              [json| 1|]
+              { matchStatus  = 200 }
+          request methodGet "/rpc/overloaded_unnamed_param" [("Content-Type", "application/octet-stream")] ""
+            `shouldRespondWith`
+              [json| 1|]
+              { matchStatus  = 200 }
+
         it "should fail to fallback to any single unnamed parameter function when using an unsupported Content-Type header" $ do
           request methodPost "/rpc/overloaded_unnamed_param"
               [("Content-Type", "text/csv")]


### PR DESCRIPTION
Closes #2147.