### PR TITLE
Simplified tests where mutations need to be verified in the db

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -273,6 +273,7 @@ test-suite querycost
                     , heredoc           >= 0.2 && < 0.3
                     , hspec             >= 2.3 && < 2.9
                     , hspec-wai         >= 0.10 && < 0.12
+                    , hspec-wai-json    >= 0.10 && < 0.12
                     , http-types        >= 0.12.3 && < 0.13
                     , lens              >= 4.14 && < 5.2
                     , lens-aeson        >= 1.0.1 && < 1.2

--- a/test/spec/Feature/OptionsSpec.hs
+++ b/test/spec/Feature/OptionsSpec.hs
@@ -91,7 +91,7 @@ spec actualPgVersion = describe "Allow header" $ do
 
   context "a function" $ do
     it "includes the POST method for a volatile function" $ do
-      r <- request methodOptions "/rpc/reset_items_tables" [] ""
+      r <- request methodOptions "/rpc/reset_table" [] ""
       liftIO $
         simpleHeaders r `shouldSatisfy`
           matchHeader "Allow" "OPTIONS,POST"

--- a/test/spec/Feature/Query/DeleteSpec.hs
+++ b/test/spec/Feature/Query/DeleteSpec.hs
@@ -1,5 +1,7 @@
 module Feature.Query.DeleteSpec where
 
+import Data.Aeson.QQ
+
 import Network.Wai (Application)
 
 import Network.HTTP.Types
@@ -9,6 +11,12 @@ import Test.Hspec.Wai.JSON
 
 import Protolude  hiding (get)
 import SpecHelper
+
+tblDataBefore = [aesonQQ|[
+                  { "id": 1, "name": "item-1" }
+                , { "id": 2, "name": "item-2" }
+                , { "id": 3, "name": "item-3" }
+                ]|]
 
 spec :: SpecWith ((), Application)
 spec =
@@ -117,69 +125,39 @@ spec =
             }
 
     context "limited delete" $ do
-      it "works with the limit and offset query params" $ do
-        get "/limited_delete_items"
-          `shouldRespondWith`
-            [json|[
-              { "id": 1, "name": "item-1" }
-            , { "id": 2, "name": "item-2" }
-            , { "id": 3, "name": "item-3" }
-            ]|]
+      it "works with the limit and offset query params" $
+        verifyMutation "limited_delete_items" tblDataBefore
+          [json|[
+            { "id": 1, "name": "item-1" }
+          , { "id": 3, "name": "item-3" }
+          ]|]
+          $
+          request methodDelete "/limited_delete_items?order=id&limit=1&offset=1"
+              [("Prefer", "tx=commit")]
+              mempty
+            `shouldRespondWith`
+              ""
+              { matchStatus  = 204
+              , matchHeaders = [ matchHeaderAbsent hContentType
+                               , "Preference-Applied" <:> "tx=commit" ]
+              }
 
-        request methodDelete "/limited_delete_items?order=id&limit=1&offset=1"
-            [("Prefer", "tx=commit")]
-            mempty
-          `shouldRespondWith`
-            ""
-            { matchStatus  = 204
-            , matchHeaders = [ matchHeaderAbsent hContentType
-                             , "Preference-Applied" <:> "tx=commit" ]
-            }
-
-        get "/limited_delete_items?order=id"
-          `shouldRespondWith`
-            [json|[
-              { "id": 1, "name": "item-1" }
-            , { "id": 3, "name": "item-3" }
-            ]|]
-
-        request methodPost "/rpc/reset_items_tables"
-          [("Prefer", "tx=commit")]
-          [json| {"tbl_name": "limited_delete_items"} |]
-          `shouldRespondWith` ""
-          { matchStatus  = 204 }
-
-      it "works with the limit query param plus a filter" $ do
-        get "/limited_delete_items"
-          `shouldRespondWith`
-            [json|[
-              { "id": 1, "name": "item-1" }
-            , { "id": 2, "name": "item-2" }
-            , { "id": 3, "name": "item-3" }
-            ]|]
-
-        request methodDelete "/limited_delete_items?order=id&limit=1&id=gt.1"
-            [("Prefer", "tx=commit")]
-            mempty
-          `shouldRespondWith`
-            ""
-            { matchStatus  = 204
-            , matchHeaders = [ matchHeaderAbsent hContentType
-                             , "Preference-Applied" <:> "tx=commit" ]
-            }
-
-        get "/limited_delete_items?order=id"
-          `shouldRespondWith`
-            [json|[
-              { "id": 1, "name": "item-1" }
-            , { "id": 3, "name": "item-3" }
-            ]|]
-
-        request methodPost "/rpc/reset_items_tables"
-          [("Prefer", "tx=commit")]
-          [json| {"tbl_name": "limited_delete_items"} |]
-          `shouldRespondWith` ""
-          { matchStatus  = 204 }
+      it "works with the limit query param plus a filter" $
+        verifyMutation "limited_delete_items" tblDataBefore
+          [json|[
+            { "id": 1, "name": "item-1" }
+          , { "id": 3, "name": "item-3" }
+          ]|]
+          $
+          request methodDelete "/limited_delete_items?order=id&limit=1&id=gt.1"
+              [("Prefer", "tx=commit")]
+              mempty
+            `shouldRespondWith`
+              ""
+              { matchStatus  = 204
+              , matchHeaders = [ matchHeaderAbsent hContentType
+                               , "Preference-Applied" <:> "tx=commit" ]
+              }
 
       it "fails without an explicit order by" $
         request methodDelete "/limited_delete_items?limit=1&offset=1"
@@ -207,98 +185,53 @@ spec =
               }|]
             { matchStatus  = 400 }
 
-      it "works with views with an explicit order by unique col" $ do
-        get "/limited_delete_items_view"
-          `shouldRespondWith`
-            [json|[
-              { "id": 1, "name": "item-1" }
-            , { "id": 2, "name": "item-2" }
-            , { "id": 3, "name": "item-3" }
-            ]|]
+      it "works with views with an explicit order by unique col" $
+        verifyMutation "limited_delete_items_view" tblDataBefore
+          [json|[
+            { "id": 1, "name": "item-1" }
+          , { "id": 3, "name": "item-3" }
+          ]|]
+          $
+          request methodDelete "/limited_delete_items_view?order=id&limit=1&offset=1"
+              [("Prefer", "tx=commit")]
+              mempty
+            `shouldRespondWith`
+              ""
+              { matchStatus  = 204
+              , matchHeaders = [ matchHeaderAbsent hContentType
+                               , "Preference-Applied" <:> "tx=commit" ]
+              }
 
