### PR TITLE
Reorganize error groups

### DIFF
--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -226,7 +226,7 @@ instance JSON.ToJSON SQL.CommandError where
   toJSON (SQL.ResultError resultError) = JSON.object [
     "code"    .= InternalErrorCode00,
     "message" .= (show resultError :: Text),
-    "details" .= ("Internal error." :: Text),
+    "details" .= JSON.Null,
     "hint"    .= JSON.Null]
 
   toJSON (SQL.ClientError d) = JSON.object [

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -223,27 +223,27 @@ instance JSON.ToJSON SQL.CommandError where
         "hint"    .= (fmap T.decodeUtf8 h :: Maybe Text)]
 
   toJSON (SQL.ResultError (SQL.UnexpectedResult m)) = JSON.object [
-    "code"    .= HasqlErrorCode00,
+    "code"    .= InternalErrorCode00,
     "message" .= (m :: Text),
     "details" .= JSON.Null,
     "hint"    .= JSON.Null]
   toJSON (SQL.ResultError (SQL.RowError i SQL.EndOfInput)) = JSON.object [
-    "code"    .= HasqlErrorCode01,
+    "code"    .= InternalErrorCode01,
     "message" .= ("Row error: end of input" :: Text),
     "details" .= ("Attempt to parse more columns than there are in the result" :: Text),
     "hint"    .= (("Row number " <> show i) :: Text)]
   toJSON (SQL.ResultError (SQL.RowError i SQL.UnexpectedNull)) = JSON.object [
-    "code"    .= HasqlErrorCode02,
+    "code"    .= InternalErrorCode02,
     "message" .= ("Row error: unexpected null" :: Text),
     "details" .= ("Attempt to parse a NULL as some value." :: Text),
     "hint"    .= (("Row number " <> show i) :: Text)]
   toJSON (SQL.ResultError (SQL.RowError i (SQL.ValueError d))) = JSON.object [
-    "code"    .= HasqlErrorCode03,
+    "code"    .= InternalErrorCode03,
     "message" .= ("Row error: Wrong value parser used" :: Text),
     "details" .= d,
     "hint"    .= (("Row number " <> show i) :: Text)]
   toJSON (SQL.ResultError (SQL.UnexpectedAmountOfRows i)) = JSON.object [
-    "code"    .= HasqlErrorCode04,
+    "code"    .= InternalErrorCode04,
     "message" .= ("Unexpected amount of rows" :: Text),
     "details" .= i,
     "hint"    .= JSON.Null]
@@ -462,12 +462,6 @@ data ErrorCode
   | JWTErrorCode00
   | JWTErrorCode01
   | JWTErrorCode02
-  -- Hasql library errors
-  | HasqlErrorCode00
-  | HasqlErrorCode01
-  | HasqlErrorCode02
-  | HasqlErrorCode03
-  | HasqlErrorCode04
   -- Uncategorized errors that are not related to a single module
   | GeneralErrorCode00
   | GeneralErrorCode01
@@ -476,6 +470,12 @@ data ErrorCode
   | GeneralErrorCode04
   | GeneralErrorCode05
   | GeneralErrorCode06
+  -- Internal errors related to the Hasql library
+  | InternalErrorCode00
+  | InternalErrorCode01
+  | InternalErrorCode02
+  | InternalErrorCode03
+  | InternalErrorCode04
 
 instance JSON.ToJSON ErrorCode where
   toJSON e = JSON.toJSON (buildErrorCode e)
@@ -509,12 +509,6 @@ buildErrorCode code = "PGRST" <> case code of
   JWTErrorCode01         -> "301"
   JWTErrorCode02         -> "302"
 
-  HasqlErrorCode00       -> "400"
-  HasqlErrorCode01       -> "401"
-  HasqlErrorCode02       -> "402"
-  HasqlErrorCode03       -> "403"
-  HasqlErrorCode04       -> "404"
-
   GeneralErrorCode00     -> "500"
   GeneralErrorCode01     -> "501"
   GeneralErrorCode02     -> "502"
@@ -522,3 +516,9 @@ buildErrorCode code = "PGRST" <> case code of
   GeneralErrorCode04     -> "504"
   GeneralErrorCode05     -> "505"
   GeneralErrorCode06     -> "506"
