### PR TITLE
fix: restrict generated m2m relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2155, Ignore `max-rows` on POST, PATCH, PUT and DELETE - @steve-chavez
  - #2239, Fix misleading disambiguation error where the content of the `relationship` key looks like valid syntax - @laurenceisla
  - #2254, Fix inferring a foreign key column as a primary key column on views - @steve-chavez
+ - #2070, Restrict generated many-to-many relationships - @steve-chavez
+   + Only adds many-to-many relationships when: a table has FKs to two other tables and these FK columns are part of the table's PK columns.
 
 ### Changed
 
@@ -59,6 +61,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2156, using PATCH/DELETE with `limit/offset` throws an error on views - @steve-chavez
  - #2155, `max-rows` is no longer applied on POST/PATCH/PUT/DELETE returned rows - @steve-chavez
    + This was misleading because the affected rows were not really affected by `max-rows`, only the returned rows were limited
+ - #2070, Restrict generated many-to-many relationships - @steve-chavez
+   + A primary key that contains the foreign key columns is now needed for generating many-to-many relationships.
 
 ## [9.0.0] - 2021-11-25
 

--- a/test/spec/Feature/Query/QuerySpec.hs
+++ b/test/spec/Feature/Query/QuerySpec.hs
@@ -434,17 +434,23 @@ spec actualPgVersion = do
 
     it "requesting data using many<->many relation defined by composite keys" $
       get "/users_tasks?user_id=eq.1&task_id=eq.1&select=user_id,files(filename,content)" `shouldRespondWith`
-        [json|[{"user_id":1,"files":[{"filename":"command.com","content":"#include <unix.h>"},{"filename":"autoexec.bat","content":"@ECHO OFF"},{"filename":"README.md","content":"# make $$$!"}]}]|]
+        [json|[{"user_id":1,"files":[{"filename":"autoexec.bat","content":"@ECHO OFF"},{"filename":"command.com","content":"#include <unix.h>"},{"filename":"README.md","content":"# make $$$!"}]}]|]
         { matchHeaders = [matchContentTypeJson] }
 
     it "requesting data using many<->many (composite keys) relation using hint" $
       get "/users_tasks?user_id=eq.1&task_id=eq.1&select=user_id,files!touched_files(filename,content)" `shouldRespondWith`
-        [json|[{"user_id":1,"files":[{"filename":"command.com","content":"#include <unix.h>"},{"filename":"autoexec.bat","content":"@ECHO OFF"},{"filename":"README.md","content":"# make $$$!"}]}]|]
+        [json|[{"user_id":1,"files":[{"filename":"autoexec.bat","content":"@ECHO OFF"},{"filename":"command.com","content":"#include <unix.h>"},{"filename":"README.md","content":"# make $$$!"}]}]|]
         { matchHeaders = [matchContentTypeJson] }
 
     it "requesting children with composite key" $
       get "/users_tasks?user_id=eq.2&task_id=eq.6&select=*, comments(content)" `shouldRespondWith`
         [json|[{"user_id":2,"task_id":6,"comments":[{"content":"Needs to be delivered ASAP"}]}]|]
+        { matchHeaders = [matchContentTypeJson] }
+
+    -- https://github.com/PostgREST/postgrest/issues/2070
+    it "one-to-many embeds without a disambiguation error due to wrongly generated many-to-many relationships" $
+      get "/plate?select=*,well(*)" `shouldRespondWith`
+        [json|[]|]
         { matchHeaders = [matchContentTypeJson] }
 
     describe "computed columns" $ do

--- a/test/spec/fixtures/privileges.sql
+++ b/test/spec/fixtures/privileges.sql
@@ -172,6 +172,8 @@ GRANT ALL ON TABLE
     , limited_delete_items_cpk
     , limited_delete_items_no_pk
     , limited_delete_items_view
+    , plate
+    , well
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;


### PR DESCRIPTION
Fixes https://github.com/PostgREST/postgrest/issues/2070.

Now we only add m2m relationship based on [strict junctions](https://en.wikipedia.org/wiki/Associative_entity):

- A table has FKs to two other tables
- **These FK columns are part of the table's PK columns.**