-        request methodDelete "/limited_delete_items_view?order=id&limit=1&offset=1"
-            [("Prefer", "tx=commit")]
-            mempty
-          `shouldRespondWith`
-            ""
-            { matchStatus  = 204
-            , matchHeaders = [ matchHeaderAbsent hContentType
-                             , "Preference-Applied" <:> "tx=commit" ]
-            }
+      it "works with views with an explicit order by composite pk" $
+        verifyMutation "limited_delete_items_cpk_view" tblDataBefore
+          [json|[
+            { "id": 1, "name": "item-1" }
+          , { "id": 3, "name": "item-3" }
+          ]|]
+          $
+          request methodDelete "/limited_delete_items_cpk_view?order=id,name&limit=1&offset=1"
+              [("Prefer", "tx=commit")]
+              mempty
+            `shouldRespondWith`
+              ""
+              { matchStatus  = 204
+              , matchHeaders = [ matchHeaderAbsent hContentType
+                               , "Preference-Applied" <:> "tx=commit" ]
+              }
 
-        get "/limited_delete_items_view"
-          `shouldRespondWith`
-            [json|[
-              { "id": 1, "name": "item-1" }
-            , { "id": 3, "name": "item-3" }
-            ]|]
-
-        request methodPost "/rpc/reset_items_tables"
-          [("Prefer", "tx=commit")]
-          [json| {"tbl_name": "limited_delete_items_view"} |]
-          `shouldRespondWith` ""
-          { matchStatus  = 204 }
-
-      it "works with views with an explicit order by composite pk" $ do
-        get "/limited_delete_items_cpk_view"
-          `shouldRespondWith`
-            [json|[
-              { "id": 1, "name": "item-1" }
-            , { "id": 2, "name": "item-2" }
-            , { "id": 3, "name": "item-3" }
-            ]|]
-
-        request methodDelete "/limited_delete_items_cpk_view?order=id,name&limit=1&offset=1"
-            [("Prefer", "tx=commit")]
-            mempty
-          `shouldRespondWith`
-            ""
-            { matchStatus  = 204
-            , matchHeaders = [ matchHeaderAbsent hContentType
-                             , "Preference-Applied" <:> "tx=commit" ]
-            }
-
-        get "/limited_delete_items_cpk_view"
-          `shouldRespondWith`
-            [json|[
-              { "id": 1, "name": "item-1" }
-            , { "id": 3, "name": "item-3" }
-            ]|]
-
-        request methodPost "/rpc/reset_items_tables"
-          [("Prefer", "tx=commit")]
-          [json| {"tbl_name": "limited_delete_items_cpk_view"} |]
-          `shouldRespondWith` ""
-          { matchStatus  = 204 }
-
-      it "works on a table without a pk by ordering by 'ctid'" $ do
-        get "/limited_delete_items_no_pk"
-          `shouldRespondWith`
-            [json|[
-              { "id": 1, "name": "item-1" }
-            , { "id": 2, "name": "item-2" }
-            , { "id": 3, "name": "item-3" }
-            ]|]
-
-        request methodDelete "/limited_delete_items_no_pk?order=ctid&limit=1&offset=1"
-            [("Prefer", "tx=commit")]
-            mempty
-          `shouldRespondWith`
-            ""
-            { matchStatus  = 204
-            , matchHeaders = [ matchHeaderAbsent hContentType
-                             , "Preference-Applied" <:> "tx=commit" ]
-            }
-
-        get "/limited_delete_items_no_pk"
-          `shouldRespondWith`
-            [json|[
-              { "id": 1, "name": "item-1" }
-            , { "id": 3, "name": "item-3" }
-            ]|]
-
-        request methodPost "/rpc/reset_items_tables"
-          [("Prefer", "tx=commit")]
-          [json| {"tbl_name": "limited_delete_items_no_pk"} |]
-          `shouldRespondWith` ""
-          { matchStatus  = 204 }
+      it "works on a table without a pk by ordering by 'ctid'" $
+        verifyMutation "limited_delete_items_no_pk" tblDataBefore
+          [json|[
+            { "id": 1, "name": "item-1" }
+          , { "id": 3, "name": "item-3" }
+          ]|]
+          $
+          request methodDelete "/limited_delete_items_no_pk?order=ctid&limit=1&offset=1"
+              [("Prefer", "tx=commit")]
+              mempty
+            `shouldRespondWith`
+              ""
+              { matchStatus  = 204
+              , matchHeaders = [ matchHeaderAbsent hContentType
+                               , "Preference-Applied" <:> "tx=commit" ]
+              }

--- a/test/spec/Feature/Query/DeleteSpec.hs
+++ b/test/spec/Feature/Query/DeleteSpec.hs
@@ -126,38 +126,24 @@ spec =
 
     context "limited delete" $ do
       it "works with the limit and offset query params" $
-        verifyMutation "limited_delete_items" tblDataBefore
-          [json|[
-            { "id": 1, "name": "item-1" }
-          , { "id": 3, "name": "item-3" }
-          ]|]
-          $
-          request methodDelete "/limited_delete_items?order=id&limit=1&offset=1"
-              [("Prefer", "tx=commit")]
-              mempty
-            `shouldRespondWith`
-              ""
-              { matchStatus  = 204
-              , matchHeaders = [ matchHeaderAbsent hContentType
-                               , "Preference-Applied" <:> "tx=commit" ]
-              }
+        baseTable "limited_delete_items" "id" tblDataBefore
+        `mutatesWith`
+        requestMutation methodDelete "/limited_delete_items?order=id&limit=1&offset=1" mempty
+        `shouldMutateInto`
+        [json|[
+          { "id": 1, "name": "item-1" }
+        , { "id": 3, "name": "item-3" }
+        ]|]
 
       it "works with the limit query param plus a filter" $
