### PR TITLE
postgresql-libpq: use PostgREST fork with reduced copies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,14 +148,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Linux & test
+          - name: Linux
             runs-on: ubuntu-latest
             cache: |
               ~/.stack
               .stack-work
             artifact: postgrest-ubuntu-x64
 
-          - name: MacOS & test
+          - name: MacOS
             runs-on: macos-latest
             cache: |
               ~/.stack

--- a/cabal.project.non-nix
+++ b/cabal.project.non-nix
@@ -13,3 +13,8 @@ packages: .
 --  type: git
 --  location: https://github.com/PostgREST/hasql-pool.git
 --  tag: 4d462c4d47d762effefc7de6c85eaed55f144f1d
+
+source-repository-package
+  type: git
+  location: https://github.com/PostgREST/postgresql-libpq.git
+  tag: 33ff97db570b5b432255f5f24a68db51453f6eb8

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -53,6 +53,16 @@ let
             sha256 = "sha256-9GE9qyymTLXw4ZW6LbNnn4T2tCgNYVEuBIPcUA83xCg=";
           }
           { });
+
+      postgresql-libpq = lib.dontCheck
+        (prev.callCabal2nix "postgresql-libpq"
+          (super.fetchFromGitHub {
+            owner = "PostgREST";
+            repo = "postgresql-libpq";
+            rev = "cef92cb4c07b56568dffdbf4b719258b82183119"; # master as of 2022-09-05
+            sha256 = "sha256-BWXfGHhcNuOGdFRxDshbcnxaRTDwEC1Eswwf8jOdqWQ=";
+          })
+          { });
     } // extraOverrides final prev;
 in
 {

--- a/stack.yaml
+++ b/stack.yaml
@@ -22,3 +22,5 @@ extra-deps:
   - optparse-applicative-0.16.1.0@sha256:418c22ed6a19124d457d96bc66bd22c93ac22fad0c7100fe4972bbb4ac989731,4982
   - protolude-0.3.2@sha256:2a38b3dad40d238ab644e234b692c8911423f9d3ed0e36b62287c4a698d92cd1,2240
   - ptr-0.16.8.2@sha256:708ebb95117f2872d2c5a554eb6804cf1126e86abe793b2673f913f14e5eb1ac,3959
+  - git: https://github.com/PostgREST/postgresql-libpq.git
+    commit: 33ff97db570b5b432255f5f24a68db51453f6eb8

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,13 +6,6 @@
 
 packages:
 - completed:
-    hackage: hasql-pool-0.8.0.2@sha256:15473f336c2bd1da161cd03635841f38b0c177d7b8662762c8708c239a428f04,1907
-    pantry-tree:
-      size: 505
-      sha256: 495dfdf8b7f7d910e2e8a7a7e8d71c8dbf9d439e048de5bc2a66a762011cbdc2
-  original:
-    hackage: hasql-pool-0.8.0.2
-- completed:
     hackage: HTTP-4000.3.16@sha256:6042643c15a0b43e522a6693f1e322f05000d519543a84149cb80aeffee34f71,5947
     pantry-tree:
       size: 1428
@@ -55,6 +48,13 @@ packages:
   original:
     hackage: hasql-notifications-0.2.0.3@sha256:aca3f7ee847a8f0b7ef6f989dc48f4a094a06c1a34e92aa3c8bb230085966ea6,2027
 - completed:
+    hackage: hasql-pool-0.8.0.2@sha256:15473f336c2bd1da161cd03635841f38b0c177d7b8662762c8708c239a428f04,1907
+    pantry-tree:
+      size: 505
+      sha256: 495dfdf8b7f7d910e2e8a7a7e8d71c8dbf9d439e048de5bc2a66a762011cbdc2
+  original:
+    hackage: hasql-pool-0.8.0.2@sha256:15473f336c2bd1da161cd03635841f38b0c177d7b8662762c8708c239a428f04,1907
+- completed:
     hackage: hasql-transaction-1.0.1.2@sha256:297b158cd1f0727f9b0e175bd7d3741c1bcb725a8094956d0ee79b41aafdb30a,2890
     pantry-tree:
       size: 983
@@ -89,6 +89,17 @@ packages:
       sha256: 557c438345de19f82bf01d676100da2a191ef06f624e7a4b90b09ac17cbb52a5
   original:
     hackage: ptr-0.16.8.2@sha256:708ebb95117f2872d2c5a554eb6804cf1126e86abe793b2673f913f14e5eb1ac,3959
+- completed:
+    name: postgresql-libpq
+    version: 0.9.4.3
+    git: https://github.com/PostgREST/postgresql-libpq.git
+    pantry-tree:
+      size: 1081
+      sha256: 0df271e48af32eb8292a45301af45e114110d54099ee73dbc609d39770e8175e
+    commit: 33ff97db570b5b432255f5f24a68db51453f6eb8
+  original:
+    git: https://github.com/PostgREST/postgresql-libpq.git
+    commit: 33ff97db570b5b432255f5f24a68db51453f6eb8
 snapshots:
 - completed:
     size: 618951


### PR DESCRIPTION
This pulls in the change from https://github.com/PostgREST/postgresql-libpq/pull/1.

This is the postgresql-libpq part of #2349. See #2422 for discussion around forked dependencies.