### PR TITLE
refactor: merge Column list into Table

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -485,7 +485,7 @@ handleOpenApi headersOnly tSchema (RequestContext conf@AppConfig{..} dbStructure
     lift $ case configOpenApiMode of
       OAFollowPriv ->
         OpenAPI.encode conf dbStructure
-           <$> SQL.statement tSchema (DbStructure.accessibleTables ctxPgVersion configDbPreparedStatements)
+           <$> SQL.statement [tSchema] (DbStructure.accessibleTables ctxPgVersion configDbPreparedStatements)
            <*> SQL.statement tSchema (DbStructure.accessibleProcs ctxPgVersion configDbPreparedStatements)
            <*> SQL.statement tSchema (DbStructure.schemaDescription configDbPreparedStatements)
       OAIgnorePriv ->

--- a/src/PostgREST/DbStructure/Table.hs
+++ b/src/PostgREST/DbStructure/Table.hs
@@ -28,6 +28,7 @@ data Table = Table
   , tableUpdatable   :: Bool
   , tableDeletable   :: Bool
   , tablePKCols      :: [FieldName]
+  , tableColumns     :: [Column]
   }
   deriving (Show, Ord, Generic, JSON.ToJSON)
 
@@ -35,8 +36,7 @@ instance Eq Table where
   Table{tableSchema=s1,tableName=n1} == Table{tableSchema=s2,tableName=n2} = s1 == s2 && n1 == n2
 
 data Column = Column
-  { colTable       :: Table
-  , colName        :: FieldName
+  { colName        :: FieldName
   , colDescription :: Maybe Text
   , colNullable    :: Bool
   , colType        :: Text
@@ -44,9 +44,6 @@ data Column = Column
   , colDefault     :: Maybe Text
   , colEnum        :: [Text]
   }
-  deriving (Ord, Generic, JSON.ToJSON)
-
-instance Eq Column where
-  Column{colTable=t1,colName=n1} == Column{colTable=t2,colName=n2} = t1 == t2 && n1 == n2
+  deriving (Eq, Show, Ord, Generic, JSON.ToJSON)
 
 type TablesMap = M.HashMap QualifiedIdentifier Table

--- a/test/memory/memory-tests.sh
+++ b/test/memory/memory-tests.sh
@@ -102,21 +102,21 @@ postJsonArrayTest(){
 
 echo "Running memory usage tests.."
 
-jsonKeyTest "1M" "POST" "/rpc/leak?columns=blob" "13M"
-jsonKeyTest "1M" "POST" "/leak?columns=blob" "13M"
-jsonKeyTest "1M" "PATCH" "/leak?id=eq.1&columns=blob" "13M"
+jsonKeyTest "1M" "POST" "/rpc/leak?columns=blob" "15M"
+jsonKeyTest "1M" "POST" "/leak?columns=blob" "15M"
+jsonKeyTest "1M" "PATCH" "/leak?id=eq.1&columns=blob" "15M"
 
-jsonKeyTest "10M" "POST" "/rpc/leak?columns=blob" "41M"
-jsonKeyTest "10M" "POST" "/leak?columns=blob" "41M"
-jsonKeyTest "10M" "PATCH" "/leak?id=eq.1&columns=blob" "41M"
+jsonKeyTest "10M" "POST" "/rpc/leak?columns=blob" "43M"
+jsonKeyTest "10M" "POST" "/leak?columns=blob" "43M"
+jsonKeyTest "10M" "PATCH" "/leak?id=eq.1&columns=blob" "43M"
 
 jsonKeyTest "50M" "POST" "/rpc/leak?columns=blob" "171M"
 jsonKeyTest "50M" "POST" "/leak?columns=blob" "171M"
 jsonKeyTest "50M" "PATCH" "/leak?id=eq.1&columns=blob" "171M"
 
-postJsonArrayTest "1000" "/perf_articles?columns=id,body" "11M"
-postJsonArrayTest "10000" "/perf_articles?columns=id,body" "11M"
-postJsonArrayTest "100000" "/perf_articles?columns=id,body" "21M"
+postJsonArrayTest "1000" "/perf_articles?columns=id,body" "13M"
+postJsonArrayTest "10000" "/perf_articles?columns=id,body" "13M"
+postJsonArrayTest "100000" "/perf_articles?columns=id,body" "23M"
 
 trap - int term exit
 

--- a/test/spec/Feature/OpenApi/OpenApiSpec.hs
+++ b/test/spec/Feature/OpenApi/OpenApiSpec.hs
@@ -523,7 +523,7 @@ spec actualPgVersion = describe "OpenAPI" $ do
 
         types `shouldBe` Just [aesonQQ|
             {
-              "format": "test.enum_menagerie_type",
+              "format": "enum_menagerie_type",
               "type": "string",
               "enum": [
                 "foo",


### PR DESCRIPTION
Merges the SQL query of `allColumns` into `allTables`.

I thought with this we'd get a considerable reduction of the apflora `dump-schema` output but:

```
du -sh old.json new.json

68M    old.json
67M     new.json
```

Just 1M reduction. Which goes on to show the big reduction [before](https://github.com/PostgREST/postgrest/pull/2254#issuecomment-1104163025) was because the bulk of the size comes from the Relationship list.