### PR TITLE
Limited update/delete part 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + #1689, Add the ability to run without `db-anon-role` disabling anonymous access. - @wolfgangwalther
  - #1543, Allow access to fields of composite types in select=, order= and filters through JSON operators -> and ->>. - @wolfgangwalther
  - #2075, Allow access to array items in ?select=, ?order= and filters through JSON operators -> and ->>. - @wolfgangwalther
- - #2156, Allow applying `limit/offset` to UPDATE/DELETE to only affect a subset of rows - @steve-chavez
-   + Uses the table primary key, so it needs a select privilege on the primary key columns
-   + If no primary key is available, it will fallback to using the "ctid" system column(will also require a select privilege on it)
-   + Doesn't work on views and it will throw an error if tried
+ - #2156, #2211, Allow applying `limit/offset` to UPDATE/DELETE to only affect a subset of rows - @steve-chavez
+   + It requires an explicit `order` on a unique column(s)
  - #1917, Add error codes with the `"PGRST"` prefix to the error response body to differentiate PostgREST errors from PostgreSQL errors - @laurenceisla
  - #1917, Normalize the error response body by always having the `detail` and `hint` error fields with a `null` value if they are empty - @laurenceisla
  - #2176, Errors raised with `SQLSTATE` now include the message and the code in the response body - @laurenceisla

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -370,9 +370,6 @@ handleUpdate identifier context@(RequestContext _ _ ApiRequest{..} _) = do
 
 handleSingleUpsert :: QualifiedIdentifier -> RequestContext-> DbHandler Wai.Response
 handleSingleUpsert identifier context@(RequestContext _ ctxDbStructure ApiRequest{..} _) = do
-  when (iTopLevelRange /= RangeQuery.allRange) $
-    throwError Error.PutRangeNotAllowedError
-
   let pkCols = maybe mempty tablePKCols $ M.lookup identifier $ dbTables ctxDbStructure
 
   WriteQueryResult{..} <- writeQuery MutationSingleUpsert identifier False pkCols context

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -23,7 +23,6 @@ module PostgREST.DbStructure
   , queryDbStructure
   , accessibleTables
   , accessibleProcs
-  , findIfView
   , schemaDescription
   ) where
 
@@ -65,9 +64,6 @@ data DbStructure = DbStructure
   , dbProcs         :: ProcsMap
   }
   deriving (Generic, JSON.ToJSON)