-        verifyMutation "limited_delete_items" tblDataBefore
-          [json|[
-            { "id": 1, "name": "item-1" }
-          , { "id": 3, "name": "item-3" }
-          ]|]
-          $
-          request methodDelete "/limited_delete_items?order=id&limit=1&id=gt.1"
-              [("Prefer", "tx=commit")]
-              mempty
-            `shouldRespondWith`
-              ""
-              { matchStatus  = 204
-              , matchHeaders = [ matchHeaderAbsent hContentType
-                               , "Preference-Applied" <:> "tx=commit" ]
-              }
+        baseTable "limited_delete_items" "id" tblDataBefore
+        `mutatesWith`
+        requestMutation methodDelete "/limited_delete_items?order=id&limit=1&id=gt.1" mempty
+        `shouldMutateInto`
+        [json|[
+          { "id": 1, "name": "item-1" }
+        , { "id": 3, "name": "item-3" }
+        ]|]
 
       it "fails without an explicit order by" $
         request methodDelete "/limited_delete_items?limit=1&offset=1"
@@ -186,52 +172,31 @@ spec =
             { matchStatus  = 400 }
 
       it "works with views with an explicit order by unique col" $
-        verifyMutation "limited_delete_items_view" tblDataBefore
-          [json|[
-            { "id": 1, "name": "item-1" }
-          , { "id": 3, "name": "item-3" }
-          ]|]
-          $
-          request methodDelete "/limited_delete_items_view?order=id&limit=1&offset=1"
-              [("Prefer", "tx=commit")]
-              mempty
-            `shouldRespondWith`
-              ""
-              { matchStatus  = 204
-              , matchHeaders = [ matchHeaderAbsent hContentType
-                               , "Preference-Applied" <:> "tx=commit" ]
-              }
+        baseTable "limited_delete_items_view" "id" tblDataBefore
+        `mutatesWith`
+        requestMutation methodDelete "/limited_delete_items_view?order=id&limit=1&offset=1" mempty
+        `shouldMutateInto`
+        [json|[
+          { "id": 1, "name": "item-1" }
+        , { "id": 3, "name": "item-3" }
+        ]|]
 
       it "works with views with an explicit order by composite pk" $
-        verifyMutation "limited_delete_items_cpk_view" tblDataBefore
-          [json|[
-            { "id": 1, "name": "item-1" }
-          , { "id": 3, "name": "item-3" }
-          ]|]
-          $
-          request methodDelete "/limited_delete_items_cpk_view?order=id,name&limit=1&offset=1"
-              [("Prefer", "tx=commit")]
-              mempty
-            `shouldRespondWith`
-              ""
-              { matchStatus  = 204
-              , matchHeaders = [ matchHeaderAbsent hContentType
-                               , "Preference-Applied" <:> "tx=commit" ]
-              }
+        baseTable "limited_delete_items_cpk_view" "id" tblDataBefore
+        `mutatesWith`
+        requestMutation methodDelete "/limited_delete_items_cpk_view?order=id,name&limit=1&offset=1" mempty
+        `shouldMutateInto`
+        [json|[
+          { "id": 1, "name": "item-1" }
+        , { "id": 3, "name": "item-3" }
+        ]|]
 
       it "works on a table without a pk by ordering by 'ctid'" $
-        verifyMutation "limited_delete_items_no_pk" tblDataBefore
-          [json|[
-            { "id": 1, "name": "item-1" }
-          , { "id": 3, "name": "item-3" }
-          ]|]
-          $
-          request methodDelete "/limited_delete_items_no_pk?order=ctid&limit=1&offset=1"
-              [("Prefer", "tx=commit")]
-              mempty
-            `shouldRespondWith`
-              ""
-              { matchStatus  = 204
-              , matchHeaders = [ matchHeaderAbsent hContentType
-                               , "Preference-Applied" <:> "tx=commit" ]
-              }
+        baseTable "limited_delete_items_no_pk" "id" tblDataBefore
+        `mutatesWith`
+        requestMutation methodDelete "/limited_delete_items_no_pk?order=ctid&limit=1&offset=1" mempty
+        `shouldMutateInto`
+        [json|[
+          { "id": 1, "name": "item-1" }
+        , { "id": 3, "name": "item-3" }
+        ]|]

--- a/test/spec/Feature/Query/PgSafeUpdateSpec.hs
+++ b/test/spec/Feature/Query/PgSafeUpdateSpec.hs
@@ -1,5 +1,7 @@
 module Feature.Query.PgSafeUpdateSpec where
 
+import Data.Aeson.QQ
+
 import Network.Wai (Application)
 
 import Network.HTTP.Types
@@ -9,6 +11,12 @@ import Test.Hspec.Wai.JSON
 
 import Protolude  hiding (get, put)
 import SpecHelper
+
+tblDataBefore = [aesonQQ|[
+                  { "id": 1, "name": "item-1", "observation": null }
+                , { "id": 2, "name": "item-2", "observation": null }
+                , { "id": 3, "name": "item-3", "observation": null }
+                ]|]
 
 spec :: SpecWith ((), Application)
 spec =
@@ -27,40 +35,24 @@ spec =
             }|]
             { matchStatus  = 400 }
 
