### PR TITLE
fix: json/jsonb columns should have type "object" in OpenAPI spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
- - #2165, Fix json/jsonb columns should have type "object" in OpenAPI spec
+ - #2165, Fix json/jsonb columns should not have type in OpenAPI spec
  - #2020, Execute deferred constraint triggers when using `Prefer: tx=rollback` - @wolfgangwalther
  - #2058, Return 204 No Content without Content-Type for PUT - @wolfgangwalther
  - #2077, Fix `is` not working with upper or mixed case values like `NULL, TrUe, FaLsE` - @steve-chavez

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+ - #2165, Fix json/jsonb columns should have type "object" in OpenAPI spec
  - #2020, Execute deferred constraint triggers when using `Prefer: tx=rollback` - @wolfgangwalther
  - #2058, Return 204 No Content without Content-Type for PUT - @wolfgangwalther
  - #2077, Fix `is` not working with upper or mixed case values like `NULL, TrUe, FaLsE` - @steve-chavez

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -2,10 +2,10 @@
 Module      : PostgREST.OpenAPI
 Description : Generates the OpenAPI output
 -}
+{-# LANGUAGE DataKinds       #-}
 {-# LANGUAGE LambdaCase      #-}
 {-# LANGUAGE NamedFieldPuns  #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE DataKinds       #-}
 module PostgREST.OpenAPI (encode) where
 
 import qualified Data.Aeson            as JSON
@@ -25,7 +25,7 @@ import Network.URI                (URI (..), URIAuth (..))
 import Control.Lens (at, (.~), (?~))
 
 import Data.Swagger
-import Data.Swagger.Internal              (SwaggerKind(SwaggerKindSchema))
+import Data.Swagger.Internal (SwaggerKind (SwaggerKindSchema))
 
 import PostgREST.Config                   (AppConfig (..), Proxy (..),
                                            isMalformedProxyUri, toURI)

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -5,6 +5,7 @@ Description : Generates the OpenAPI output
 {-# LANGUAGE LambdaCase      #-}
 {-# LANGUAGE NamedFieldPuns  #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE DataKinds       #-}
 module PostgREST.OpenAPI (encode) where
 
 import qualified Data.Aeson            as JSON
@@ -24,6 +25,7 @@ import Network.URI                (URI (..), URIAuth (..))
 import Control.Lens (at, (.~), (?~))
 
 import Data.Swagger
+import Data.Swagger.Internal              (SwaggerKind(SwaggerKindSchema))
 
 import PostgREST.Config                   (AppConfig (..), Proxy (..),
                                            isMalformedProxyUri, toURI)
@@ -55,7 +57,7 @@ encode conf dbStructure tables procs schemaDescription =
 makeMimeList :: [ContentType] -> MimeList
 makeMimeList cs = MimeList $ fmap (fromString . BS.unpack . toMime) cs
 
-toSwaggerType :: Text -> SwaggerType t
+toSwaggerType :: Text -> SwaggerType 'SwaggerKindSchema
 toSwaggerType "character varying" = SwaggerString
 toSwaggerType "character"         = SwaggerString
 toSwaggerType "text"              = SwaggerString
@@ -67,6 +69,8 @@ toSwaggerType "numeric"           = SwaggerNumber
 toSwaggerType "real"              = SwaggerNumber
 toSwaggerType "double precision"  = SwaggerNumber
 toSwaggerType "ARRAY"             = SwaggerArray
+toSwaggerType "json"              = SwaggerObject
+toSwaggerType "jsonb"             = SwaggerObject
 toSwaggerType _                   = SwaggerString
 
 parseDefault :: Text -> Text -> Text

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -2,7 +2,6 @@
 Module      : PostgREST.OpenAPI
 Description : Generates the OpenAPI output
 -}
-{-# LANGUAGE DataKinds       #-}
 {-# LANGUAGE LambdaCase      #-}
 {-# LANGUAGE NamedFieldPuns  #-}
 {-# LANGUAGE RecordWildCards #-}

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -883,17 +883,19 @@ def test_admin_live_dependent_on_main_app(defaultenv):
         response = postgrest.admin.get("/live")
         assert response.status_code == 503
 
+
 @pytest.mark.parametrize("specialhostvalue", FIXTURES["specialhostvalues"])
 def test_admin_works_with_host_special_values(specialhostvalue, defaultenv):
     "Should get a success from the admin live and ready endpoints when using special host values for the main app"
 
     with run(env=defaultenv, port=freeport(), host=specialhostvalue) as postgrest:
 
-      response = postgrest.admin.get("/live")
-      assert response.status_code == 200
+        response = postgrest.admin.get("/live")
+        assert response.status_code == 200
 
-      response = postgrest.admin.get("/ready")
-      assert response.status_code == 200
+        response = postgrest.admin.get("/ready")
+        assert response.status_code == 200
+
 
 @pytest.mark.parametrize(
     "level, has_output",

--- a/test/spec/Feature/OpenApi/OpenApiSpec.hs
+++ b/test/spec/Feature/OpenApi/OpenApiSpec.hs
@@ -430,6 +430,36 @@ spec actualPgVersion = describe "OpenAPI" $ do
             }
           |]
 
+    it "json to object" $ do
+      r <- simpleBody <$> get "/"
+
+      let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_json"
+
+      liftIO $
+
+        types `shouldBe` Just
+          [aesonQQ|
+            {
+              "format": "json",
+              "type": "object"
+            }
+          |]
+
+    it "jsonb to object" $ do
+      r <- simpleBody <$> get "/"
+
+      let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_jsonb"
+
+      liftIO $
+
+        types `shouldBe` Just
+          [aesonQQ|
+            {
+              "format": "jsonb",
+              "type": "object"
+            }
+          |]
+
   describe "Detects default values" $ do
 
     it "text" $ do
@@ -549,11 +579,11 @@ spec actualPgVersion = describe "OpenAPI" $ do
                 },
                 "json": {
                   "format": "json",
-                  "type": "string"
+                  "type": "object"
                 },
                 "jsonb": {
                   "format": "jsonb",
-                  "type": "string"
+                  "type": "object"
                 }
               },
               "type": "object",

--- a/test/spec/Feature/OpenApi/OpenApiSpec.hs
+++ b/test/spec/Feature/OpenApi/OpenApiSpec.hs
@@ -430,7 +430,7 @@ spec actualPgVersion = describe "OpenAPI" $ do
             }
           |]
 
-    it "json to object" $ do
+    it "json to any" $ do
       r <- simpleBody <$> get "/"
 
       let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_json"
@@ -440,12 +440,11 @@ spec actualPgVersion = describe "OpenAPI" $ do
         types `shouldBe` Just
           [aesonQQ|
             {
-              "format": "json",
-              "type": "object"
+              "format": "json"
             }
           |]
 
-    it "jsonb to object" $ do
+    it "jsonb to any" $ do
       r <- simpleBody <$> get "/"
 
       let types = r ^? key "definitions" . key "openapi_types" . key "properties" . key "a_jsonb"
@@ -455,8 +454,7 @@ spec actualPgVersion = describe "OpenAPI" $ do
         types `shouldBe` Just
           [aesonQQ|
             {
-              "format": "jsonb",
-              "type": "object"
+              "format": "jsonb"
             }
           |]
 
@@ -578,12 +576,10 @@ spec actualPgVersion = describe "OpenAPI" $ do
                   "type": "integer"
                 },
                 "json": {
-                  "format": "json",
-                  "type": "object"
+                  "format": "json"
                 },
                 "jsonb": {
-                  "format": "jsonb",
-                  "type": "object"
+                  "format": "jsonb"
                 }
               },
               "type": "object",

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -1807,7 +1807,9 @@ CREATE TABLE test.openapi_types(
   "a_bigint" bigint,
   "a_numeric" numeric,
   "a_real" real,
-  "a_double_precision" double precision
+  "a_double_precision" double precision,
+  "a_json" json,
+  "a_jsonb" jsonb
 );
 
 CREATE TABLE test.openapi_defaults(


### PR DESCRIPTION
Fixes #2165

I couldn't find a way to type `toSwaggerType` that didn't involve `DataKinds` and importing from `Data.Swagger.Internal` ... 🤔 but glad to change that if someone knows how.