+
+  InternalErrorCode00    -> "X00"
+  InternalErrorCode01    -> "X01"
+  InternalErrorCode02    -> "X02"
+  InternalErrorCode03    -> "X03"
+  InternalErrorCode04    -> "X04"

--- a/test/spec/Feature/Query/ErrorSpec.hs
+++ b/test/spec/Feature/Query/ErrorSpec.hs
@@ -27,7 +27,7 @@ spec = do
           [json|
             {"hint": null,
              "details": null,
-             "code": "PGRST506",
+             "code": "PGRST117",
              "message":"Unsupported HTTP verb: CONNECT"}|]
           { matchStatus = 405 }
 
@@ -39,7 +39,7 @@ spec = do
           [json|
             {"hint": null,
              "details": null,
-             "code": "PGRST506",
+             "code": "PGRST117",
              "message":"Unsupported HTTP verb: TRACE"}|]
           { matchStatus = 405 }
 
@@ -51,6 +51,6 @@ spec = do
           [json|
             {"hint": null,
              "details": null,
-             "code": "PGRST506",
+             "code": "PGRST117",
              "message":"Unsupported HTTP verb: OTHER"}|]
           { matchStatus = 405 }

--- a/test/spec/Feature/Query/QuerySpec.hs
+++ b/test/spec/Feature/Query/QuerySpec.hs
@@ -1013,21 +1013,21 @@ spec actualPgVersion = do
     it "fails if a single column is not selected" $ do
       request methodGet "/images?select=img,name&name=eq.A.png" (acceptHdrs "application/octet-stream") ""
         `shouldRespondWith`
-          [json| {"message":"application/octet-stream requested but more than one column was selected","code":"PGRST502","details":null,"hint":null} |]
+          [json| {"message":"application/octet-stream requested but more than one column was selected","code":"PGRST113","details":null,"hint":null} |]
           { matchStatus = 406 }
 
       request methodGet "/images?select=*&name=eq.A.png"
           (acceptHdrs "application/octet-stream")
           ""
         `shouldRespondWith`
-          [json| {"message":"application/octet-stream requested but more than one column was selected","code":"PGRST502","details":null,"hint":null} |]
+          [json| {"message":"application/octet-stream requested but more than one column was selected","code":"PGRST113","details":null,"hint":null} |]
           { matchStatus = 406 }
 
       request methodGet "/images?name=eq.A.png"
           (acceptHdrs "application/octet-stream")
           ""
         `shouldRespondWith`
-          [json| {"message":"application/octet-stream requested but more than one column was selected","code":"PGRST502","details":null,"hint":null} |]
+          [json| {"message":"application/octet-stream requested but more than one column was selected","code":"PGRST113","details":null,"hint":null} |]
           { matchStatus = 406 }
 
     it "concatenates results if more than one row is returned" $

--- a/test/spec/Feature/Query/RpcSpec.hs
+++ b/test/spec/Feature/Query/RpcSpec.hs
@@ -1024,7 +1024,7 @@ spec actualPgVersion =
           request methodPost "/rpc/ret_rows_with_base64_bin"
               (acceptHdrs "application/octet-stream") ""
             `shouldRespondWith`
-              [json| {"message":"application/octet-stream requested but more than one column was selected","code":"PGRST502","details":null,"hint":null} |]
+              [json| {"message":"application/octet-stream requested but more than one column was selected","code":"PGRST113","details":null,"hint":null} |]
               { matchStatus = 406 }
 
     context "only for GET rpc" $ do
@@ -1094,25 +1094,25 @@ spec actualPgVersion =
       it "fails when setting headers with wrong json structure" $ do
         get "/rpc/bad_guc_headers_1"
           `shouldRespondWith`
-          [json|{"message":"response.headers guc must be a JSON array composed of objects with a single key and a string value","code":"PGRST500","details":null,"hint":null}|]
+          [json|{"message":"response.headers guc must be a JSON array composed of objects with a single key and a string value","code":"PGRST111","details":null,"hint":null}|]
           { matchStatus  = 500
           , matchHeaders = [ matchContentTypeJson ]
           }
         get "/rpc/bad_guc_headers_2"
           `shouldRespondWith`