-      it "allows full table update if a filter is present" $ do
-        get "/safe_update_items"
-          `shouldRespondWith`
-            [json|[
-              { "id": 1, "name": "item-1", "observation": null }
-            , { "id": 2, "name": "item-2", "observation": null }
-            , { "id": 3, "name": "item-3", "observation": null }
-            ]|]
-
-        request methodPatch "/safe_update_items?id=gt.0"
-            [("Prefer", "tx=commit"), ("Prefer", "count=exact")]
-            [json| {"name": "updated-item"} |]
-          `shouldRespondWith`
-            ""
-            { matchStatus  = 204
-            , matchHeaders = [ matchHeaderAbsent hContentType
-                             , "Content-Range" <:> "0-2/3"
-                             , "Preference-Applied" <:> "tx=commit" ]
-            }
-
-        get "/safe_update_items?order=id"
-          `shouldRespondWith`
-            [json|[
-              { "id": 1, "name": "updated-item", "observation": null }
-            , { "id": 2, "name": "updated-item", "observation": null }
-            , { "id": 3, "name": "updated-item", "observation": null }
-            ]|]
-
-        request methodPost "/rpc/reset_items_tables"
-          [("Prefer", "tx=commit")]
-          [json| {"tbl_name": "safe_update_items"} |]
-          `shouldRespondWith` ""
-          { matchStatus  = 204 }
-
+      it "allows full table update if a filter is present" $
+        verifyMutation "safe_update_items" tblDataBefore
+          [json|[
+            { "id": 1, "name": "updated-item", "observation": null }
+          , { "id": 2, "name": "updated-item", "observation": null }
+          , { "id": 3, "name": "updated-item", "observation": null }
+          ]|]
+          $
+          request methodPatch "/safe_update_items?id=gt.0"
+              [("Prefer", "tx=commit"), ("Prefer", "count=exact")]
+              [json| {"name": "updated-item"} |]
+            `shouldRespondWith`
+              ""
+              { matchStatus  = 204
+              , matchHeaders = [ matchHeaderAbsent hContentType
+                               , "Content-Range" <:> "0-2/3"
+                               , "Preference-Applied" <:> "tx=commit" ]
+              }
 
     context "Full table delete" $ do
       it "does not delete and throws error if no condition is present" $
@@ -74,101 +66,56 @@ spec =
             }|]
             { matchStatus  = 400 }
 
-      it "allows full table delete if a filter is present" $ do
-        get "/safe_delete_items"
-          `shouldRespondWith`
-            [json|[
-              { "id": 1, "name": "item-1", "observation": null }
-            , { "id": 2, "name": "item-2", "observation": null }
-            , { "id": 3, "name": "item-3", "observation": null }
-            ]|]
-
-        request methodDelete "/safe_delete_items?id=gt.0"
-            [("Prefer", "tx=commit"), ("Prefer", "count=exact")]
-            mempty
-          `shouldRespondWith`
-            ""
-            { matchStatus  = 204
-            , matchHeaders = [ matchHeaderAbsent hContentType
-                             , "Content-Range" <:> "*/3"
-                             , "Preference-Applied" <:> "tx=commit" ]
-            }
-
-        get "/safe_delete_items?order=id"
-          `shouldRespondWith`
-            [json|[]|]
-
-        request methodPost "/rpc/reset_items_tables"
-          [("Prefer", "tx=commit")]
-          [json| {"tbl_name": "safe_delete_items"} |]
-          `shouldRespondWith` ""
-          { matchStatus  = 204 }
+      it "allows full table delete if a filter is present" $
+        verifyMutation "safe_delete_items" tblDataBefore
+          [json|[]|]
+          $
+          request methodDelete "/safe_delete_items?id=gt.0"
+              [("Prefer", "tx=commit"), ("Prefer", "count=exact")]
+              mempty
+            `shouldRespondWith`
+              ""
+              { matchStatus  = 204
+              , matchHeaders = [ matchHeaderAbsent hContentType
+                               , "Content-Range" <:> "*/3"
+                               , "Preference-Applied" <:> "tx=commit" ]
+              }
 
 disabledSpec :: SpecWith ((), Application)
 disabledSpec =
   describe "Disabling pg-safeupdate" $ do
     context "Full table update" $ do
-      it "works if no condition is present" $ do
-        get "/unsafe_update_items"
-          `shouldRespondWith`
-            [json|[
-              { "id": 1, "name": "item-1", "observation": null }
-            , { "id": 2, "name": "item-2", "observation": null }
-            , { "id": 3, "name": "item-3", "observation": null }
-            ]|]
-
-        request methodPatch "/unsafe_update_items"
-            [("Prefer", "tx=commit"), ("Prefer", "count=exact")]
-            [json| {"name": "updated-item"} |]
-          `shouldRespondWith`
-            ""
-            { matchStatus  = 204
-            , matchHeaders = [ matchHeaderAbsent hContentType
-                             , "Content-Range" <:> "0-2/3"
-                             , "Preference-Applied" <:> "tx=commit" ]
-            }
-
-        get "/unsafe_update_items?order=id"
-          `shouldRespondWith`
-            [json|[
-              { "id": 1, "name": "updated-item", "observation": null }
-            , { "id": 2, "name": "updated-item", "observation": null }
-            , { "id": 3, "name": "updated-item", "observation": null }
-            ]|]
-
-        request methodPost "/rpc/reset_items_tables"
-          [("Prefer", "tx=commit")]
-          [json| {"tbl_name": "unsafe_update_items"} |]
-          `shouldRespondWith` ""
-          { matchStatus  = 204 }
+      it "works if no condition is present" $
+        verifyMutation "unsafe_update_items" tblDataBefore
+          [json|[
+            { "id": 1, "name": "updated-item", "observation": null }
+          , { "id": 2, "name": "updated-item", "observation": null }
+          , { "id": 3, "name": "updated-item", "observation": null }
+          ]|]
+          $
+          request methodPatch "/unsafe_update_items"
+              [("Prefer", "tx=commit"), ("Prefer", "count=exact")]
+              [json| {"name": "updated-item"} |]
+            `shouldRespondWith`
+              ""
+              { matchStatus  = 204
+              , matchHeaders = [ matchHeaderAbsent hContentType
+                               , "Content-Range" <:> "0-2/3"
+                               , "Preference-Applied" <:> "tx=commit" ]
+              }
 
     context "Full table delete" $ do
