### PR TITLE
 Add a CI check for building with Cabal

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -211,6 +211,33 @@ jobs:
           path: postgrest
           if-no-files-found: error
 
+  Build-Cabal:
+    strategy:
+      matrix:
+        ghc: ['8.10.7', '9.2.4']
+      fail-fast: false
+    name: Build Linux (Cabal, GHC ${{ matrix.ghc }})
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: ghcup
+        run: |
+          ghcup install ghc ${{ matrix.ghc }}
+          ghcup set ghc ${{ matrix.ghc }}
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cabal
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.ghc }}-
+      - name: Install dependencies
+        run: |
+          cabal update
+          cabal build --only-dependencies --enable-tests --enable-benchmarks
+      - name: Build
+        run: cabal build --enable-tests --enable-benchmarks all
+
   Build-Cabal-Arm:
     name: Build aarch64 (Cabal)
     if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/rel-') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -220,7 +220,7 @@ jobs:
     env:
       GITHUB_COMMIT: ${{ github.sha }}
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - id: Remote-Dir
         name: Unique directory name for the remote build
         run: echo "::set-output name=remotepath::postgrest-build-$(uuidgen)"


### PR DESCRIPTION
The idea is that this ensures
1. that it's easy for contributors to hack on PostgREST without
   getting nix set up
2. we see things break more easily outside the very controlled nix
   environment (e.g. it would be easy to add a GHC 9.4.2 build here,
   or to see some problems with the version bounds)

I wanted to have a check like this around while working on https://github.com/PostgREST/postgrest/pull/2444, to ensure that that forked dependency doesn't cause cabal builds to fail.