### PR TITLE
nix: assorted improvements

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -149,6 +149,7 @@ rec {
       inherit postgrest devCabalOptions withTools;
       ghc = pkgs.haskell.compiler."${compiler}";
       inherit (pkgs.haskell.packages."${compiler}") hpc-codecov;
+      inherit (pkgs.haskell.packages."${compiler}") weeder;
     };
 
   withTools =

--- a/nix/hsie/default.nix
+++ b/nix/hsie/default.nix
@@ -16,7 +16,12 @@ let
   ghc = ghcWithPackages modules;
   hsie =
     runCommand "haskellimports" { inherit name src; }
-      "${ghc}/bin/ghc -O -Werror -Wall -package ghc $src -o $out";
+      ''
+        cd $TMP
+        cp $src $TMP/Main.hs
+        ${ghc}/bin/ghc -O -Werror -Wall -package ghc Main.hs -o Main
+        cp Main $out
+      '';
   bin =
     runCommand name { inherit hsie name; }
       ''

--- a/nix/tools/tests.nix
+++ b/nix/tools/tests.nix
@@ -5,12 +5,12 @@
 , ghc
 , glibcLocales
 , gnugrep
-, haskellPackages
 , hpc-codecov
 , jq
 , postgrest
 , python3
 , runtimeShell
+, weeder
 , withTools
 , yq
 }:
@@ -137,7 +137,7 @@ let
 
         (
           trap 'echo Found dead code: Check file list above.' ERR ;
-          ${haskellPackages.weeder}/bin/weeder --config=./test/weeder.dhall
+          ${weeder}/bin/weeder --config=./test/weeder.dhall
         )
 
         # collect all tests

--- a/nix/tools/tests.nix
+++ b/nix/tools/tests.nix
@@ -20,11 +20,13 @@ let
       {
         name = "postgrest-test-spec";
         docs = "Run the Haskell test suite";
+        args = [ "ARG_LEFTOVERS([hspec arguments])" ];
         inRootDir = true;
         withEnv = postgrest.env;
       }
       ''
-        ${withTools.withPg} ${cabal-install}/bin/cabal v2-run ${devCabalOptions} test:spec
+        ${withTools.withPg} ${cabal-install}/bin/cabal v2-run ${devCabalOptions} \
+          test:spec -- "''${_arg_leftovers[@]}"
       '';
 
   testQuerycost =


### PR DESCRIPTION
This collects some changes to the nix scripts that came out of #2292, but that should be good independently.

- fix running test script when there's no glibc
- fix possible weeder GHC version mismatch
- pass through arguments for postgrest-test-spec
- fix hsie build (#2304)