### PR TITLE
Remove armv7 architectures from CI for ARM builds

### DIFF
--- a/.github/scripts/arm/docker-env/Dockerfile
+++ b/.github/scripts/arm/docker-env/Dockerfile
@@ -1,70 +1,13 @@
-# Build PostgREST for ARM architectures
-
-FROM ubuntu:focal as postgrest-build
-
-RUN apt-get update -y \
-    && apt-get upgrade -y \
-    && apt-get install -y git build-essential curl libffi-dev libffi7 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5 llvm libnuma-dev zlib1g-dev libpq-dev jq gcc \
-    && apt-get clean
-
-# Install ghcup
-ENV BOOTSTRAP_HASKELL_NONINTERACTIVE=1
-RUN bash -c "curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh"
-
-# Add ghcup to PATH
-ENV PATH=${PATH}:/root/.local/bin
-ENV PATH=${PATH}:/root/.ghcup/bin
-
-# Install cabal
-RUN bash -c "ghcup upgrade"
-RUN bash -c "ghcup install cabal 3.4.0.0"
-RUN bash -c "ghcup set cabal 3.4.0.0"
-
-# Install GHC
-RUN bash -c "ghcup install ghc 8.10.7"
-RUN bash -c "ghcup set ghc 8.10.7"
-
-# Update Path to include Cabal and GHC exports
-RUN bash -c "echo PATH="$HOME/.local/bin:$PATH" >> $HOME/.bashrc"
-RUN bash -c "echo export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH" >> $HOME/.bashrc"
-RUN bash -c "source $HOME/.bashrc"
-
-# Clone the repository
-RUN git clone https://github.com/PostgREST/postgrest.git /postgrest
-WORKDIR /postgrest
-RUN cabal v2-update && cabal v2-build
-
-# Arguments are declared here to save the above installation in cache
-ARG PGRST_GITHUB_COMMIT
-
-RUN git pull origin main \
-    && git checkout $PGRST_GITHUB_COMMIT
-
-# Build PostgREST
-RUN mkdir -p /build-export
-RUN cabal v2-update && cabal v2-build
-RUN PGRST_BIN=$(cabal exec which postgrest | tail -1) \
-    && mv $PGRST_BIN /build-export
-
-
-
-# Simple image to generate the PostgREST binaries
-
-FROM scratch as postgrest-bin
-
-COPY --from=postgrest-build /build-export /
-
-
-
 # PostgREST docker hub image
 
 FROM ubuntu:focal AS postgrest
 
-RUN apt-get update -y
-RUN apt install libpq-dev zlib1g-dev jq gcc libnuma-dev -y
-RUN apt-get clean
+RUN apt-get update -y \
+    && apt install -y --no-install-recommends libpq-dev zlib1g-dev jq gcc libnuma-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-COPY --from=postgrest-bin postgrest /usr/bin/postgrest
+COPY postgrest /usr/bin/postgrest
 
 EXPOSE 3000
 

--- a/.github/scripts/arm/docker-publish.sh
+++ b/.github/scripts/arm/docker-publish.sh
@@ -13,11 +13,11 @@ PGRST_GITHUB_COMMIT="$1"
 DOCKER_REPO="$2"
 DOCKER_USER="$3"
 DOCKER_PASS="$4"
-SCRIPT_PATH="$5"
+SCRIPT_DIR="$5"
 PGRST_VERSION="v$6"
 IS_PRERELEASE="$7"
 
-DOCKER_BUILD_PATH="$SCRIPT_PATH/docker-env"
+DOCKER_BUILD_DIR="$SCRIPT_DIR/docker-env"
 
 clean_env()
 {
@@ -31,15 +31,13 @@ sudo docker logout
 trap clean_env sigint sigterm exit
 
 # Move to the docker build environment
-cd ~/$DOCKER_BUILD_PATH
+cd ~/$DOCKER_BUILD_DIR
 
 # Push final images to Docker hub
 # NOTE: This command publishes a separate ARM image because the builds cannot
 #       be added to the manifest if they are not in the registry beforehand.
 #       This image must be manually deleted from Docker Hub at the end of the process.
 sudo docker buildx build --build-arg PGRST_GITHUB_COMMIT=$PGRST_GITHUB_COMMIT \
-                         --platform linux/arm/v7,linux/arm64 \
-                         --cache-from $DOCKER_REPO/postgrest-build-arm \
                          -t $DOCKER_REPO/postgrest:$PGRST_VERSION-arm \
                          --push .
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -222,16 +222,13 @@ jobs:
           if-no-files-found: error
 
   Build-Cabal-Arm:
-    name: Build armv7/aarch64 (Cabal)
+    name: Build aarch64 (Cabal)
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     outputs:
       remotepath: ${{ steps.Remote-Dir.outputs.remotepath }}
     env:
       GITHUB_COMMIT: ${{ github.sha }}
-      DOCKER_REPO: "postgrest"
-      DOCKER_USER: "stevechavez"
-      DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
     steps:
       - uses: actions/checkout@v2.4.0
       - id: Remote-Dir
@@ -258,8 +255,8 @@ jobs:
           fingerprint: ${{ secrets.SSH_ARM_FINGERPRINT }}
           command_timeout: 120m
           script_stop: true
-          envs: GITHUB_COMMIT,DOCKER_REPO,DOCKER_USER,DOCKER_PASS,REMOTE_DIR
-          script: bash ~/$REMOTE_DIR/build.sh "$GITHUB_COMMIT" "$DOCKER_REPO" "$DOCKER_USER" "$DOCKER_PASS" "$REMOTE_DIR"
+          envs: GITHUB_COMMIT,REMOTE_DIR
+          script: bash ~/$REMOTE_DIR/build.sh "$GITHUB_COMMIT" "$REMOTE_DIR"
       - name: Download binaries from remote server
         uses: nicklasfrahm/scp-action@main
         with:
@@ -276,13 +273,7 @@ jobs:
         uses: actions/upload-artifact@v2.3.1
         with:
           name: postgrest-ubuntu-aarch64
-          path: result/linux_arm64/postgrest
-          if-no-files-found: error
-      - name: Save armv7 executable as artifact
-        uses: actions/upload-artifact@v2.3.1
-        with:
-          name: postgrest-ubuntu-armv7
-          path: result/linux_arm_v7/postgrest
+          path: result/postgrest
           if-no-files-found: error
 
 
@@ -384,9 +375,6 @@ jobs:
 
           tar cJvf "release-bundle/postgrest-v$VERSION-ubuntu-aarch64.tar.xz" \
             -C artifacts/postgrest-ubuntu-aarch64 postgrest
-
-          tar cJvf "release-bundle/postgrest-v$VERSION-ubuntu-armv7.tar.xz" \
-            -C artifacts/postgrest-ubuntu-armv7 postgrest
 
           zip "release-bundle/postgrest-v$VERSION-windows-x64.zip" \
             artifacts/postgrest-windows-x64/postgrest.exe


### PR DESCRIPTION
There's a problem with the cache image for ARM builds using Docker added in #2127 (cannot pull or push to the registry). This change makes use of the remote server to build natively (without Docker) for `aarch64` architectures and removes `armv7` builds from the CI until a better alternative to build for that architecture is found.