### PR TITLE
Add CI runs for PR to branches starting with rel-

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - main
+      - rel-*
     tags:
       - v*
   pull_request:
     branches:
       - main
+      - rel-*
 
 jobs:
   Lint-Style:
@@ -220,7 +222,7 @@ jobs:
 
   Build-Cabal-Arm:
     name: Build aarch64 (Cabal)
-    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/rel-') }}
     runs-on: ubuntu-latest
     outputs:
       remotepath: ${{ steps.Remote-Dir.outputs.remotepath }}
@@ -466,7 +468,7 @@ jobs:
     needs:
       - Build-Cabal-Arm
       - Release-Docker
-    if: ${{ always() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
+    if: ${{ always() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/rel-')) }}
     runs-on: ubuntu-latest
     env:
       REMOTE_DIR: ${{ needs.Build-Cabal-Arm.outputs.remotepath }}


### PR DESCRIPTION
Branches starting with `rel-*` will support small fixes. This allows that PRs (and pushes) done to that branch run the CI, e.g. #2296