### PR TITLE
refactor: add plan module

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -59,13 +59,14 @@ library
                       PostgREST.Query.QueryBuilder
                       PostgREST.Query.SqlFragment
                       PostgREST.Query.Statements
+                      PostgREST.Plan
+                      PostgREST.Plan.CallPlan
+                      PostgREST.Plan.MutatePlan
+                      PostgREST.Plan.ReadPlan
                       PostgREST.RangeQuery
                       PostgREST.Request.ApiRequest
-                      PostgREST.Request.DbRequestBuilder
-                      PostgREST.Request.MutateQuery
                       PostgREST.Request.Preferences
                       PostgREST.Request.QueryParams
-                      PostgREST.Request.ReadQuery
                       PostgREST.Request.Types
                       PostgREST.Response
                       PostgREST.Response.OpenAPI

--- a/src/PostgREST/Plan/CallPlan.hs
+++ b/src/PostgREST/Plan/CallPlan.hs
@@ -1,0 +1,25 @@
+module PostgREST.Plan.CallPlan
+  ( CallPlan(..)
+  , CallParams(..)
+  )
+where
+
+import qualified Data.ByteString.Lazy              as LBS
+import           PostgREST.DbStructure.Identifiers (FieldName,
+                                                    QualifiedIdentifier)
+import           PostgREST.DbStructure.Proc        (ProcParam (..))
+
+import Protolude
+
+data CallPlan = FunctionCall
+  { funCQi           :: QualifiedIdentifier
+  , funCParams       :: CallParams
+  , funCArgs         :: Maybe LBS.ByteString
+  , funCScalar       :: Bool
+  , funCMultipleCall :: Bool
+  , funCReturning    :: [FieldName]
+  }
+
+data CallParams
+  = KeyParams [ProcParam] -- ^ Call with key params: func(a := val1, b:= val2)
+  | OnePosParam ProcParam -- ^ Call with positional params(only one supported): func(val)

