### PR TITLE
nix: Remove deprecation warning for dockerTools.buildImage { contents }

### DIFF
--- a/nix/tools/docker/default.nix
+++ b/nix/tools/docker/default.nix
@@ -8,7 +8,7 @@ let
     dockerTools.buildImage {
       name = "postgrest";
       tag = "latest";
-      contents = postgrest;
+      copyToRoot = postgrest;
 
       # Set the current time as the image creation date. This makes the build
       # non-reproducible, but that should not be an issue for us.


### PR DESCRIPTION
Whenever we push to main right now, the cachix push job fails: https://github.com/PostgREST/postgrest/actions/runs/3338831343/jobs/5527008514

While looking at it, I noticed the deprecation warning for $subject. Changed that here. Couldn't find any problem with pushing to cachix, though. I just set up the auth token for the first time and pushed successfully from my local machine.

@steve-chavez any idea why it's currently failing on main? This will prevent us from doing a release, I think.

I will merge this fix when CI ran through and see whether it changes anything... but I don't expect it to.