### PR TITLE
refactor: move pool release on shutdown out of signal handler

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -132,7 +132,7 @@ run installHandlers maybeRunWithSocket appState = do
           AppState.logWithZTime appState $ "Listening on unix socket " <> show socket
           runWithSocket (serverSettings conf) app configServerUnixSocketMode socket
         Nothing ->
-          panic "Cannot run with unix socket on non-unix plattforms."
+          panic "Cannot run with unix socket on non-unix platforms."
     Nothing ->
       do
         AppState.logWithZTime appState $ "Listening on port " <> show configServerPort

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -2,6 +2,7 @@
 
 module PostgREST.AppState
   ( AppState
+  , destroy
   , getConfig
   , getDbStructure
   , getIsListenerOn
@@ -88,6 +89,9 @@ initWithPool newPool conf =
     <*> mkAutoUpdate defaultUpdateSettings { updateAction = getZonedTime }
     <*> myThreadId
     <*> newIORef 0
+
+destroy :: AppState -> IO ()
+destroy = releasePool
 
 initPool :: AppConfig -> IO SQL.Pool
 initPool AppConfig{..} =

--- a/src/PostgREST/Unix.hs
+++ b/src/PostgREST/Unix.hs
@@ -43,11 +43,7 @@ runAppWithSocket settings app socketFileMode socketFilePath =
 -- | Set signal handlers, only for systems with signals
 installSignalHandlers :: AppState.AppState -> IO ()
 installSignalHandlers appState = do
-  -- Releases the connection pool whenever the program is terminated,
-  -- see https://github.com/PostgREST/postgrest/issues/268
-  let interrupt = do
-        AppState.releasePool appState
-        throwTo (AppState.getMainThreadId appState) UserInterrupt
+  let interrupt = throwTo (AppState.getMainThreadId appState) UserInterrupt
   install Signals.sigINT interrupt
   install Signals.sigTERM interrupt
 

--- a/test/spec/Main.hs
+++ b/test/spec/Main.hs
@@ -64,7 +64,7 @@ main :: IO ()
 main = do
   pool <- P.acquire (3, 10, toUtf8 $ configDbUri testCfg)
 
-  actualPgVersion <- either (panic.show) id <$> P.use pool queryPgVersion
+  actualPgVersion <- either (panic . show) id <$> P.use pool queryPgVersion
 
   baseDbStructure <-
     loadDbStructure pool


### PR DESCRIPTION
This changes behaviour somewhat in that:
- We now consistently release the pool on shutdown, even on non-Unix
  platforms, and including for CmdDumpConfig.
- We release the pool *after* interrupting `App.run`, which will
  rather cause more than fewer connection to be closed properly.
  (Previously any in-use connections would not have been caught by
  `releasePool`, though *maybe* the `UserInterrupt` handling in
  the web handler ends up closing the connections properly already
  anyway).
    
(The main aim of the change is to make it clearer when and why the
pool is released.)
