### PR TITLE
Bypass FreeBSD builds due to timeouts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -234,7 +234,7 @@ jobs:
       - Test-Memory-Nix
       - Build-Static-Nix
       - Build-Stack
-      - Get-FreeBSD-CirrusCI
+      #- Get-FreeBSD-CirrusCI
     outputs:
       version: ${{ steps.Identify-Version.outputs.version }}
       isprerelease: ${{ steps.Identify-Version.outputs.isprerelease }}
@@ -314,8 +314,9 @@ jobs:
           tar cJvf "release-bundle/postgrest-v$VERSION-macos-x64.tar.xz" \
             -C artifacts/postgrest-macos-x64 postgrest
 
-          tar cJvf "release-bundle/postgrest-v$VERSION-freebsd-x64.tar.xz" \
-            -C artifacts/postgrest-freebsd-x64 postgrest
+          # TODO: Fix timeouts for FreeBSD builds in Cirrus
+          #tar cJvf "release-bundle/postgrest-v$VERSION-freebsd-x64.tar.xz" \
+          #  -C artifacts/postgrest-freebsd-x64 postgrest
 
           zip "release-bundle/postgrest-v$VERSION-windows-x64.zip" \
             artifacts/postgrest-windows-x64/postgrest.exe


### PR DESCRIPTION
There were long timeouts in the previous v9.9.0.20220326 prerelease with FreeBSD builds in Cirrus, bypassing for now. The binaries will be uploaded manually.
