### PR TITLE
Data Representations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+ - #2523, Data representations - @aljungberg
+   + Allows for flexible API output formatting and input parsing on a per-column type basis using regular SQL functions configured in the database
+   + Enables greater flexibility in the form and shape of your APIs, both for output and input, making PostgREST a more versatile general-purpose API server
+   + Examples include base64 encode/decode your binary data (like a `bytea` column containing an image), choose whether to present a timestamp column as seconds since the Unix epoch or as an ISO 8601 string, or represent fixed precision decimals as strings, not doubles, to preserve precision
+   + ...and accept the same in `POST/PUT/PATCH` by configuring the reverse transformation(s)
+   + Other use-cases include custom representation of enums, arrays, nested objects, CSS hex colour strings, gzip compressed fields, metric to imperial conversions, and much more
+   + Works when using the `select` parameter to select only a subset of columns, embedding through complex joins, renaming fields, with views and computed columns
+   + Works when filtering on a formatted column without extra indexes by parsing to the canonical representation
+   + Works for data `RETURNING` operations, such as requesting the full body in a POST/PUT/PATCH with `Prefer: return=representation`
+   + Works for batch updates and inserts
+   + Completely optional, define the functions in the database and they will be used automatically everywhere
+   + Data representations preserve the ability to write to the original column and require no extra storage or complex triggers (compared to using `GENERATED ALWAYS` columns)
+   + Note: data representations require Postgres 10 (Postgres 11 if using `IN` predicates); data representations are not implemented for RPC 
+ - #2622, Consider any PostgreSQL authentication failure as fatal and exit immediately - @michivi
+
 ### Added
 
  - #1414, Add related orders - @steve-chavez
@@ -329,7 +344,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Deprecated
 
-- #1348, Deprecate `.` symbol for disambiguating resource embedding(added in #918). The url-safe '!' should be used instead. We refrained from using `+` as part of our syntax because it conflicts with some http clients and proxies.
++- #1348, Deprecate `.` symbol for disambiguating resource embedding(added in #918). The url-safe '!' should be used instead. We refrained from using `+` as part of our syntax because it conflicts with some http clients and proxies.
 
 ## [6.0.1] - 2019-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + Completely optional, define the functions in the database and they will be used automatically everywhere
    + Data representations preserve the ability to write to the original column and require no extra storage or complex triggers (compared to using `GENERATED ALWAYS` columns)
    + Note: data representations require Postgres 10 (Postgres 11 if using `IN` predicates); data representations are not implemented for RPC 
- - #2622, Consider any PostgreSQL authentication failure as fatal and exit immediately - @michivi
 
 ### Added
 
@@ -344,7 +343,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Deprecated
 
