### PR TITLE
Refactor/Cleaning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ __pycache__
 coverage
 .hpc
 loadtest
+.history

--- a/nix/tools/withTools.nix
+++ b/nix/tools/withTools.nix
@@ -62,7 +62,7 @@ let
 
         log "Starting the database cluster..."
         # Instead of listening on a local port, we will listen on a unix domain socket.
-        pg_ctl -l "$tmpdir/db.log" -w start -o "-F -c listen_addresses=\"\" -k $PGHOST" \
+        pg_ctl -l "$tmpdir/db.log" -w start -o "-F -c listen_addresses=\"\" -k $PGHOST -c log_statement=\"all\"" \
           >> "$setuplog"
 
         stop () {

--- a/shell.nix
+++ b/shell.nix
@@ -46,6 +46,8 @@ lib.overrideDerivation postgrest.env (
 
     shellHook =
       ''
+        export HISTFILE=.history
+
         source ${pkgs.bashCompletion}/etc/profile.d/bash_completion.sh
         source ${pkgs.git}/share/git/contrib/completion/git-completion.bash
         source ${postgrest.hsie.bashCompletion}

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -63,8 +63,7 @@ import PostgREST.Config                  (AppConfig (..),
 import PostgREST.Config.PgVersion        (PgVersion (..))
 import PostgREST.ContentType             (ContentType (..))
 import PostgREST.DbStructure             (DbStructure (..),
-                                          findIfView, findTable,
-                                          tablePKCols)
+                                          findIfView, tablePKCols)
 import PostgREST.DbStructure.Identifiers (FieldName,
                                           QualifiedIdentifier (..),
                                           Schema)
@@ -417,7 +416,7 @@ handleDelete identifier context@(RequestContext _ ctxDbStructure ApiRequest{..} 
 
 handleInfo :: Monad m => QualifiedIdentifier -> RequestContext -> Handler m Wai.Response
 handleInfo identifier RequestContext{..} =
-  case findTable identifier $ dbTables ctxDbStructure of
+  case M.lookup identifier $ dbTables ctxDbStructure of
     Just table ->
       return $ Wai.responseLBS HTTP.status200 [allOrigins, allowH table] mempty
     Nothing ->

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -417,7 +417,7 @@ handleDelete identifier context@(RequestContext _ ctxDbStructure ApiRequest{..} 
 
 handleInfo :: Monad m => QualifiedIdentifier -> RequestContext -> Handler m Wai.Response
 handleInfo identifier RequestContext{..} =
-  case findTable (qiSchema identifier) (qiName identifier) $ dbTables ctxDbStructure of
+  case findTable identifier $ dbTables ctxDbStructure of
     Just table ->
       return $ Wai.responseLBS HTTP.status200 [allOrigins, allowH table] mempty
     Nothing ->
@@ -491,7 +491,7 @@ handleOpenApi headersOnly tSchema (RequestContext conf@AppConfig{..} dbStructure
            <*> SQL.statement tSchema (DbStructure.schemaDescription configDbPreparedStatements)
       OAIgnorePriv ->
         OpenAPI.encode conf dbStructure
-              (filter (\x -> tableSchema x == tSchema) $ DbStructure.dbTables dbStructure)
+              (M.filterWithKey (\(QualifiedIdentifier sch _) _ ->  sch == tSchema) $ DbStructure.dbTables dbStructure)
               (M.filterWithKey (\(QualifiedIdentifier sch _) _ ->  sch == tSchema) $ DbStructure.dbProcs dbStructure)
           <$> SQL.statement tSchema (DbStructure.schemaDescription configDbPreparedStatements)
       OADisabled ->

--- a/src/PostgREST/DbStructure/Relationship.hs
+++ b/src/PostgREST/DbStructure/Relationship.hs
@@ -11,7 +11,8 @@ module PostgREST.DbStructure.Relationship
 
 import qualified Data.Aeson as JSON
 
-import PostgREST.DbStructure.Table (Column (..), Table (..))
+import PostgREST.DbStructure.Identifiers (QualifiedIdentifier)
+import PostgREST.DbStructure.Table       (Column (..), Table)
 
 import Protolude
 
@@ -23,9 +24,9 @@ import Protolude
 --
 -- TODO merge relColumns and relForeignColumns to a tuple or Data.Bimap
 data Relationship = Relationship
-  { relTable          :: Table
+  { relTable          :: QualifiedIdentifier
   , relColumns        :: [Column]
-  , relForeignTable   :: Table
+  , relForeignTable   :: QualifiedIdentifier
   , relForeignColumns :: [Column]
   , relCardinality    :: Cardinality
   }
@@ -44,7 +45,7 @@ type FKConstraint = Text
 
 -- | Junction table on an M2M relationship
 data Junction = Junction
-  { junTable       :: Table
+  { junTable       :: QualifiedIdentifier
   , junConstraint1 :: FKConstraint
   , junColumns1    :: [Column]
   , junConstraint2 :: FKConstraint

--- a/src/PostgREST/DbStructure/Table.hs
+++ b/src/PostgREST/DbStructure/Table.hs
@@ -4,11 +4,10 @@
 module PostgREST.DbStructure.Table
   ( Column(..)
   , Table(..)
-  , tableQi
   , TablesMap
   ) where
 
-import qualified Data.Aeson as JSON
+import qualified Data.Aeson          as JSON
 import qualified Data.HashMap.Strict as M
 
 import PostgREST.DbStructure.Identifiers (FieldName,
@@ -33,9 +32,6 @@ data Table = Table
 
 instance Eq Table where
   Table{tableSchema=s1,tableName=n1} == Table{tableSchema=s2,tableName=n2} = s1 == s2 && n1 == n2
-
-tableQi :: Table -> QualifiedIdentifier
-tableQi Table{tableSchema=s, tableName=n} = QualifiedIdentifier s n
 
 data Column = Column
   { colTable       :: Table

--- a/src/PostgREST/DbStructure/Table.hs
+++ b/src/PostgREST/DbStructure/Table.hs
@@ -5,9 +5,11 @@ module PostgREST.DbStructure.Table
   ( Column(..)
   , Table(..)
   , tableQi
+  , TablesMap
   ) where
 
 import qualified Data.Aeson as JSON
+import qualified Data.HashMap.Strict as M
 
 import PostgREST.DbStructure.Identifiers (FieldName,
                                           QualifiedIdentifier (..),
@@ -50,8 +52,4 @@ data Column = Column
 instance Eq Column where
   Column{colTable=t1,colName=n1} == Column{colTable=t2,colName=n2} = t1 == t2 && n1 == n2
 
-data PrimaryKey = PrimaryKey
-  { pkTable :: Table
-  , pkName  :: Text
-  }
-  deriving (Generic, JSON.ToJSON)
+type TablesMap = M.HashMap QualifiedIdentifier Table

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -34,20 +34,20 @@ import PostgREST.DbStructure.Proc         (ProcDescription (..),
 import PostgREST.DbStructure.Relationship (Cardinality (..),
                                            PrimaryKey (..),
                                            Relationship (..))
-import PostgREST.DbStructure.Table        (Column (..), Table (..))
+import PostgREST.DbStructure.Table        (Column (..), Table (..), TablesMap)
 import PostgREST.Version                  (docsVersion, prettyVersion)
 
 import PostgREST.ContentType
 
 import Protolude hiding (Proxy, get)
 
-encode :: AppConfig -> DbStructure -> [Table] -> M.HashMap k [ProcDescription] -> Maybe Text -> LBS.ByteString
+encode :: AppConfig -> DbStructure -> TablesMap -> M.HashMap k [ProcDescription] -> Maybe Text -> LBS.ByteString
 encode conf dbStructure tables procs schemaDescription =
   JSON.encode $
     postgrestSpec
       (dbRelationships dbStructure)
       (concat $ M.elems procs)
-      (openApiTableInfo dbStructure <$> tables)
+      (openApiTableInfo dbStructure <$> (snd <$> M.toList tables))
       (proxyUri conf)
       schemaDescription
       (dbPrimaryKeys dbStructure)

--- a/src/PostgREST/OpenAPI.hs
+++ b/src/PostgREST/OpenAPI.hs
@@ -29,12 +29,14 @@ import PostgREST.Config                   (AppConfig (..), Proxy (..),
                                            isMalformedProxyUri, toURI)
 import PostgREST.DbStructure              (DbStructure (..),
                                            tableCols, tablePKCols)
+import PostgREST.DbStructure.Identifiers  (QualifiedIdentifier (..))
 import PostgREST.DbStructure.Proc         (ProcDescription (..),
                                            ProcParam (..))
 import PostgREST.DbStructure.Relationship (Cardinality (..),
                                            PrimaryKey (..),
                                            Relationship (..))
-import PostgREST.DbStructure.Table        (Column (..), Table (..), TablesMap)
+import PostgREST.DbStructure.Table        (Column (..), Table (..),
+                                           TablesMap)
 import PostgREST.Version                  (docsVersion, prettyVersion)
 
 import PostgREST.ContentType
@@ -103,7 +105,7 @@ makeProperty rels pks c = (colName c, Inline s)
           _                                                 -> False
           ) rels
         fCol = colName <$> (headMay . relForeignColumns =<< rel)
-        fTbl = tableName . relForeignTable <$> rel
+        fTbl = qiName . relForeignTable <$> rel
         fTblCol = (,) <$> fTbl <*> fCol
       in
         (\(a, b) -> T.intercalate "" ["This is a Foreign Key to `", a, ".", b, "`.<fk table='", a, "' column='", b, "'/>"]) <$> fTblCol

--- a/src/PostgREST/Query/QueryBuilder.hs
+++ b/src/PostgREST/Query/QueryBuilder.hs
@@ -25,7 +25,6 @@ import PostgREST.DbStructure.Identifiers  (QualifiedIdentifier (..))
 import PostgREST.DbStructure.Proc         (ProcParam (..))
 import PostgREST.DbStructure.Relationship (Cardinality (..),
                                            Relationship (..))
-import PostgREST.DbStructure.Table        (Table (..))
 import PostgREST.Request.Preferences      (PreferResolution (..))
 
 import PostgREST.Query.SqlFragment
@@ -51,7 +50,7 @@ readRequestToQuery (Node (Select colSelects mainQi tblAlias implJoins logicFores
     (joins, selects) = foldr getJoinsSelects ([],[]) forest
 
 getJoinsSelects :: ReadRequest -> ([SQL.Snippet], [SQL.Snippet]) -> ([SQL.Snippet], [SQL.Snippet])
-getJoinsSelects rr@(Node (_, (name, Just Relationship{relCardinality=card,relTable=Table{tableName=table}}, alias, _, joinType, _)) _) (joins,selects) =
+getJoinsSelects rr@(Node (_, (name, Just Relationship{relCardinality=card,relTable=QualifiedIdentifier{qiName=table}}, alias, _, joinType, _)) _) (joins,selects) =
   let subquery = readRequestToQuery rr in
   case card of
     M2O _ ->

--- a/test/spec/Feature/OpenApi/RootSpec.hs
+++ b/test/spec/Feature/OpenApi/RootSpec.hs
@@ -27,9 +27,6 @@ spec =
       request methodGet "/"
         [("Accept", "application/json")] "" `shouldRespondWith`
         [json| {
-            "tableName": "orders_view", "tableSchema": "test",
-            "tableDeletable": true, "tableUpdatable": true,
-            "tableIsView":true, "tableInsertable": true,
-            "tableDescription": null
+          "qiSchema":"test","qiName":"orders_view"
           } |]
         { matchHeaders = [matchContentTypeJson] }


### PR DESCRIPTION
Some refactors needed for https://github.com/PostgREST/postgrest/issues/2070#issuecomment-1093547838.

The general idea is that we want to have the Relationships and PKCols as Table attributes in our internal cache. This will avoid unnecessary searches - increasing perf and making it easier to do some logic with table attributes.

It also gets us closer to only needing to execute a single query for the internal cache.