### PR TITLE
nix: bump nixpkgs version

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@ let
     "postgrest";
 
   compiler =
-    "ghc922";
+    "ghc923";
 
   # PostgREST source files, filtered based on the rules in the .gitignore files
   # and file extensions. We want to include as litte as possible, as the files

--- a/nix/nixpkgs-version.nix
+++ b/nix/nixpkgs-version.nix
@@ -1,6 +1,6 @@
 # Pinned version of Nixpkgs, generated with postgrest-nixpkgs-upgrade.
 {
-  date = "2022-03-30";
-  rev = "9a5aa75d56ad4163521f1692469e6dc54b90068c";
-  tarballHash = "1f3wyldcx1zpyk2q6122mkg16chf9j7swwx1v6f1dg126xz1238f";
+  date = "2022-07-14";
+  rev = "8eb14e7e79d6c34a9cce146182bfc8c820d527c2";
+  tarballHash = "063g7vyyyfhacsi3272k76cq5b03xgl6dza9xzx5g62x6qyzn2i5";
 }

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -31,64 +31,6 @@ let
       #
       # To get the sha256:
       #   nix-prefetch-url --unpack https://github.com/<owner>/<repo>/archive/<commit>.tar.gz
-
-      protolude =
-        prev.callHackageDirect
-          {
-            pkg = "protolude";
-            ver = "0.3.1";
-            sha256 = "0gf0mn1ycllr69kdq1p07qf7935s10jz0nnhynwqy3d6nmycxr5j";
-          }
-          { };
-
-      configurator-pg =
-        prev.callHackageDirect
-          {
-            pkg = "configurator-pg";
-            ver = "0.2.6";
-            sha256 = "sha256-nkamTOpP/w0vQfOXsoQKEstW3n9qyRsv0TocrEerKlU=";
-          }
-          { };
-
-      hasql-dynamic-statements =
-        lib.dontCheck (prev.callHackageDirect
-          {
-            pkg = "hasql-dynamic-statements";
-            ver = "0.3.1.1";
-            sha256 = "sha256-jF50GcCtEUV3TN1UsD4LaSBH6arcqfKhxOk+b+c8Bl8=";
-          }
-          { });
-
-      hasql-implicits =
-        lib.dontCheck (prev.callHackageDirect
-          {
-            pkg = "hasql-implicits";
-            ver = "0.1.0.3";
-            sha256 = "sha256-IpAOVHNdXJ53B/fmo+DeNUKiBSS6Bo7Uha/krpMt64g=";
-          }
-          { });
-
-      hspec-wai-json =
-        lib.dontCheck (lib.unmarkBroken prev.hspec-wai-json);
-
-      ptr =
-        prev.callHackageDirect
-          {
-            pkg = "ptr";
-            ver = "0.16.8.2";
-            sha256 = "sha256-Ei2GeQ0AjoxvsvmWbdPELPLtSaowoaj9IzsIiySgkAQ=";
-          }
-          { };
-
-      weeder =
-        lib.dontCheck (prev.callHackageDirect
-          {
-            pkg = "weeder";
-            ver = "2.4.0";
-            sha256 = "sha256-Nhp8EogHJ5SIr67060TPEvQbN/ECg3cRJFQnUtJUyC0=";
-          }
-          { });
-
     } // extraOverrides final prev;
 in
 {

--- a/nix/patches/nixpkgs-openssl-split-runtime-dependencies-of-static-builds.patch
+++ b/nix/patches/nixpkgs-openssl-split-runtime-dependencies-of-static-builds.patch
@@ -1,8 +1,8 @@
 diff --git a/pkgs/development/libraries/openssl/default.nix b/pkgs/development/libraries/openssl/default.nix
-index d4be8cc2428..3979698711f 100644
+index db6e0101fec..108527df50c 100644
 --- a/pkgs/development/libraries/openssl/default.nix
 +++ b/pkgs/development/libraries/openssl/default.nix
-@@ -43,9 +43,21 @@ let
+@@ -44,9 +44,21 @@ let
        substituteInPlace crypto/async/arch/async_posix.h \
          --replace '!defined(__ANDROID__) && !defined(__OpenBSD__)' \
                    '!defined(__ANDROID__) && !defined(__OpenBSD__) && 0'
@@ -25,7 +25,7 @@ index d4be8cc2428..3979698711f 100644
      setOutputFlags = false;
      separateDebugInfo =
        !stdenv.hostPlatform.isDarwin &&
-@@ -95,7 +107,17 @@ let
+@@ -102,7 +114,17 @@ let
      configureFlags = [
        "shared" # "shared" builds both shared and static libraries
        "--libdir=lib"
@@ -44,17 +44,17 @@ index d4be8cc2428..3979698711f 100644
      ] ++ lib.optionals withCryptodev [
        "-DHAVE_CRYPTODEV"
        "-DUSE_CRYPTODEV_DIGESTS"
-@@ -126,6 +148,9 @@ let
+@@ -140,6 +162,9 @@ let
        if [ -n "$(echo $out/lib/*.so $out/lib/*.dylib $out/lib/*.dll)" ]; then
            rm "$out/lib/"*.a
        fi
 +
 +      # 'etc' is a separate output on static builds only.
 +      etc=$out
-     '' + lib.optionalString (!stdenv.hostPlatform.isWindows)
+     '') + lib.optionalString (!stdenv.hostPlatform.isWindows)
        # Fix bin/c_rehash's perl interpreter line
        #
-@@ -147,14 +172,15 @@ let
+@@ -161,14 +186,15 @@ let
        mv $out/include $dev/
  
        # remove dependency on Perl at runtime

--- a/nix/static-haskell-package.nix
+++ b/nix/static-haskell-package.nix
@@ -58,7 +58,7 @@ let
   defaultCabalPackageVersionComingWithGhc =
     {
       ghc8107 = "Cabal_3_2_1_0";
-      ghc922 = "Cabal_3_6_3_0";
+      ghc923 = "Cabal_3_6_3_0";
     }."${compiler}";
 
   # The static-haskell-nix 'survey' derives a full static set of Haskell


### PR DESCRIPTION
This updates nixpkgs to a current version, where we no longer need to override Haskell dependencies.