### PR TITLE
Fix computed relationships with non SETOF return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2356, Fix a regression in openapi output with mode follow-privileges - @wolfgangwalther
  - #2283, Fix infinite recursion when loading schema cache with self-referencing view - @wolfgangwalther
  - #2343, Return status code 200 for PATCH requests which don't affect any rows - @wolfgangwalther
+ - #2481, Treat computed relationships not marked SETOF as M2O/O2O relationship - @wolfgangwalther
 
 ### Changed
 

--- a/src/PostgREST/SchemaCache.hs
+++ b/src/PostgREST/SchemaCache.hs
@@ -727,12 +727,12 @@ allComputedRels =
     computed_rels as (
       select
         (parse_ident(p.pronamespace::regnamespace::text))[1] as schema,
-        p.proname::text          as name,
-        arg_schema.nspname::text as rel_table_schema,
-        arg_name.typname::text   as rel_table_name,
-        ret_schema.nspname::text as rel_ftable_schema,
-        ret_name.typname::text   as rel_ftable_name,
-        p.prorows = 1            as single_row
+        p.proname::text                  as name,
+        arg_schema.nspname::text         as rel_table_schema,
+        arg_name.typname::text           as rel_table_name,
+        ret_schema.nspname::text         as rel_ftable_schema,
+        ret_name.typname::text           as rel_ftable_name,
+        not p.proretset or p.prorows = 1 as single_row
       from pg_proc p
         join pg_type      arg_name   on arg_name.oid = p.proargtypes[0]
         join pg_namespace arg_schema on arg_schema.oid = arg_name.typnamespace

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -2737,6 +2737,10 @@ CREATE FUNCTION test.computed_designers(test.videogames) RETURNS SETOF test.desi
   SELECT * FROM test.designers WHERE id = $1.designer_id;
 $$ LANGUAGE sql STABLE ROWS 1;
 
+CREATE FUNCTION test.computed_designers_noset(test.videogames) RETURNS test.designers AS $$
+  SELECT * FROM test.designers WHERE id = $1.designer_id;
+$$ LANGUAGE sql STABLE;
+
 CREATE FUNCTION test.computed_videogames(test.designers) RETURNS SETOF test.videogames AS $$
   SELECT * FROM test.videogames WHERE designer_id = $1.id;
 $$ LANGUAGE sql STABLE;


### PR DESCRIPTION
Fixes #2481.

We should still advertise the usage of `SETOF` and `ROWS 1` in the docs, because that's the better choice for inlining. Still, making the non-SETOF case "just work" seems like a good idea.

~~(Based on #2539, only last commit is relevant)~~