### PR TITLE
Nix: allow building from pure-eval mode

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,5 @@
+{ system ? builtins.currentSystem }:
+
 let
   name =
     "postgrest";
@@ -42,7 +44,7 @@ let
 
   # Evaluated expression of the Nixpkgs repository.
   pkgs =
-    import nixpkgs { inherit overlays; };
+    import nixpkgs { inherit overlays system; };
 
   postgresqlVersions =
     [
@@ -64,7 +66,7 @@ let
   # Function that derives a fully static Haskell package based on
   # nh2/static-haskell-nix
   staticHaskellPackage =
-    import nix/static-haskell-package.nix { inherit nixpkgs compiler patches allOverlays; };
+    import nix/static-haskell-package.nix { inherit nixpkgs system compiler patches allOverlays; };
 
   # Options passed to cabal in dev tools and tests
   devCabalOptions =

--- a/nix/overlays/gitignore.nix
+++ b/nix/overlays/gitignore.nix
@@ -12,8 +12,8 @@ self: super:
       gitignoreSrc = super.fetchFromGitHub {
         owner = "hercules-ci";
         repo = "gitignore";
-        rev = "211907489e9f198594c0eb0ca9256a1949c9d412";
-        sha256 = "06j7wpvj54khw0z10fjyi31kpafkr6hi1k0di13k1xp8kywvfyx8";
+        rev = "a20de23b925fd8264fd7fad6454652e142fd7f73";
+        sha256 = "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=";
       };
     in
     (super.callPackage gitignoreSrc { }).gitignoreSource;

--- a/nix/static-haskell-package.nix
+++ b/nix/static-haskell-package.nix
@@ -1,5 +1,5 @@
 # Derive a fully static Haskell package based on musl instead of glibc.
-{ nixpkgs, compiler, patches, allOverlays }:
+{ nixpkgs, system, compiler, patches, allOverlays }:
 
 name: src:
 let
@@ -46,7 +46,7 @@ let
 
   # Apply our overlay to nixpkgs.
   normalPkgs =
-    import nixpkgs { inherit overlays; };
+    import nixpkgs { inherit overlays system; };
 
   defaultCabalPackageVersionComingWithGhc =
     {

--- a/shell.nix
+++ b/shell.nix
@@ -11,7 +11,7 @@
 }:
 let
   postgrest =
-    import ./default.nix;
+    import ./default.nix { };
 
   inherit (postgrest) pkgs;
 


### PR DESCRIPTION
I am using PostgREST in a flake, which uses Nix pure evaluation mode by default, which cannot use builtins.currentSystem.
Also updated nix-gitignore to include this fix to stop attempting to read ~/.gitignore https://github.com/hercules-ci/gitignore.nix/pull/58

The type of default.nix is changed from an attrset to a function. nix-build still works (nix-build . -A postgrestStatic), but if other people import default.nix in their own expression maybe default.nix should be renamed to pure.nix, and default.nix change to
```nix
import ./pure.nix { }
```
??

https://github.com/hercules-ci/gitignore.nix/pull/58
<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs     - https://github.com/PostgREST/postgrest-docs
-->