-      it "works if no condition is present" $ do
-        get "/unsafe_delete_items"
-          `shouldRespondWith`
-            [json|[
-              { "id": 1, "name": "item-1", "observation": null }
-            , { "id": 2, "name": "item-2", "observation": null }
-            , { "id": 3, "name": "item-3", "observation": null }
-            ]|]
-
-        request methodDelete "/unsafe_delete_items"
-            [("Prefer", "tx=commit"), ("Prefer", "count=exact")]
-            mempty
-          `shouldRespondWith`
-            ""
-            { matchStatus  = 204
-            , matchHeaders = [ matchHeaderAbsent hContentType
-                             , "Content-Range" <:> "*/3"
-                             , "Preference-Applied" <:> "tx=commit" ]
-            }
-
-        get "/unsafe_delete_items?order=id"
-          `shouldRespondWith`
-            [json|[]|]
-
-        request methodPost "/rpc/reset_items_tables"
-          [("Prefer", "tx=commit")]
-          [json| {"tbl_name": "unsafe_delete_items"} |]
-          `shouldRespondWith` ""
-          { matchStatus  = 204 }
+      it "works if no condition is present" $
+        verifyMutation "unsafe_delete_items" tblDataBefore
+          [json|[]|]
+          $
+          request methodDelete "/unsafe_delete_items"
+              [("Prefer", "tx=commit"), ("Prefer", "count=exact")]
+              mempty
+            `shouldRespondWith`
+              ""
+              { matchStatus  = 204
+              , matchHeaders = [ matchHeaderAbsent hContentType
+                               , "Content-Range" <:> "*/3"
+                               , "Preference-Applied" <:> "tx=commit" ]
+              }

--- a/test/spec/Feature/Query/UpdateSpec.hs
+++ b/test/spec/Feature/Query/UpdateSpec.hs
@@ -1,5 +1,7 @@
 module Feature.Query.UpdateSpec where
 
+import Data.Aeson.QQ
+
 import Network.Wai (Application)
 import Test.Hspec  hiding (pendingWith)
 
@@ -9,6 +11,12 @@ import Test.Hspec.Wai.JSON
 
 import Protolude  hiding (get)
 import SpecHelper
+
+tblDataBefore = [aesonQQ|[
+                  { "id": 1, "name": "item-1" }
+                , { "id": 2, "name": "item-2" }
+                , { "id": 3, "name": "item-3" }
+                ]|]
 
 spec :: SpecWith ((), Application)
 spec = do
@@ -388,105 +396,60 @@ spec = do
           }
 
   context "limited update" $ do
-    it "works with the limit query param" $ do
-      get "/limited_update_items"
-        `shouldRespondWith`
-          [json|[
-            { "id": 1, "name": "item-1" }
-          , { "id": 2, "name": "item-2" }
-          , { "id": 3, "name": "item-3" }
-          ]|]
+    it "works with the limit query param" $
+      verifyMutation "limited_update_items" tblDataBefore
+        [json|[
+          { "id": 1, "name": "updated-item" }
+        , { "id": 2, "name": "updated-item" }
+        , { "id": 3, "name": "item-3" }
+        ]|]
+        $
+        request methodPatch "/limited_update_items?order=id&limit=2"
+            [("Prefer", "tx=commit"), ("Prefer", "count=exact")]
+            [json| {"name": "updated-item"} |]
+          `shouldRespondWith`
+            ""
+            { matchStatus  = 204
+            , matchHeaders = [ matchHeaderAbsent hContentType
+                             , "Content-Range" <:> "0-1/2"
+                             , "Preference-Applied" <:> "tx=commit" ]
+            }
 
-      request methodPatch "/limited_update_items?order=id&limit=2"
-          [("Prefer", "tx=commit"), ("Prefer", "count=exact")]
-          [json| {"name": "updated-item"} |]
-        `shouldRespondWith`
-          ""
-          { matchStatus  = 204
-          , matchHeaders = [ matchHeaderAbsent hContentType
-                           , "Content-Range" <:> "0-1/2"
-                           , "Preference-Applied" <:> "tx=commit" ]
-          }
+    it "works with the limit query param plus a filter" $
+      verifyMutation "limited_update_items" tblDataBefore
+        [json|[
+          { "id": 1, "name": "item-1" }
+        , { "id": 2, "name": "item-2" }
+        , { "id": 3, "name": "updated-item" }
+        ]|]
+        $
+        request methodPatch "/limited_update_items?order=id&limit=1&id=gt.2"
+            [("Prefer", "tx=commit")]
+            [json| {"name": "updated-item"} |]
+          `shouldRespondWith`
+            ""
+            { matchStatus  = 204
+            , matchHeaders = [ matchHeaderAbsent hContentType
+                             , "Preference-Applied" <:> "tx=commit" ]
+            }
 
-      get "/limited_update_items?order=id"
-        `shouldRespondWith`
-          [json|[
-            { "id": 1, "name": "updated-item" }
-          , { "id": 2, "name": "updated-item" }
-          , { "id": 3, "name": "item-3" }
-          ]|]
-
-      request methodPost "/rpc/reset_items_tables"
-        [("Prefer", "tx=commit")]
-        [json| {"tbl_name": "limited_update_items"} |]
-        `shouldRespondWith` ""
-        { matchStatus  = 204 }
-
-    it "works with the limit query param plus a filter" $ do
-      get "/limited_update_items"
-        `shouldRespondWith`
-          [json|[
-            { "id": 1, "name": "item-1" }
-          , { "id": 2, "name": "item-2" }
-          , { "id": 3, "name": "item-3" }
-          ]|]
-
-      request methodPatch "/limited_update_items?order=id&limit=1&id=gt.2"
-          [("Prefer", "tx=commit")]
-          [json| {"name": "updated-item"} |]
-        `shouldRespondWith`
-          ""
-          { matchStatus  = 204
-          , matchHeaders = [ matchHeaderAbsent hContentType
-                           , "Preference-Applied" <:> "tx=commit" ]
-          }
-
-      get "/limited_update_items?order=id"
-        `shouldRespondWith`
-          [json|[
-            { "id": 1, "name": "item-1" }
-          , { "id": 2, "name": "item-2" }
-          , { "id": 3, "name": "updated-item" }
-          ]|]
-
-      request methodPost "/rpc/reset_items_tables"
-        [("Prefer", "tx=commit")]
-        [json| {"tbl_name": "limited_update_items"} |]
-        `shouldRespondWith` ""
-        { matchStatus  = 204 }
-
-    it "works with the limit and offset query params" $ do
-      get "/limited_update_items"
-        `shouldRespondWith`
-          [json|[
-            { "id": 1, "name": "item-1" }
-          , { "id": 2, "name": "item-2" }
-          , { "id": 3, "name": "item-3" }
-          ]|]
-
-      request methodPatch "/limited_update_items?order=id&limit=1&offset=1"
-          [("Prefer", "tx=commit")]
-          [json| {"name": "updated-item"} |]
-        `shouldRespondWith`
-          ""
-          { matchStatus  = 204
-          , matchHeaders = [ matchHeaderAbsent hContentType
-                           , "Preference-Applied" <:> "tx=commit" ]
-          }
-
-      get "/limited_update_items?order=id"
-        `shouldRespondWith`
-          [json|[
-            { "id": 1, "name": "item-1" }
-          , { "id": 2, "name": "updated-item" }
-          , { "id": 3, "name": "item-3" }
-          ]|]
-
-      request methodPost "/rpc/reset_items_tables"
-        [("Prefer", "tx=commit")]
-        [json| {"tbl_name": "limited_update_items"} |]
-        `shouldRespondWith` ""
-        { matchStatus  = 204 }
+    it "works with the limit and offset query params" $
+      verifyMutation "limited_update_items" tblDataBefore
+        [json|[
+          { "id": 1, "name": "item-1" }
+        , { "id": 2, "name": "updated-item" }
+        , { "id": 3, "name": "item-3" }
+        ]|]
+        $
+        request methodPatch "/limited_update_items?order=id&limit=1&offset=1"
+            [("Prefer", "tx=commit")]
+            [json| {"name": "updated-item"} |]
+          `shouldRespondWith`
+            ""
+            { matchStatus  = 204
+            , matchHeaders = [ matchHeaderAbsent hContentType
+                             , "Preference-Applied" <:> "tx=commit" ]
+            }
 
     it "fails without an explicit order by" $
       request methodPatch "/limited_update_items?limit=1&offset=1"
