### PR TITLE
fix: columns w/ dollar sign($) don't need quoting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2364, "404 Not Found" on nested routes and "405 Method Not Allowed" errors no longer start an empty database transaction - @steve-chavez
  - #2342, Fix inaccurate result count when an inner embed was selected after a normal embed in the query string - @laurenceisla
  - #2376, OPTIONS requests no longer start an empty database transaction - @steve-chavez
+ - #2395, Allow using columns with dollar sign($) without double quoting in filters and `select` - @steve-chavez
 
 ### Changed
 
@@ -70,7 +71,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + Previously, those RPCs would return "null" as a body with Content-Type: application/json.
  - #2156, `limit/offset` now limits the affected rows on UPDATE/DELETE  - @steve-chavez
    + Previously, `limit/offset` only limited the returned rows but not the actual updated rows
- - #2156, using PATCH/DELETE with `limit/offset` throws an error on views - @steve-chavez
  - #2155, `max-rows` is no longer applied on POST/PATCH/PUT/DELETE returned rows - @steve-chavez
    + This was misleading because the affected rows were not really affected by `max-rows`, only the returned rows were limited
  - #2070, Restrict generated many-to-many relationships - @steve-chavez

--- a/test/spec/Feature/Query/QuerySpec.hs
+++ b/test/spec/Feature/Query/QuerySpec.hs
@@ -1002,6 +1002,11 @@ spec actualPgVersion = do
         [json|[{":arr->ow::cast":" arrow-1 ","(inside,parens)":" parens-1 ","a.dotted.column":" dotted-1 ","  col  w  space  ":" space-1"}]|]
         { matchHeaders = [matchContentTypeJson] }
 
+    it "will select and filter a column that has dollars in(without double quoting)" $
+      get "/do$llar$s?select=a$num$&a$num$=eq.100" `shouldRespondWith`
+        [json|[{"a$num$":100}]|]
+        { matchHeaders = [matchContentTypeJson] }
+
   context "binary output" $ do
     it "can query if a single column is selected" $
       request methodGet "/images_base64?select=img&name=eq.A.png" (acceptHdrs "application/octet-stream") ""

--- a/test/spec/fixtures/data.sql
+++ b/test/spec/fixtures/data.sql
@@ -800,3 +800,6 @@ INSERT INTO shop_bles(id, name, coords, shop_id, range_area) VALUES(2, 'Beacon-2
 
 TRUNCATE TABLE "SPECIAL ""@/\#~_-".names CASCADE;
 INSERT INTO "SPECIAL ""@/\#~_-".names (id, name) VALUES (1, 'John'), (2, 'Mary');
+
+TRUNCATE TABLE do$llar$s CASCADE;
+INSERT INTO do$llar$s (a$num$) VALUES (100), (200), (300);

--- a/test/spec/fixtures/privileges.sql
+++ b/test/spec/fixtures/privileges.sql
@@ -194,6 +194,7 @@ GRANT ALL ON TABLE
     , shops
     , shop_bles
     , "SPECIAL ""@/\#~_-".names
+    , do$llar$s
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -2685,3 +2685,7 @@ $$ LANGUAGE sql;
 CREATE FUNCTION test.special_extended_schema(val text) RETURNS text AS $$
   SELECT get_val_special(val);
 $$ LANGUAGE sql;
+
+CREATE TABLE do$llar$s (
+  a$num$ numeric
+);


### PR DESCRIPTION
PostgreSQL identifiers can have the dollar sign($) inside them without the need for double quoting.

>SQL identifiers and key words must begin with a letter (a-z, but also letters with diacritical marks and non-Latin letters) or an underscore (_). Subsequent characters in an identifier or key word can be letters, underscores, digits (0-9), or dollar signs ($).

https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS