### PR TITLE
raise timeout in failing schema cache reload test

### DIFF
--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -863,7 +863,7 @@ def test_admin_ready_includes_schema_cache_state(defaultenv):
 
         # force a reconnection so the new role setting is picked up
         postgrest.process.send_signal(signal.SIGUSR1)
-        time.sleep(0.1)
+        time.sleep(2)
 
         response = postgrest.admin.get("/ready")
         assert response.status_code == 503


### PR DESCRIPTION
Locally, this make the test hang. Filing this PR to see if the same happens in CI, and to ask for help.

This is a test that's causing me trouble while upgrading hasql-pool.