@@ -514,102 +477,56 @@ spec = do
             }|]
           { matchStatus  = 400 }
 
-    it "works with views with an explicit order by unique col" $ do
-      get "/limited_update_items_view"
-        `shouldRespondWith`
-          [json|[
-            { "id": 1, "name": "item-1" }
-          , { "id": 2, "name": "item-2" }
-          , { "id": 3, "name": "item-3" }
-          ]|]
+    it "works with views with an explicit order by unique col" $
+      verifyMutation "limited_update_items_view" tblDataBefore
+        [json|[
+          { "id": 1, "name": "item-1" }
+        , { "id": 2, "name": "updated-item" }
+        , { "id": 3, "name": "item-3" }
+        ]|]
+        $
+        request methodPatch "/limited_update_items_view?order=id&limit=1&offset=1"
+            [("Prefer", "tx=commit")]
+            [json| {"name": "updated-item"} |]
+          `shouldRespondWith`
+            ""
+            { matchStatus  = 204
+            , matchHeaders = [ matchHeaderAbsent hContentType
+                             , "Preference-Applied" <:> "tx=commit" ]
+            }
 
-      request methodPatch "/limited_update_items_view?order=id&limit=1&offset=1"
-          [("Prefer", "tx=commit")]
-          [json| {"name": "updated-item"} |]
-        `shouldRespondWith`
-          ""
-          { matchStatus  = 204
-          , matchHeaders = [ matchHeaderAbsent hContentType
-                           , "Preference-Applied" <:> "tx=commit" ]
-          }
+    it "works with views with an explicit order by composite pk" $
+      verifyMutation "limited_update_items_cpk_view" tblDataBefore
+        [json|[
+          { "id": 1, "name": "item-1" }
+        , { "id": 2, "name": "updated-item" }
+        , { "id": 3, "name": "item-3" }
+        ]|]
+        $
+        request methodPatch "/limited_update_items_cpk_view?order=id,name&limit=1&offset=1"
+            [("Prefer", "tx=commit")]
+            [json| {"name": "updated-item"} |]
+          `shouldRespondWith`
+            ""
+            { matchStatus  = 204
+            , matchHeaders = [ matchHeaderAbsent hContentType
+                             , "Preference-Applied" <:> "tx=commit" ]
+            }
 
-      get "/limited_update_items_view?order=id"
-        `shouldRespondWith`
-          [json|[
-            { "id": 1, "name": "item-1" }
-          , { "id": 2, "name": "updated-item" }
-          , { "id": 3, "name": "item-3" }
-          ]|]
-
-      request methodPost "/rpc/reset_items_tables"
-        [("Prefer", "tx=commit")]
-        [json| {"tbl_name": "limited_update_items_view"} |]
-        `shouldRespondWith` ""
-        { matchStatus  = 204 }
-
-    it "works with views with an explicit order by composite pk" $ do
-      get "/limited_update_items_cpk_view"
-        `shouldRespondWith`
-          [json|[
-            { "id": 1, "name": "item-1" }
-          , { "id": 2, "name": "item-2" }
-          , { "id": 3, "name": "item-3" }
-          ]|]
-
-      request methodPatch "/limited_update_items_cpk_view?order=id,name&limit=1&offset=1"
-          [("Prefer", "tx=commit")]
-          [json| {"name": "updated-item"} |]
-        `shouldRespondWith`
-          ""
-          { matchStatus  = 204
-          , matchHeaders = [ matchHeaderAbsent hContentType
-                           , "Preference-Applied" <:> "tx=commit" ]
-          }
-
-      get "/limited_update_items_cpk_view?order=id,name"
-        `shouldRespondWith`
-          [json|[
-            { "id": 1, "name": "item-1" }
-          , { "id": 2, "name": "updated-item" }
-          , { "id": 3, "name": "item-3" }
-          ]|]
-
-      request methodPost "/rpc/reset_items_tables"
-        [("Prefer", "tx=commit")]
-        [json| {"tbl_name": "limited_update_items_cpk_view"} |]
-        `shouldRespondWith` ""
-        { matchStatus  = 204 }
-
-
-    it "works on a table without a pk by ordering by 'ctid'" $ do
-      get "/limited_update_items_no_pk"
-        `shouldRespondWith`
-          [json|[
-            { "id": 1, "name": "item-1" }
-          , { "id": 2, "name": "item-2" }
-          , { "id": 3, "name": "item-3" }
-          ]|]
-
-      request methodPatch "/limited_update_items_no_pk?order=ctid&limit=1"
-          [("Prefer", "tx=commit")]
-          [json| {"name": "updated-item"} |]
-        `shouldRespondWith`
-          ""
-          { matchStatus  = 204
-          , matchHeaders = [ matchHeaderAbsent hContentType
-                           , "Preference-Applied" <:> "tx=commit" ]
-          }
-
-      get "/limited_update_items_no_pk?order=id"
-        `shouldRespondWith`
-          [json|[
-            { "id": 1, "name": "updated-item" }
-          , { "id": 2, "name": "item-2" }
-          , { "id": 3, "name": "item-3" }
-          ]|]
-
-      request methodPost "/rpc/reset_items_tables"
-        [("Prefer", "tx=commit")]
-        [json| {"tbl_name": "limited_update_items_no_pk"} |]
-        `shouldRespondWith` ""
-        { matchStatus  = 204 }
+    it "works on a table without a pk by ordering by 'ctid'" $
+      verifyMutation "limited_update_items_no_pk" tblDataBefore
+        [json|[
+          { "id": 1, "name": "updated-item" }
+        , { "id": 2, "name": "item-2" }
+        , { "id": 3, "name": "item-3" }
+        ]|]
+        $
+        request methodPatch "/limited_update_items_no_pk?order=ctid&limit=1"
+            [("Prefer", "tx=commit")]
+            [json| {"name": "updated-item"} |]
+          `shouldRespondWith`
+            ""
+            { matchStatus  = 204
+            , matchHeaders = [ matchHeaderAbsent hContentType
+                             , "Preference-Applied" <:> "tx=commit" ]
+            }

