### PR TITLE
refactor: correlated subquery for o2m query

### DIFF
--- a/test/spec/Feature/Query/PlanSpec.hs
+++ b/test/spec/Feature/Query/PlanSpec.hs
@@ -14,8 +14,8 @@ import           Test.Hspec           hiding (pendingWith)
 import           Test.Hspec.Wai
 import           Test.Hspec.Wai.JSON
 
-import PostgREST.Config.PgVersion (PgVersion, pgVersion120,
-                                   pgVersion130, pgVersion100)
+import PostgREST.Config.PgVersion (PgVersion, pgVersion100,
+                                   pgVersion120, pgVersion130)
 import Protolude                  hiding (get)
 import SpecHelper
 
@@ -274,8 +274,8 @@ spec actualPgVersion = do
       let totalCost  = simpleBody r ^? nth 0 . key "Plan" . key "Total Cost"
       liftIO $ totalCost `shouldBe`
           if actualPgVersion > pgVersion120
-            then Just [aesonQQ|58.26|]
-            else Just [aesonQQ|33.25|]
+            then Just [aesonQQ|33.25|]
+            else Just [aesonQQ|33.27|]
 
     it "a many to one doesn't surpass a threshold" $ do
       r <- request methodGet "/projects?select=*,clients(*)&id=eq.1"
@@ -293,9 +293,9 @@ spec actualPgVersion = do
 
       let totalCost  = simpleBody r ^? nth 0 . key "Plan" . key "Total Cost"
       liftIO $ totalCost `shouldBe`
-          if | actualPgVersion > pgVersion120 -> Just [aesonQQ|130.44|]
-             | actualPgVersion > pgVersion100 -> Just [aesonQQ|69.34|]
-             | otherwise                      -> Just [aesonQQ|70.79|]
+          if | actualPgVersion > pgVersion120 -> Just [aesonQQ|69.34|]
+             | actualPgVersion > pgVersion100 -> Just [aesonQQ|69.36|]
+             | otherwise                      -> Just [aesonQQ|70.81|]
 
 disabledSpec :: SpecWith ((), Application)
 disabledSpec =


### PR DESCRIPTION
Improves the query plan costs(compare tests on 48003e7235219ac843c95554cfe8afbeab523447 to 23b9b74155056f337cd493f5162248f61a1e453d) by changing the query from using a subquery:

```sql
SELECT
  "test"."clients".*,
  COALESCE (
    (SELECT json_agg("clients".*)
      FROM (
        SELECT "test"."projects".*
        FROM "test"."projects"
        WHERE "test"."clients"."id" = "test"."projects"."client_id"  ) "clients" )
    , '[]') AS "projects"
FROM "test"."clients"
```

To a correlated subquery using LATERAL:

```sql
SELECT
  "test"."clients".*,
  COALESCE( "clients_projects"."_clients_projects", '[]') AS "projects"
FROM "test"."clients"
LEFT JOIN LATERAL (
  SELECT json_agg("_clients_projects") AS "_clients_projects"
  FROM (
    SELECT "test"."projects".*
    FROM "test"."projects"
    WHERE "test"."clients"."id" = "test"."projects"."client_id"   ) AS "_clients_projects"
) AS "clients_projects" ON TRUE
```

We already used LATERAL for INNER JOINs but not for LEFT JOINs. This also reduces/clarifies the code a bit.

Previous discussion https://github.com/PostgREST/postgrest/pull/1949#issuecomment-924191966