### PR TITLE
fix: Remove admin-server-port from in-db configuration

### DIFF
--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -348,7 +348,7 @@ parser optPath env dbSettings =
         reloadableDbSetting =
           let dbSettingName = T.pack $ dashToUnderscore <$> toS key in
           if dbSettingName `notElem` [
-            "server_host", "server_port", "server_unix_socket", "server_unix_socket_mode", "log_level",
+            "server_host", "server_port", "server_unix_socket", "server_unix_socket_mode", "admin_server_port", "log_level",
             "db_uri", "db_channel_enabled", "db_channel", "db_pool", "db_pool_timeout", "db_config"]
           then lookup dbSettingName dbSettings
           else Nothing

--- a/test/io/db_config.sql
+++ b/test/io/db_config.sql
@@ -29,6 +29,7 @@ ALTER ROLE db_config_authenticator SET pgrst.server_host = 'ignored';
 ALTER ROLE db_config_authenticator SET pgrst.server_port = 'ignored';
 ALTER ROLE db_config_authenticator SET pgrst.server_unix_socket = 'ignored';
 ALTER ROLE db_config_authenticator SET pgrst.server_unix_socket_mode = 'ignored';
+ALTER ROLE db_config_authenticator SET pgrst.admin_server_port = 'ignored';
 ALTER ROLE db_config_authenticator SET pgrst.log_level = 'ignored';
 ALTER ROLE db_config_authenticator SET pgrst.db_uri = 'postgresql://ignored';
 ALTER ROLE db_config_authenticator SET pgrst.db_channel_enabled = 'ignored';


### PR DESCRIPTION
Fixed as discussed here https://github.com/PostgREST/postgrest-docs/pull/508#discussion_r812359107