### PR TITLE
refactor code interacting with pool for consistency, and misc fixes

### DIFF
--- a/nix/tools/style.nix
+++ b/nix/tools/style.nix
@@ -46,7 +46,7 @@ let
 
         trap "echo postgrest-style-check failed. Run postgrest-style to fix issues automatically." ERR
 
-        ${git}/bin/git diff-index --exit-code HEAD -- '*.hs' '*.lhs' '*.nix'
+        ${git}/bin/git diff-index --exit-code HEAD -- '*.hs' '*.lhs' '*.nix' '*.py'
       '';
 
   lint =

--- a/src/PostgREST/Admin.hs
+++ b/src/PostgREST/Admin.hs
@@ -11,7 +11,6 @@ import Network.Socket.ByteString
 import qualified Network.HTTP.Types.Status as HTTP
 import qualified Network.Wai               as Wai
 
-import qualified Hasql.Pool    as SQL
 import qualified Hasql.Session as SQL
 
 import qualified PostgREST.AppState as AppState
@@ -27,7 +26,7 @@ postgrestAdmin appState appConfig req respond  = do
   isConnectionUp      <-
     if configDbChannelEnabled appConfig
       then AppState.getIsListenerOn appState
-      else isRight <$> SQL.use (AppState.getPool appState) (SQL.sql "SELECT 1")
+      else isRight <$> AppState.usePool appState (SQL.sql "SELECT 1")
 
   case Wai.pathInfo req of
     ["ready"] ->

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -24,10 +24,12 @@ module PostgREST.AppState
   , putRetryNextIn
   , releasePool
   , signalListener
+  , usePool
   , waitListener
   ) where
 
-import qualified Hasql.Pool as SQL
+import qualified Hasql.Pool    as SQL
+import qualified Hasql.Session as SQL
 
 import Control.AutoUpdate (defaultUpdateSettings, mkAutoUpdate,
                            updateAction)
@@ -95,6 +97,9 @@ initPool AppConfig{..} =
 
 getPool :: AppState -> SQL.Pool
 getPool = statePool
+
+usePool :: AppState -> SQL.Session a -> IO (Either SQL.UsageError a)
+usePool AppState{..} = SQL.use statePool
 
 releasePool :: AppState -> IO ()
 releasePool AppState{..} = SQL.release statePool

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -97,7 +97,7 @@ getPool :: AppState -> SQL.Pool
 getPool = statePool
 
 releasePool :: AppState -> IO ()
-releasePool AppState{..} = SQL.release statePool >> throwTo stateMainThreadId UserInterrupt
+releasePool AppState{..} = SQL.release statePool
 
 getPgVersion :: AppState -> IO PgVersion
 getPgVersion = readIORef . statePgVersion

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -9,7 +9,6 @@ module PostgREST.AppState
   , getJsonDbS
   , getMainThreadId
   , getPgVersion
-  , getPool
   , getTime
   , getRetryNextIn
   , init
@@ -94,9 +93,6 @@ initWithPool newPool conf =
 initPool :: AppConfig -> IO SQL.Pool
 initPool AppConfig{..} =
   SQL.acquire (configDbPoolSize, configDbPoolTimeout, toUtf8 configDbUri)
-
-getPool :: AppState -> SQL.Pool
-getPool = statePool
 
 usePool :: AppState -> SQL.Session a -> IO (Either SQL.UsageError a)
 usePool AppState{..} = SQL.use statePool

--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -11,7 +11,6 @@ module PostgREST.CLI
 import qualified Data.Aeson                 as JSON
 import qualified Data.ByteString.Char8      as BS
 import qualified Data.ByteString.Lazy       as LBS
-import qualified Hasql.Pool                 as SQL
 import qualified Hasql.Transaction.Sessions as SQL
 import qualified Options.Applicative        as O
 
@@ -49,7 +48,7 @@ dumpSchema appState = do
   AppConfig{..} <- AppState.getConfig appState
   result <-
     let transaction = if configDbPreparedStatements then SQL.transaction else SQL.unpreparedTransaction in
-    SQL.use (AppState.getPool appState) $
+    AppState.usePool appState $
       transaction SQL.ReadCommitted SQL.Read $
         queryDbStructure
           (toList configDbSchemas)

--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -55,7 +55,7 @@ dumpSchema appState = do
           (toList configDbSchemas)
           configDbExtraSearchPath
           configDbPreparedStatements
-  SQL.release $ AppState.getPool appState
+  AppState.releasePool appState
   case result of
     Left e -> do
       hPutStrLn stderr $ "An error ocurred when loading the schema cache:\n" <> show e

