### PR TITLE
feat: add one to one relationship for resource embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + Different options for the plan can be used with the `options` parameter: `Accept: application/vnd.pgrst.plan; options=analyze|verbose|settings|buffers|wal`
    + The plan can be obtained in text or json by using different media type suffixes: `Accept: application/vnd.pgrst.plan+text` and `Accept: application/vnd.pgrst.plan+json`.
  - #2144, Allow extending/overriding relationships for resource embedding - @steve-chavez
+ - #1984, Detect one-to-one relationships for resource embedding  - @steve-chavez
+   + Detected when there's a foreign key with a unique constraint or when a foreign key is also a primary key
 
 ### Fixed
 
@@ -81,6 +83,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + This embedding form was easily made ambiguous whenever a new view was added.
    + For migrating, clients must be updated to the embedding form of `/view?select=*,other_view!column(*)`.
  - #2312, Using `Prefer: return=representation` no longer returns a `Location` header - @laurenceisla
+ - #1984, For the cases where one to one relationships are detected, json objects will be returned instead of json arrays of length 1
+   + If you wish to override this behavior, you can use computed relationships to return arrays again
 
 ## [9.0.1] - 2022-06-03
 

--- a/src/PostgREST/DbStructure/Relationship.hs
+++ b/src/PostgREST/DbStructure/Relationship.hs
@@ -37,12 +37,13 @@ data Relationship = Relationship
 
 -- | The relationship cardinality
 -- | https://en.wikipedia.org/wiki/Cardinality_(data_modeling)
--- TODO: missing one-to-one
 data Cardinality
   = O2M {relCons :: FKConstraint, relColumns :: [(FieldName, FieldName)]}
   -- ^ one-to-many
   | M2O {relCons :: FKConstraint, relColumns :: [(FieldName, FieldName)]}
   -- ^ many-to-one
+  | O2O {relCons :: FKConstraint, relColumns :: [(FieldName, FieldName)]}
+  -- ^ one-to-one, this is a refinement over M2O so operating on it is pretty much the same as M2O
   | M2M Junction
   -- ^ many-to-many
   deriving (Eq, Ord, Generic, JSON.ToJSON)

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -188,6 +188,10 @@ compressedRel Relationship{..} =
             "cardinality" .= ("many-to-one" :: Text)
           , "relationship" .= (cons <> " using " <> qiName relTable <> fmtEls (fst <$> relColumns) <> " and " <> qiName relForeignTable <> fmtEls (snd <$> relColumns))
           ]
+        O2O cons relColumns -> [
+            "cardinality" .= ("one-to-one" :: Text)
+          , "relationship" .= (cons <> " using " <> qiName relTable <> fmtEls (fst <$> relColumns) <> " and " <> qiName relForeignTable <> fmtEls (snd <$> relColumns))
+          ]
         O2M cons relColumns -> [
             "cardinality" .= ("one-to-many" :: Text)
           , "relationship" .= (cons <> " using " <> qiName relTable <> fmtEls (fst <$> relColumns) <> " and " <> qiName relForeignTable <> fmtEls (snd <$> relColumns))
@@ -201,6 +205,7 @@ relHint rels = T.intercalate ", " (hintList <$> rels)
       case relCardinality of
         M2M Junction{..} -> buildHint (qiName junTable)
         M2O cons _       -> buildHint cons
+        O2O cons _       -> buildHint cons
         O2M cons _       -> buildHint cons
     -- An ambiguousness error cannot happen for computed relationships TODO refactor so this mempty is not needed
     hintList ComputedRelationship{} = mempty

--- a/test/spec/Feature/Query/ComputedRelsSpec.hs
+++ b/test/spec/Feature/Query/ComputedRelsSpec.hs
@@ -92,10 +92,18 @@ spec = describe "computed relationships" $ do
         {"name":"fezz","child_web_content":[{"name":"wut"}],"parent_web_content":{"name":"tardis"}}
       ]|] { matchHeaders = [matchContentTypeJson] }
 
-  it "can override detected relationships" $ do
+  it "can override many-to-one and one-to-many relationships" $ do
     get "/videogames?select=*,designers!inner(*)"
       `shouldRespondWith`
       [json|[]|] { matchHeaders = [matchContentTypeJson] }
     get "/designers?select=*,videogames!inner(*)"
+      `shouldRespondWith`
+      [json|[]|] { matchHeaders = [matchContentTypeJson] }
+
+  it "can override one-to-one relationships(would give disambiguation errors otherwise)" $ do
+    get "/first_1?select=*,second_1(*)"
+      `shouldRespondWith`
+      [json|[]|] { matchHeaders = [matchContentTypeJson] }
+    get "/second_1?select=*,first_1(*)"
       `shouldRespondWith`
       [json|[]|] { matchHeaders = [matchContentTypeJson] }

--- a/test/spec/Feature/Query/DeleteSpec.hs
+++ b/test/spec/Feature/Query/DeleteSpec.hs
@@ -78,6 +78,32 @@ spec =
           , matchHeaders = ["Content-Range" <:> "*/*"]
           }
 
