### PR TITLE
correct query on rpc count=exact

### DIFF
--- a/src/PostgREST/Query/QueryBuilder.hs
+++ b/src/PostgREST/Query/QueryBuilder.hs
@@ -236,11 +236,12 @@ readRequestToCountQuery (Node (Select{from=mainQi, fromAlias=tblAlias, implicitJ
     then mempty
     else " WHERE " ) <>
   intercalateSnippet " AND " (
-    map (pgFmtLogicTree mainQi) logicForest ++
+    map (pgFmtLogicTree treeQi) logicForest ++
     map pgFmtJoinCondition joinConditions_ ++
     subQueries
   )
   where
+    treeQi = maybe mainQi (QualifiedIdentifier (qiSchema mainQi)) tblAlias
     tabl = fromQi mainQi <> maybe mempty (\a -> " AS " <> pgFmtIdent a) tblAlias
     implJs = fromQi <$> implJoins
     subQueries = foldr existsSubquery [] forest

--- a/test/spec/Feature/Query/RpcSpec.hs
+++ b/test/spec/Feature/Query/RpcSpec.hs
@@ -69,6 +69,20 @@ spec actualPgVersion =
                              , "Content-Range" <:> "0-0/2" ]
             }
 
+      it "includes exact count if requested" $ do
+        request methodHead "/rpc/getallprojects"
+                [("Prefer", "count=exact")] ""
+           `shouldRespondWith` ""
+            { matchStatus = 200
+            , matchHeaders = ["Content-Range" <:> "0-4/5"]
+            }
+        request methodHead "/rpc/getallprojects?select=*,clients!inner(*)&clients.id=eq.1"
+                [("Prefer", "count=exact")] ""
+           `shouldRespondWith` ""
+            { matchStatus = 200
+            , matchHeaders = ["Content-Range" <:> "0-1/2"]
+            }
+
       it "returns proper json" $ do
         post "/rpc/getitemrange" [json| { "min": 2, "max": 4 } |] `shouldRespondWith`
           [json| [ {"id": 3}, {"id":4} ] |]


### PR DESCRIPTION
Closes https://github.com/PostgREST/postgrest/issues/2369, correct https://github.com/PostgREST/postgrest/commit/e4006da9bccaba85dc141779f48692448eb16fca.

Adds missing tests for `count=exact` on rpc.