### PR TITLE
tests: don't specify openapi root result

### DIFF
--- a/test/spec/Feature/OpenApi/RootSpec.hs
+++ b/test/spec/Feature/OpenApi/RootSpec.hs
@@ -26,7 +26,5 @@ spec =
     it "accepts application/json" $
       request methodGet "/"
         [("Accept", "application/json")] "" `shouldRespondWith`
-        [json|
-            [{"qiSchema":"test","qiName":"authors_w_entities"},"test"]
-          |]
+        200
         { matchHeaders = [matchContentTypeJson] }


### PR DESCRIPTION
Whereas the test used to specify a body of

    [{"qiName":"referrals","qiSchema":"test"},"private"]

we see both

    [{"qiName":"authors_w_entities","qiSchema":"test"},"test"]

and

    [{"qiName":"organizations","qiSchema":"test"},"test"]

on the GHC 9.2 upgrade PR.

This changes the test to no longer expect a particular body.

Compare:
- https://github.com/PostgREST/postgrest/pull/2292#issuecomment-1146160792
- https://github.com/PostgREST/postgrest/issues/1698