--- a/src/PostgREST/Config/Database.hs
+++ b/src/PostgREST/Config/Database.hs
@@ -10,7 +10,6 @@ import PostgREST.Config.PgVersion (PgVersion (..))
 
 import qualified Hasql.Decoders             as HD
 import qualified Hasql.Encoders             as HE
-import qualified Hasql.Pool                 as SQL
 import           Hasql.Session              (Session, statement)
 import qualified Hasql.Statement            as SQL
 import qualified Hasql.Transaction          as SQL
@@ -29,11 +28,10 @@ pgVersionStatement = SQL.Statement sql HE.noParams versionRow False
     sql = "SELECT current_setting('server_version_num')::integer, current_setting('server_version')"
     versionRow = HD.singleRow $ PgVersion <$> column HD.int4 <*> column HD.text
 
-queryDbSettings :: SQL.Pool -> Bool -> IO (Either SQL.UsageError [(Text, Text)])
-queryDbSettings pool prepared =
+queryDbSettings :: Bool -> Session [(Text, Text)]
+queryDbSettings prepared =
   let transaction = if prepared then SQL.transaction else SQL.unpreparedTransaction in
-  SQL.use pool . transaction SQL.ReadCommitted SQL.Read $
-    SQL.statement mempty dbSettingsStatement
+  transaction SQL.ReadCommitted SQL.Read $ SQL.statement mempty dbSettingsStatement
 
 -- | Get db settings from the connection role. Global settings will be overridden by database specific settings.
 dbSettingsStatement :: SQL.Statement () [(Text, Text)]

--- a/src/PostgREST/Workers.hs
+++ b/src/PostgREST/Workers.hs
@@ -110,7 +110,7 @@ connectionWorker appState = do
 connectionStatus :: AppState -> IO ConnectionStatus
 connectionStatus appState =
   retrying retrySettings shouldRetry $
-    const $ SQL.release pool >> getConnectionStatus
+    const $ AppState.releasePool appState >> getConnectionStatus
   where
     pool = AppState.getPool appState
     retrySettings = capDelay delayMicroseconds $ exponentialBackoff backoffMicroseconds

--- a/src/PostgREST/Workers.hs
+++ b/src/PostgREST/Workers.hs
@@ -234,7 +234,7 @@ reReadConfig startingUp appState = do
   AppConfig{..} <- AppState.getConfig appState
   dbSettings <-
     if configDbConfig then do
-      qDbSettings <- queryDbSettings (AppState.getPool appState) configDbPreparedStatements
+      qDbSettings <- SQL.use (AppState.getPool appState) $ queryDbSettings configDbPreparedStatements
       case qDbSettings of
         Left e -> do
           let

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -840,8 +840,7 @@ def set_statement_timeout(postgrest, role, milliseconds):
     use a postgrest instance that doesn't use the affected role."""
 
     response = postgrest.session.post(
-        "/rpc/set_statement_timeout",
-        data={"role": role, "milliseconds": milliseconds}
+        "/rpc/set_statement_timeout", data={"role": role, "milliseconds": milliseconds}
     )
     assert response.status_code == 204
 
@@ -855,7 +854,7 @@ def test_statement_timeout(defaultenv, metapostgrest):
     "Statement timeout times out slow statements"
 
     role = "timeout_authenticator"
-    set_statement_timeout(metapostgrest, role, 1000) # 1 second
+    set_statement_timeout(metapostgrest, role, 1000)  # 1 second
 
     env = {
         **defaultenv,
@@ -890,7 +889,7 @@ def test_change_statement_timeout(defaultenv, metapostgrest):
         response = postgrest.session.get("/rpc/sleep?seconds=1")
         assert response.status_code == 204
 
-        set_statement_timeout(metapostgrest, role, 500) # 0.5s
+        set_statement_timeout(metapostgrest, role, 500)  # 0.5s
 
         # trigger schema refresh
         postgrest.process.send_signal(signal.SIGUSR1)
@@ -901,7 +900,7 @@ def test_change_statement_timeout(defaultenv, metapostgrest):
         data = response.json()
         assert data["message"] == "canceling statement due to statement timeout"
 
-        set_statement_timeout(metapostgrest, role, 2000) # 2s
+        set_statement_timeout(metapostgrest, role, 2000)  # 2s
 
         # trigger role setting refresh
         postgrest.process.send_signal(signal.SIGUSR1)


### PR DESCRIPTION
Largely, this collects all interaction with the connection pool in AppState helpers `usePool` and `releasePool`. (It's not obviously better to use `AppState.usePool` in place of `SQL.use . AppState.getPool`, but for now this approach is more consistent than what we had before, and will allow easily doing things like putting the pool in an IORef in the context of #2391.)