-          [json|{"message":"response.headers guc must be a JSON array composed of objects with a single key and a string value","code":"PGRST500","details":null,"hint":null}|]
+          [json|{"message":"response.headers guc must be a JSON array composed of objects with a single key and a string value","code":"PGRST111","details":null,"hint":null}|]
           { matchStatus  = 500
           , matchHeaders = [ matchContentTypeJson ]
           }
         get "/rpc/bad_guc_headers_3"
           `shouldRespondWith`
-          [json|{"message":"response.headers guc must be a JSON array composed of objects with a single key and a string value","code":"PGRST500","details":null,"hint":null}|]
+          [json|{"message":"response.headers guc must be a JSON array composed of objects with a single key and a string value","code":"PGRST111","details":null,"hint":null}|]
           { matchStatus  = 500
           , matchHeaders = [ matchContentTypeJson ]
           }
         post "/rpc/bad_guc_headers_1" [json|{}|]
           `shouldRespondWith`
-          [json|{"message":"response.headers guc must be a JSON array composed of objects with a single key and a string value","code":"PGRST500","details":null,"hint":null}|]
+          [json|{"message":"response.headers guc must be a JSON array composed of objects with a single key and a string value","code":"PGRST111","details":null,"hint":null}|]
           { matchStatus  = 500
           , matchHeaders = [ matchContentTypeJson ]
           }
@@ -1183,7 +1183,7 @@ spec actualPgVersion =
         it "fails when setting invalid status guc" $
           get "/rpc/send_bad_status"
             `shouldRespondWith`
-            [json|{"message":"response.status guc must be a valid status code","code":"PGRST501","details":null,"hint":null}|]
+            [json|{"message":"response.status guc must be a valid status code","code":"PGRST112","details":null,"hint":null}|]
             { matchStatus  = 500
             , matchHeaders = [ matchContentTypeJson ]
             }

--- a/test/spec/Feature/Query/SingularSpec.hs
+++ b/test/spec/Feature/Query/SingularSpec.hs
@@ -69,7 +69,7 @@ spec =
             [("Prefer", "tx=commit"), singular]
             [json| { address: "zzz" } |]
           `shouldRespondWith`
