### PR TITLE
ci: Run ARM builds on releases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -220,7 +220,7 @@ jobs:
 
   Build-Cabal-Arm:
     name: Build aarch64 (Cabal)
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     outputs:
       remotepath: ${{ steps.Remote-Dir.outputs.remotepath }}
@@ -466,7 +466,7 @@ jobs:
     needs:
       - Build-Cabal-Arm
       - Release-Docker
-    if: ${{ always() && github.ref == 'refs/heads/main' }}
+    if: ${{ always() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
     runs-on: ubuntu-latest
     env:
       REMOTE_DIR: ${{ needs.Build-Cabal-Arm.outputs.remotepath }}


### PR DESCRIPTION
ARM builds are no longer skipped for releases (on version tag push).
