### PR TITLE
avoid copy when encoding request body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
  - #1385, Deprecate bulk-calls when including the `Prefer: params=multiple-objects` in the request. A function with a JSON array or object parameter should be used instead for a better performance.
 
+### Changed
+ - #2261, #2349, #2467, Reduce allocations communication with PostgreSQL, particularly for request bodies. - @robx
+
 ## [10.0.0] - 2022-08-18
 
 ### Added

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -13,13 +13,10 @@ let
       #       {
       #         pkg = "protolude";
       #         ver = "0.3.0";
-      #         sha256 = "0iwh4wsjhb7pms88lw1afhdal9f86nrrkkvv65f9wxbd1b159n72";
+      #         sha256 = "<sha256>";
       #       }
       #       { };
       #
-      # To get the sha256:
-      #   nix-prefetch-url --unpack https://hackage.haskell.org/package/protolude-0.3.0/protolude-0.3.0.tar.gz
-
       # To temporarily pin unreleased versions from GitHub:
       #   <name> =
       #     prev.callCabal2nixWithOptions "<name>" (super.fetchFromGitHub {
@@ -29,8 +26,8 @@ let
       #       sha256 = "<sha256>";
       #    }) "--subpath=<subpath>" {};
       #
-      # To get the sha256:
-      #   nix-prefetch-url --unpack https://github.com/<owner>/<repo>/archive/<commit>.tar.gz
+      # To fill in the sha256:
+      #   update-nix-fetchgit nix/overlays/haskell-packages.nix
 
       hasql = lib.dontCheck prev.hasql_1_6_0_1;
       hasql-dynamic-statements = lib.dontCheck prev.hasql-dynamic-statements_0_3_1_2;

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -29,7 +29,29 @@ let
       # To fill in the sha256:
       #   update-nix-fetchgit nix/overlays/haskell-packages.nix
 
-      hasql = lib.dontCheck prev.hasql_1_6_0_1;
+      hashtables = lib.dontCheck prev.hashtables_1_3;
+      isomorphism-class = lib.unmarkBroken prev.isomorphism-class;
+      text-builder = lib.dontCheck prev.text-builder_0_6_7;
+      text-builder-dev = lib.dontCheck prev.text-builder-dev_0_3_3;
+
+      postgresql-binary = lib.dontCheck
+        (prev.callHackageDirect
+          {
+            pkg = "postgresql-binary";
+            ver = "0.12.5";
+            sha256 = "1vk97lw25i7d0pvjzd7s3m13nya9ycnrjr8y4qhw2jgjnvkblnzv";
+          }
+          { });
+
+      hasql = lib.dontCheck
+        (prev.callHackageDirect
+          {
+            pkg = "hasql";
+            ver = "1.6.1.1";
+            sha256 = "1sv0500dvfln9ljxkd2jrfl9nbpkax7z5b8zjy9yjps1r6s1cmj0";
+          }
+          { });
+
       hasql-dynamic-statements = lib.dontCheck prev.hasql-dynamic-statements_0_3_1_2;
       hasql-transaction = lib.dontCheck prev.hasql-transaction_1_0_1_2;
 
@@ -38,7 +60,7 @@ let
           {
             pkg = "hasql-notifications";
             ver = "0.2.0.3";
-            sha256 = "sha256-x8EGEMVYSw4O1Kn6MxOB+/3y3ITxqESDfrYgM8B1hOw=";
+            sha256 = "1v44fp03685ngs1l9a7ihkfg5zgvh49k7ym9sh70wjsqql80dhf7";
           }
           { });
 
@@ -47,7 +69,7 @@ let
           {
             pkg = "hasql-pool";
             ver = "0.8.0.2";
-            sha256 = "sha256-9GE9qyymTLXw4ZW6LbNnn4T2tCgNYVEuBIPcUA83xCg=";
+            sha256 = "0a646w7m1p430hp52q8d52sgd14zcyrjvflmw7qbak565jmksqgl";
           }
           { });
 
@@ -56,8 +78,8 @@ let
           (super.fetchFromGitHub {
             owner = "PostgREST";
             repo = "postgresql-libpq";
-            rev = "cef92cb4c07b56568dffdbf4b719258b82183119"; # master as of 2022-09-05
-            sha256 = "sha256-BWXfGHhcNuOGdFRxDshbcnxaRTDwEC1Eswwf8jOdqWQ=";
+            rev = "cef92cb4c07b56568dffdbf4b719258b82183119"; # master
+            sha256 = "0r59klrz47qcnd22s47h612mlz3jbg40wwalfj3f6djwg0cdyr85";
           })
           { });
     } // extraOverrides final prev;

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -85,7 +85,7 @@ library
                     , cookie                    >= 0.4.2 && < 0.5
                     , either                    >= 4.4.1 && < 5.1
                     , gitrev                    >= 1.2 && < 1.4