-            [json|{"details":"Results contain 4 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST505","hint":null}|]
+            [json|{"details":"Results contain 4 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST116","hint":null}|]
             { matchStatus  = 406
             , matchHeaders = [ matchContentTypeSingular
                              , "Preference-Applied" <:> "tx=commit" ]
@@ -85,7 +85,7 @@ spec =
             [("Prefer", "tx=commit"), ("Prefer", "return=representation"), singular]
             [json| { address: "zzz" } |]
           `shouldRespondWith`
-            [json|{"details":"Results contain 4 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST505","hint":null}|]
+            [json|{"details":"Results contain 4 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST116","hint":null}|]
             { matchStatus  = 406
             , matchHeaders = [ matchContentTypeSingular
                              , "Preference-Applied" <:> "tx=commit" ]
@@ -100,7 +100,7 @@ spec =
         request methodPatch "/items?id=gt.0&id=lt.0"
                 [singular] [json|{"id":1}|]
           `shouldRespondWith`
-                  [json|{"details":"Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST505","hint":null}|]
+                  [json|{"details":"Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST116","hint":null}|]
                   { matchStatus  = 406
                   , matchHeaders = [matchContentTypeSingular]
                   }
@@ -109,7 +109,7 @@ spec =
         request methodPatch "/items?id=gt.0&id=lt.0"
                 [("Prefer", "return=representation"), singular] [json|{"id":1}|]
           `shouldRespondWith`
-                  [json|{"details":"Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST505","hint":null}|]
+                  [json|{"details":"Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST116","hint":null}|]
                   { matchStatus  = 406
                   , matchHeaders = [matchContentTypeSingular]
                   }
@@ -141,7 +141,7 @@ spec =
             [("Prefer", "tx=commit"), singular]
             [json| [ { id: 200, address: "xxx" }, { id: 201, address: "yyy" } ] |]
           `shouldRespondWith`
-            [json|{"details":"Results contain 2 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST505","hint":null}|]
+            [json|{"details":"Results contain 2 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST116","hint":null}|]
             { matchStatus  = 406
             , matchHeaders = [ matchContentTypeSingular
                              , "Preference-Applied" <:> "tx=commit" ]
@@ -157,7 +157,7 @@ spec =
             [("Prefer", "tx=commit"), ("Prefer", "return=representation"), singular]
             [json| [ { id: 202, address: "xxx" }, { id: 203, address: "yyy" } ] |]
           `shouldRespondWith`
-            [json|{"details":"Results contain 2 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST505","hint":null}|]
+            [json|{"details":"Results contain 2 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST116","hint":null}|]
             { matchStatus  = 406
             , matchHeaders = [ matchContentTypeSingular
                              , "Preference-Applied" <:> "tx=commit" ]
@@ -173,7 +173,7 @@ spec =
             [("Prefer", "tx=commit"), ("Prefer", "return=minimal"), singular]
             [json| [ { id: 204, address: "xxx" }, { id: 205, address: "yyy" } ] |]
           `shouldRespondWith`
-            [json|{"details":"Results contain 2 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST505","hint":null}|]
+            [json|{"details":"Results contain 2 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST116","hint":null}|]
             { matchStatus  = 406
             , matchHeaders = [ matchContentTypeSingular
                              , "Preference-Applied" <:> "tx=commit" ]
@@ -189,7 +189,7 @@ spec =
                 [singular]
                 [json| [ ] |]
           `shouldRespondWith`
-                  [json|{"details":"Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST505","hint":null}|]
+                  [json|{"details":"Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST116","hint":null}|]
                   { matchStatus  = 406
                   , matchHeaders = [matchContentTypeSingular]
                   }
@@ -199,7 +199,7 @@ spec =
                 [("Prefer", "return=representation"), singular]
                 [json| [ ] |]
           `shouldRespondWith`
-                  [json|{"details":"Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST505","hint":null}|]
+                  [json|{"details":"Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST116","hint":null}|]
                   { matchStatus  = 406
                   , matchHeaders = [matchContentTypeSingular]
                   }
@@ -222,7 +222,7 @@ spec =
             [("Prefer", "tx=commit"), singular]
             ""
           `shouldRespondWith`
-            [json|{"details":"Results contain 5 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST505","hint":null}|]
+            [json|{"details":"Results contain 5 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST116","hint":null}|]
             { matchStatus  = 406
             , matchHeaders = [ matchContentTypeSingular
                              , "Preference-Applied" <:> "tx=commit" ]
@@ -240,7 +240,7 @@ spec =
         request methodDelete "/items?id=gt.5&id=lt.11"
             [("Prefer", "tx=commit"), ("Prefer", "return=representation"), singular] ""
           `shouldRespondWith`
-            [json|{"details":"Results contain 5 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST505","hint":null}|]
+            [json|{"details":"Results contain 5 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST116","hint":null}|]
             { matchStatus  = 406
             , matchHeaders = [ matchContentTypeSingular
                              , "Preference-Applied" <:> "tx=commit" ]
@@ -257,7 +257,7 @@ spec =
         request methodDelete "/items?id=lt.0"
                 [singular] ""
           `shouldRespondWith`
-                [json|{"details":"Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST505","hint":null}|]
+                [json|{"details":"Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST116","hint":null}|]
                 { matchStatus  = 406
                 , matchHeaders = [matchContentTypeSingular]
                 }
@@ -266,7 +266,7 @@ spec =
         request methodDelete "/items?id=lt.0"
                 [("Prefer", "return=representation"), singular] ""
           `shouldRespondWith`
-                [json|{"details":"Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST505","hint":null}|]
+                [json|{"details":"Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST116","hint":null}|]
                 { matchStatus  = 406
                 , matchHeaders = [matchContentTypeSingular]
                 }
@@ -276,7 +276,7 @@ spec =
         request methodPost "/rpc/getproject"
                 [singular] [json|{ "id": 9999999}|]
           `shouldRespondWith`
-                [json|{"details":"Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST505","hint":null}|]
+                [json|{"details":"Results contain 0 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST116","hint":null}|]
                 { matchStatus  = 406
                 , matchHeaders = [matchContentTypeSingular]
                 }
@@ -299,7 +299,7 @@ spec =
         request methodPost "/rpc/getallprojects"
                 [singular] "{}"
           `shouldRespondWith`
-                [json|{"details":"Results contain 5 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST505","hint":null}|]
+                [json|{"details":"Results contain 5 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST116","hint":null}|]
                 { matchStatus  = 406
                 , matchHeaders = [matchContentTypeSingular]
                 }
@@ -314,7 +314,7 @@ spec =
             [("Prefer", "tx=commit"), singular]
             [json| {"id_l": 1, "id_h": 2, "name": "changed"} |]
           `shouldRespondWith`
-            [json|{"details":"Results contain 2 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST505","hint":null}|]
+            [json|{"details":"Results contain 2 rows, application/vnd.pgrst.object+json requires 1 row","message":"JSON object requested, multiple (or no) rows returned","code":"PGRST116","hint":null}|]
             { matchStatus  = 406
             , matchHeaders = [ matchContentTypeSingular
                              , "Preference-Applied" <:> "tx=commit" ]

--- a/test/spec/Feature/Query/UpsertSpec.hs
+++ b/test/spec/Feature/Query/UpsertSpec.hs
@@ -199,21 +199,21 @@ spec actualPgVersion =
           request methodPut "/tiobe_pls?name=eq.Javascript" [("Range", "0-5")]
             [json| [ { "name": "Javascript", "rank": 1 } ]|]
             `shouldRespondWith`
-            [json|{"message":"Range header and limit/offset querystring parameters are not allowed for PUT","code":"PGRST503","details":null,"hint":null}|]
+            [json|{"message":"Range header and limit/offset querystring parameters are not allowed for PUT","code":"PGRST114","details":null,"hint":null}|]
             { matchStatus = 400 , matchHeaders = [matchContentTypeJson] }
 
         it "fails if limit is specified" $
           put "/tiobe_pls?name=eq.Javascript&limit=1"
             [json| [ { "name": "Javascript", "rank": 1 } ]|]
             `shouldRespondWith`
-            [json|{"message":"Range header and limit/offset querystring parameters are not allowed for PUT","code":"PGRST503","details":null,"hint":null}|]
+            [json|{"message":"Range header and limit/offset querystring parameters are not allowed for PUT","code":"PGRST114","details":null,"hint":null}|]
             { matchStatus = 400 , matchHeaders = [matchContentTypeJson] }
 
         it "fails if offset is specified" $
           put "/tiobe_pls?name=eq.Javascript&offset=1"
             [json| [ { "name": "Javascript", "rank": 1 } ]|]
             `shouldRespondWith`
-            [json|{"message":"Range header and limit/offset querystring parameters are not allowed for PUT","code":"PGRST503","details":null,"hint":null}|]
+            [json|{"message":"Range header and limit/offset querystring parameters are not allowed for PUT","code":"PGRST114","details":null,"hint":null}|]
             { matchStatus = 400 , matchHeaders = [matchContentTypeJson] }
 
         it "rejects every other filter than pk cols eq's" $ do
@@ -254,12 +254,12 @@ spec actualPgVersion =
       it "fails if the uri primary key doesn't match the payload primary key" $ do
         put "/tiobe_pls?name=eq.MATLAB" [json| [ { "name": "Perl", "rank": 17 } ]|]
           `shouldRespondWith`
-          [json|{"message":"Payload values do not match URL in primary key column(s)","code":"PGRST504","details":null,"hint":null}|]
+          [json|{"message":"Payload values do not match URL in primary key column(s)","code":"PGRST115","details":null,"hint":null}|]
           { matchStatus = 400 , matchHeaders = [matchContentTypeJson] }
         put "/employees?first_name=eq.Wendy&last_name=eq.Anderson"
           [json| [ { "first_name": "Susan", "last_name": "Heidt", "salary": "48000", "company": "GEX", "occupation": "Railroad engineer" } ]|]
           `shouldRespondWith`
-          [json|{"message":"Payload values do not match URL in primary key column(s)","code":"PGRST504","details":null,"hint":null}|]
+          [json|{"message":"Payload values do not match URL in primary key column(s)","code":"PGRST115","details":null,"hint":null}|]
           { matchStatus = 400 , matchHeaders = [matchContentTypeJson] }
 
       it "fails if the table has no PK" $


### PR DESCRIPTION
Followed the example of [PostgreSQL internal errors](https://www.postgresql.org/docs/current/errcodes-appendix.html) and separated the Hasql errors from the group sequence (now starts with X instead of 4) and changed the name to Internal errors.

Also moved some General errors that should be in the Api Request group.

