### PR TITLE
ci: fix macos build by invalidating cache (fixes #2465)

### DIFF
--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,6 +3,7 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
+
 packages:
 - completed:
     hackage: hasql-pool-0.8.0.2@sha256:15473f336c2bd1da161cd03635841f38b0c177d7b8662762c8708c239a428f04,1907


### PR DESCRIPTION
It turns out an updated base image had libpq in a different location, which means the stack-cached artifacts of e.g. postgresql-libpq were no longer valid.

This is a one-off fix to invalidate the cache.

I'm not sure there's a good way to fix future instances of this -- we might try to determine some kind of hash of the runner and put that into the cache key, but that seems a bit too involved.