-                    , hasql                     >= 1.6 && < 1.7
+                    , hasql                     >= 1.6.1.1 && < 1.7
                     , hasql-dynamic-statements  >= 0.3.1 && < 0.4
                     , hasql-notifications       >= 0.1 && < 0.3
                     , hasql-pool                >= 0.8.0.2 && < 0.9

--- a/shell.nix
+++ b/shell.nix
@@ -40,6 +40,7 @@ lib.overrideDerivation postgrest.env (
         pkgs.cabal2nix
         pkgs.git
         pkgs.postgresql
+        pkgs.update-nix-fetchgit
         postgrest.hsie.bin
       ]
       ++ toolboxes;

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -128,7 +128,7 @@ normalizedBody body =
         "END AS val",
       "FROM pgrst_payload)"])
   where
-    jsonPlaceHolder = SQL.encoderAndParam (HE.nullable HE.unknown) (LBS.toStrict <$> body) <> "::json"
+    jsonPlaceHolder = SQL.encoderAndParam (HE.nullable HE.jsonLazyBytes) body
 
 singleParameter :: Maybe LBS.ByteString -> ByteString -> SQL.Snippet
 singleParameter body typ =

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,17 +10,23 @@ nix:
   pure: false
 
 extra-deps:
-  - HTTP-4000.3.16@sha256:6042643c15a0b43e522a6693f1e322f05000d519543a84149cb80aeffee34f71,5947
-  - configurator-pg-0.2.6@sha256:cd9b06a458428e493a4d6def725af7ab1ab0fef678fbd871f9586fc7f9aa70be,2849
-  - hasql-1.6.0.1@sha256:adb92e68a3741f422a3bb776a12d5cf2bb83303778f343106f9a1cc2b4fcdf73,6628
-  - hasql-dynamic-statements-0.3.1.2@sha256:417aa533c84f074e2fa16bb2c4d4231326aa512097dd1025d915388e56acd1eb,2675
-  - hasql-implicits-0.1.0.5@sha256:d16aacad6dc21428d72447d3ae8bcc03839a2f0aa1ec29c797ed9aca4609f9af,1361
-  - hasql-notifications-0.2.0.3@sha256:aca3f7ee847a8f0b7ef6f989dc48f4a094a06c1a34e92aa3c8bb230085966ea6,2027
-  - hasql-pool-0.8.0.2@sha256:15473f336c2bd1da161cd03635841f38b0c177d7b8662762c8708c239a428f04,1907
-  - hasql-transaction-1.0.1.2@sha256:297b158cd1f0727f9b0e175bd7d3741c1bcb725a8094956d0ee79b41aafdb30a,2890
-  - lens-aeson-1.1.3@sha256:52c8eaecd2d1c2a969c0762277c4a8ee72c339a686727d5785932e72ef9c3050,1764
-  - optparse-applicative-0.16.1.0@sha256:418c22ed6a19124d457d96bc66bd22c93ac22fad0c7100fe4972bbb4ac989731,4982
-  - protolude-0.3.2@sha256:2a38b3dad40d238ab644e234b692c8911423f9d3ed0e36b62287c4a698d92cd1,2240
-  - ptr-0.16.8.2@sha256:708ebb95117f2872d2c5a554eb6804cf1126e86abe793b2673f913f14e5eb1ac,3959
+  - HTTP-4000.3.16
+  - configurator-pg-0.2.6
+  - hashable-1.4.1.0
+  - hashtables-1.3
+  - hasql-1.6.1.1
+  - hasql-dynamic-statements-0.3.1.2
+  - hasql-implicits-0.1.0.5
+  - hasql-notifications-0.2.0.3
+  - hasql-pool-0.8.0.2
+  - hasql-transaction-1.0.1.2
+  - isomorphism-class-0.1.0.6
+  - lens-aeson-1.1.3
+  - optparse-applicative-0.16.1.0
+  - postgresql-binary-0.12.5
+  - protolude-0.3.2
+  - ptr-0.16.8.2
+  - text-builder-0.6.7
+  - text-builder-dev-0.3.3
   - git: https://github.com/PostgREST/postgresql-libpq.git
     commit: 33ff97db570b5b432255f5f24a68db51453f6eb8

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,7 +3,6 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-
 packages:
 - completed:
     hackage: HTTP-4000.3.16@sha256:6042643c15a0b43e522a6693f1e322f05000d519543a84149cb80aeffee34f71,5947
@@ -11,84 +10,126 @@ packages:
       size: 1428
       sha256: b73a7f6d21cf20bbf819e19039409c9010efb5000d2b72cdd8fd67a9027c14e8
   original:
-    hackage: HTTP-4000.3.16@sha256:6042643c15a0b43e522a6693f1e322f05000d519543a84149cb80aeffee34f71,5947
+    hackage: HTTP-4000.3.16
 - completed:
     hackage: configurator-pg-0.2.6@sha256:cd9b06a458428e493a4d6def725af7ab1ab0fef678fbd871f9586fc7f9aa70be,2849
     pantry-tree:
       size: 2463
       sha256: 97efe7a22afc93033bda5adcffdabc0f1c30dc32b2c3ba02114ce7cd74c942fd
   original:
-    hackage: configurator-pg-0.2.6@sha256:cd9b06a458428e493a4d6def725af7ab1ab0fef678fbd871f9586fc7f9aa70be,2849
+    hackage: configurator-pg-0.2.6
 - completed:
-    hackage: hasql-1.6.0.1@sha256:adb92e68a3741f422a3bb776a12d5cf2bb83303778f343106f9a1cc2b4fcdf73,6628
+    hackage: hashable-1.4.1.0@sha256:50b2f002c68fe67730ee7a3cd8607486197dd99b084255005ad51ecd6970a41b,5019
+    pantry-tree:
+      size: 1248
+      sha256: 9af2f7a42674f7effcabbebc043f97057240783f1709338a77f58216f4a5f18c
+  original:
+    hackage: hashable-1.4.1.0
+- completed:
+    hackage: hashtables-1.3@sha256:ab21804fdafbbd8ad918b2911dabb729ae0ea891780fe66bf7804cbcd07edadf,10379
+    pantry-tree:
+      size: 2895
+      sha256: e71f113ad989dbc994e0fb52bcc219d62930de9afa8b3441bf7909e864481b33
+  original:
+    hackage: hashtables-1.3
+- completed:
+    hackage: hasql-1.6.1.1@sha256:948a2137308cc5354e4997bc3666753867124cd25db792424cb9614b1c1b44cf,6626
     pantry-tree:
       size: 2622
-      sha256: c7b9df36feb75fe43c4e3804ba1eb61e37a39fa97173c5eed35245b17d10fd8e
+      sha256: 28d21bf061522fc513f040e9c383b90532222b7258216cc094e07736add8be10
   original:
-    hackage: hasql-1.6.0.1@sha256:adb92e68a3741f422a3bb776a12d5cf2bb83303778f343106f9a1cc2b4fcdf73,6628
+    hackage: hasql-1.6.1.1
 - completed:
     hackage: hasql-dynamic-statements-0.3.1.2@sha256:417aa533c84f074e2fa16bb2c4d4231326aa512097dd1025d915388e56acd1eb,2675
     pantry-tree:
       size: 595
       sha256: 91696d3f3e0ef3254772ae5a8e4e89be68285febb49b302ed83d85ac4037a417
   original:
-    hackage: hasql-dynamic-statements-0.3.1.2@sha256:417aa533c84f074e2fa16bb2c4d4231326aa512097dd1025d915388e56acd1eb,2675
+    hackage: hasql-dynamic-statements-0.3.1.2
 - completed:
     hackage: hasql-implicits-0.1.0.5@sha256:d16aacad6dc21428d72447d3ae8bcc03839a2f0aa1ec29c797ed9aca4609f9af,1361
     pantry-tree:
       size: 264
       sha256: 0451b99a0a1d02db673d0c40acdf60d4e769e15852eed9e8dc05bffaf43efb70
   original:
-    hackage: hasql-implicits-0.1.0.5@sha256:d16aacad6dc21428d72447d3ae8bcc03839a2f0aa1ec29c797ed9aca4609f9af,1361
+    hackage: hasql-implicits-0.1.0.5
 - completed:
     hackage: hasql-notifications-0.2.0.3@sha256:aca3f7ee847a8f0b7ef6f989dc48f4a094a06c1a34e92aa3c8bb230085966ea6,2027
     pantry-tree:
       size: 452
       sha256: 999f0f2856a00d21f4498a8a58452bbefc4ea972fe2984fd234a68a5fe61d98b
   original:
-    hackage: hasql-notifications-0.2.0.3@sha256:aca3f7ee847a8f0b7ef6f989dc48f4a094a06c1a34e92aa3c8bb230085966ea6,2027
+    hackage: hasql-notifications-0.2.0.3
 - completed:
     hackage: hasql-pool-0.8.0.2@sha256:15473f336c2bd1da161cd03635841f38b0c177d7b8662762c8708c239a428f04,1907
     pantry-tree:
       size: 505
       sha256: 495dfdf8b7f7d910e2e8a7a7e8d71c8dbf9d439e048de5bc2a66a762011cbdc2
   original:
-    hackage: hasql-pool-0.8.0.2@sha256:15473f336c2bd1da161cd03635841f38b0c177d7b8662762c8708c239a428f04,1907
+    hackage: hasql-pool-0.8.0.2
 - completed:
     hackage: hasql-transaction-1.0.1.2@sha256:297b158cd1f0727f9b0e175bd7d3741c1bcb725a8094956d0ee79b41aafdb30a,2890
     pantry-tree:
       size: 983
       sha256: 3679e6d5c835cc17a8fa0c252b8221e282880044b7219aa1de2531bbd5c40691
   original:
-    hackage: hasql-transaction-1.0.1.2@sha256:297b158cd1f0727f9b0e175bd7d3741c1bcb725a8094956d0ee79b41aafdb30a,2890
+    hackage: hasql-transaction-1.0.1.2
+- completed:
+    hackage: isomorphism-class-0.1.0.6@sha256:d93da31287359c761953b876354de28381f409c5c50e3241c572a443e50c553d,1703
+    pantry-tree:
+      size: 465
+      sha256: c97f922d1ae8f1a0db4c28fac9383d2716934879e95ff0b2b88ebb861d6fba14
+  original:
+    hackage: isomorphism-class-0.1.0.6
 - completed:
     hackage: lens-aeson-1.1.3@sha256:52c8eaecd2d1c2a969c0762277c4a8ee72c339a686727d5785932e72ef9c3050,1764
     pantry-tree:
       size: 541
       sha256: b31392b78f2a03111c805f4400007778eb93b49f998ab41dfbebaaf9b5526bad
   original:
-    hackage: lens-aeson-1.1.3@sha256:52c8eaecd2d1c2a969c0762277c4a8ee72c339a686727d5785932e72ef9c3050,1764
+    hackage: lens-aeson-1.1.3
 - completed:
     hackage: optparse-applicative-0.16.1.0@sha256:418c22ed6a19124d457d96bc66bd22c93ac22fad0c7100fe4972bbb4ac989731,4982
     pantry-tree:
       size: 2979
       sha256: dd092d843091c08691485d68a1908517079b1bc6f3d73928f37635a19dc27fc1
   original:
-    hackage: optparse-applicative-0.16.1.0@sha256:418c22ed6a19124d457d96bc66bd22c93ac22fad0c7100fe4972bbb4ac989731,4982
+    hackage: optparse-applicative-0.16.1.0
+- completed:
+    hackage: postgresql-binary-0.12.5@sha256:de9da3cba9be541d6c75ae8da2858c33d83dc1b2e0c639b0b9781816b78a91f4,5594
+    pantry-tree:
+      size: 1619
+      sha256: b392337f91031a5b3407393e2f04dfe4e7a28019e88eae6a9370538b90e28c51
+  original:
+    hackage: postgresql-binary-0.12.5
 - completed:
     hackage: protolude-0.3.2@sha256:2a38b3dad40d238ab644e234b692c8911423f9d3ed0e36b62287c4a698d92cd1,2240
     pantry-tree:
       size: 1594
       sha256: a36d2912ac552d950ba4476de7d950b56b82dd28e48b9f4d0efee938f10bc525
   original:
-    hackage: protolude-0.3.2@sha256:2a38b3dad40d238ab644e234b692c8911423f9d3ed0e36b62287c4a698d92cd1,2240
+    hackage: protolude-0.3.2
 - completed:
     hackage: ptr-0.16.8.2@sha256:708ebb95117f2872d2c5a554eb6804cf1126e86abe793b2673f913f14e5eb1ac,3959
     pantry-tree:
       size: 1303
       sha256: 557c438345de19f82bf01d676100da2a191ef06f624e7a4b90b09ac17cbb52a5
   original:
-    hackage: ptr-0.16.8.2@sha256:708ebb95117f2872d2c5a554eb6804cf1126e86abe793b2673f913f14e5eb1ac,3959
+    hackage: ptr-0.16.8.2
+- completed:
+    hackage: text-builder-0.6.7@sha256:efbb3e06107e9c8d1cfe85c963938ca9f375a74379af03da3173be4ef5c37bcf,2364
+    pantry-tree:
+      size: 425
+      sha256: cd0ae197e6f9f3860a8ab71f5b87c4a8452ed1fce2fdfd35e36d68ded6e6648e
+  original:
+    hackage: text-builder-0.6.7
+- completed:
+    hackage: text-builder-dev-0.3.3@sha256:79ec422defcc2e5b34f94129c72b98d34b2efc1ed8bbd945ccb8f4f535a892c3,2784
+    pantry-tree:
+      size: 724
+      sha256: 8883631a132438e7892fcb13e89d6bbcdc0ac76c56fbea8df8d7aa482ce81f73
+  original:
+    hackage: text-builder-dev-0.3.3
 - completed:
     name: postgresql-libpq
     version: 0.9.4.3


### PR DESCRIPTION
(Updated after the merge of #2467)

This update hasql and switches to the new lazy json byte encoder, saving one copy of the request body.
After the merge of the libpq change in #2467, this is now essentially what #2333 was.