### PR TITLE
fix: no empty transaction on bad URL/method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #1959, An accidental full table PATCH(without filters) is not possible anymore, it requires filters or a `limit` parameter - @steve-chavez, @laurenceisla
  - #2317, Increase the `db-pool-timeout` to 1 hour to prevent frequent high connection latency - @steve-chavez
  - #2341, The search path now correctly identifies schemas with uppercase and special characters in their names (regression) - @laurenceisla
- - #2364, "404 Not Found" on nested routes doesn't start an empty database transaction - @steve-chavez
+ - #2364, "404 Not Found" on nested routes and "405 Method Not Allowed" errors no longer start an empty database transaction - @steve-chavez
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #1959, An accidental full table PATCH(without filters) is not possible anymore, it requires filters or a `limit` parameter - @steve-chavez, @laurenceisla
  - #2317, Increase the `db-pool-timeout` to 1 hour to prevent frequent high connection latency - @steve-chavez
  - #2341, The search path now correctly identifies schemas with uppercase and special characters in their names (regression) - @laurenceisla
+ - #2364, "404 Not Found" on nested routes doesn't start an empty database transaction - @steve-chavez
 
 ### Changed
 

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -2,7 +2,7 @@ name:               postgrest
 version:            9.0.1.20220630
 synopsis:           REST API for any Postgres database
 description:        Reads the schema of a PostgreSQL database and creates RESTful routes
-                    for tables, views, and functions, supporting all HTTP verbs that security
+                    for tables, views, and functions, supporting all HTTP methods that security
                     permits.
 license:            MIT
 license-file:       LICENSE

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -610,9 +610,9 @@ contentTypeHeaders RequestContext{..} =
 -- than `*`
 binaryField :: Monad m => RequestContext -> ReadRequest -> Handler m (Maybe FieldName)
 binaryField RequestContext{..} readReq
-  | returnsScalar (iTarget ctxApiRequest) && iAcceptMediaType ctxApiRequest `elem` rawMediaTypes ctxConfig =
+  | returnsScalar (iTarget ctxApiRequest) && isRawMediaType =
       return $ Just "pgrst_scalar"
-  | iAcceptMediaType ctxApiRequest `elem` rawMediaTypes ctxConfig =
+  | isRawMediaType =
       let
         fldNames = fstFieldNames readReq
         fieldName = headMay fldNames
@@ -623,10 +623,8 @@ binaryField RequestContext{..} readReq
         throwError $ Error.BinaryFieldError (iAcceptMediaType ctxApiRequest)
   | otherwise =
       return Nothing
-
-rawMediaTypes :: AppConfig -> [MediaType]
-rawMediaTypes AppConfig{..} =
-  (MediaType.decodeMediaType <$> configRawMediaTypes) `union` [MTOctetStream, MTTextPlain, MTTextXML]
+  where
+    isRawMediaType = iAcceptMediaType ctxApiRequest `elem` configRawMediaTypes ctxConfig `union` [MTOctetStream, MTTextPlain, MTTextXML]
 
 profileHeader :: ApiRequest -> Maybe HTTP.Header
 profileHeader ApiRequest{..} =

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -61,6 +61,7 @@ instance PgrstError ApiRequestError where
   status InvalidBody{}           = HTTP.status400
   status InvalidFilters          = HTTP.status405
   status InvalidRange            = HTTP.status416
+  status NotFound                = HTTP.status404
   status NoRelBetween{}          = HTTP.status400
   status NoRpc{}                 = HTTP.status404
   status NotEmbedded{}           = HTTP.status400
@@ -113,6 +114,7 @@ instance JSON.ToJSON ApiRequestError where
     "message" .= ("None of these media types are available: " <> T.intercalate ", " (map T.decodeUtf8 cts)),
     "details" .= JSON.Null,
     "hint"    .= JSON.Null]
