### PR TITLE
No column or hint as target for embedding views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2070, Restrict generated many-to-many relationships - @steve-chavez
    + Only adds many-to-many relationships when: a table has FKs to two other tables and these FK columns are part of the table's PK columns.
  - #2278, Allow casting to types with underscores and numbers(e.g. `select=oid_array::_int4`) - @steve-chavez
+ - #2277, #2238, #1643, Prevent views from breaking one-to-many/many-to-one embeds when using column or FK as target - @steve-chavez
+    + When using a column or FK as target for embedding(`/tbl?select=*,col-or-fk(*)`), only tables are now detected and views are not.
+    + You can still use a column or an inferred FK on a view to embed a table(`/view?select=*,col-or-fk(*)`)
 
 ### Changed
 
@@ -65,6 +68,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + This was misleading because the affected rows were not really affected by `max-rows`, only the returned rows were limited
  - #2070, Restrict generated many-to-many relationships - @steve-chavez
    + A primary key that contains the foreign key columns is now needed for generating many-to-many relationships.
+ - #2277, Views now are not detected when embedding using the column or FK as target (`/view?select=*,column(*)`) - @steve-chavez
+   + This embedding form was easily made ambiguous whenever a new view was added.
+   + For migrating, clients must be updated to the embedding form of `/view?select=*,other_view!column(*)`.
 
 ## [9.0.0] - 2021-11-25
 

--- a/src/PostgREST/DbStructure/Relationship.hs
+++ b/src/PostgREST/DbStructure/Relationship.hs
@@ -23,6 +23,8 @@ data Relationship = Relationship
   , relForeignTable :: QualifiedIdentifier
   , relIsSelf       :: Bool -- ^ Whether is a self relationship
   , relCardinality  :: Cardinality
+  , relTableIsView  :: Bool
+  , relFTableIsView :: Bool
   }
   deriving (Eq, Ord, Generic, JSON.ToJSON)
 

--- a/test/spec/fixtures/data.sql
+++ b/test/spec/fixtures/data.sql
@@ -775,3 +775,6 @@ INSERT INTO oid_test(id, oid_col, oid_array_col) VALUES (1, '12345', '{1,2,3,4,5
 TRUNCATE TABLE private.internal_job CASCADE;
 INSERT INTO private.internal_job (id, parent_id) VALUES (1, null);
 INSERT INTO private.internal_job (id, parent_id) VALUES (2, 1);
+
+TRUNCATE TABLE test.test CASCADE;
+INSERT INTO test.test (id, parent_id) VALUES (1, null), (2, 1);

--- a/test/spec/fixtures/privileges.sql
+++ b/test/spec/fixtures/privileges.sql
@@ -181,6 +181,11 @@ GRANT ALL ON TABLE
     , xmltest
     , oid_test
     , job
+    , series
+    , adaptation_notifications
+    , series_popularity
+    , test
+    , view_test
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -2605,3 +2605,28 @@ CREATE TABLE private.internal_job
 CREATE VIEW test.job AS
 SELECT j.id, j.parent_id
 FROM private.internal_job j;
+
+-- https://github.com/PostgREST/postgrest/issues/2238
+CREATE TABLE series (
+    id bigint PRIMARY KEY,
+    title text NOT NULL
+);
+
+CREATE TABLE adaptation_notifications (
+    id bigint PRIMARY KEY,
+    series bigint REFERENCES series(id),
+    status text
+);
+
+CREATE VIEW series_popularity AS
+SELECT id, random() AS popularity_score
+FROM series;
+
+-- https://github.com/PostgREST/postgrest/issues/1643
+CREATE TABLE test.test (
+  id BIGINT NOT NULL PRIMARY KEY,
+  parent_id BIGINT CONSTRAINT parent_test REFERENCES test(id)
+);
+
+CREATE OR REPLACE VIEW test.view_test AS
+  SELECT id FROM test.test;


### PR DESCRIPTION
Closes https://github.com/PostgREST/postgrest/issues/2277, closes https://github.com/PostgREST/postgrest/issues/2238, closes https://github.com/PostgREST/postgrest/issues/1643.

- [x] When using a column or FK for embedding, only tables should be detected and views not.
- [x] Using a column/FK embed on views will still work for getting tables.
- [x] Make it possible to use the col-as-target for self-referencing relationships in views