--- a/test/spec/Feature/Query/UpdateSpec.hs
+++ b/test/spec/Feature/Query/UpdateSpec.hs
@@ -397,59 +397,40 @@ spec = do
 
   context "limited update" $ do
     it "works with the limit query param" $
-      verifyMutation "limited_update_items" tblDataBefore
-        [json|[
-          { "id": 1, "name": "updated-item" }
-        , { "id": 2, "name": "updated-item" }
-        , { "id": 3, "name": "item-3" }
-        ]|]
-        $
-        request methodPatch "/limited_update_items?order=id&limit=2"
-            [("Prefer", "tx=commit"), ("Prefer", "count=exact")]
-            [json| {"name": "updated-item"} |]
-          `shouldRespondWith`
-            ""
-            { matchStatus  = 204
-            , matchHeaders = [ matchHeaderAbsent hContentType
-                             , "Content-Range" <:> "0-1/2"
-                             , "Preference-Applied" <:> "tx=commit" ]
-            }
+      baseTable "limited_update_items" "id" tblDataBefore
+      `mutatesWith`
+      requestMutation methodPatch "/limited_update_items?order=id&limit=2"
+        [json| {"name": "updated-item"} |]
+      `shouldMutateInto`
+      [json|[
+        { "id": 1, "name": "updated-item" }
+      , { "id": 2, "name": "updated-item" }
+      , { "id": 3, "name": "item-3" }
+      ]|]
 
     it "works with the limit query param plus a filter" $
-      verifyMutation "limited_update_items" tblDataBefore
-        [json|[
-          { "id": 1, "name": "item-1" }
-        , { "id": 2, "name": "item-2" }
-        , { "id": 3, "name": "updated-item" }
-        ]|]
-        $
-        request methodPatch "/limited_update_items?order=id&limit=1&id=gt.2"
-            [("Prefer", "tx=commit")]
-            [json| {"name": "updated-item"} |]
-          `shouldRespondWith`
-            ""
-            { matchStatus  = 204
-            , matchHeaders = [ matchHeaderAbsent hContentType
-                             , "Preference-Applied" <:> "tx=commit" ]
-            }
+      baseTable "limited_update_items" "id" tblDataBefore
+      `mutatesWith`
+      requestMutation methodPatch "/limited_update_items?order=id&limit=1&id=gt.2"
+        [json| {"name": "updated-item"} |]
+      `shouldMutateInto`
+      [json|[
+        { "id": 1, "name": "item-1" }
+      , { "id": 2, "name": "item-2" }
+      , { "id": 3, "name": "updated-item" }
+      ]|]
 
     it "works with the limit and offset query params" $
-      verifyMutation "limited_update_items" tblDataBefore
-        [json|[
-          { "id": 1, "name": "item-1" }
-        , { "id": 2, "name": "updated-item" }
-        , { "id": 3, "name": "item-3" }
-        ]|]
-        $
-        request methodPatch "/limited_update_items?order=id&limit=1&offset=1"
-            [("Prefer", "tx=commit")]
-            [json| {"name": "updated-item"} |]
-          `shouldRespondWith`
-            ""
-            { matchStatus  = 204
-            , matchHeaders = [ matchHeaderAbsent hContentType
-                             , "Preference-Applied" <:> "tx=commit" ]
-            }
+      baseTable "limited_update_items" "id" tblDataBefore
+      `mutatesWith`
+      requestMutation methodPatch "/limited_update_items?order=id&limit=1&offset=1"
+        [json| {"name": "updated-item"} |]
+      `shouldMutateInto`
+      [json|[
+        { "id": 1, "name": "item-1" }
+      , { "id": 2, "name": "updated-item" }
+      , { "id": 3, "name": "item-3" }
+      ]|]
 
     it "fails without an explicit order by" $
       request methodPatch "/limited_update_items?limit=1&offset=1"
@@ -478,49 +459,37 @@ spec = do
           { matchStatus  = 400 }
 
     it "works with views with an explicit order by unique col" $
-      verifyMutation "limited_update_items_view" tblDataBefore
-        [json|[
-          { "id": 1, "name": "item-1" }
-        , { "id": 2, "name": "updated-item" }
-        , { "id": 3, "name": "item-3" }
-        ]|]
-        $
-        request methodPatch "/limited_update_items_view?order=id&limit=1&offset=1"
-            [("Prefer", "tx=commit")]
-            [json| {"name": "updated-item"} |]
-          `shouldRespondWith`
-            ""
-            { matchStatus  = 204
-            , matchHeaders = [ matchHeaderAbsent hContentType
-                             , "Preference-Applied" <:> "tx=commit" ]
-            }
+      baseTable "limited_update_items_view" "id" tblDataBefore
+      `mutatesWith`
+      requestMutation methodPatch "/limited_update_items_view?order=id&limit=1&offset=1"
+        [json| {"name": "updated-item"} |]
+      `shouldMutateInto`
+      [json|[
+        { "id": 1, "name": "item-1" }
+      , { "id": 2, "name": "updated-item" }
+      , { "id": 3, "name": "item-3" }
+      ]|]
 
     it "works with views with an explicit order by composite pk" $