+  toJSON NotFound = JSON.object []
   toJSON (NotEmbedded resource) = JSON.object [
     "code"    .= ApiRequestErrorCode08,
     "message" .= ("Cannot apply filter because '" <> resource <> "' is not an embedded resource in this request" :: Text),
@@ -311,7 +313,6 @@ data Error
   | JwtTokenMissing
   | JwtTokenRequired
   | NoSchemaCacheError
-  | NotFound
   | OffLimitsChangesError Int64 Integer
   | PgErr PgError
   | PutMatchingPkError
@@ -327,7 +328,6 @@ instance PgrstError Error where
   status JwtTokenMissing         = HTTP.status500
   status JwtTokenRequired        = HTTP.unauthorized401
   status NoSchemaCacheError      = HTTP.status503
-  status NotFound                = HTTP.status404
   status OffLimitsChangesError{} = HTTP.status400
   status (PgErr err)             = status err
   status PutMatchingPkError      = HTTP.status400
@@ -404,7 +404,6 @@ instance JSON.ToJSON Error where
     "details" .= JSON.Null,
     "hint"    .= JSON.Null]
 
-  toJSON NotFound = JSON.object []
   toJSON (PgErr err) = JSON.toJSON err
   toJSON (ApiRequestError err) = JSON.toJSON err
 

--- a/src/PostgREST/Request/ApiRequest.hs
+++ b/src/PostgREST/Request/ApiRequest.hs
@@ -420,7 +420,7 @@ findAcceptMediaType conf action path accepts =
 requestMediaTypes :: AppConfig -> Action -> Path -> [MediaType]
 requestMediaTypes conf action path =
   case action of
-    ActionRead _    -> defaultMediaTypes ++ rawMediaTypes conf
+    ActionRead _    -> defaultMediaTypes ++ rawMediaTypes
     ActionInvoke _  -> invokeMediaTypes
     ActionInspect _ -> [MTOpenAPI, MTApplicationJSON]
     ActionInfo      -> [MTTextCSV]
@@ -428,14 +428,11 @@ requestMediaTypes conf action path =
   where
     invokeMediaTypes =
       defaultMediaTypes
-        ++ rawMediaTypes conf
+        ++ rawMediaTypes
         ++ [MTOpenAPI | pIsRootSpec path]
     defaultMediaTypes =
       [MTApplicationJSON, MTSingularJSON, MTGeoJSON, MTTextCSV]
