### PR TITLE
Fix bug "UNION types \"char\" and text cannot be matched" with v9.0.1.+++ versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2342, Fix inaccurate result count when an inner embed was selected after a normal embed in the query string - @laurenceisla
  - #2376, OPTIONS requests no longer start an empty database transaction - @steve-chavez
  - #2395, Allow using columns with dollar sign($) without double quoting in filters and `select` - @steve-chavez
+ - #2410, Fix loop crash error on startup in Postgres 15 beta 2. Log: "UNION types \"char\" and text cannot be matched". - @yevon
 
 ### Changed
 

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -656,7 +656,7 @@ allViewsKeyDependencies =
       pks_fks as (
         -- pk + fk referencing col
         select
-          cast(contype as text) contype,
+          contype::text as contype,
           conname,
           conrelid as resorigtbl,
           unnest(conkey) as resorigcol

--- a/src/PostgREST/DbStructure.hs
+++ b/src/PostgREST/DbStructure.hs
@@ -656,7 +656,7 @@ allViewsKeyDependencies =
       pks_fks as (
         -- pk + fk referencing col
         select
-          contype,
+          cast(contype as text) contype,
           conname,
           conrelid as resorigtbl,
           unnest(conkey) as resorigcol


### PR DESCRIPTION
The query in:

https://github.com/PostgREST/postgrest/blob/bac63f339daa4a9292870b0674b41cde2bcfee74/src/PostgREST/DbStructure.hs#L655-L809

Doesn't properly consider the type of the column contype (char) of the table pg_constraint. So when it tries to make a union with the concat function (text), fails with a missmatch type error. This fixes the issue. 

Related issue here:

[Reported issue](https://github.com/PostgREST/postgrest/issues/2410)

#2410 