-      verifyMutation "limited_update_items_cpk_view" tblDataBefore
-        [json|[
-          { "id": 1, "name": "item-1" }
-        , { "id": 2, "name": "updated-item" }
-        , { "id": 3, "name": "item-3" }
-        ]|]
-        $
-        request methodPatch "/limited_update_items_cpk_view?order=id,name&limit=1&offset=1"
-            [("Prefer", "tx=commit")]
-            [json| {"name": "updated-item"} |]
-          `shouldRespondWith`
-            ""
-            { matchStatus  = 204
-            , matchHeaders = [ matchHeaderAbsent hContentType
-                             , "Preference-Applied" <:> "tx=commit" ]
-            }
+      baseTable "limited_update_items_cpk_view" "id" tblDataBefore
+      `mutatesWith`
+      requestMutation methodPatch "/limited_update_items_cpk_view?order=id,name&limit=1&offset=1"
+        [json| {"name": "updated-item"} |]
+      `shouldMutateInto`
+      [json|[
+        { "id": 1, "name": "item-1" }
+      , { "id": 2, "name": "updated-item" }
+      , { "id": 3, "name": "item-3" }
+      ]|]
 
     it "works on a table without a pk by ordering by 'ctid'" $
-      baseTable "limited_update_items_no_pk" "order=id" tblDataBefore 
+      baseTable "limited_update_items_no_pk" "id" tblDataBefore
       `mutatesWith`
       requestMutation methodPatch "/limited_update_items_no_pk?order=ctid&limit=1"
         [json| {"name": "updated-item"} |]
       `shouldMutateInto`
-        [json|[
-          { "id": 1, "name": "updated-item" }
-        , { "id": 2, "name": "item-2" }
-        , { "id": 3, "name": "item-3" }
-        ]|]
+      [json|[
+        { "id": 1, "name": "updated-item" }
+      , { "id": 2, "name": "item-2" }
+      , { "id": 3, "name": "item-3" }
+      ]|]

--- a/test/spec/Feature/Query/UpdateSpec.hs
+++ b/test/spec/Feature/Query/UpdateSpec.hs
@@ -514,19 +514,13 @@ spec = do
             }
 
     it "works on a table without a pk by ordering by 'ctid'" $
-      verifyMutation "limited_update_items_no_pk" tblDataBefore
+      baseTable "limited_update_items_no_pk" "order=id" tblDataBefore 
+      `mutatesWith`
+      requestMutation methodPatch "/limited_update_items_no_pk?order=ctid&limit=1"
+        [json| {"name": "updated-item"} |]
+      `shouldMutateInto`
         [json|[
           { "id": 1, "name": "updated-item" }
         , { "id": 2, "name": "item-2" }
         , { "id": 3, "name": "item-3" }
         ]|]
-        $
-        request methodPatch "/limited_update_items_no_pk?order=ctid&limit=1"
-            [("Prefer", "tx=commit")]
-            [json| {"name": "updated-item"} |]
-          `shouldRespondWith`
-            ""
-            { matchStatus  = 204
-            , matchHeaders = [ matchHeaderAbsent hContentType
-                             , "Preference-Applied" <:> "tx=commit" ]
-            }

--- a/test/spec/SpecHelper.hs
+++ b/test/spec/SpecHelper.hs
@@ -260,14 +260,14 @@ shouldMutateInto (MutationCheck (BaseTable tblName tblOrd dataBefore) mutation) 
     [json| {"tbl_name": #{decodeUtf8 tblName}, "tbl_data": #{dataBefore}} |]
   `shouldRespondWith` 204
 
--- | Mutates the base table data using the requested mutation
+-- | How the base table data will change using the requested mutation
 mutatesWith :: BaseTable -> WaiExpectation () -> MutationCheck
-mutatesWith baseTbl reqMut = MutationCheck baseTbl reqMut
+mutatesWith = MutationCheck
 
 -- | The original table data before it is modified.
 -- The column order is needed for an accurate comparison after the mutation
 baseTable :: ByteString -> ByteString -> Value -> BaseTable
-baseTable tbl ordr base = BaseTable tbl ordr base
+baseTable = BaseTable
 
 -- | The mutation (update/delete) that will be applied to the base table
 requestMutation :: Method -> ByteString -> BL.ByteString -> WaiExpectation ()

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -2531,13 +2531,15 @@ select *, 'static'::text as static from limited_delete_items;
 create view limited_delete_items_cpk_view as
 select * from limited_delete_items_cpk;
 
-create function reset_items_tables(tbl_name text default '') returns void as $_$ begin
+create function reset_table(tbl_name text default '', tbl_data json default '{}') returns void as $_$ begin
   execute format(
   $$
     delete from %I where true; -- WHERE is required for pg-safeupdate tests
-    insert into %I values (1, 'item-1'), (2, 'item-2'), (3, 'item-3');
+    insert into %I
+    select * from json_populate_recordset(null::%I, $1);
   $$::text,
-  tbl_name, tbl_name);
+  tbl_name, tbl_name, tbl_name)
+  using tbl_data;
 end; $_$ language plpgsql volatile;
 
 -- tables for ensuring we generate real junctions for many-to-many relationships

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -2531,7 +2531,7 @@ select *, 'static'::text as static from limited_delete_items;
 create view limited_delete_items_cpk_view as
 select * from limited_delete_items_cpk;
 
-create function reset_table(tbl_name text default '', tbl_data json default '{}') returns void as $_$ begin
+create function reset_table(tbl_name text default '', tbl_data json default '[]') returns void as $_$ begin
   execute format(
   $$
     delete from %I where true; -- WHERE is required for pg-safeupdate tests


### PR DESCRIPTION
Some mutations tests (updates/deletes) need to verify if the change did happen in the databas, which makes them bulky and difficult to read. 

This PR moves that logic to `SpecHelper.hs` and uses it as a global function for the tests that need it.