-+- #1348, Deprecate `.` symbol for disambiguating resource embedding(added in #918). The url-safe '!' should be used instead. We refrained from using `+` as part of our syntax because it conflicts with some http clients and proxies.
+- #1348, Deprecate `.` symbol for disambiguating resource embedding(added in #918). The url-safe '!' should be used instead. We refrained from using `+` as part of our syntax because it conflicts with some http clients and proxies.
 
 ## [6.0.1] - 2019-07-30
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 ![Logo](static/bigger-logo.png "Logo")
 
 [![Donate](https://img.shields.io/badge/Donate-Patreon-orange.svg?colorB=F96854)](https://www.patreon.com/postgrest)

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -48,6 +48,7 @@ library
                       PostgREST.SchemaCache.Identifiers
                       PostgREST.SchemaCache.Proc
                       PostgREST.SchemaCache.Relationship
+                      PostgREST.SchemaCache.Representations
                       PostgREST.SchemaCache.Table
                       PostgREST.Error
                       PostgREST.Logger

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -36,7 +36,7 @@ import Data.Tree               (Tree (..))
 
 import PostgREST.ApiRequest                  (Action (..),
                                               ApiRequest (..),
-                                           InvokeMethod (..),
+                                              InvokeMethod (..),
                                               Mutation (..),
                                               Payload (..))
 import PostgREST.Config                      (AppConfig (..))

--- a/src/PostgREST/Plan/MutatePlan.hs
+++ b/src/PostgREST/Plan/MutatePlan.hs
@@ -6,8 +6,9 @@ where
 import qualified Data.ByteString.Lazy as LBS
 
 import PostgREST.ApiRequest.Preferences  (PreferResolution)
-import PostgREST.ApiRequest.Types        (LogicTree, OrderTerm)
-import PostgREST.Plan.Types              (TypedField)
+import PostgREST.ApiRequest.Types        (OrderTerm)
+import PostgREST.Plan.Types              (CoercibleField,
+                                          TypedLogicTree)
 import PostgREST.RangeQuery              (NonnegRange)
 import PostgREST.SchemaCache.Identifiers (FieldName,
                                           QualifiedIdentifier)
@@ -18,25 +19,25 @@ import Protolude
 data MutatePlan
   = Insert
       { in_        :: QualifiedIdentifier
-      , insCols    :: [TypedField]
+      , insCols    :: [CoercibleField]
       , insBody    :: Maybe LBS.ByteString
       , onConflict :: Maybe (PreferResolution, [FieldName])
-      , where_     :: [LogicTree]
+      , where_     :: [TypedLogicTree]
       , returning  :: [FieldName]
       , insPkCols  :: [FieldName]
       }
   | Update
       { in_       :: QualifiedIdentifier
-      , updCols   :: [TypedField]
+      , updCols   :: [CoercibleField]
       , updBody   :: Maybe LBS.ByteString
-      , where_    :: [LogicTree]
+      , where_    :: [TypedLogicTree]
       , mutRange  :: NonnegRange
       , mutOrder  :: [OrderTerm]
       , returning :: [FieldName]
       }
   | Delete
       { in_       :: QualifiedIdentifier
-      , where_    :: [LogicTree]
+      , where_    :: [TypedLogicTree]
       , mutRange  :: NonnegRange
       , mutOrder  :: [OrderTerm]
       , returning :: [FieldName]

--- a/src/PostgREST/Plan/MutatePlan.hs
+++ b/src/PostgREST/Plan/MutatePlan.hs
@@ -8,7 +8,7 @@ import qualified Data.ByteString.Lazy as LBS
 import PostgREST.ApiRequest.Preferences  (PreferResolution)
 import PostgREST.ApiRequest.Types        (OrderTerm)
 import PostgREST.Plan.Types              (CoercibleField,
-                                          TypedLogicTree)
+                                          CoercibleLogicTree)
 import PostgREST.RangeQuery              (NonnegRange)
 import PostgREST.SchemaCache.Identifiers (FieldName,
                                           QualifiedIdentifier)
@@ -22,7 +22,7 @@ data MutatePlan
       , insCols    :: [CoercibleField]
       , insBody    :: Maybe LBS.ByteString
       , onConflict :: Maybe (PreferResolution, [FieldName])
-      , where_     :: [TypedLogicTree]
+      , where_     :: [CoercibleLogicTree]
       , returning  :: [FieldName]
       , insPkCols  :: [FieldName]
       }
@@ -30,14 +30,14 @@ data MutatePlan
       { in_       :: QualifiedIdentifier
       , updCols   :: [CoercibleField]
       , updBody   :: Maybe LBS.ByteString
-      , where_    :: [TypedLogicTree]
+      , where_    :: [CoercibleLogicTree]
       , mutRange  :: NonnegRange
       , mutOrder  :: [OrderTerm]
       , returning :: [FieldName]
       }
   | Delete
       { in_       :: QualifiedIdentifier
-      , where_    :: [TypedLogicTree]
+      , where_    :: [CoercibleLogicTree]
       , mutRange  :: NonnegRange
       , mutOrder  :: [OrderTerm]
       , returning :: [FieldName]

--- a/src/PostgREST/Plan/ReadPlan.hs
+++ b/src/PostgREST/Plan/ReadPlan.hs
@@ -10,7 +10,7 @@ import PostgREST.ApiRequest.Types         (Alias, Cast, Depth, Hint,
                                            JoinType, NodeName,
                                            OrderTerm)
 import PostgREST.Plan.Types               (CoercibleField (..),
-                                           TypedLogicTree)
+                                           CoercibleLogicTree)
 import PostgREST.RangeQuery               (NonnegRange)
 import PostgREST.SchemaCache.Identifiers  (FieldName,
                                            QualifiedIdentifier)
@@ -31,7 +31,7 @@ data ReadPlan = ReadPlan
   { select       :: [(CoercibleField, Maybe Cast, Maybe Alias)]
   , from         :: QualifiedIdentifier
   , fromAlias    :: Maybe Alias
-  , where_       :: [TypedLogicTree]
+  , where_       :: [CoercibleLogicTree]
   , order        :: [OrderTerm]
   , range_       :: NonnegRange
   , relName      :: NodeName

--- a/src/PostgREST/Plan/ReadPlan.hs
+++ b/src/PostgREST/Plan/ReadPlan.hs
@@ -6,9 +6,11 @@ module PostgREST.Plan.ReadPlan
 
 import Data.Tree (Tree (..))
 
-import PostgREST.ApiRequest.Types         (Alias, Cast, Depth, Field,
-                                           Hint, JoinType, LogicTree,
-                                           NodeName, OrderTerm)
+import PostgREST.ApiRequest.Types         (Alias, Cast, Depth, Hint,
+                                           JoinType, NodeName,
+                                           OrderTerm)
+import PostgREST.Plan.Types               (CoercibleField (..),
+                                           TypedLogicTree)
 import PostgREST.RangeQuery               (NonnegRange)
 import PostgREST.SchemaCache.Identifiers  (FieldName,
                                            QualifiedIdentifier)
@@ -26,10 +28,10 @@ data JoinCondition =
   deriving (Eq)
 
 data ReadPlan = ReadPlan
-  { select       :: [(Field, Maybe Cast, Maybe Alias)]
+  { select       :: [(CoercibleField, Maybe Cast, Maybe Alias)]
   , from         :: QualifiedIdentifier
   , fromAlias    :: Maybe Alias
-  , where_       :: [LogicTree]
+  , where_       :: [TypedLogicTree]
   , order        :: [OrderTerm]
   , range_       :: NonnegRange
   , relName      :: NodeName

--- a/src/PostgREST/Plan/Types.hs
+++ b/src/PostgREST/Plan/Types.hs
@@ -1,24 +1,49 @@
 module PostgREST.Plan.Types
-  ( TypedField(..)
-  , resolveTableField
-
+  ( CoercibleField(..)
+  , unknownField
+  , TypedLogicTree(..)
+  , TypedFilter(..)
+  , TransformerProc
   ) where
 
-import qualified Data.HashMap.Strict.InsOrd as HMI
+import PostgREST.ApiRequest.Types (JsonPath, LogicOperator, OpExpr)
 
 import PostgREST.SchemaCache.Identifiers (FieldName)
-import PostgREST.SchemaCache.Table       (Column (..), Table (..))
 
 import Protolude
 
--- | A TypedField is a field with sufficient information to be read from JSON with `json_to_recordset`.
-data TypedField = TypedField
-   { tfName   :: FieldName
-   , tfIRType :: Text -- ^ The initial type of the field, before any casting.
-   } deriving (Eq)
+type TransformerProc = Text
 
-resolveTableField :: Table -> FieldName -> Maybe TypedField
-resolveTableField table fieldName =
-  case HMI.lookup fieldName (tableColumns table) of
-    Just column -> Just $ TypedField (colName column) (colNominalType column)
-    Nothing     -> Nothing
+-- | A CoercibleField pairs the name of a query element with any type coercion information we need for some specific use case.
+-- |
+-- | As suggested by the name, it's often a reference to a field in a table but really it can be any nameable element (function parameter, calculation with an alias, etc) with a knowable type.
+-- |
+-- | In the simplest case, it allows us to parse JSON payloads with `json_to_recordset`, for which we need to know both the name and the type of each thing we'd like to extract. At a higher level, CoercibleField generalises to reflect that any value we work with in a query may need type specific handling.
+-- |
+-- | CoercibleField is the foundation for the Data Representations feature. This feature allow user-definable mappings between database types so that the same data can be presented or interpreted in various ways as needed. Sometimes the way Postgres coerces data implicitly isn't right for the job. Different mappings might be appropriate for different situations: parsing a filter from a query string requires one function (text -> field type) while parsing a payload from JSON takes another (json -> field type). And the reverse, outputting a field as JSON, requires yet a third (field type -> json). CoercibleField is that "job specific" reference to an element paired with the type we desire for that particular purpose and the function we'll use to get there, if any.
+-- |
+-- | In the planning phase, we "resolve" generic named elements into these specialised CoercibleFields. Again this is context specific: two different CoercibleFields both representing the exact same table column in the database, even in the same query, might have two different target types and mapping functions. For example, one might represent a column in a filter, and another the very same column in an output role to be sent in the response body.
+-- |
+-- | The type value is allowed to be the empty string. The analog here is soft type checking in programming languages: sometimes we don't need a variable to have a specified type and things will work anyhow. So the empty type variant is valid when we don't know and *don't need to know* about the specific type in some context. Note that this variation should not be used if it guarantees failure: in that case you should instead raise an error at the planning stage and bail out. For example, we can't parse JSON with `json_to_recordset` without knowing the types of each recipient field, and so error out. Using the empty string for the type would be incorrect and futile. On the other hand we use the empty type for RPC calls since type resolution isn't implemented for RPC, but it's fine because the query still works with Postgres' implicit coercion. In the future, hopefully we will support data representations across the board and then the empty type may be permanently retired.
+data CoercibleField = CoercibleField
+  { tfName      :: FieldName
+  , tfJsonPath  :: JsonPath
+  , tfIRType    :: Text -- ^ The native Postgres type of the field, the type before mapping.
+  , tfTransform :: Maybe TransformerProc -- ^ The optional mapping from irType -> targetType.
+  } deriving (Eq)
+
+unknownField :: FieldName -> JsonPath -> CoercibleField
+unknownField name path = CoercibleField name path "" Nothing
+
+-- | Like a regular LogicTree but with field type information.
+data TypedLogicTree
+  = TypedExpr Bool LogicOperator [TypedLogicTree]
+  | TypedStmnt TypedFilter
+  deriving (Eq)
+
+data TypedFilter = TypedFilter
+  { typedField  :: CoercibleField
+  , typedOpExpr :: OpExpr
+  }
+  | TypedFilterNullEmbed Bool FieldName
+  deriving (Eq)

--- a/src/PostgREST/Plan/Types.hs
+++ b/src/PostgREST/Plan/Types.hs
@@ -1,8 +1,8 @@
 module PostgREST.Plan.Types
   ( CoercibleField(..)
   , unknownField
-  , TypedLogicTree(..)
-  , TypedFilter(..)
+  , CoercibleLogicTree(..)
+  , CoercibleFilter(..)
   , TransformerProc
   ) where
 
@@ -35,15 +35,15 @@ data CoercibleField = CoercibleField
 unknownField :: FieldName -> JsonPath -> CoercibleField
 unknownField name path = CoercibleField name path "" Nothing
 
--- | Like a regular LogicTree but with field type information.
-data TypedLogicTree
-  = TypedExpr Bool LogicOperator [TypedLogicTree]
-  | TypedStmnt TypedFilter
+-- | Like an API request LogicTree, but with coercible field information.
+data CoercibleLogicTree
+  = CoercibleExpr Bool LogicOperator [CoercibleLogicTree]
+  | CoercibleStmnt CoercibleFilter
   deriving (Eq)
 
-data TypedFilter = TypedFilter
-  { typedField  :: CoercibleField
-  , typedOpExpr :: OpExpr
+data CoercibleFilter = CoercibleFilter
+  { field  :: CoercibleField
+  , opExpr :: OpExpr
   }
-  | TypedFilterNullEmbed Bool FieldName
+  | CoercibleFilterNullEmbed Bool FieldName
   deriving (Eq)

--- a/src/PostgREST/Plan/Types.hs
+++ b/src/PostgREST/Plan/Types.hs
@@ -26,10 +26,10 @@ type TransformerProc = Text
 -- |
 -- | The type value is allowed to be the empty string. The analog here is soft type checking in programming languages: sometimes we don't need a variable to have a specified type and things will work anyhow. So the empty type variant is valid when we don't know and *don't need to know* about the specific type in some context. Note that this variation should not be used if it guarantees failure: in that case you should instead raise an error at the planning stage and bail out. For example, we can't parse JSON with `json_to_recordset` without knowing the types of each recipient field, and so error out. Using the empty string for the type would be incorrect and futile. On the other hand we use the empty type for RPC calls since type resolution isn't implemented for RPC, but it's fine because the query still works with Postgres' implicit coercion. In the future, hopefully we will support data representations across the board and then the empty type may be permanently retired.
 data CoercibleField = CoercibleField
-  { tfName      :: FieldName
-  , tfJsonPath  :: JsonPath
-  , tfIRType    :: Text -- ^ The native Postgres type of the field, the type before mapping.
-  , tfTransform :: Maybe TransformerProc -- ^ The optional mapping from irType -> targetType.
+  { cfName      :: FieldName
+  , cfJsonPath  :: JsonPath
+  , cfIRType    :: Text -- ^ The native Postgres type of the field, the type before mapping.
+  , cfTransform :: Maybe TransformerProc -- ^ The optional mapping from irType -> targetType.
   } deriving (Eq)
 
 unknownField :: FieldName -> JsonPath -> CoercibleField

--- a/src/PostgREST/Plan/Types.hs
+++ b/src/PostgREST/Plan/Types.hs
@@ -28,7 +28,7 @@ type TransformerProc = Text
 data CoercibleField = CoercibleField
   { cfName      :: FieldName
   , cfJsonPath  :: JsonPath
-  , cfIRType    :: Text -- ^ The native Postgres type of the field, the type before mapping.
+  , cfIRType    :: Text -- ^ The native Postgres type of the field, the intermediate (IR) type before mapping.
   , cfTransform :: Maybe TransformerProc -- ^ The optional mapping from irType -> targetType.
   } deriving (Eq)
 

--- a/src/PostgREST/Query/QueryBuilder.hs
+++ b/src/PostgREST/Query/QueryBuilder.hs
@@ -53,7 +53,7 @@ readPlanToQuery (Node ReadPlan{select,from=mainQi,fromAlias,where_=logicForest,o
   where
     fromFrag = fromF relToParent mainQi fromAlias
     qi = getQualifiedIdentifier relToParent mainQi fromAlias
-    defSelect = [(("*", []), Nothing, Nothing)] -- gets all the columns in case of an empty select, ignoring/obtaining these columns is done at the aggregation stage
+    defSelect = [(unknownField "*" [], Nothing, Nothing)] -- gets all the columns in case of an empty select, ignoring/obtaining these columns is done at the aggregation stage
     (selects, joins) = foldr getSelectsJoins ([],[]) forest
 
 getSelectsJoins :: ReadPlanTree -> ([SQL.Snippet], [SQL.Snippet]) -> ([SQL.Snippet], [SQL.Snippet])

--- a/src/PostgREST/Query/QueryBuilder.hs
+++ b/src/PostgREST/Query/QueryBuilder.hs
@@ -98,12 +98,12 @@ mutatePlanToQuery (Insert mainQi iCols body onConflct putConditions returnings _
         MergeDuplicates  ->
           if null iCols
              then "DO NOTHING"
-             else "DO UPDATE SET " <> BS.intercalate ", " ((pgFmtIdent . tfName) <> const " = EXCLUDED." <> (pgFmtIdent . tfName) <$> iCols)
+             else "DO UPDATE SET " <> BS.intercalate ", " ((pgFmtIdent . cfName) <> const " = EXCLUDED." <> (pgFmtIdent . cfName) <$> iCols)
       ) onConflct,
     returningF mainQi returnings
     ])
   where
-    cols = BS.intercalate ", " $ pgFmtIdent . tfName <$> iCols
+    cols = BS.intercalate ", " $ pgFmtIdent . cfName <$> iCols
 
 -- An update without a limit is always filtered with a WHERE
 mutatePlanToQuery (Update mainQi uCols body logicForest range ordts returnings)
@@ -138,8 +138,8 @@ mutatePlanToQuery (Update mainQi uCols body logicForest range ordts returnings)
     whereLogic = if null logicForest then mempty else " WHERE " <> intercalateSnippet " AND " (pgFmtLogicTree mainQi <$> logicForest)
     mainTbl = SQL.sql (fromQi mainQi)
     emptyBodyReturnedColumns = if null returnings then "NULL" else BS.intercalate ", " (pgFmtColumn (QualifiedIdentifier mempty $ qiName mainQi) <$> returnings)
-    nonRangeCols = BS.intercalate ", " (pgFmtIdent . tfName <> const " = _." <> pgFmtIdent . tfName <$> uCols)
-    rangeCols = BS.intercalate ", " ((\col -> pgFmtIdent (tfName col) <> " = (SELECT " <> pgFmtIdent (tfName col) <> " FROM pgrst_update_body) ") <$> uCols)
+    nonRangeCols = BS.intercalate ", " (pgFmtIdent . cfName <> const " = _." <> pgFmtIdent . cfName <$> uCols)
+    rangeCols = BS.intercalate ", " ((\col -> pgFmtIdent (cfName col) <> " = (SELECT " <> pgFmtIdent (cfName col) <> " FROM pgrst_update_body) ") <$> uCols)
     (whereRangeIdF, rangeIdF) = mutRangeF mainQi (fst . otTerm <$> ordts)
 
 mutatePlanToQuery (Delete mainQi logicForest range ordts returnings)

--- a/src/PostgREST/SchemaCache/Representations.hs
+++ b/src/PostgREST/SchemaCache/Representations.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric  #-}
+
+module PostgREST.SchemaCache.Representations
+  ( DataRepresentation(..)
+  , RepresentationsMap
+  ) where
+
+import qualified Data.Aeson          as JSON
+import qualified Data.HashMap.Strict as HM
+
+
+import Protolude
+
+-- | Data representations allow user customisation of how to present and receive data through APIs, per field.
+-- This structure is used for the library of available transforms. It answers questions like:
+-- - What function, if any, should be used to present a certain field that's been selected for API output?
+-- - How do we parse incoming data for a certain field type when inserting or updating?
+-- - And similarly, how do we parse textual data in a query string to be used as a filter?
+--
+-- Support for outputting special formats like CSV and binary data would fit into the same system.
+data DataRepresentation = DataRepresentation
+  { drSourceType :: Text
+  , drTargetType :: Text
+  , drFunction   :: Text
+  } deriving (Eq, Show, Generic, JSON.ToJSON, JSON.FromJSON)
+
+-- The representation map maps from (source type, target type) to a DR.
+type RepresentationsMap = HM.HashMap (Text, Text) DataRepresentation

--- a/test/spec/Feature/Query/ComputedRelsSpec.hs
+++ b/test/spec/Feature/Query/ComputedRelsSpec.hs
@@ -139,6 +139,11 @@ spec = describe "computed relationships" $ do
       [("Prefer", "tx=commit")]
       [json| {"name": "Sid Meier"} |]
       `shouldRespondWith` 204
+    -- need to poke the second one too to prevent inherent ordering from changing
+    request methodPatch "/designers?id=eq.2"
+      [("Prefer", "tx=commit")]
+      [json| {"name": "Hironobu Sakaguchi"} |]
+      `shouldRespondWith` 204
 
   it "works with self joins" $
     get "/web_content?select=name,child_web_content(name),parent_web_content(name)&id=in.(0,1)"

--- a/test/spec/Feature/Query/ComputedRelsSpec.hs
+++ b/test/spec/Feature/Query/ComputedRelsSpec.hs
@@ -104,6 +104,42 @@ spec = describe "computed relationships" $ do
         [json|[ {"name":"Final Fantasy I","designer":{"name":"Hironobu Sakaguchi"}} ]|]
         { matchStatus  = 200 }
 
+  it "applies data representations to response" $ do
+    -- A smoke test for data reps in the presence of computed relations.
+
+    -- The data rep here title cases the designer name before presentation. So here the lowercase version will be saved,
+    -- but the title case version returned. Pulling in a computed relation should not confuse this.
+    request methodPatch "/designers?select=name,videogames:computed_videogames(name)&id=eq.1"
+      [("Prefer", "return=representation"), ("Prefer", "tx=commit")]
+      [json| {"name": "sidney k. meier"} |]
+      `shouldRespondWith`
+      [json|[{"name":"Sidney K. Meier","videogames":[{"name":"Civilization I"}, {"name":"Civilization II"}]}]|]
+      { matchStatus = 200 }
+
+    -- Verify it was saved the way we requested (there's no text data rep for this column, so if we select with the wrong casing, it should fail.)
+    get "/designers?select=id&name=eq.Sidney%20K.%20Meier"
+      `shouldRespondWith`
+      [json|[]|]
+      { matchStatus = 200, matchHeaders = [matchContentTypeJson] }
+    -- But with the right casing it works.
+    get "/designers?select=id,name&name=eq.sidney%20k.%20meier"
+      `shouldRespondWith`
+      [json|[{"id": 1, "name":"Sidney K. Meier"}]|]
+      { matchStatus = 200, matchHeaders = [matchContentTypeJson] }
+
+    -- Most importantly, if you read it back even via a computed relation, the data rep should be applied.
+    get "/videogames?select=name,designer:computed_designers(*)&id=eq.1"
+      `shouldRespondWith`
+      [json|[
+        {"name":"Civilization I","designer":{"id": 1, "name":"Sidney K. Meier"}}
+      ]|] { matchHeaders = [matchContentTypeJson] }
+
+    -- reset the test fixture
+    request methodPatch "/designers?id=eq.1"
+      [("Prefer", "tx=commit")]
+      [json| {"name": "Sid Meier"} |]
+      `shouldRespondWith` 204
+
   it "works with self joins" $
     get "/web_content?select=name,child_web_content(name),parent_web_content(name)&id=in.(0,1)"
     `shouldRespondWith`

--- a/test/spec/Feature/Query/InsertSpec.hs
+++ b/test/spec/Feature/Query/InsertSpec.hs
@@ -11,8 +11,9 @@ import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 import Text.Heredoc
 
-import PostgREST.Config.PgVersion (PgVersion, pgVersion110,
-                                   pgVersion112, pgVersion130)
+import PostgREST.Config.PgVersion (PgVersion, pgVersion100,
+                                   pgVersion110, pgVersion112,
+                                   pgVersion130)
 
 import Protolude  hiding (get)
 import SpecHelper
@@ -657,3 +658,114 @@ spec actualPgVersion = do
                              , "Location" <:> "/test_null_pk_competitors_sponsors?id=eq.1&sponsor_id=is.null"
                              , "Content-Range" <:> "*/*" ]
             }
+
+  -- Data representations for payload parsing requires Postgrest 10 or above.
+  when (actualPgVersion >= pgVersion100) $ do
+    describe "Data representations" $ do
+      context "on regular table" $ do
+        it "parses values in POST body" $
+          -- we don't check that the parsing is correct here, just that it's happening. If it doesn't happen we'll get a
+          -- an "invalid input syntax for type integer:" error.
+          request methodPost "/datarep_todos" [("Prefer", "return=headers-only")]
+            [json| {"id":5, "name": "party", "label_color": "#001100", "due_at": "2018-01-03T11:00:00+00"} |]
+            `shouldRespondWith`
+            ""
+              { matchStatus  = 201
+              , matchHeaders = [ matchHeaderAbsent hContentType
+                               , "Location" <:> "/datarep_todos?id=eq.5"
+                               , "Content-Range" <:> "*/*" ]
+              }
+
+        it "parses values in POST body and formats individually selected values in return=representation" $
+          request methodPost "/datarep_todos?select=id,label_color" [("Prefer", "return=representation")]
+            [json| {"id":5, "name": "party", "label_color": "#001100", "due_at": "2018-01-03T11:00:00+00"} |]
+            `shouldRespondWith`
+            [json| [{"id":5, "label_color": "#001100"}] |]
+              { matchStatus  = 201
+              , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
+                                "Content-Range" <:> "*/*"]
+              }
+
+        it "parses values in POST body and formats values in return=representation" $
+          request methodPost "/datarep_todos" [("Prefer", "return=representation")]
+            [json| {"id":5, "name": "party", "label_color": "#001100", "due_at": "2018-01-03T11:00:00+00"} |]
+            `shouldRespondWith`
+            [json| [{"id":5,"name": "party", "label_color": "#001100", "due_at":"2018-01-03T11:00:00+00"}] |]
+              { matchStatus  = 201
+              , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
+                                "Content-Range" <:> "*/*"]
+              }
+
+      context "with ?columns parameter" $ do
+        it "ignores json keys not included in ?columns; parses only the ones specified" $
+          request methodPost "/datarep_todos?columns=id,label_color&select=id,name,label_color,due_at" [("Prefer", "return=representation")]
+            [json| {"id":5, "name": "party", "label_color": "#001100", "due_at": "invalid but should be ignored"} |]
+            `shouldRespondWith`
+            [json| [{"id":5, "name":null, "label_color": "#001100", "due_at": "2018-01-01T00:00:00+00"}] |]
+              { matchStatus  = 201
+              , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
+                                "Content-Range" <:> "*/*"]
+              }
+
+        it "fails without parsing anything if at least one specified column doesn't exist" $
+          request methodPost "/datarep_todos?columns=id,label_color,helicopters&select=id,name,label_color,due_at" [("Prefer", "return=representation")]
+            [json| {"due_at": "2019-01-03T11:00:00+00", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
+            `shouldRespondWith`
+            [json| {"code":"PGRST118","message":"Column 'helicopters' of relation 'datarep_todos' does not exist","details":null,"hint":null} |]
+              { matchStatus  = 400
+              , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8"]
+              }
+
+      context "on updatable view" $ do
+        it "parses values in POST body" $
+          -- we don't check that the parsing is correct here, just that it's happening. If it doesn't happen we'll get a
+          -- an "invalid input syntax for type integer:" error.
+          request methodPost "/datarep_todos_computed" [("Prefer", "return=headers-only")]
+            [json| {"id":5, "name": "party", "label_color": "#001100", "due_at": "2018-01-03T11:00:00+00"} |]
+            `shouldRespondWith`
+            ""
+              { matchStatus  = 201
+              , matchHeaders = [ matchHeaderAbsent hContentType
+                               , "Location" <:> "/datarep_todos_computed?id=eq.5"
+                               , "Content-Range" <:> "*/*" ]
+              }
+
+        it "parses values in POST body and formats individually selected values in return=representation" $
+          request methodPost "/datarep_todos_computed?select=id,label_color" [("Prefer", "return=representation")]
+            [json| {"id":5, "name": "party", "label_color": "#001100", "due_at": "2018-01-03T11:00:00+00"} |]
+            `shouldRespondWith`
+            [json| [{"id":5, "label_color": "#001100"}] |]
+              { matchStatus  = 201
+              , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
+                                "Content-Range" <:> "*/*"]
+              }
+
+        it "parses values in POST body and formats values in return=representation" $
+          request methodPost "/datarep_todos_computed" [("Prefer", "return=representation")]
+            [json| {"id":5, "name": "party", "label_color": "#001100", "due_at": "2018-01-03T11:00:00+00"} |]
+            `shouldRespondWith`
+            [json| [{"id":5,"name": "party", "label_color": "#001100", "due_at":"2018-01-03T11:00:00+00", "dark_color":"#000880"}] |]
+              { matchStatus  = 201
+              , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
+                                "Content-Range" <:> "*/*"]
+              }
+
+      context "on updatable views with ?columns parameter" $ do
+        it "ignores json keys not included in ?columns; parses only the ones specified" $
+          request methodPost "/datarep_todos_computed?columns=id,label_color&select=id,name,label_color,due_at" [("Prefer", "return=representation")]
+            [json| {"id":5, "name": "party", "label_color": "#001100", "due_at": "invalid but should be ignored"} |]
+            `shouldRespondWith`
+            [json| [{"id":5, "name":null, "label_color": "#001100", "due_at": "2018-01-01T00:00:00+00"}] |]
+              { matchStatus  = 201
+              , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
+                                "Content-Range" <:> "*/*"]
+              }
+
+        it "fails without parsing anything if at least one specified column doesn't exist" $
+          request methodPost "/datarep_todos_computed?columns=id,label_color,helicopters&select=id,name,label_color,due_at" [("Prefer", "return=representation")]
+            [json| {"due_at": "2019-01-03T11:00:00+00", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
+            `shouldRespondWith`
+            [json| {"code":"PGRST118","message":"Column 'helicopters' of relation 'datarep_todos_computed' does not exist","details":null,"hint":null} |]
+              { matchStatus  = 400
+              , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8"]
+              }

--- a/test/spec/Feature/Query/InsertSpec.hs
+++ b/test/spec/Feature/Query/InsertSpec.hs
@@ -659,7 +659,7 @@ spec actualPgVersion = do
                              , "Content-Range" <:> "*/*" ]
             }
 
-  -- Data representations for payload parsing requires Postgrest 10 or above.
+  -- Data representations for payload parsing requires Postgres 10 or above.
   when (actualPgVersion >= pgVersion100) $ do
     describe "Data representations" $ do
       context "on regular table" $ do
@@ -688,9 +688,9 @@ spec actualPgVersion = do
 
         it "parses values in POST body and formats values in return=representation" $
           request methodPost "/datarep_todos" [("Prefer", "return=representation")]
-            [json| {"id":5, "name": "party", "label_color": "#001100", "due_at": "2018-01-03T11:00:00+00"} |]
+            [json| {"id":5, "name": "party", "label_color": "#001100", "due_at": "2018-01-03T11:00:00+00", "icon_image": "3q2+7w", "created_at":-15, "budget": "-100000000000000.13"} |]
             `shouldRespondWith`
-            [json| [{"id":5,"name": "party", "label_color": "#001100", "due_at":"2018-01-03T11:00:00+00"}] |]
+            [json| [{"id":5,"name": "party", "label_color": "#001100", "due_at":"2018-01-03T11:00:00+00", "icon_image": "3q2+7w==", "created_at":-15, "budget": "-100000000000000.13"}] |]
               { matchStatus  = 201
               , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
                                 "Content-Range" <:> "*/*"]

--- a/test/spec/Feature/Query/InsertSpec.hs
+++ b/test/spec/Feature/Query/InsertSpec.hs
@@ -690,7 +690,7 @@ spec actualPgVersion = do
           request methodPost "/datarep_todos" [("Prefer", "return=representation")]
             [json| {"id":5, "name": "party", "label_color": "#001100", "due_at": "2018-01-03T11:00:00+00", "icon_image": "3q2+7w", "created_at":-15, "budget": "-100000000000000.13"} |]
             `shouldRespondWith`
-            [json| [{"id":5,"name": "party", "label_color": "#001100", "due_at":"2018-01-03T11:00:00+00", "icon_image": "3q2+7w==", "created_at":-15, "budget": "-100000000000000.13"}] |]
+            [json| [{"id":5,"name": "party", "label_color": "#001100", "due_at":"2018-01-03T11:00:00Z", "icon_image": "3q2+7w==", "created_at":-15, "budget": "-100000000000000.13"}] |]
               { matchStatus  = 201
               , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
                                 "Content-Range" <:> "*/*"]
@@ -701,7 +701,7 @@ spec actualPgVersion = do
           request methodPost "/datarep_todos?columns=id,label_color&select=id,name,label_color,due_at" [("Prefer", "return=representation")]
             [json| {"id":5, "name": "party", "label_color": "#001100", "due_at": "invalid but should be ignored"} |]
             `shouldRespondWith`
-            [json| [{"id":5, "name":null, "label_color": "#001100", "due_at": "2018-01-01T00:00:00+00"}] |]
+            [json| [{"id":5, "name":null, "label_color": "#001100", "due_at": "2018-01-01T00:00:00Z"}] |]
               { matchStatus  = 201
               , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
                                 "Content-Range" <:> "*/*"]
@@ -744,7 +744,7 @@ spec actualPgVersion = do
           request methodPost "/datarep_todos_computed" [("Prefer", "return=representation")]
             [json| {"id":5, "name": "party", "label_color": "#001100", "due_at": "2018-01-03T11:00:00+00"} |]
             `shouldRespondWith`
-            [json| [{"id":5,"name": "party", "label_color": "#001100", "due_at":"2018-01-03T11:00:00+00", "dark_color":"#000880"}] |]
+            [json| [{"id":5,"name": "party", "label_color": "#001100", "due_at":"2018-01-03T11:00:00Z", "dark_color":"#000880"}] |]
               { matchStatus  = 201
               , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
                                 "Content-Range" <:> "*/*"]
@@ -755,7 +755,7 @@ spec actualPgVersion = do
           request methodPost "/datarep_todos_computed?columns=id,label_color&select=id,name,label_color,due_at" [("Prefer", "return=representation")]
             [json| {"id":5, "name": "party", "label_color": "#001100", "due_at": "invalid but should be ignored"} |]
             `shouldRespondWith`
-            [json| [{"id":5, "name":null, "label_color": "#001100", "due_at": "2018-01-01T00:00:00+00"}] |]
+            [json| [{"id":5, "name":null, "label_color": "#001100", "due_at": "2018-01-01T00:00:00Z"}] |]
               { matchStatus  = 201
               , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
                                 "Content-Range" <:> "*/*"]

--- a/test/spec/Feature/Query/QuerySpec.hs
+++ b/test/spec/Feature/Query/QuerySpec.hs
@@ -1317,25 +1317,25 @@ spec actualPgVersion = do
     it "formats star select" $
       get "/datarep_todos?select=*&id=lt.4" `shouldRespondWith`
         [json| [
-          {"id":1,"name":"Report","label_color":"#000000","due_at":"2018-01-02T00:00:00+00"},
-          {"id":2,"name":"Essay","label_color":"#000100","due_at":"2018-01-03T00:00:00+00"},
-          {"id":3,"name":"Algebra","label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456+00"}
+          {"id":1,"name":"Report","label_color":"#000000","due_at":"2018-01-02T00:00:00+00","icon_image":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQAAAAA3bvkkAAAAABBJREFUeJxiYAEAAAAA//8DAAAABgAFBXv6vUAAAAAASUVORK5CYII=","created_at":1513213350,"budget":"12.50"},
+           {"id":2,"name":"Essay","label_color":"#000100","due_at":"2018-01-03T00:00:00+00","icon_image":null,"created_at":1513213350,"budget":"100000000000000.13"},
+           {"id":3,"name":"Algebra","label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456+00","icon_image":null,"created_at":1513213350,"budget":"0.00"}
         ] |]
         { matchHeaders = [matchContentTypeJson] }
     it "formats implicit star select" $
       get "/datarep_todos?id=lt.4" `shouldRespondWith`
         [json| [
-          {"id":1,"name":"Report","label_color":"#000000","due_at":"2018-01-02T00:00:00+00"},
-          {"id":2,"name":"Essay","label_color":"#000100","due_at":"2018-01-03T00:00:00+00"},
-          {"id":3,"name":"Algebra","label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456+00"}
+          {"id":1,"name":"Report","label_color":"#000000","due_at":"2018-01-02T00:00:00+00","icon_image":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQAAAAA3bvkkAAAAABBJREFUeJxiYAEAAAAA//8DAAAABgAFBXv6vUAAAAAASUVORK5CYII=","created_at":1513213350,"budget":"12.50"},
+ {"id":2,"name":"Essay","label_color":"#000100","due_at":"2018-01-03T00:00:00+00","icon_image":null,"created_at":1513213350,"budget":"100000000000000.13"},
+ {"id":3,"name":"Algebra","label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456+00","icon_image":null,"created_at":1513213350,"budget":"0.00"}
         ] |]
         { matchHeaders = [matchContentTypeJson] }
     it "formats star and explicit mix" $
       get "/datarep_todos?select=due_at,*&id=lt.4" `shouldRespondWith`
         [json| [
-          {"id":1,"name":"Report","label_color":"#000000","due_at":"2018-01-02T00:00:00+00"},
-          {"id":2,"name":"Essay","label_color":"#000100","due_at":"2018-01-03T00:00:00+00"},
-          {"id":3,"name":"Algebra","label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456+00"}
+          {"due_at":"2018-01-02T00:00:00+00","id":1,"name":"Report","label_color":"#000000","due_at":"2018-01-02T00:00:00+00","icon_image":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQAAAAA3bvkkAAAAABBJREFUeJxiYAEAAAAA//8DAAAABgAFBXv6vUAAAAAASUVORK5CYII=","created_at":1513213350,"budget":"12.50"},
+           {"due_at":"2018-01-03T00:00:00+00","id":2,"name":"Essay","label_color":"#000100","due_at":"2018-01-03T00:00:00+00","icon_image":null,"created_at":1513213350,"budget":"100000000000000.13"},
+           {"due_at":"2018-01-01T14:12:34.123456+00","id":3,"name":"Algebra","label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456+00","icon_image":null,"created_at":1513213350,"budget":"0.00"}
         ] |]
         { matchHeaders = [matchContentTypeJson] }
     it "formats through join" $
@@ -1345,10 +1345,8 @@ spec actualPgVersion = do
     it "formats through join with star select" $
       get "/datarep_next_two_todos?select=id,name,second_item:datarep_todos!datarep_next_two_todos_second_item_id_fkey(*)" `shouldRespondWith`
         [json| [
-          {"id":1,"name":"school related","second_item":
-            {"id": 3, "name": "Algebra", "label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456+00"}},
-          {"id":2,"name":"do these first","second_item":
-            {"id": 3, "name": "Algebra", "label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456+00"}}
+          {"id":1,"name":"school related","second_item":{"id":3,"name":"Algebra","label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456+00","icon_image":null,"created_at":1513213350,"budget":"0.00"}},
+          {"id":2,"name":"do these first","second_item":{"id":3,"name":"Algebra","label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456+00","icon_image":null,"created_at":1513213350,"budget":"0.00"}}
         ] |]
         { matchHeaders = [matchContentTypeJson] }
     it "uses text parser on value for filter given through query parameters" $

--- a/test/spec/Feature/Query/QuerySpec.hs
+++ b/test/spec/Feature/Query/QuerySpec.hs
@@ -1284,7 +1284,7 @@ spec actualPgVersion = do
         { matchHeaders = [matchContentTypeJson] }
     it "formats two columns with different formatters" $
       get "/datarep_todos?select=id,label_color,due_at&id=lt.4" `shouldRespondWith`
-        [json| [{"id":1,"label_color":"#000000","due_at":"2018-01-02T00:00:00+00"},{"id":2,"label_color":"#000100","due_at":"2018-01-03T00:00:00+00"},{"id":3,"label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456+00"}] |]
+        [json| [{"id":1,"label_color":"#000000","due_at":"2018-01-02T00:00:00Z"},{"id":2,"label_color":"#000100","due_at":"2018-01-03T00:00:00Z"},{"id":3,"label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456Z"}] |]
         { matchHeaders = [matchContentTypeJson] }
     it "fails in some reasonable way when selecting fields that don't exist" $
       get "/datarep_todos?select=id,label_color,banana" `shouldRespondWith`
@@ -1312,52 +1312,51 @@ spec actualPgVersion = do
     it "formats nulls" $
       -- due_at is formatted as NULL but label_color NULLs become empty strings-- it's up to the formatting function.
       get "/datarep_todos?select=id,label_color,due_at&id=gt.2&id=lt.5" `shouldRespondWith`
-        [json| [{"id":3,"label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456+00"},{"id":4,"label_color":"","due_at":null}] |]
+        [json| [{"id":3,"label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456Z"},{"id":4,"label_color":"","due_at":null}] |]
         { matchHeaders = [matchContentTypeJson] }
     it "formats star select" $
       get "/datarep_todos?select=*&id=lt.4" `shouldRespondWith`
         [json| [
-          {"id":1,"name":"Report","label_color":"#000000","due_at":"2018-01-02T00:00:00+00","icon_image":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQAAAAA3bvkkAAAAABBJREFUeJxiYAEAAAAA//8DAAAABgAFBXv6vUAAAAAASUVORK5CYII=","created_at":1513213350,"budget":"12.50"},
-           {"id":2,"name":"Essay","label_color":"#000100","due_at":"2018-01-03T00:00:00+00","icon_image":null,"created_at":1513213350,"budget":"100000000000000.13"},
-           {"id":3,"name":"Algebra","label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456+00","icon_image":null,"created_at":1513213350,"budget":"0.00"}
+          {"id":1,"name":"Report","label_color":"#000000","due_at":"2018-01-02T00:00:00Z","icon_image":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQAAAAA3bvkkAAAAABBJREFUeJxiYAEAAAAA//8DAAAABgAFBXv6vUAAAAAASUVORK5CYII=","created_at":1513213350,"budget":"12.50"},
+           {"id":2,"name":"Essay","label_color":"#000100","due_at":"2018-01-03T00:00:00Z","icon_image":null,"created_at":1513213350,"budget":"100000000000000.13"},
+           {"id":3,"name":"Algebra","label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456Z","icon_image":null,"created_at":1513213350,"budget":"0.00"}
         ] |]
         { matchHeaders = [matchContentTypeJson] }
     it "formats implicit star select" $
       get "/datarep_todos?id=lt.4" `shouldRespondWith`
         [json| [
-          {"id":1,"name":"Report","label_color":"#000000","due_at":"2018-01-02T00:00:00+00","icon_image":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQAAAAA3bvkkAAAAABBJREFUeJxiYAEAAAAA//8DAAAABgAFBXv6vUAAAAAASUVORK5CYII=","created_at":1513213350,"budget":"12.50"},
- {"id":2,"name":"Essay","label_color":"#000100","due_at":"2018-01-03T00:00:00+00","icon_image":null,"created_at":1513213350,"budget":"100000000000000.13"},
- {"id":3,"name":"Algebra","label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456+00","icon_image":null,"created_at":1513213350,"budget":"0.00"}
+          {"id":1,"name":"Report","label_color":"#000000","due_at":"2018-01-02T00:00:00Z","icon_image":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQAAAAA3bvkkAAAAABBJREFUeJxiYAEAAAAA//8DAAAABgAFBXv6vUAAAAAASUVORK5CYII=","created_at":1513213350,"budget":"12.50"},
+ {"id":2,"name":"Essay","label_color":"#000100","due_at":"2018-01-03T00:00:00Z","icon_image":null,"created_at":1513213350,"budget":"100000000000000.13"},
+ {"id":3,"name":"Algebra","label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456Z","icon_image":null,"created_at":1513213350,"budget":"0.00"}
         ] |]
         { matchHeaders = [matchContentTypeJson] }
     it "formats star and explicit mix" $
       get "/datarep_todos?select=due_at,*&id=lt.4" `shouldRespondWith`
         [json| [
-          {"due_at":"2018-01-02T00:00:00+00","id":1,"name":"Report","label_color":"#000000","due_at":"2018-01-02T00:00:00+00","icon_image":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQAAAAA3bvkkAAAAABBJREFUeJxiYAEAAAAA//8DAAAABgAFBXv6vUAAAAAASUVORK5CYII=","created_at":1513213350,"budget":"12.50"},
-           {"due_at":"2018-01-03T00:00:00+00","id":2,"name":"Essay","label_color":"#000100","due_at":"2018-01-03T00:00:00+00","icon_image":null,"created_at":1513213350,"budget":"100000000000000.13"},
-           {"due_at":"2018-01-01T14:12:34.123456+00","id":3,"name":"Algebra","label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456+00","icon_image":null,"created_at":1513213350,"budget":"0.00"}
+          {"due_at":"2018-01-02T00:00:00Z","id":1,"name":"Report","label_color":"#000000","due_at":"2018-01-02T00:00:00Z","icon_image":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQAAAAA3bvkkAAAAABBJREFUeJxiYAEAAAAA//8DAAAABgAFBXv6vUAAAAAASUVORK5CYII=","created_at":1513213350,"budget":"12.50"},
+           {"due_at":"2018-01-03T00:00:00Z","id":2,"name":"Essay","label_color":"#000100","due_at":"2018-01-03T00:00:00Z","icon_image":null,"created_at":1513213350,"budget":"100000000000000.13"},
+           {"due_at":"2018-01-01T14:12:34.123456Z","id":3,"name":"Algebra","label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456Z","icon_image":null,"created_at":1513213350,"budget":"0.00"}
         ] |]
         { matchHeaders = [matchContentTypeJson] }
     it "formats through join" $
       get "/datarep_next_two_todos?select=id,name,first_item:datarep_todos!datarep_next_two_todos_first_item_id_fkey(label_color,due_at)" `shouldRespondWith`
-        [json| [{"id":1,"name":"school related","first_item":{"label_color":"#000100","due_at":"2018-01-03T00:00:00+00"}},{"id":2,"name":"do these first","first_item":{"label_color":"#000000","due_at":"2018-01-02T00:00:00+00"}}] |]
+        [json| [{"id":1,"name":"school related","first_item":{"label_color":"#000100","due_at":"2018-01-03T00:00:00Z"}},{"id":2,"name":"do these first","first_item":{"label_color":"#000000","due_at":"2018-01-02T00:00:00Z"}}] |]
         { matchHeaders = [matchContentTypeJson] }
     it "formats through join with star select" $
       get "/datarep_next_two_todos?select=id,name,second_item:datarep_todos!datarep_next_two_todos_second_item_id_fkey(*)" `shouldRespondWith`
         [json| [
-          {"id":1,"name":"school related","second_item":{"id":3,"name":"Algebra","label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456+00","icon_image":null,"created_at":1513213350,"budget":"0.00"}},
-          {"id":2,"name":"do these first","second_item":{"id":3,"name":"Algebra","label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456+00","icon_image":null,"created_at":1513213350,"budget":"0.00"}}
+          {"id":1,"name":"school related","second_item":{"id":3,"name":"Algebra","label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456Z","icon_image":null,"created_at":1513213350,"budget":"0.00"}},
+          {"id":2,"name":"do these first","second_item":{"id":3,"name":"Algebra","label_color":"#01E240","due_at":"2018-01-01T14:12:34.123456Z","icon_image":null,"created_at":1513213350,"budget":"0.00"}}
         ] |]
         { matchHeaders = [matchContentTypeJson] }
     it "uses text parser on value for filter given through query parameters" $
       get "/datarep_todos?select=id,due_at&label_color=eq.000100" `shouldRespondWith`
-        [json| [{"id":2,"due_at":"2018-01-03T00:00:00+00"}] |]
+        [json| [{"id":2,"due_at":"2018-01-03T00:00:00Z"}] |]
         { matchHeaders = [matchContentTypeJson] }
     it "in the absense of text parser, does not try to use the JSON parser for query parameters" $
-      get "/datarep_todos?select=id,due_at&due_at=eq.T" `shouldRespondWith`
-        -- okay this test is a bit of a hack but we prove the parser is not used because it'd replace the T and fail a
-        -- different way.
-        [json| {"code":"22007","details":null,"hint":null,"message":"invalid input syntax for type timestamp with time zone: \"T\""} |]
+      get "/datarep_todos?select=id,due_at&due_at=eq.Z" `shouldRespondWith`
+        -- we prove the parser is not used because it'd replace the Z with `+00:00` and a different error message.
+        [json| {"code":"22007","details":null,"hint":null,"message":"invalid input syntax for type timestamp with time zone: \"Z\""} |]
         { matchStatus  = 400
         , matchHeaders = [matchContentTypeJson]
         }
@@ -1367,19 +1366,19 @@ spec actualPgVersion = do
       it "uses text parser for filter with 'IN' predicates" $
         get "/datarep_todos?select=id,due_at&label_color=in.(000100,01E240)" `shouldRespondWith`
           [json| [
-            {"id":2, "due_at": "2018-01-03T00:00:00+00"},
-            {"id":3, "due_at": "2018-01-01T14:12:34.123456+00"}
+            {"id":2, "due_at": "2018-01-03T00:00:00Z"},
+            {"id":3, "due_at": "2018-01-01T14:12:34.123456Z"}
           ] |]
           { matchHeaders = [matchContentTypeJson] }
       it "uses text parser for filter with 'NOT IN' predicates" $
         get "/datarep_todos?select=id,due_at&label_color=not.in.(000000,01E240)" `shouldRespondWith`
           [json| [
-            {"id":2, "due_at": "2018-01-03T00:00:00+00"}
+            {"id":2, "due_at": "2018-01-03T00:00:00Z"}
           ] |]
           { matchHeaders = [matchContentTypeJson] }
     it "uses text parser on value for filter across relations" $
       get "/datarep_next_two_todos?select=id,name,datarep_todos!datarep_next_two_todos_first_item_id_fkey(label_color,due_at)&datarep_todos.label_color=neq.000100" `shouldRespondWith`
-        [json| [{"id":1,"name":"school related","datarep_todos":null},{"id":2,"name":"do these first","datarep_todos":{"label_color":"#000000","due_at":"2018-01-02T00:00:00+00"}}] |]
+        [json| [{"id":1,"name":"school related","datarep_todos":null},{"id":2,"name":"do these first","datarep_todos":{"label_color":"#000000","due_at":"2018-01-02T00:00:00Z"}}] |]
         { matchHeaders = [matchContentTypeJson] }
     -- This is not supported by data reps (would be hard to make it work with high performance). So the test just
     -- verifies we don't panic or add inappropriate SQL to the filters.

--- a/test/spec/Feature/Query/UpdateSpec.hs
+++ b/test/spec/Feature/Query/UpdateSpec.hs
@@ -547,7 +547,7 @@ spec actualPgVersion = do
       , { "id": 3, "name": "item-3" }
       ]|]
 
-  -- Data representations for payload parsing requires Postgrest 10 or above.
+  -- Data representations for payload parsing requires Postgres 10 or above.
   when (actualPgVersion >= pgVersion100) $ do
     describe "Data representations" $ do
       context "for a single row" $ do
@@ -573,9 +573,9 @@ spec actualPgVersion = do
 
         it "parses values in payload and formats values in return=representation" $
           request methodPatch "/datarep_todos?id=eq.2" [("Prefer", "return=representation")]
-            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:20+00"} |]
+            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:20+00", "icon_image": "3q2+7w"} |]
             `shouldRespondWith`
-            [json| [{"id":2, "name": "Essay", "label_color": "#221100", "due_at":"2019-01-03T11:00:20+00"}] |]
+            [json|  [{"id":2,"name":"Essay","label_color":"#221100","due_at":"2019-01-03T11:00:20+00","icon_image":"3q2+7w==","created_at":1513213350,"budget":"100000000000000.13"}] |]
               { matchStatus  = 200
               , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
                                 "Content-Range" <:> "0-0/*"]
@@ -583,10 +583,10 @@ spec actualPgVersion = do
 
         it "parses values in payload and formats star mixed selected values in return=representation" $
           request methodPatch "/datarep_todos?id=eq.2&select=due_at,*" [("Prefer", "return=representation")]
-            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00"} |]
+            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00", "created_at": 0} |]
             `shouldRespondWith`
             -- end up with due_at twice here but that's unrelated to data reps
-            [json| [{"due_at":"2019-01-03T11:00:00+00", "id":2, "name":"Essay", "label_color":"#221100", "due_at":"2019-01-03T11:00:00+00"}] |]
+            [json| [{"due_at":"2019-01-03T11:00:00+00","id":2,"name":"Essay","label_color":"#221100","due_at":"2019-01-03T11:00:00+00","icon_image":null,"created_at":0,"budget":"100000000000000.13"}] |]
               { matchStatus  = 200
               , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
                                 "Content-Range" <:> "0-0/*"]
@@ -608,12 +608,12 @@ spec actualPgVersion = do
 
         it "parses values in payload and formats values in return=representation" $
           request methodPatch "/datarep_todos?id=lt.4" [("Prefer", "return=representation")]
-            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00"} |]
+            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00", "icon_image": "3q2+7w="} |]
             `shouldRespondWith`
             [json| [
-              {"id":1, "name": "Report", "label_color": "#221100", "due_at":"2019-01-03T11:00:00+00"},
-              {"id":2, "name": "Essay", "label_color": "#221100", "due_at":"2019-01-03T11:00:00+00"},
-              {"id":3, "name": "Algebra", "label_color": "#221100", "due_at":"2019-01-03T11:00:00+00"}
+              {"id":1,"name":"Report","label_color":"#221100","due_at":"2019-01-03T11:00:00+00","icon_image":"3q2+7w==","created_at":1513213350,"budget":"12.50"},
+              {"id":2,"name":"Essay","label_color":"#221100","due_at":"2019-01-03T11:00:00+00","icon_image":"3q2+7w==","created_at":1513213350,"budget":"100000000000000.13"},
+              {"id":3,"name":"Algebra","label_color":"#221100","due_at":"2019-01-03T11:00:00+00","icon_image":"3q2+7w==","created_at":1513213350,"budget":"0.00"}
             ] |]
               { matchStatus  = 200
               , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
@@ -625,7 +625,7 @@ spec actualPgVersion = do
             [json| {"due_at": "2019-01-03T11:00:00+00", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
             `shouldRespondWith`
             [json| [
-              {"id":2, "name": "Essay", "label_color": "#000100", "due_at":"2019-01-03T11:00:00+00"}
+               {"id":2,"name":"Essay","label_color":"#000100","due_at":"2019-01-03T11:00:00+00","icon_image":null,"created_at":1513213350,"budget":"100000000000000.13"}
             ] |]
               { matchStatus  = 200
               , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",

--- a/test/spec/Feature/Query/UpdateSpec.hs
+++ b/test/spec/Feature/Query/UpdateSpec.hs
@@ -9,6 +9,9 @@ import Network.HTTP.Types
 import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 
+import PostgREST.Config.PgVersion (PgVersion, pgVersion100)
+
+
 import Protolude  hiding (get)
 import SpecHelper
 
@@ -18,8 +21,8 @@ tblDataBefore = [aesonQQ|[
                 , { "id": 3, "name": "item-3" }
                 ]|]
 
-spec :: SpecWith ((), Application)
-spec = do
+spec :: PgVersion -> SpecWith ((), Application)
+spec actualPgVersion = do
   describe "Patching record" $ do
     context "to unknown uri" $
       it "indicates no table found by returning 404" $
@@ -543,3 +546,187 @@ spec = do
       , { "id": 2, "name": "item-2" }
       , { "id": 3, "name": "item-3" }
       ]|]
+
+  -- Data representations for payload parsing requires Postgrest 10 or above.
+  when (actualPgVersion >= pgVersion100) $ do
+    describe "Data representations" $ do
+      context "for a single row" $ do
+        it "parses values in payload" $
+          request methodPatch "/datarep_todos?id=eq.2" [("Prefer", "return=headers-only")]
+            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00"} |]
+            `shouldRespondWith`
+            ""
+              { matchStatus  = 204
+              , matchHeaders = [ matchHeaderAbsent hContentType
+                               , "Content-Range" <:> "0-0/*" ]
+              }
+
+        it "parses values in payload and formats individually selected values in return=representation" $
+          request methodPatch "/datarep_todos?id=eq.2&select=id,label_color" [("Prefer", "return=representation")]
+            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00"} |]
+            `shouldRespondWith`
+            [json| [{"id":2, "label_color": "#221100"}] |]
+              { matchStatus  = 200
+              , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
+                                "Content-Range" <:> "0-0/*"]
+              }
+
+        it "parses values in payload and formats values in return=representation" $
+          request methodPatch "/datarep_todos?id=eq.2" [("Prefer", "return=representation")]
+            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:20+00"} |]
+            `shouldRespondWith`
+            [json| [{"id":2, "name": "Essay", "label_color": "#221100", "due_at":"2019-01-03T11:00:20+00"}] |]
+              { matchStatus  = 200
+              , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
+                                "Content-Range" <:> "0-0/*"]
+              }
+
+        it "parses values in payload and formats star mixed selected values in return=representation" $
+          request methodPatch "/datarep_todos?id=eq.2&select=due_at,*" [("Prefer", "return=representation")]
+            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00"} |]
+            `shouldRespondWith`
+            -- end up with due_at twice here but that's unrelated to data reps
+            [json| [{"due_at":"2019-01-03T11:00:00+00", "id":2, "name":"Essay", "label_color":"#221100", "due_at":"2019-01-03T11:00:00+00"}] |]
+              { matchStatus  = 200
+              , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
+                                "Content-Range" <:> "0-0/*"]
+              }
+      context "for multiple rows" $ do
+        it "parses values in payload and formats individually selected values in return=representation" $
+          request methodPatch "/datarep_todos?id=lt.4&select=id,name,label_color" [("Prefer", "return=representation")]
+            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00"} |]
+            `shouldRespondWith`
+            [json| [
+              {"id":1, "name": "Report", "label_color": "#221100"},
+              {"id":2, "name": "Essay", "label_color": "#221100"},
+              {"id":3, "name": "Algebra", "label_color": "#221100"}
+            ] |]
+              { matchStatus  = 200
+              , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
+                                "Content-Range" <:> "0-2/*"]
+              }
+
+        it "parses values in payload and formats values in return=representation" $
+          request methodPatch "/datarep_todos?id=lt.4" [("Prefer", "return=representation")]
+            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00"} |]
+            `shouldRespondWith`
+            [json| [
+              {"id":1, "name": "Report", "label_color": "#221100", "due_at":"2019-01-03T11:00:00+00"},
+              {"id":2, "name": "Essay", "label_color": "#221100", "due_at":"2019-01-03T11:00:00+00"},
+              {"id":3, "name": "Algebra", "label_color": "#221100", "due_at":"2019-01-03T11:00:00+00"}
+            ] |]
+              { matchStatus  = 200
+              , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
+                                "Content-Range" <:> "0-2/*"]
+              }
+      context "with ?columns parameter" $ do
+        it "ignores json keys not included in ?columns; parses only the ones specified" $
+          request methodPatch "/datarep_todos?id=eq.2&columns=due_at" [("Prefer", "return=representation")]
+            [json| {"due_at": "2019-01-03T11:00:00+00", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
+            `shouldRespondWith`
+            [json| [
+              {"id":2, "name": "Essay", "label_color": "#000100", "due_at":"2019-01-03T11:00:00+00"}
+            ] |]
+              { matchStatus  = 200
+              , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
+                                "Content-Range" <:> "0-0/*"]
+              }
+
+        it "fails if at least one specified column doesn't exist" $
+          request methodPatch "/datarep_todos?id=eq.2&columns=label_color,helicopters" [("Prefer", "return=representation")]
+            [json| {"due_at": "2019-01-03T11:00:00+00", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
+            `shouldRespondWith`
+            [json| {"code":"PGRST118","message":"Column 'helicopters' of relation 'datarep_todos' does not exist","details":null,"hint":null} |]
+              { matchStatus  = 400
+              , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8"]
+              }
+
+        it "ignores json keys and gives 200 if no record updated" $
+          request methodPatch "/datarep_todos?id=eq.2001&columns=label_color" [("Prefer", "return=representation")]
+           [json| {"due_at": "2019-01-03T11:00:00+00", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
+           `shouldRespondWith` 200
+      context "on a view" $ do
+        context "for a single row" $ do
+          it "parses values in payload" $
+            request methodPatch "/datarep_todos_computed?id=eq.2" [("Prefer", "return=headers-only")]
+              [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00"} |]
+              `shouldRespondWith`
+              ""
+                { matchStatus  = 204
+                , matchHeaders = [ matchHeaderAbsent hContentType
+                                 , "Content-Range" <:> "0-0/*" ]
+                }
+
+          it "parses values in payload and formats individually selected values in return=representation" $
+            request methodPatch "/datarep_todos_computed?id=eq.2&select=id,label_color" [("Prefer", "return=representation")]
+              [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00"} |]
+              `shouldRespondWith`
+              [json| [{"id":2, "label_color": "#221100"}] |]
+                { matchStatus  = 200
+                , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
+                                  "Content-Range" <:> "0-0/*"]
+                }
+
+          it "parses values in payload and formats values in return=representation" $
+            request methodPatch "/datarep_todos_computed?id=eq.2" [("Prefer", "return=representation")]
+              [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:20+00"} |]
+              `shouldRespondWith`
+              [json| [{"id":2, "name": "Essay", "label_color": "#221100", "dark_color":"#110880", "due_at":"2019-01-03T11:00:20+00"}] |]
+                { matchStatus  = 200
+                , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
+                                  "Content-Range" <:> "0-0/*"]
+                }
+        context "for multiple rows" $ do
+          it "parses values in payload and formats individually selected values in return=representation" $
+            request methodPatch "/datarep_todos_computed?id=lt.4&select=id,name,label_color,dark_color" [("Prefer", "return=representation")]
+              [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00"} |]
+              `shouldRespondWith`
+              [json| [
+                {"id":1, "name": "Report", "label_color": "#221100", "dark_color":"#110880"},
+                {"id":2, "name": "Essay", "label_color": "#221100", "dark_color":"#110880"},
+                {"id":3, "name": "Algebra", "label_color": "#221100", "dark_color":"#110880"}
+              ] |]
+                { matchStatus  = 200
+                , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
+                                  "Content-Range" <:> "0-2/*"]
+                }
+
+          it "parses values in payload and formats values in return=representation" $
+            request methodPatch "/datarep_todos_computed?id=lt.4" [("Prefer", "return=representation")]
+              [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00"} |]
+              `shouldRespondWith`
+              [json| [
+                {"id":1, "name": "Report", "label_color": "#221100", "dark_color":"#110880", "due_at":"2019-01-03T11:00:00+00"},
+                {"id":2, "name": "Essay", "label_color": "#221100", "dark_color":"#110880", "due_at":"2019-01-03T11:00:00+00"},
+                {"id":3, "name": "Algebra", "label_color": "#221100", "dark_color":"#110880", "due_at":"2019-01-03T11:00:00+00"}
+              ] |]
+                { matchStatus  = 200
+                , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
+                                  "Content-Range" <:> "0-2/*"]
+                }
+        context "with ?columns parameter" $ do
+          it "ignores json keys not included in ?columns; parses only the ones specified" $
+            request methodPatch "/datarep_todos_computed?id=eq.2&columns=due_at" [("Prefer", "return=representation")]
+              [json| {"due_at": "2019-01-03T11:00:00+00", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
+              `shouldRespondWith`
+              [json| [
+                {"id":2, "name": "Essay", "label_color": "#000100", "dark_color": "#000080", "due_at":"2019-01-03T11:00:00+00"}
+              ] |]
+                { matchStatus  = 200
+                , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
+                                  "Content-Range" <:> "0-0/*"]
+                }
+
+          it "fails if at least one specified column doesn't exist" $
+            request methodPatch "/datarep_todos_computed?id=eq.2&columns=label_color,helicopters" [("Prefer", "return=representation")]
+              [json| {"due_at": "2019-01-03T11:00:00+00", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
+              `shouldRespondWith`
+              [json| {"code":"PGRST118","message":"Column 'helicopters' of relation 'datarep_todos_computed' does not exist","details":null,"hint":null} |]
+                { matchStatus  = 400
+                , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8"]
+                }
+
+          it "ignores json keys and gives 200 if no record updated" $
+            request methodPatch "/datarep_todos_computed?id=eq.2001&columns=label_color" [("Prefer", "return=representation")]
+             [json| {"due_at": "2019-01-03T11:00:00+00", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
+             `shouldRespondWith` 200

--- a/test/spec/Feature/Query/UpdateSpec.hs
+++ b/test/spec/Feature/Query/UpdateSpec.hs
@@ -553,7 +553,7 @@ spec actualPgVersion = do
       context "for a single row" $ do
         it "parses values in payload" $
           request methodPatch "/datarep_todos?id=eq.2" [("Prefer", "return=headers-only")]
-            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00"} |]
+            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00Z"} |]
             `shouldRespondWith`
             ""
               { matchStatus  = 204
@@ -563,7 +563,7 @@ spec actualPgVersion = do
 
         it "parses values in payload and formats individually selected values in return=representation" $
           request methodPatch "/datarep_todos?id=eq.2&select=id,label_color" [("Prefer", "return=representation")]
-            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00"} |]
+            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00Z"} |]
             `shouldRespondWith`
             [json| [{"id":2, "label_color": "#221100"}] |]
               { matchStatus  = 200
@@ -573,9 +573,9 @@ spec actualPgVersion = do
 
         it "parses values in payload and formats values in return=representation" $
           request methodPatch "/datarep_todos?id=eq.2" [("Prefer", "return=representation")]
-            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:20+00", "icon_image": "3q2+7w"} |]
+            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:20Z", "icon_image": "3q2+7w"} |]
             `shouldRespondWith`
-            [json|  [{"id":2,"name":"Essay","label_color":"#221100","due_at":"2019-01-03T11:00:20+00","icon_image":"3q2+7w==","created_at":1513213350,"budget":"100000000000000.13"}] |]
+            [json|  [{"id":2,"name":"Essay","label_color":"#221100","due_at":"2019-01-03T11:00:20Z","icon_image":"3q2+7w==","created_at":1513213350,"budget":"100000000000000.13"}] |]
               { matchStatus  = 200
               , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
                                 "Content-Range" <:> "0-0/*"]
@@ -583,10 +583,10 @@ spec actualPgVersion = do
 
         it "parses values in payload and formats star mixed selected values in return=representation" $
           request methodPatch "/datarep_todos?id=eq.2&select=due_at,*" [("Prefer", "return=representation")]
-            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00", "created_at": 0} |]
+            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00Z", "created_at": 0} |]
             `shouldRespondWith`
             -- end up with due_at twice here but that's unrelated to data reps
-            [json| [{"due_at":"2019-01-03T11:00:00+00","id":2,"name":"Essay","label_color":"#221100","due_at":"2019-01-03T11:00:00+00","icon_image":null,"created_at":0,"budget":"100000000000000.13"}] |]
+            [json| [{"due_at":"2019-01-03T11:00:00Z","id":2,"name":"Essay","label_color":"#221100","due_at":"2019-01-03T11:00:00Z","icon_image":null,"created_at":0,"budget":"100000000000000.13"}] |]
               { matchStatus  = 200
               , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
                                 "Content-Range" <:> "0-0/*"]
@@ -594,7 +594,7 @@ spec actualPgVersion = do
       context "for multiple rows" $ do
         it "parses values in payload and formats individually selected values in return=representation" $
           request methodPatch "/datarep_todos?id=lt.4&select=id,name,label_color" [("Prefer", "return=representation")]
-            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00"} |]
+            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00Z"} |]
             `shouldRespondWith`
             [json| [
               {"id":1, "name": "Report", "label_color": "#221100"},
@@ -608,12 +608,12 @@ spec actualPgVersion = do
 
         it "parses values in payload and formats values in return=representation" $
           request methodPatch "/datarep_todos?id=lt.4" [("Prefer", "return=representation")]
-            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00", "icon_image": "3q2+7w="} |]
+            [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00Z", "icon_image": "3q2+7w="} |]
             `shouldRespondWith`
             [json| [
-              {"id":1,"name":"Report","label_color":"#221100","due_at":"2019-01-03T11:00:00+00","icon_image":"3q2+7w==","created_at":1513213350,"budget":"12.50"},
-              {"id":2,"name":"Essay","label_color":"#221100","due_at":"2019-01-03T11:00:00+00","icon_image":"3q2+7w==","created_at":1513213350,"budget":"100000000000000.13"},
-              {"id":3,"name":"Algebra","label_color":"#221100","due_at":"2019-01-03T11:00:00+00","icon_image":"3q2+7w==","created_at":1513213350,"budget":"0.00"}
+              {"id":1,"name":"Report","label_color":"#221100","due_at":"2019-01-03T11:00:00Z","icon_image":"3q2+7w==","created_at":1513213350,"budget":"12.50"},
+              {"id":2,"name":"Essay","label_color":"#221100","due_at":"2019-01-03T11:00:00Z","icon_image":"3q2+7w==","created_at":1513213350,"budget":"100000000000000.13"},
+              {"id":3,"name":"Algebra","label_color":"#221100","due_at":"2019-01-03T11:00:00Z","icon_image":"3q2+7w==","created_at":1513213350,"budget":"0.00"}
             ] |]
               { matchStatus  = 200
               , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
@@ -622,10 +622,10 @@ spec actualPgVersion = do
       context "with ?columns parameter" $ do
         it "ignores json keys not included in ?columns; parses only the ones specified" $
           request methodPatch "/datarep_todos?id=eq.2&columns=due_at" [("Prefer", "return=representation")]
-            [json| {"due_at": "2019-01-03T11:00:00+00", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
+            [json| {"due_at": "2019-01-03T11:00:00Z", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
             `shouldRespondWith`
             [json| [
-               {"id":2,"name":"Essay","label_color":"#000100","due_at":"2019-01-03T11:00:00+00","icon_image":null,"created_at":1513213350,"budget":"100000000000000.13"}
+               {"id":2,"name":"Essay","label_color":"#000100","due_at":"2019-01-03T11:00:00Z","icon_image":null,"created_at":1513213350,"budget":"100000000000000.13"}
             ] |]
               { matchStatus  = 200
               , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
@@ -634,7 +634,7 @@ spec actualPgVersion = do
 
         it "fails if at least one specified column doesn't exist" $
           request methodPatch "/datarep_todos?id=eq.2&columns=label_color,helicopters" [("Prefer", "return=representation")]
-            [json| {"due_at": "2019-01-03T11:00:00+00", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
+            [json| {"due_at": "2019-01-03T11:00:00Z", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
             `shouldRespondWith`
             [json| {"code":"PGRST118","message":"Column 'helicopters' of relation 'datarep_todos' does not exist","details":null,"hint":null} |]
               { matchStatus  = 400
@@ -643,13 +643,13 @@ spec actualPgVersion = do
 
         it "ignores json keys and gives 200 if no record updated" $
           request methodPatch "/datarep_todos?id=eq.2001&columns=label_color" [("Prefer", "return=representation")]
-           [json| {"due_at": "2019-01-03T11:00:00+00", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
+           [json| {"due_at": "2019-01-03T11:00:00Z", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
            `shouldRespondWith` 200
       context "on a view" $ do
         context "for a single row" $ do
           it "parses values in payload" $
             request methodPatch "/datarep_todos_computed?id=eq.2" [("Prefer", "return=headers-only")]
-              [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00"} |]
+              [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00Z"} |]
               `shouldRespondWith`
               ""
                 { matchStatus  = 204
@@ -659,7 +659,7 @@ spec actualPgVersion = do
 
           it "parses values in payload and formats individually selected values in return=representation" $
             request methodPatch "/datarep_todos_computed?id=eq.2&select=id,label_color" [("Prefer", "return=representation")]
-              [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00"} |]
+              [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00Z"} |]
               `shouldRespondWith`
               [json| [{"id":2, "label_color": "#221100"}] |]
                 { matchStatus  = 200
@@ -669,9 +669,9 @@ spec actualPgVersion = do
 
           it "parses values in payload and formats values in return=representation" $
             request methodPatch "/datarep_todos_computed?id=eq.2" [("Prefer", "return=representation")]
-              [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:20+00"} |]
+              [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:20Z"} |]
               `shouldRespondWith`
-              [json| [{"id":2, "name": "Essay", "label_color": "#221100", "dark_color":"#110880", "due_at":"2019-01-03T11:00:20+00"}] |]
+              [json| [{"id":2, "name": "Essay", "label_color": "#221100", "dark_color":"#110880", "due_at":"2019-01-03T11:00:20Z"}] |]
                 { matchStatus  = 200
                 , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
                                   "Content-Range" <:> "0-0/*"]
@@ -679,7 +679,7 @@ spec actualPgVersion = do
         context "for multiple rows" $ do
           it "parses values in payload and formats individually selected values in return=representation" $
             request methodPatch "/datarep_todos_computed?id=lt.4&select=id,name,label_color,dark_color" [("Prefer", "return=representation")]
-              [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00"} |]
+              [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00Z"} |]
               `shouldRespondWith`
               [json| [
                 {"id":1, "name": "Report", "label_color": "#221100", "dark_color":"#110880"},
@@ -693,12 +693,12 @@ spec actualPgVersion = do
 
           it "parses values in payload and formats values in return=representation" $
             request methodPatch "/datarep_todos_computed?id=lt.4" [("Prefer", "return=representation")]
-              [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00+00"} |]
+              [json| {"label_color": "#221100", "due_at": "2019-01-03T11:00:00Z"} |]
               `shouldRespondWith`
               [json| [
-                {"id":1, "name": "Report", "label_color": "#221100", "dark_color":"#110880", "due_at":"2019-01-03T11:00:00+00"},
-                {"id":2, "name": "Essay", "label_color": "#221100", "dark_color":"#110880", "due_at":"2019-01-03T11:00:00+00"},
-                {"id":3, "name": "Algebra", "label_color": "#221100", "dark_color":"#110880", "due_at":"2019-01-03T11:00:00+00"}
+                {"id":1, "name": "Report", "label_color": "#221100", "dark_color":"#110880", "due_at":"2019-01-03T11:00:00Z"},
+                {"id":2, "name": "Essay", "label_color": "#221100", "dark_color":"#110880", "due_at":"2019-01-03T11:00:00Z"},
+                {"id":3, "name": "Algebra", "label_color": "#221100", "dark_color":"#110880", "due_at":"2019-01-03T11:00:00Z"}
               ] |]
                 { matchStatus  = 200
                 , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
@@ -707,10 +707,10 @@ spec actualPgVersion = do
         context "with ?columns parameter" $ do
           it "ignores json keys not included in ?columns; parses only the ones specified" $
             request methodPatch "/datarep_todos_computed?id=eq.2&columns=due_at" [("Prefer", "return=representation")]
-              [json| {"due_at": "2019-01-03T11:00:00+00", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
+              [json| {"due_at": "2019-01-03T11:00:00Z", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
               `shouldRespondWith`
               [json| [
-                {"id":2, "name": "Essay", "label_color": "#000100", "dark_color": "#000080", "due_at":"2019-01-03T11:00:00+00"}
+                {"id":2, "name": "Essay", "label_color": "#000100", "dark_color": "#000080", "due_at":"2019-01-03T11:00:00Z"}
               ] |]
                 { matchStatus  = 200
                 , matchHeaders = ["Content-Type" <:> "application/json; charset=utf-8",
@@ -719,7 +719,7 @@ spec actualPgVersion = do
 
           it "fails if at least one specified column doesn't exist" $
             request methodPatch "/datarep_todos_computed?id=eq.2&columns=label_color,helicopters" [("Prefer", "return=representation")]
-              [json| {"due_at": "2019-01-03T11:00:00+00", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
+              [json| {"due_at": "2019-01-03T11:00:00Z", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
               `shouldRespondWith`
               [json| {"code":"PGRST118","message":"Column 'helicopters' of relation 'datarep_todos_computed' does not exist","details":null,"hint":null} |]
                 { matchStatus  = 400
@@ -728,5 +728,5 @@ spec actualPgVersion = do
 
           it "ignores json keys and gives 200 if no record updated" $
             request methodPatch "/datarep_todos_computed?id=eq.2001&columns=label_color" [("Prefer", "return=representation")]
-             [json| {"due_at": "2019-01-03T11:00:00+00", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
+             [json| {"due_at": "2019-01-03T11:00:00Z", "smth": "here", "label_color": "invalid", "fake_id": 13} |]
              `shouldRespondWith` 200

--- a/test/spec/Main.hs
+++ b/test/spec/Main.hs
@@ -148,7 +148,7 @@ main = do
         , ("Feature.Query.RawOutputTypesSpec"            , Feature.Query.RawOutputTypesSpec.spec)
         , ("Feature.Query.RpcSpec"                       , Feature.Query.RpcSpec.spec actualPgVersion)
         , ("Feature.Query.SingularSpec"                  , Feature.Query.SingularSpec.spec)
-        , ("Feature.Query.UpdateSpec"                    , Feature.Query.UpdateSpec.spec)
+        , ("Feature.Query.UpdateSpec"                    , Feature.Query.UpdateSpec.spec actualPgVersion)
         , ("Feature.Query.UpsertSpec"                    , Feature.Query.UpsertSpec.spec actualPgVersion)
         , ("Feature.Query.ComputedRelsSpec"              , Feature.Query.ComputedRelsSpec.spec)
         , ("Feature.Query.RelatedQueriesSpec"            , Feature.Query.RelatedQueriesSpec.spec)

--- a/test/spec/fixtures/data.sql
+++ b/test/spec/fixtures/data.sql
@@ -840,8 +840,8 @@ TRUNCATE TABLE subscriptions CASCADE;
 INSERT INTO subscriptions(subscriber,subscribed) VALUES (3,1), (4,1), (1,2);
 
 TRUNCATE TABLE datarep_todos CASCADE;
-INSERT INTO datarep_todos VALUES (1, 'Report', 0, '2018-01-02');
-INSERT INTO datarep_todos VALUES (2, 'Essay', 256, '2018-01-03');
+INSERT INTO datarep_todos VALUES (1, 'Report', 0, '2018-01-02', '\x89504e470d0a1a0a0000000d4948445200000001000000010100000000376ef924000000001049444154789c62600100000000ffff03000000060005057bfabd400000000049454e44ae426082', '2017-12-14 01:02:30', 12.50); -- smallest possible PNG
+INSERT INTO datarep_todos VALUES (2, 'Essay', 256, '2018-01-03', NULL, '2017-12-14 01:02:30', 100000000000000.13); -- a number which can't be represented by a 64-bit float
 INSERT INTO datarep_todos VALUES (3, 'Algebra', 123456, '2018-01-01 14:12:34.123456');
 INSERT INTO datarep_todos VALUES (4, 'Opus Magnum', NULL, NULL);
 

--- a/test/spec/fixtures/data.sql
+++ b/test/spec/fixtures/data.sql
@@ -838,3 +838,13 @@ INSERT INTO posters(id,name) VALUES (1,'Mark'), (2,'Elon'), (3,'Bill'), (4,'Jeff
 
 TRUNCATE TABLE subscriptions CASCADE;
 INSERT INTO subscriptions(subscriber,subscribed) VALUES (3,1), (4,1), (1,2);
+
+TRUNCATE TABLE datarep_todos CASCADE;
+INSERT INTO datarep_todos VALUES (1, 'Report', 0, '2018-01-02');
+INSERT INTO datarep_todos VALUES (2, 'Essay', 256, '2018-01-03');
+INSERT INTO datarep_todos VALUES (3, 'Algebra', 123456, '2018-01-01 14:12:34.123456');
+INSERT INTO datarep_todos VALUES (4, 'Opus Magnum', NULL, NULL);
+
+TRUNCATE TABLE datarep_next_two_todos CASCADE;
+INSERT INTO datarep_next_two_todos VALUES (1, 2, 3, 'school related');
+INSERT INTO datarep_next_two_todos VALUES (2, 1, 3, 'do these first');

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -3145,11 +3145,11 @@ CREATE OR REPLACE FUNCTION isodate(json) RETURNS public.isodate AS $$
 $$ LANGUAGE SQL IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION isodate(text) RETURNS public.isodate AS $$
-  SELECT (replace($1, 'T', ' ')::timestamp with time zone)::public.isodate;
+  SELECT (replace($1, 'Z', '+00:00')::timestamp with time zone)::public.isodate;
 $$ LANGUAGE SQL IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION json(public.isodate) RETURNS json AS $$
-  SELECT to_json(replace($1::text, ' ', 'T'));
+  SELECT to_json(replace(to_json($1)#>>'{}', '+00:00', 'Z'));
 $$ LANGUAGE SQL IMMUTABLE;
 
 CREATE CAST (public.isodate AS json) WITH FUNCTION json(public.isodate) AS IMPLICIT;


### PR DESCRIPTION
<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs     - https://github.com/PostgREST/postgrest-docs
-->

# Data Representations

Present and receive API fields with custom formatting rules.

For certain APIs, the default conversion to and from JSON performed by PostgreSQL may not be right. For example you might wish to represent dates in UNIX epoch timestamp format, fixed precision decimals as strings rather than JSON floats, colours as CSS hex strings, binary blobs as base64 data and so forth. Perhaps you even need different representations in different API endpoints. 

Data Representations allow you to create custom, two-way convertible representations of your data on a per field level using standard PostgreSQL functions. Just create a `domain`, which we can view as a kind of type alias that does nothing by default, and then define casts to and from JSON. (Normally PostgreSQL ignores domain casts, but Data Representations detects those casts and applies them automatically as needed.)

Features:

- Lets you define custom data types and attendant formatters and parsers.
- Use them in your base tables to apply custom representations globally in all APIs using those tables.
- Or create views with different representations for the same underlying columns.
- Presents data: fields transparently formatted into JSON when using for example `GET`.
- Receive data: automatically parses custom data types in incoming JSON payloads when using `POST` or `PATCH`.
- Filters: parses query parameters sent as plain text if you also specify a `TEXT->my custom type` cast.
- Works for data `RETURNING` operations, like if you request the full body of your patched resource with `return=presentation`.
- Works for batch editing.
- Completely opt in. If you don't want it, don't define any domain casts. (There's no reason to do so in ordinary usage since PostgreSQL doesn't support such casts.)
- Fully integrated: unlike a naive implementation where you create a view with computed columns that formats the data the way you want it, with Data Representations you don't lose the ability to write to those fields. They are two-way.
- High performant: since your filters are parsed to their native data type *before* being applied for filtering, you don't need a second index of your computed presentation value. Querying is as fast as querying the underlying true data type.

## Example

PostgreSQL has a built-in formatter for dates:

```bash
curl "http://mypostgrest/todo?select=id,due_at&id=eq.1"
[{"id":1, "due_at":"2018-01-02T00:00:00+00:00"}]
```

Let's replace the `+00:00` suffix with `Z`, an equivalent but shorter ISO 8601 date:

```sql
CREATE DOMAIN public.isodate AS timestamp with time zone;
CREATE OR REPLACE FUNCTION json(public.isodate) RETURNS json AS $$
    SELECT to_json(replace(to_json($1)#>>'{}', '+00:00', 'Z'));
$$ LANGUAGE SQL IMMUTABLE;
CREATE CAST (public.isodate AS json) WITH FUNCTION json(public.isodate) AS IMPLICIT;
ALTER TABLE todo ALTER COLUMN due_at TYPE public.isodate;
```

The underlying data is unchanged since our custom domain is just an alias for `timestamp with time zone`.

```bash
# ... after reloading PostgREST to refresh the schema cache ...
curl "http://mypostgrest/todo?select=id,due_at&id=eq.1"
[{"id":1, "due_at":"2018-01-02T00:00:00Z"}]
```

Let's look at some colours.

```bash
curl "http://mypostgrest/todo?select=id,label_color&id=eq.3"
{"id":3, "label_color":123456}
```

In this case we store our colour as an integer, so it's being formatted as an integer by PostgreSQL. Let's consider that an implementation detail we wish to hide from our API consumers.

```sql
CREATE DOMAIN public.color AS INTEGER CHECK (VALUE >= 0 AND VALUE <= 16777215);

CREATE OR REPLACE FUNCTION color(json) RETURNS public.color AS $$
    SELECT color($1 #>> '{}');
$$ LANGUAGE SQL IMMUTABLE;

CREATE OR REPLACE FUNCTION color(text) RETURNS public.color AS $$
    SELECT ('x' || lpad((CASE WHEN SUBSTRING($1::text, 1, 1) = '#' THEN SUBSTRING($1::text, 2) ELSE $1::text END), 8, '0'))::bit(32)::int;
$$ LANGUAGE SQL IMMUTABLE;

CREATE OR REPLACE FUNCTION json(public.color) RETURNS json AS $$
    SELECT
        CASE WHEN $1 IS NULL THEN to_json(''::text)
        ELSE to_json('#' || lpad(upper(to_hex($1)), 6, '0'))
        END;
$$ LANGUAGE SQL IMMUTABLE;

CREATE CAST (public.color AS json) WITH FUNCTION json(public.color) AS IMPLICIT;
CREATE CAST (json AS public.color) WITH FUNCTION color(json) AS IMPLICIT;
```

```bash
# ... after reloading PostgREST to refresh the schema cache ...
curl "http://mypostgrest/todo?select=id,label_color&id=eq.3"
{"id":3, "label_color":"#01E240"}

curl -X PATCH "http://mypostgrest/todo?select=id,label_color&id=eq.2"
     -H 'Content-Type: application/json'
     -H 'Accept: application/json'
     -d '{"label_color": "#221100"}'

curl "http://mypostgrest/todo?select=id,label_color&id=eq.2"
[{"id":2, "label_color": "#221100"}]
```

To the outside world, it looks just like if your column type is a string with hexadecimal values, while under the hood it's an integer which even comes with a built in check constraint on validity. Your data is clean, space efficient, yet presented and interpreted in a user friendly manner.

What about filtering? For that we need one last converter. Since query parameters are given as strings, let's make a `text->color` cast. We already have the function for it.

```sql
CREATE CAST (text AS public.color) WITH FUNCTION color(text) AS IMPLICIT;
```

Now we can filter:

```bash
curl "http://mypostgrest/todo?select=id,label_color&label_color=eq.#221100"
[{"id":2, "label_color": "#221100"}]
```

Under the hood the value is *first* converted to its underlying integer type before querying the table, which ensures maximum performance. Without Data Representations it would have been easy to end up with a situation where instead PostgresSQL had to format every row colour as a hexadecimal string and then compare, making index usage hard.

### TODO

- Docs. The above can be used as a starting point for docs.

This pull request implements #2310. I renamed the concept from "transformers" to "data representations" which seemed more intuitive.

### Future Direction

Some things that could be implemented in the future:

- Custom representations for CSV and binary content types.
- Method to activate data representations without changing column types (when that isn't convenient).