### PR TITLE
Add doctest for pField

### DIFF
--- a/src/PostgREST/Request/QueryParams.hs
+++ b/src/PostgREST/Request/QueryParams.hs
@@ -360,6 +360,20 @@ pJsonPath = many pJsonOperation
                  try eof in
       try pJIdx <|> try pJKey
 
+-- |
+-- Parse the field (name and json operator) in select, order and filters
+--
+-- >>> P.parse pField "" "column"
+-- Right ("column",[])
+--
+-- >>> P.parse pField "" "column->text"
+-- Right ("column",[JArrow {jOp = JKey {jVal = "text"}}])
+--
+-- Ignores leading and trailing spaces
+--
+-- >>> P.parse pField "" " column "
+-- Right ("column",[])
+--
 pField :: Parser Field
 pField = lexeme $ (,) <$> pFieldName <*> P.option [] pJsonPath
 


### PR DESCRIPTION
The `pField` function does not ignore trailing spaces when a column is selected:
```
/table?select=name,join (*) 
```
It does work for leading spaces though: 
```
/table?select=name, join(*)
``` 
Both trailing and leading spaces will be ignored in this PR.