--- a/src/PostgREST/Plan/MutatePlan.hs
+++ b/src/PostgREST/Plan/MutatePlan.hs
@@ -1,6 +1,5 @@
-module PostgREST.Request.MutateQuery
-  ( MutateQuery(..)
-  , MutateRequest
+module PostgREST.Plan.MutatePlan
+  ( MutatePlan(..)
   )
 where
 
@@ -15,9 +14,7 @@ import PostgREST.Request.Types           (LogicTree, OrderTerm)
 
 import Protolude
 
-type MutateRequest = MutateQuery
-
-data MutateQuery
+data MutatePlan
   = Insert
       { in_        :: QualifiedIdentifier
       , insCols    :: S.Set FieldName

--- a/src/PostgREST/Plan/ReadPlan.hs
+++ b/src/PostgREST/Plan/ReadPlan.hs
@@ -1,7 +1,7 @@
-module PostgREST.Request.ReadQuery
-  ( ReadNode
-  , ReadQuery(..)
-  , ReadRequest
+{-# LANGUAGE NamedFieldPuns #-}
+module PostgREST.Plan.ReadPlan
+  ( ReadPlanTree
+  , ReadPlan(..)
   , fstFieldNames
   ) where
 
@@ -19,12 +19,9 @@ import PostgREST.Request.Types            (Alias, Depth, Hint,
 
 import Protolude
 
-type ReadRequest = Tree ReadNode
+type ReadPlanTree = Tree ReadPlan
 
-type ReadNode =
-  (ReadQuery, (NodeName, Maybe Relationship, Maybe Alias, Maybe Hint, Maybe JoinType, Depth))
-
-data ReadQuery = Select
+data ReadPlan = ReadPlan
   { select         :: [SelectItem]
   , from           :: QualifiedIdentifier
   , fromAlias      :: Maybe Alias
@@ -33,10 +30,16 @@ data ReadQuery = Select
   , joinConditions :: [JoinCondition]
   , order          :: [OrderTerm]
   , range_         :: NonnegRange
+  , nodeName       :: NodeName
+  , nodeRel        :: Maybe Relationship
+  , nodeAlias      :: Maybe Alias
+  , nodeHint       :: Maybe Hint
+  , nodeJoinType   :: Maybe JoinType
+  , nodeDepth      :: Depth
   }
   deriving (Eq)
 
 -- First level FieldNames(e.g get a,b from /table?select=a,b,other(c,d))
-fstFieldNames :: ReadRequest -> [FieldName]
-fstFieldNames (Node (sel, _) _) =
-  fst . (\(f, _, _, _, _) -> f) <$> select sel
+fstFieldNames :: ReadPlanTree -> [FieldName]
+fstFieldNames (Node ReadPlan{select} _) =
+  fst . (\(f, _, _, _, _) -> f) <$> select

--- a/src/PostgREST/Request/Types.hs
+++ b/src/PostgREST/Request/Types.hs
@@ -9,9 +9,6 @@ module PostgREST.Request.Types
   , Field
   , Filter(..)
   , Hint
-  , CallQuery(..)
-  , CallParams(..)
-  , CallRequest
   , JoinCondition(..)
   , JoinType(..)
   , JsonOperand(..)
@@ -35,12 +32,9 @@ module PostgREST.Request.Types
   , SelectItem
   ) where
 
-import qualified Data.ByteString.Lazy as LBS
-
 import PostgREST.DbStructure.Identifiers  (FieldName,
                                            QualifiedIdentifier)
-import PostgREST.DbStructure.Proc         (ProcDescription (..),
-                                           ProcParam (..))
+import PostgREST.DbStructure.Proc         (ProcDescription (..))
 import PostgREST.DbStructure.Relationship (Relationship)
 import PostgREST.MediaType                (MediaType (..))
 
@@ -75,8 +69,6 @@ data RangeError
   | LowerGTUpper
   | OutOfBounds Text Text
 
-type CallRequest = CallQuery
-
 type NodeName = Text
 type Depth = Integer
 
@@ -102,19 +94,6 @@ data OrderNulls
   = OrderNullsFirst
   | OrderNullsLast
   deriving (Eq)
-
-data CallQuery = FunctionCall
-  { funCQi           :: QualifiedIdentifier
-  , funCParams       :: CallParams
-  , funCArgs         :: Maybe LBS.ByteString
-  , funCScalar       :: Bool
-  , funCMultipleCall :: Bool
-  , funCReturning    :: [FieldName]
-  }
-
-data CallParams
-  = KeyParams [ProcParam] -- ^ Call with key params: func(a := val1, b:= val2)
-  | OnePosParam ProcParam -- ^ Call with positional params(only one supported): func(val)
 
 type Field = (FieldName, JsonPath)
 type Cast = Text

--- a/test/spec/QueryCost.hs
+++ b/test/spec/QueryCost.hs
@@ -14,8 +14,8 @@ import           Text.Heredoc
 
 import Protolude hiding (get, toS)
 
-import PostgREST.Query.QueryBuilder (requestToCallProcQuery)
-import PostgREST.Request.Types
+import PostgREST.Plan.CallPlan
+import PostgREST.Query.QueryBuilder (callPlanToQuery)
 
 import PostgREST.DbStructure.Identifiers
 import PostgREST.DbStructure.Proc
@@ -30,7 +30,7 @@ main = do
     context "call proc query" $ do
       it "should not exceed cost when calling setof composite proc" $ do
         cost <- exec pool $
-          requestToCallProcQuery (FunctionCall (QualifiedIdentifier "test" "get_projects_below")
+          callPlanToQuery (FunctionCall (QualifiedIdentifier "test" "get_projects_below")
           (KeyParams [ProcParam "id" "int" True False])
           (Just [str| {"id": 3} |]) False False [])
         liftIO $
@@ -38,13 +38,13 @@ main = do
 
       it "should not exceed cost when calling setof composite proc with empty params" $ do
         cost <- exec pool $
-          requestToCallProcQuery (FunctionCall (QualifiedIdentifier "test" "getallprojects") (KeyParams []) Nothing False False [])
+          callPlanToQuery (FunctionCall (QualifiedIdentifier "test" "getallprojects") (KeyParams []) Nothing False False [])
         liftIO $
           cost `shouldSatisfy` (< Just 30)
 
       it "should not exceed cost when calling scalar proc" $ do
         cost <- exec pool $
-          requestToCallProcQuery (FunctionCall (QualifiedIdentifier "test" "add_them")
+          callPlanToQuery (FunctionCall (QualifiedIdentifier "test" "add_them")
           (KeyParams [ProcParam "a" "int" True False, ProcParam "b" "int" True False])
           (Just [str| {"a": 3, "b": 4} |]) True False [])
         liftIO $
@@ -53,7 +53,7 @@ main = do
       context "params=multiple-objects" $ do
         it "should not exceed cost when calling setof composite proc" $ do
           cost <- exec pool $
-            requestToCallProcQuery (FunctionCall (QualifiedIdentifier "test" "get_projects_below")
+            callPlanToQuery (FunctionCall (QualifiedIdentifier "test" "get_projects_below")
             (KeyParams [ProcParam "id" "int" True False])
             (Just [str| [{"id": 1}, {"id": 4}] |]) False True [])
           liftIO $ do
@@ -63,7 +63,7 @@ main = do
 
         it "should not exceed cost when calling scalar proc" $ do
           cost <- exec pool $
-            requestToCallProcQuery (FunctionCall (QualifiedIdentifier "test" "add_them")
+            callPlanToQuery (FunctionCall (QualifiedIdentifier "test" "add_them")
             (KeyParams [ProcParam "a" "int" True False, ProcParam "b" "int" True False])
             (Just [str| [{"a": 3, "b": 4}, {"a": 1, "b": 2}, {"a": 8, "b": 7}] |]) True False [])
           liftIO $


### PR DESCRIPTION
Scaffolds the plan module. Idea taken from https://github.com/PostgREST/postgrest/issues/1804

> Plan: Use db structure to validate and plan the request, including embeds. plan :: DbStructure -> Request -> Either PlanError QueryPlan

(Mostly renaming/moving files)