### PR TITLE
Content Range unit for RFC 7233 compliance

### DIFF
--- a/src/PostgREST/RangeQuery.hs
+++ b/src/PostgREST/RangeQuery.hs
@@ -93,7 +93,7 @@ contentRangeH :: (Integral a, Show a) => a -> a -> Maybe a -> Header
 contentRangeH lower upper total =
     ("Content-Range", toUtf8 headerValue)
     where
-      headerValue   = rangeString <> "/" <> totalString :: Text
+      headerValue   = "bytes" rangeString <> "/" <> totalString :: Text
       rangeString
         | totalNotZero && fromInRange = show lower <> "-" <> show upper
         | otherwise = "*"


### PR DESCRIPTION
The Content Range response HTTP header is missing a unit declaration. It should be in the form :
`Content-Range: <unit> <range-start>-<range-end>/<size>`

Supplementary docs-
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range
https://httpwg.org/specs/rfc7233.html#header.content-range

This change also makes PostgREST compatible with Varnish HTTP Cache (https://varnish-cache.org/).
