### PR TITLE
Add underscore equality operator to filter using keys in the request body

### DIFF
--- a/src/PostgREST/Request/Types.hs
+++ b/src/PostgREST/Request/Types.hs
@@ -31,6 +31,7 @@ module PostgREST.Request.Types
   , TrileanVal(..)
   , SimpleOperator(..)
   , FtsOperator(..)
+  , BodyOperator(..)
   ) where
 
 import qualified Data.ByteString.Lazy as LBS
@@ -179,6 +180,7 @@ data Operation
   | In ListVal
   | Is TrileanVal
   | Fts FtsOperator (Maybe Language) SingleVal
+  | BodOp BodyOperator SingleVal
   deriving (Eq)
 
 type Language = Text
@@ -224,4 +226,9 @@ data FtsOperator
   | FilterFtsPlain
   | FilterFtsPhrase
   | FilterFtsWebsearch
+  deriving Eq
+
+-- | Operators for filtering using the request body
+data BodyOperator
+  = BodyOpEqual
   deriving Eq

--- a/test/spec/Feature/Query/QueryLimitedSpec.hs
+++ b/test/spec/Feature/Query/QueryLimitedSpec.hs
@@ -98,8 +98,11 @@ spec =
             [("Prefer", "return=representation")]
             [json| [{"occupation": "Barista"}] |]
           `shouldRespondWith`
-            [json|[]|]
-            { matchStatus  = 404 }
+            [json|[
+                { "first_name": "Frances M.", "last_name": "Roe", "occupation": "Barista" },
+                { "first_name": "Daniel B.", "last_name": "Lyon", "occupation": "Barista" },
+                { "first_name": "Edwin S.", "last_name": "Smith", "occupation": "Barista" } ]|]
+            { matchStatus  = 200 }
 
       it "doesn't affect deletions" $
         request methodDelete "/employees?select=first_name,last_name"


### PR DESCRIPTION
Using this idea https://github.com/PostgREST/postgrest/issues/2125#issuecomment-1200054135, the underscore operators will filter using the keys in the body. This PR implements the following:

- The `_eq` operator to verify for equality with items in the body
- Support to select any identifier in the body (not only PKs). This  gives more freedom in the case of bulk updates, e.g.:
  ```http
  PATCH /user?id=_eq.id HTTP/1.1
  
  [
    { "username": "userA", "is_active": true },
    { "username": "userB", "is_active": false }
  ]
  ```
- Full table updates are allowed once again, addressing this issue: https://github.com/PostgREST/postgrest/pull/2195#discussion_r932946412