-
-findIfView :: QualifiedIdentifier -> TablesMap -> Bool
-findIfView identifier tbls = maybe False tableIsView $ M.lookup identifier tbls
 
 -- | A view foreign key or primary key dependency detected on its source table
 data ViewKeyDependency = ViewKeyDependency {

--- a/src/PostgREST/DbStructure/Table.hs
+++ b/src/PostgREST/DbStructure/Table.hs
@@ -21,8 +21,8 @@ data Table = Table
   { tableSchema      :: Schema
   , tableName        :: TableName
   , tableDescription :: Maybe Text
-    -- TODO Find a better way to separate tables and views
-  , tableIsView      :: Bool
+     -- TODO Find a better way to separate tables and views
+   , tableIsView     :: Bool
     -- The following fields identify what can be done on the table/view, they're not related to the privileges granted to it
   , tableInsertable  :: Bool
   , tableUpdatable   :: Bool

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -20,6 +20,7 @@ module PostgREST.Query.SqlFragment
   , locationF
   , mutRangeF
   , normalizedBody
+  , orderF
   , pgFmtColumn
   , pgFmtIdent
   , pgFmtJoinCondition
@@ -331,6 +332,17 @@ currentSettingF setting =
   -- nullif is used because of https://gist.github.com/steve-chavez/8d7033ea5655096903f3b52f8ed09a15
   "nullif(current_setting('" <> setting <> "', true), '')"
 
+mutRangeF :: QualifiedIdentifier -> [FieldName] -> (SqlFragment, SqlFragment)
+mutRangeF mainQi rangeId =
+  (
+    BS.intercalate " AND " $ (\col -> pgFmtColumn mainQi col <> " = " <> pgFmtColumn (QualifiedIdentifier mempty "pgrst_affected_rows") col) <$> rangeId
+  , BS.intercalate ", " (pgFmtColumn mainQi <$> rangeId)
+  )
+
+orderF :: QualifiedIdentifier -> [OrderTerm] -> SQL.Snippet
+orderF _ []    = mempty
+orderF qi ordts = "ORDER BY " <> intercalateSnippet ", " (pgFmtOrderTerm qi <$> ordts)
+
 -- Hasql Snippet utilities
 unknownEncoder :: ByteString -> SQL.Snippet
 unknownEncoder = SQL.encoderAndParam (HE.nonNullable HE.unknown)
@@ -341,12 +353,3 @@ unknownLiteral = unknownEncoder . encodeUtf8
 intercalateSnippet :: ByteString -> [SQL.Snippet] -> SQL.Snippet
 intercalateSnippet _ [] = mempty
 intercalateSnippet frag snippets = foldr1 (\a b -> a <> SQL.sql frag <> b) snippets
-
--- the "ctid" system column is always available to tables
-mutRangeF :: QualifiedIdentifier -> [FieldName] -> (SqlFragment, SqlFragment)
-mutRangeF mainQi rangeId = (
-    BS.intercalate " AND " $
-          (\col -> pgFmtColumn mainQi col <> " = " <> pgFmtColumn (QualifiedIdentifier mempty "pgrst_affected_rows") col) <$>
-          (if null rangeId then ["ctid"] else rangeId)
-  , if null rangeId then pgFmtColumn mainQi "ctid" else BS.intercalate ", " (pgFmtColumn mainQi <$> rangeId)
-  )

--- a/src/PostgREST/Request/ApiRequest.hs
+++ b/src/PostgREST/Request/ApiRequest.hs
@@ -186,6 +186,7 @@ apiRequest conf@AppConfig{..} dbStructure req reqBody queryparams@QueryParams{..
   | shouldParsePayload && isLeft payload = either (Left . InvalidBody) witness payload
   | not expectParams && not (L.null qsParams) = Left $ ParseRequestError "Unexpected param or filter missing operator" ("Failed to parse " <> show qsParams)
   | method `elem` ["PATCH", "DELETE"] && not (null qsRanges) && null qsOrder = Left LimitNoOrderError
+  | method == "PUT" && topLevelRange /= allRange = Left PutRangeNotAllowedError
   | otherwise = do
      acceptContentType <- findAcceptContentType conf action path accepts
      checkedTarget <- target

--- a/src/PostgREST/Request/ApiRequest.hs
+++ b/src/PostgREST/Request/ApiRequest.hs
@@ -185,6 +185,7 @@ apiRequest conf@AppConfig{..} dbStructure req reqBody queryparams@QueryParams{..
   | isInvalidRange = Left InvalidRange
   | shouldParsePayload && isLeft payload = either (Left . InvalidBody) witness payload
   | not expectParams && not (L.null qsParams) = Left $ ParseRequestError "Unexpected param or filter missing operator" ("Failed to parse " <> show qsParams)
+  | method `elem` ["PATCH", "DELETE"] && not (null qsRanges) && null qsOrder = Left LimitNoOrderError
   | otherwise = do
      acceptContentType <- findAcceptContentType conf action path accepts
      checkedTarget <- target

--- a/src/PostgREST/Request/Types.hs
+++ b/src/PostgREST/Request/Types.hs
@@ -65,6 +65,7 @@ data ApiRequestError
   | InvalidBody ByteString
   | InvalidFilters
   | InvalidRange
+  | LimitNoOrderError
   | NoRelBetween Text Text Text
   | NoRpc Text Text [Text] Bool ContentType Bool
   | NotEmbedded Text
@@ -135,13 +136,15 @@ data MutateQuery
       , updCols   :: S.Set FieldName
       , updBody   :: Maybe LBS.ByteString
       , where_    :: [LogicTree]
-      , mutRange  :: (NonnegRange, [FieldName])
+      , mutRange  :: NonnegRange
+      , mutOrder  :: [OrderTerm]
       , returning :: [FieldName]
       }
   | Delete
       { in_       :: QualifiedIdentifier
       , where_    :: [LogicTree]
-      , mutRange  :: (NonnegRange, [FieldName])
+      , mutRange  :: NonnegRange
+      , mutOrder  :: [OrderTerm]
       , returning :: [FieldName]
       }
 

--- a/src/PostgREST/Request/Types.hs
+++ b/src/PostgREST/Request/Types.hs
@@ -70,6 +70,7 @@ data ApiRequestError
   | NoRpc Text Text [Text] Bool ContentType Bool
   | NotEmbedded Text
   | ParseRequestError Text Text
+  | PutRangeNotAllowedError
   | QueryParamError QPError
   | UnacceptableSchema [Text]
 

--- a/test/memory/memory-tests.sh
+++ b/test/memory/memory-tests.sh
@@ -102,21 +102,21 @@ postJsonArrayTest(){
 
 echo "Running memory usage tests.."
 
-jsonKeyTest "1M" "POST" "/rpc/leak?columns=blob" "15M"
-jsonKeyTest "1M" "POST" "/leak?columns=blob" "15M"
-jsonKeyTest "1M" "PATCH" "/leak?id=eq.1&columns=blob" "15M"
+jsonKeyTest "1M" "POST" "/rpc/leak?columns=blob" "16M"
+jsonKeyTest "1M" "POST" "/leak?columns=blob" "16M"
+jsonKeyTest "1M" "PATCH" "/leak?id=eq.1&columns=blob" "16M"
 
-jsonKeyTest "10M" "POST" "/rpc/leak?columns=blob" "43M"
-jsonKeyTest "10M" "POST" "/leak?columns=blob" "43M"
-jsonKeyTest "10M" "PATCH" "/leak?id=eq.1&columns=blob" "43M"
+jsonKeyTest "10M" "POST" "/rpc/leak?columns=blob" "44M"
+jsonKeyTest "10M" "POST" "/leak?columns=blob" "44M"
+jsonKeyTest "10M" "PATCH" "/leak?id=eq.1&columns=blob" "44M"
 
-jsonKeyTest "50M" "POST" "/rpc/leak?columns=blob" "171M"
-jsonKeyTest "50M" "POST" "/leak?columns=blob" "171M"
-jsonKeyTest "50M" "PATCH" "/leak?id=eq.1&columns=blob" "171M"
+jsonKeyTest "50M" "POST" "/rpc/leak?columns=blob" "172M"
+jsonKeyTest "50M" "POST" "/leak?columns=blob" "172M"
+jsonKeyTest "50M" "PATCH" "/leak?id=eq.1&columns=blob" "172M"
 
-postJsonArrayTest "1000" "/perf_articles?columns=id,body" "13M"
-postJsonArrayTest "10000" "/perf_articles?columns=id,body" "13M"
-postJsonArrayTest "100000" "/perf_articles?columns=id,body" "23M"
+postJsonArrayTest "1000" "/perf_articles?columns=id,body" "14M"
+postJsonArrayTest "10000" "/perf_articles?columns=id,body" "14M"
+postJsonArrayTest "100000" "/perf_articles?columns=id,body" "24M"
 
 trap - int term exit
 

--- a/test/spec/fixtures/privileges.sql
+++ b/test/spec/fixtures/privileges.sql
@@ -168,12 +168,16 @@ GRANT ALL ON TABLE
     , limited_update_items_cpk
     , limited_update_items_no_pk
     , limited_update_items_view
+    , limited_update_items_wnonuniq_view
     , limited_delete_items
     , limited_delete_items_cpk
     , limited_delete_items_no_pk
     , limited_delete_items_view
     , plate
     , well
+    , limited_delete_items_wnonuniq_view
+    , limited_delete_items_cpk_view
+    , limited_update_items_cpk_view
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -2493,6 +2493,12 @@ create table limited_update_items_no_pk(
 create view limited_update_items_view as
 select * from limited_update_items;
 
+create view limited_update_items_wnonuniq_view as
+select *, 'static'::text as static from limited_update_items;
+
+create view limited_update_items_cpk_view as
+select * from limited_update_items_cpk;
+
 create table limited_delete_items(
   id int primary key
 , name text
@@ -2511,6 +2517,12 @@ create table limited_delete_items_no_pk(
 
 create view limited_delete_items_view as
 select * from limited_delete_items;
+
+create view limited_delete_items_wnonuniq_view as
+select *, 'static'::text as static from limited_delete_items;
+
+create view limited_delete_items_cpk_view as
+select * from limited_delete_items_cpk;
 
 create function reset_limited_items(tbl_name text default '') returns void as $_$ begin
   execute format(


### PR DESCRIPTION
Continuing the work on https://github.com/PostgREST/postgrest/pull/2195.

As agreed on https://github.com/PostgREST/postgrest/pull/2195#discussion_r835779754, `limit` now works on views if they do include an explicit `order`.

### Steps

- [x] Works on views with explicit `?order`
- [x] Remove the default `ctid` fallback(tables will also need an explicit `?order`)
- [x] Apply an implicit `row_count` equal to the `limit`