### PR TITLE
RPC POST for function w/single unnamed XML param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2236, Support POSIX regular expression operators for row filtering - @enote-kane
  - #2202, Allow returning XML from RPCs - @fjf2002
  - #2269, Allow `limit=0` in the request query to return an empty array - @gautam1168, @laurenceisla
- - #2268, Allow returning XML from single-column queries #2268 - @fjf2002
+ - #2268, Allow returning XML from single-column queries - @fjf2002
+ - #2300, RPC POST for function w/single unnamed XML param #2300 - @fjf2002
 
 ### Fixed
 

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -263,7 +263,7 @@ procsSqlQuery pgVer = [q|
       ) ORDER BY idx) AS args,
       CASE COUNT(*) - COUNT(name) -- number of unnamed arguments
         WHEN 0 THEN true
-        WHEN 1 THEN (array_agg(type))[1] IN ('bytea'::regtype, 'json'::regtype, 'jsonb'::regtype, 'text'::regtype)
+        WHEN 1 THEN (array_agg(type))[1] IN ('bytea'::regtype, 'json'::regtype, 'jsonb'::regtype, 'text'::regtype, 'xml'::regtype)
         ELSE false
       END AS callable
     FROM pg_proc,

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -148,6 +148,7 @@ instance JSON.ToJSON ApiRequestError where
       (case (hasPreferSingleObject, isInvPost, contentType) of
         (True, _, _)                 -> " function with a single json or jsonb parameter"
         (_, True, CTTextPlain)       -> " function with a single unnamed text parameter"
+        (_, True, CTTextXML)         -> " function with a single unnamed xml parameter"
         (_, True, CTOctetStream)     -> " function with a single unnamed bytea parameter"
         (_, True, CTApplicationJSON) -> prms <> " function or the " <> schema <> "." <> procName <>" function with a single unnamed json or jsonb parameter"
         _                            -> prms <> " function") <>

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -2312,6 +2312,10 @@ create or replace function test.unnamed_text_param(text) returns text as $$
   select $1;
 $$ language sql;
 
+create or replace function test.unnamed_xml_param(pg_catalog.xml) returns pg_catalog.xml as $$
+  select $1;
+$$ language sql;
+
 create or replace function test.unnamed_bytea_param(bytea) returns bytea as $$
   select $1::bytea;
 $$ language sql;


### PR DESCRIPTION
RPC POST for function w/single unnamed XML param

- extends #1927 for data type xml
- part of #2188