### PR TITLE
Deprectate bulk-call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Deprecated
+
+- #1385, Deprecate bulk-calls when including the `Prefer: params=multiple-objects` in the request. A function with a JSON array or object parameter should be used instead for a better performance.
+
 ## [10.0.0] - 2022-08-18
 
 ### Added

--- a/src/PostgREST/Request/Preferences.hs
+++ b/src/PostgREST/Request/Preferences.hs
@@ -171,6 +171,7 @@ data PreferParameters
   | MultipleObjects -- ^ Pass an array of json objects as params to a stored procedure.
   deriving Eq
 
+-- TODO: Deprecate params=multiple-objects in next major version
 instance ToHeaderValue PreferParameters where
   toHeaderValue SingleObject    = "params=single-object"
   toHeaderValue MultipleObjects = "params=multiple-objects"


### PR DESCRIPTION
Deprecate bulk-call in favor of functions with JSON params, which are more efficient. Related to #1385.