### PR TITLE
Allow limit=0 in query params to return an empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2176, Errors raised with `SQLSTATE` now include the message and the code in the response body - @laurenceisla
  - #2236, Support POSIX regular expression operators for row filtering - @enote-kane
  - #2202, Allow returning XML from RPCs - @fjf2002
+ - #2269, Allow `limit=0` in the request query to return an empty array - @gautam1168, @laurenceisla
 
 ### Fixed
 

--- a/src/PostgREST/RangeQuery.hs
+++ b/src/PostgREST/RangeQuery.hs
@@ -10,6 +10,8 @@ module PostgREST.RangeQuery (
 , restrictRange
 , rangeGeq
 , allRange
+, limitZeroRange
+, hasLimitZero
 , NonnegRange
 , rangeStatusHeader
 , contentRangeH
@@ -73,6 +75,15 @@ allRange = rangeGeq 0
 rangeLeq :: Integer -> NonnegRange
 rangeLeq n =
   Range BoundaryBelowAll (BoundaryAbove n)
+
+-- Special case to allow limit 0 queries
+-- https://github.com/PostgREST/postgrest/issues/1121
+-- 0 <= x <= -1
+limitZeroRange :: Range Integer
+limitZeroRange = Range (BoundaryBelow 0) (BoundaryAbove (-1))
+
+hasLimitZero :: Range Integer -> Bool
+hasLimitZero r = rangeUpper r == rangeUpper limitZeroRange
 
 rangeStatusHeader :: NonnegRange -> Int64 -> Maybe Int64 -> (Status, Header)
 rangeStatusHeader topLevelRange queryTotal tableTotal =

--- a/test/spec/Feature/Query/RangeSpec.hs
+++ b/test/spec/Feature/Query/RangeSpec.hs
@@ -184,12 +184,12 @@ spec = do
             [json|[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9},{"id":10},{"id":11},{"id":12},{"id":13},{"id":14},{"id":15}]|]
             { matchHeaders = ["Content-Range" <:> "0-14/*"] }
 
-      it "fails if limit equals 0" $
+      it "succeeds and returns an empty array if limit equals 0" $
         get "/items?select=id&limit=0"
-          `shouldRespondWith` [json|{"message":"HTTP Range error","code":"PGRST103","details":null,"hint":null}|]
-          { matchStatus  = 416
-          , matchHeaders = [matchContentTypeJson]
-          }
+          `shouldRespondWith` [json|[]|]
+            { matchStatus  = 200
+            , matchHeaders = ["Content-Range" <:> "*/*"]
+            }
 
       it "fails if limit is negative" $
         get "/items?select=id&limit=-1"


### PR DESCRIPTION
Closes #1121.

Continues what was discussed in PR #1929