### PR TITLE
Addition of Content Range unit for RFC compliance

### DIFF
--- a/src/PostgREST/RangeQuery.hs
+++ b/src/PostgREST/RangeQuery.hs
@@ -91,7 +91,7 @@ rangeStatusHeader topLevelRange queryTotal tableTotal =
 
 contentRangeH :: (Integral a, Show a) => a -> a -> Maybe a -> Header
 contentRangeH lower upper total =
-    ("Content-Range", toUtf8 headerValue)
+    ("Content-Range", "bytes" toUtf8 headerValue)
     where
       headerValue   = rangeString <> "/" <> totalString :: Text
       rangeString


### PR DESCRIPTION
The Content Range response HTTP header is missing a unit declaration. It should be in the form :
`Content-Range: <unit> <range-start>-<range-end>/<size>`

Supplementary docs-
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range
https://httpwg.org/specs/rfc7233.html#header.content-range

This change makes Postgrest compatible with Varnish.

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs     - https://github.com/PostgREST/postgrest-docs
-->