-
-rawMediaTypes :: AppConfig -> [MediaType]
-rawMediaTypes AppConfig{..} =
-  (MediaType.decodeMediaType <$> configRawMediaTypes) `union` [MTOctetStream, MTTextPlain, MTTextXML]
+    rawMediaTypes = configRawMediaTypes conf `union` [MTOctetStream, MTTextPlain, MTTextXML]
 
 {-|
   Search a pg proc by matching name and arguments keys to parameters. Since a function can be overloaded,

--- a/src/PostgREST/Request/Types.hs
+++ b/src/PostgREST/Request/Types.hs
@@ -55,6 +55,7 @@ data ApiRequestError
   | InvalidFilters
   | InvalidRange
   | LimitNoOrderError
+  | NotFound
   | NoRelBetween Text Text Text
   | NoRpc Text Text [Text] Bool MediaType Bool
   | NotEmbedded Text

--- a/src/PostgREST/Request/Types.hs
+++ b/src/PostgREST/Request/Types.hs
@@ -47,13 +47,13 @@ import Protolude
 
 
 data ApiRequestError
-  = ActionInappropriate
-  | AmbiguousRelBetween Text Text [Relationship]
+  = AmbiguousRelBetween Text Text [Relationship]
   | AmbiguousRpc [ProcDescription]
   | MediaTypeError [ByteString]
   | InvalidBody ByteString
   | InvalidFilters
   | InvalidRange
+  | InvalidRpcMethod ByteString
   | LimitNoOrderError
   | NotFound
   | NoRelBetween Text Text Text
@@ -63,6 +63,7 @@ data ApiRequestError
   | PutRangeNotAllowedError
   | QueryParamError QPError
   | UnacceptableSchema [Text]
+  | UnsupportedMethod ByteString
 
 data QPError = QPError Text Text
 

--- a/test/spec/Feature/OpenApi/DisabledOpenApiSpec.hs
+++ b/test/spec/Feature/OpenApi/DisabledOpenApiSpec.hs
@@ -11,10 +11,6 @@ import Protolude
 spec :: SpecWith ((), Application)
 spec =
   describe "Disabled OpenApi" $ do
-    it "does not accept application/openapi+json and responds with 415" $
+    it "responds with 404" $
       request methodGet "/"
-        [("Accept","application/openapi+json")] "" `shouldRespondWith` 415
-
-    it "accepts application/json and responds with 404" $
-      request methodGet "/"
-        [("Accept","application/json")] "" `shouldRespondWith` 404
+        [("Accept","application/openapi+json")] "" `shouldRespondWith` 404

--- a/test/spec/Feature/OptionsSpec.hs
+++ b/test/spec/Feature/OptionsSpec.hs
@@ -16,7 +16,7 @@ import SpecHelper
 spec :: PgVersion -> SpecWith ((), Application)
 spec actualPgVersion = describe "Allow header" $ do
   context "a table" $ do
-    it "includes read/write verbs for writeable table" $ do
+    it "includes read/write methods for writeable table" $ do
       r <- request methodOptions "/items" [] ""
       liftIO $
         simpleHeaders r `shouldSatisfy`
@@ -24,7 +24,7 @@ spec actualPgVersion = describe "Allow header" $ do
 
   when (actualPgVersion >= pgVersion100) $
     context "a partitioned table" $ do
-      it "includes read/write verbs for writeable partitioned tables" $ do
+      it "includes read/write methods for writeable partitioned tables" $ do
         r <- request methodOptions "/car_models" [] ""
         liftIO $
           simpleHeaders r `shouldSatisfy`
@@ -37,50 +37,50 @@ spec actualPgVersion = describe "Allow header" $ do
 
   context "a view" $ do
     context "auto updatable" $ do
-      it "includes read/write verbs for auto updatable views with pk" $ do
+      it "includes read/write methods for auto updatable views with pk" $ do
         r <- request methodOptions "/projects_auto_updatable_view_with_pk" [] ""
         liftIO $
           simpleHeaders r `shouldSatisfy`
             matchHeader "Allow" "OPTIONS,GET,HEAD,POST,PUT,PATCH,DELETE"
 
-      it "includes read/write verbs for auto updatable views without pk" $ do
+      it "includes read/write methods for auto updatable views without pk" $ do
         r <- request methodOptions "/projects_auto_updatable_view_without_pk" [] ""
         liftIO $
           simpleHeaders r `shouldSatisfy`
             matchHeader "Allow" "OPTIONS,GET,HEAD,POST,PATCH,DELETE"
 
     context "non auto updatable" $ do
-      it "includes read verbs for non auto updatable views" $ do
+      it "includes read methods for non auto updatable views" $ do
         r <- request methodOptions "/projects_view_without_triggers" [] ""
         liftIO $
           simpleHeaders r `shouldSatisfy`
             matchHeader "Allow" "OPTIONS,GET,HEAD"
 
-      it "includes read/write verbs for insertable, updatable and deletable views with pk" $ do
+      it "includes read/write methods for insertable, updatable and deletable views with pk" $ do
         r <- request methodOptions "/projects_view_with_all_triggers_with_pk" [] ""
         liftIO $
           simpleHeaders r `shouldSatisfy`
             matchHeader "Allow" "OPTIONS,GET,HEAD,POST,PUT,PATCH,DELETE"
 
-      it "includes read/write verbs for insertable, updatable and deletable views without pk" $ do
+      it "includes read/write methods for insertable, updatable and deletable views without pk" $ do
         r <- request methodOptions "/projects_view_with_all_triggers_without_pk" [] ""
         liftIO $
           simpleHeaders r `shouldSatisfy`
             matchHeader "Allow" "OPTIONS,GET,HEAD,POST,PATCH,DELETE"
 
-      it "includes read and insert verbs for insertable views" $ do
+      it "includes read and insert methods for insertable views" $ do
         r <- request methodOptions "/projects_view_with_insert_trigger" [] ""
         liftIO $
           simpleHeaders r `shouldSatisfy`
             matchHeader "Allow" "OPTIONS,GET,HEAD,POST"
 
-      it "includes read and update verbs for updatable views" $ do
+      it "includes read and update methods for updatable views" $ do
         r <- request methodOptions "/projects_view_with_update_trigger" [] ""
         liftIO $
           simpleHeaders r `shouldSatisfy`
             matchHeader "Allow" "OPTIONS,GET,HEAD,PATCH"
 
-      it "includes read and delete verbs for deletable views" $ do
+      it "includes read and delete methods for deletable views" $ do
         r <- request methodOptions "/projects_view_with_delete_trigger" [] ""
         liftIO $
           simpleHeaders r `shouldSatisfy`

--- a/test/spec/Feature/Query/ErrorSpec.hs
+++ b/test/spec/Feature/Query/ErrorSpec.hs
@@ -35,7 +35,7 @@ spec = do
             {"hint": null,
              "details": null,
              "code": "PGRST117",
-             "message":"Unsupported HTTP verb: CONNECT"}|]
+             "message":"Unsupported HTTP method: CONNECT"}|]
           { matchStatus = 405 }
 
     it "should return 405 for TRACE method" $
