### PR TITLE
fix: allow cast on types with underscores/numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2254, Fix inferring a foreign key column as a primary key column on views - @steve-chavez
  - #2070, Restrict generated many-to-many relationships - @steve-chavez
    + Only adds many-to-many relationships when: a table has FKs to two other tables and these FK columns are part of the table's PK columns.
+ - #2278, Allow casting to types with underscores and numbers(e.g. `select=oid_array::_int4`) - @steve-chavez
 
 ### Changed
 

--- a/src/PostgREST/Request/QueryParams.hs
+++ b/src/PostgREST/Request/QueryParams.hs
@@ -394,7 +394,7 @@ pFieldSelect = lexeme $
     do
       alias <- optionMaybe ( try(pFieldName <* aliasSeparator) )
       fld <- pField
-      cast' <- optionMaybe (string "::" *> many letter)
+      cast' <- optionMaybe (string "::" *> many (letter <|> digit <|> oneOf "_"))
       return (fld, toS <$> cast', alias, Nothing, Nothing)
   )
   <|> do

--- a/test/spec/Feature/Query/QuerySpec.hs
+++ b/test/spec/Feature/Query/QuerySpec.hs
@@ -365,6 +365,13 @@ spec actualPgVersion = do
         , matchHeaders = []
         }
 
+    it "can cast types with underscore and numbers" $
+      get "/oid_test?select=id,oid_col::int,oid_array_col::_int4"
+        `shouldRespondWith` [json|
+          [{"id":1,"oid_col":12345,"oid_array_col":[1,2,3,4,5]}]
+        |]
+        { matchHeaders = [matchContentTypeJson] }
+
     it "requesting parents and children" $
       get "/projects?id=eq.1&select=id, name, clients(*), tasks(id, name)" `shouldRespondWith`
         [json|[{"id":1,"name":"Windows 7","clients":{"id":1,"name":"Microsoft"},"tasks":[{"id":1,"name":"Design w7"},{"id":2,"name":"Code w7"}]}]|]

--- a/test/spec/fixtures/data.sql
+++ b/test/spec/fixtures/data.sql
@@ -762,3 +762,12 @@ INSERT INTO test.limited_delete_items_cpk VALUES (1, 'item-1'), (2, 'item-2'), (
 
 TRUNCATE TABLE test.limited_delete_items_no_pk CASCADE;
 INSERT INTO test.limited_delete_items_no_pk VALUES (1, 'item-1'), (2, 'item-2'), (3, 'item-3');
+
+TRUNCATE TABLE test.xmltest CASCADE;
+INSERT INTO test.xmltest VALUES
+(1, '<myxml>foo</myxml>'),
+(2, 'bar'),
+(3, '<foobar><baz/></foobar>');
+
+TRUNCATE TABLE test.oid_test CASCADE;
+INSERT INTO oid_test(id, oid_col, oid_array_col) VALUES (1, '12345', '{1,2,3,4,5}'::oid[]);

--- a/test/spec/fixtures/privileges.sql
+++ b/test/spec/fixtures/privileges.sql
@@ -179,6 +179,7 @@ GRANT ALL ON TABLE
     , limited_delete_items_cpk_view
     , limited_update_items_cpk_view
     , xmltest
+    , oid_test
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -2589,7 +2589,7 @@ CREATE TABLE test.xmltest (
     xml pg_catalog.xml NOT NULL
 );
 
-INSERT INTO test.xmltest VALUES
-(1, '<myxml>foo</myxml>'),
-(2, 'bar'),
-(3, '<foobar><baz/></foobar>');
+CREATE TABLE oid_test(
+  id int,
+  oid_col oid,
+  oid_array_col oid[]);


### PR DESCRIPTION
Now possible:

```http
GET /tbl?select=oid_array::_int4
```

`_int4` is the base name of the `int[]` cast.

Allowing brackets `[]` in the parsers would be a bit more effort and also they need to be urlencoded.