+      it "embeds an O2O relationship after delete" $ do
+        request methodDelete "/students?id=eq.1&select=name,students_info(address)"
+                [("Prefer", "return=representation")] ""
+          `shouldRespondWith`
+          [json|[
+            {
+              "name": "John Doe",
+              "students_info":{"address":"Street 1"}
+            }
+          ]|]
+          { matchStatus  = 200,
+            matchHeaders = [matchContentTypeJson]
+          }
+        request methodDelete "/students_info?id=eq.1&select=address,students(name)"
+                [("Prefer", "return=representation")] ""
+          `shouldRespondWith`
+          [json|[
+            {
+              "address": "Street 1",
+              "students":{"name": "John Doe"}
+            }
+          ]|]
+          { matchStatus  = 200,
+            matchHeaders = [matchContentTypeJson]
+          }
+
     context "known route, no records matched" $
       it "includes [] body if return=rep" $
         request methodDelete "/items?id=eq.101"

--- a/test/spec/Feature/Query/EmbedDisambiguationSpec.hs
+++ b/test/spec/Feature/Query/EmbedDisambiguationSpec.hs
@@ -106,6 +106,20 @@ spec =
           , matchHeaders = [matchContentTypeJson]
           }
 
+      it "errs on an ambiguous embed that has two one-to-one relationships" $
+        get "/first?select=second(*)" `shouldRespondWith`
+          [json| {
+            "code":"PGRST201",
+            "details":[
+              {"cardinality":"one-to-one","embedding":"first with second","relationship":"first_second_id_1_fkey using first(second_id_1) and second(id)"},
+              {"cardinality":"one-to-one","embedding":"first with second","relationship":"first_second_id_2_fkey using first(second_id_2) and second(id)"}
+            ],
+            "hint":"Try changing 'second' to one of the following: 'second!first_second_id_1_fkey', 'second!first_second_id_2_fkey'. Find the desired relationship in the 'details' key.","message":"Could not embed because more than one relationship was found for 'first' and 'second'"
+            }|]
+          { matchStatus  = 300
+          , matchHeaders = [matchContentTypeJson]
+          }
+
     context "disambiguating requests with embed hints" $ do
 
       context "using FK to specify the relationship" $ do

--- a/test/spec/Feature/Query/RpcSpec.hs
+++ b/test/spec/Feature/Query/RpcSpec.hs
@@ -269,6 +269,20 @@ spec actualPgVersion =
           ]|]
           { matchHeaders = [matchContentTypeJson] }
 
+      it "can embed an O2O relationship" $ do
+        get "/rpc/allcapitals?select=name,country(name)"
+          `shouldRespondWith` [json|[
+            {"name":"Kabul","country":{"name":"Afghanistan"}},
+            {"name":"Algiers","country":{"name":"Algeria"}}]
+          |]
+          { matchHeaders = [matchContentTypeJson] }
+        get "/rpc/allcountries?select=name,capital(name)"
+          `shouldRespondWith` [json|[
+            {"name":"Afghanistan","capital":{"name":"Kabul"}},
+            {"name":"Algeria","capital":{"name":"Algiers"}}
+          ]|]
+          { matchHeaders = [matchContentTypeJson] }
+
       when (actualPgVersion >= pgVersion110) $
         it "can embed if rpc returns domain of table type" $ do
           post "/rpc/getproject_domain?select=id,name,client:clients(id),tasks(id)"

--- a/test/spec/Feature/Query/UpdateSpec.hs
+++ b/test/spec/Feature/Query/UpdateSpec.hs
@@ -374,6 +374,34 @@ spec = do
           matchHeaders = [matchContentTypeJson]
         }
 
+    it "embeds an O2O relationship after update" $ do
+      request methodPatch "/students?id=eq.1&select=name,students_info(address)"
+              [("Prefer", "return=representation")]
+        [json|{"name": "Johnny Doe"}|]
+        `shouldRespondWith`
+        [json|[
+          {
+            "name": "Johnny Doe",
+            "students_info":{"address":"Street 1"}
+          }
+        ]|]
+        { matchStatus  = 200,
+          matchHeaders = [matchContentTypeJson]
+        }
+      request methodPatch "/students_info?id=eq.1&select=address,students(name)"
+              [("Prefer", "return=representation")]
+        [json|{"address": "New Street 1"}|]
+        `shouldRespondWith`
+        [json|[
+          {
+            "address": "New Street 1",
+            "students":{"name": "John Doe"}
+          }
+        ]|]
+        { matchStatus  = 200,
+          matchHeaders = [matchContentTypeJson]
+        }
+
   context "table with limited privileges" $ do
     it "succeeds updating row and gives a 204 when using return=minimal" $
       request methodPatch "/app_users?id=eq.1"