@@ -47,7 +47,7 @@ spec = do
             {"hint": null,
              "details": null,
              "code": "PGRST117",
-             "message":"Unsupported HTTP verb: TRACE"}|]
+             "message":"Unsupported HTTP method: TRACE"}|]
           { matchStatus = 405 }
 
     it "should return 405 for OTHER method" $
@@ -59,5 +59,5 @@ spec = do
             {"hint": null,
              "details": null,
              "code": "PGRST117",
-             "message":"Unsupported HTTP verb: OTHER"}|]
+             "message":"Unsupported HTTP method: OTHER"}|]
           { matchStatus = 405 }

--- a/test/spec/Feature/Query/ErrorSpec.hs
+++ b/test/spec/Feature/Query/ErrorSpec.hs
@@ -18,6 +18,13 @@ spec = do
     it "gives 404 when requesting a nonexistent table in this nonexistent schema" $
       get "/nonexistent_table" `shouldRespondWith` 404
 
+  describe "Non existent URL" $ do
+    it "gives 404 on a single nested route" $
+      get "/projects/nested" `shouldRespondWith` 404
+
+    it "gives 404 on a double nested route" $
+      get "/projects/nested/double" `shouldRespondWith` 404
+
   describe "Unsupported HTTP methods" $ do
     it "should return 405 for CONNECT method" $
       request methodConnect "/"

--- a/test/spec/Feature/Query/RpcSpec.hs
+++ b/test/spec/Feature/Query/RpcSpec.hs
@@ -516,11 +516,11 @@ spec actualPgVersion =
           simpleStatus p `shouldBe` internalServerError500
           isErrorFormat (simpleBody p) `shouldBe` True
 
-    context "unsupported verbs" $ do
+    context "unsupported method" $ do
       it "DELETE fails" $
         request methodDelete "/rpc/sayhello" [] ""
           `shouldRespondWith`
-          [json|{"message":"Bad Request","code":"PGRST101","details":null,"hint":null}|]
+          [json|{"message":"Cannot use the DELETE method on RPC","code":"PGRST101","details":null,"hint":null}|]
           { matchStatus  = 405
           , matchHeaders = [matchContentTypeJson]
           }

--- a/test/spec/SpecHelper.hs
+++ b/test/spec/SpecHelper.hs
@@ -26,6 +26,7 @@ import PostgREST.Config                  (AppConfig (..),
                                           OpenAPIMode (..),
                                           parseSecret)
 import PostgREST.DbStructure.Identifiers (QualifiedIdentifier (..))
+import PostgREST.MediaType               (MediaType (..))
 import Protolude                         hiding (toS)
 import Protolude.Conv                    (toS)
 
@@ -176,7 +177,7 @@ testCfgRootSpec :: AppConfig
 testCfgRootSpec = baseCfg { configDbRootSpec = Just $ QualifiedIdentifier mempty "root"}
 
 testCfgHtmlRawOutput :: AppConfig
-testCfgHtmlRawOutput = baseCfg { configRawMediaTypes = ["text/html"] }
+testCfgHtmlRawOutput = baseCfg { configRawMediaTypes = [MTOther "text/html"] }
 
 testCfgResponseHeaders :: AppConfig
 testCfgResponseHeaders = baseCfg { configDbPreRequest = Just $ QualifiedIdentifier mempty "custom_headers" }


### PR DESCRIPTION
Closes https://github.com/PostgREST/postgrest/issues/2364.

Removes the `ActionUnknown` and `TargetUnknown` types and ensures an error is raised at the ApiRequest level(no db connection from the pool here).

Also untangles the `ApiRequest` code a bit, making it more linear.

Not using connections cannot be tested for now but once metrics(https://github.com/PostgREST/postgrest/pull/2129) is merged it could be done by checking the pool `takes`.