### PR TITLE
nix: Add command to remove old hie files in postgrest-clean

### DIFF
--- a/nix/tools/cabalTools.nix
+++ b/nix/tools/cabalTools.nix
@@ -28,6 +28,8 @@ let
       ''
         # clean old coverage data, too
         rm -rf .hpc coverage
+        # clean old hie files
+        find . -name "*.hie" -type f -delete
         exec ${cabal-install}/bin/cabal v2-clean
       '';
 


### PR DESCRIPTION
Got this error when running `postgrest-coverage` even after running `postgrest-clean`: 

```log
incompatible hie file: /home/laurence/Projects/postgrest/test/spec/QueryCost.hie
    this version of weeder was compiled with GHC version 9022
    the hie files in this project were generated with GHC version 8107
    weeder must be built with the same GHC version as the project it is used on
```

Removing the `*.hie` files worked, so I added this command to `postgrest-clean` in case anyone gets this problem in the future.