### PR TITLE
refactor: reduce OpenAPI(PKcols in table, ViewKeyDependency type)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2147, Ignore `Content-Type` headers for `GET` requests when calling RPCs. Previously, `GET` without parameters, but with `Content-Type: text/plain` or `Content-Type: application/octet-stream` would fail with `404 Not Found`, even if a function without arguments was available.
  - #2155, Ignore `max-rows` on POST, PATCH, PUT and DELETE - @steve-chavez
  - #2239, Fix misleading disambiguation error where the content of the `relationship` key looks like valid syntax - @laurenceisla
+ - #2254, Fix inferring a foreign key column as a primary key column on views - @steve-chavez
 
 ### Changed
 

--- a/src/PostgREST/DbStructure/Table.hs
+++ b/src/PostgREST/DbStructure/Table.hs
@@ -27,6 +27,7 @@ data Table = Table
   , tableInsertable  :: Bool
   , tableUpdatable   :: Bool
   , tableDeletable   :: Bool
+  , tablePKCols      :: [FieldName]
   }
   deriving (Show, Ord, Generic, JSON.ToJSON)
 

--- a/src/PostgREST/Query/QueryBuilder.hs
+++ b/src/PostgREST/Query/QueryBuilder.hs
@@ -53,7 +53,7 @@ getJoinsSelects :: ReadRequest -> ([SQL.Snippet], [SQL.Snippet]) -> ([SQL.Snippe
 getJoinsSelects rr@(Node (_, (name, Just Relationship{relCardinality=card,relTable=QualifiedIdentifier{qiName=table}}, alias, _, joinType, _)) _) (joins,selects) =
   let subquery = readRequestToQuery rr in
   case card of
-    M2O _ ->
+    M2O _ _ ->
       let aliasOrName = fromMaybe name alias
           localTableName = pgFmtIdent $ table <> "_" <> aliasOrName
           sel = SQL.sql ("row_to_json(" <> localTableName <> ".*) AS " <> pgFmtIdent aliasOrName)

--- a/test/spec/Feature/OpenApi/RootSpec.hs
+++ b/test/spec/Feature/OpenApi/RootSpec.hs
@@ -27,6 +27,6 @@ spec =
       request methodGet "/"
         [("Accept", "application/json")] "" `shouldRespondWith`
         [json| {
-          "qiSchema":"test","qiName":"orders_view"
+          "qiSchema":"test","qiName":"has_fk"
           } |]
         { matchHeaders = [matchContentTypeJson] }

--- a/test/spec/Feature/Query/InsertSpec.hs
+++ b/test/spec/Feature/Query/InsertSpec.hs
@@ -595,7 +595,7 @@ spec actualPgVersion = do
             }
 
     context "requesting header only representation" $ do
-      it "returns a location header" $
+      it "returns a location header with a composite PK col" $
         request methodPost "/compound_pk_view" [("Prefer", "return=headers-only")]
             [json|{"k1":1,"k2":"test","extra":2}|]
           `shouldRespondWith`
@@ -606,13 +606,13 @@ spec actualPgVersion = do
                              , "Content-Range" <:> "*/*" ]
             }
 
-      it "should not throw and return location header when a PK is null" $
+      it "returns location header with a single PK col" $
         request methodPost "/test_null_pk_competitors_sponsors" [("Prefer", "return=headers-only")]
             [json|{"id":1}|]
           `shouldRespondWith`
             ""
             { matchStatus  = 201
             , matchHeaders = [ matchHeaderAbsent hContentType
-                             , "Location" <:> "/test_null_pk_competitors_sponsors?id=eq.1&sponsor_id=is.null"
+                             , "Location" <:> "/test_null_pk_competitors_sponsors?id=eq.1"
                              , "Content-Range" <:> "*/*" ]
             }


### PR DESCRIPTION
* Get PKcols inside tables - done with SQL for tables and with an additional step in Haskell for views.

  This fixes an fk column being considered as a pk column on views and corrects the test added on https://github.com/PostgREST/postgrest/pull/1875/files/1d549768580310e18aac4ffa6dbd01c5b77934a7#r853674126

* classify view key dependencies in SQL

* remove Column from Relationship

* Merge cols/fcols in Relationship and ensure allM2ORels and allViewsKeyDependencies fk columns are ordered - done by attnum in SQL

* Cardinality now contains relColumns instead of Relationship - this simplifies getJoinConditions.

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs     - https://github.com/PostgREST/postgrest-docs
-->