--- a/test/spec/fixtures/data.sql
+++ b/test/spec/fixtures/data.sql
@@ -812,3 +812,15 @@ INSERT INTO designers(id, name) VALUES (1, 'Sid Meier'), (2, 'Hironobu Sakaguchi
 
 TRUNCATE TABLE videogames CASCADE;
 INSERT INTO videogames(id, name, designer_id) VALUES (1, 'Civilization I', 1), (2, 'Civilization II', 1), (3, 'Final Fantasy I', 2), (4, 'Final Fantasy II', 2);
+
+TRUNCATE TABLE students CASCADE;
+INSERT INTO students(id, code, name) VALUES (1, '0001', 'John Doe'), (2, '0002', 'Jane Doe');
+
+TRUNCATE TABLE students_info CASCADE;
+INSERT INTO students_info(id, code, address) VALUES (1, '0001', 'Street 1'), (2, '0002', 'Street 2');
+
+TRUNCATE TABLE country CASCADE;
+INSERT INTO country(id, name) VALUES (1, 'Afghanistan'), (2, 'Algeria');
+
+TRUNCATE TABLE capital CASCADE;
+INSERT INTO capital(id, name, country_id) VALUES (1, 'Kabul', 1), (2, 'Algiers', 2);

--- a/test/spec/fixtures/privileges.sql
+++ b/test/spec/fixtures/privileges.sql
@@ -199,6 +199,16 @@ GRANT ALL ON TABLE
     , unsafe_delete_items
     , videogames
     , designers
+    , students
+    , students_info
+    , students_view
+    , students_info_view
+    , country
+    , capital
+    , first
+    , second
+    , first_1
+    , second_1
 TO postgrest_test_anonymous;
 
 GRANT INSERT ON TABLE insertonly TO postgrest_test_anonymous;

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -2400,7 +2400,7 @@ CREATE TABLE contact (
 
 CREATE TABLE clientinfo (
   id serial primary key
-, clientid int unique references client(id)
+, clientid int references client(id)
 , other text
 );
 
@@ -2753,3 +2753,76 @@ $$ LANGUAGE sql STABLE ROWS 1;
 CREATE FUNCTION test.videogames(test.designers) RETURNS SETOF test.videogames AS $$
   SELECT * FROM test.videogames WHERE FALSE;
 $$ LANGUAGE sql STABLE;
+
+CREATE TABLE test.students(
+  id int
+, code text
+, name text
+, primary key(id, code)
+);
+
+CREATE TABLE test.students_info(
+  id int
+, code text
+, address text
+, primary key(id, code)
+, foreign key (id, code) references test.students(id, code) on delete cascade
+);
+
+CREATE TABLE test.country(
+  id int primary key
+, name text
+);
+
+CREATE TABLE test.capital(
+  id int primary key
+, name text
+, country_id int unique
+, foreign key (country_id) references test.country(id)
+);
+
+CREATE FUNCTION test.allcountries() RETURNS SETOF test.country AS $$
+  SELECT * FROM test.country;
+$$ LANGUAGE sql STABLE;
+
+CREATE FUNCTION test.allcapitals() RETURNS SETOF test.capital AS $$
+  SELECT * FROM test.capital;
+$$ LANGUAGE sql STABLE;
+
+create view students_view as
+select * from students;
+
+create view students_info_view as
+select * from students_info;
+
+create table test.second (
+  id int primary key,
+  name text
+);
+
+create table test.first (
+  id int primary key,
+  name text,
+  second_id_1 int references test.second unique,
+  second_id_2 int references test.second unique
+);
+
+create table test.second_1 (
+  id int primary key,
+  name text
+);
+
+create table test.first_1 (
+  id int primary key,
+  name text,
+  second_id_1 int references test.second unique,
+  second_id_2 int references test.second unique
+);
+
+CREATE FUNCTION test.second_1(test.first_1) RETURNS SETOF test.second_1 AS $$
+  SELECT * FROM test.second_1 WHERE id = $1.second_id_1;
+$$ LANGUAGE sql STABLE ROWS 1;
+
+CREATE FUNCTION test.first_1(test.second_1) RETURNS SETOF test.first_1 AS $$
+  SELECT * FROM test.first_1 WHERE second_id_1 = $1.id;
+$$ LANGUAGE sql STABLE ROWS 1;


### PR DESCRIPTION
Closes https://github.com/PostgREST/postgrest/issues/1984. One to one relationships are detected when:

- There's a foreign key which is also a primary key:

```sql
-- one-to-one rel between students and students_info
CREATE TABLE test.students(
  id int
, code text
, name text
, primary key(id, code)
);

CREATE TABLE test.students_info(
  id int
, code text
, address text
, primary key(id, code)
, foreign key (id, code) references test.students(id, code)
);
```

- There's a foreign key with an unique constraint

```sql
-- one-to-one rel between country and capital
CREATE TABLE test.country(
  id int primary key
, name text
);

CREATE TABLE test.capital(
  id int primary key
, name text
, country_id int unique
, foreign key (country_id) references test.country(id)
);
```

([There's a blog post by Vertabelo that makes this clearer](https://vertabelo.com/blog/one-to-one-relationship-in-database))

This works across the board(tables, views, rpc, mutations, computed rels can override them). O2O rels are a refinement of M2O rels, so no news rels are added and there is no potential for new disambiguation conflicts.

