### PR TITLE
Correct live/ready checks to consider special host values

### DIFF
--- a/src/PostgREST/Admin.hs
+++ b/src/PostgREST/Admin.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RecordWildCards #-}
 module PostgREST.Admin
   ( postgrestAdmin
   ) where
@@ -38,37 +39,37 @@ postgrestAdmin appState appConfig req respond  = do
 
 -- Try to connect to the main app socket
 -- Note that it doesn't even send a valid HTTP request, we just want to check that the main app is accepting connections
+-- The code for resolving the "*4", "!4", "*6", "!6", "*" special values is taken from
+-- https://hackage.haskell.org/package/streaming-commons-0.2.2.4/docs/src/Data.Streaming.Network.html#bindPortGenEx
 reachMainApp :: AppConfig -> IO [Either IOException ()]
-reachMainApp appConfig =
-  case configServerUnixSocket appConfig of
+reachMainApp AppConfig{..} =
+  case configServerUnixSocket of
     Just path ->  do
       sock <- socket AF_UNIX Stream 0
-      connect sock $ SockAddrUnix path
-      res <- try . withSocketsDo $ bracket (pure sock) close sendEmpty
-      pure [res]
+      (:[]) <$> try (do
+        connect sock $ SockAddrUnix path
+        withSocketsDo $ bracket (pure sock) close sendEmpty)
     Nothing -> do
-      addrs <-
-        let host = if configServerHost appConfig `elem` ["*4", "!4", "*6", "!6"]
-                     then Nothing
-                     else Just $ configServerHost appConfig in
-        getAddrInfo (Just $ defaultHints { addrSocketType = Stream, addrFlags = [AI_PASSIVE] })
-                             (T.unpack <$> host)
-                             (Just . show $ configServerPort appConfig)
       let
-        addrs4 = filter (\x -> addrFamily x /= AF_INET6) addrs
-        addrs6 = filter (\x -> addrFamily x == AF_INET6) addrs
-        addrs' =
-          case configServerHost appConfig of
-              "*4" -> addrs4 ++ addrs6
-              "!4" -> addrs4
-              "*6" -> addrs6 ++ addrs4
-              "!6" -> addrs6
-              _    -> addrs
-      tryAddr `traverse` addrs'
+        host | configServerHost `elem` ["*4", "!4", "*6", "!6", "*"] = Nothing
+             | otherwise                                             = Just configServerHost
+        filterAddrs xs =
+          case configServerHost of
+              "*4" -> ipv4Addrs xs ++ ipv6Addrs xs
+              "!4" -> ipv4Addrs xs
+              "*6" -> ipv6Addrs xs ++ ipv4Addrs xs
+              "!6" -> ipv6Addrs xs
+              _    -> xs
+        ipv4Addrs xs = filter ((/=) AF_INET6 . addrFamily) xs
+        ipv6Addrs xs = filter ((==) AF_INET6 . addrFamily) xs
+
+      addrs <- getAddrInfo (Just $ defaultHints { addrSocketType = Stream }) (T.unpack <$> host) (Just . show $ configServerPort)
+      tryAddr `traverse` filterAddrs addrs
   where
     sendEmpty sock = void $ send sock mempty
     tryAddr :: AddrInfo -> IO (Either IOException ())
     tryAddr addr = do
       sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
-      connect sock $ addrAddress addr
-      try . withSocketsDo $ bracket (pure sock) close sendEmpty
+      try $ do
+        connect sock $ addrAddress addr
+        withSocketsDo $ bracket (pure sock) close sendEmpty

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -131,7 +131,7 @@ run installHandlers maybeRunWithSocket appState = do
           AppState.logWithZTime appState $ "Listening on unix socket " <> show socket
           runWithSocket (serverSettings conf) app configServerUnixSocketMode socket
         Nothing ->
-          panic "Cannot run with socket on non-unix plattforms."
+          panic "Cannot run with unix socket on non-unix plattforms."
     Nothing ->
       do
         AppState.logWithZTime appState $ "Listening on port " <> show configServerPort

--- a/test/io/fixtures.yaml
+++ b/test/io/fixtures.yaml
@@ -171,3 +171,10 @@ invalidjointypes:
   - 'left!'
   - 'right'
   - '.#$$%&$%/'
+
+specialhostvalues:
+  - '*4'
+  - '!4'
+  - '*6'
+  - '!6'
+  - '*'


### PR DESCRIPTION
Fixes https://github.com/PostgREST/postgrest/issues/2174.

Took a different route from the one suggested in https://github.com/PostgREST/postgrest/issues/2174#issuecomment-1045978929. I avoided including the [streaming-commons](https://hackage.haskell.org/package/streaming-commons) dependency and instead just handled the special host values in the admin server logic by stealing some of the code from [bindPortGenEx](https://hackage.haskell.org/package/streaming-commons-0.2.2.4/docs/src/Data.Streaming.Network.html#bindPortGenEx). That seemed like a simpler change.

### TODO

- [x] Refactor
- [x] Make tests green