### PR TITLE
Json to recordset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
  - #2548, Fix regression when embedding views with partial references to multi column FKs - @wolfgangwalther
  - #2558, Fix regression when requesting limit=0 and `db-max-row` is set - @laurenceisla
+ - #2542, Return a clear error without hitting the database when trying to update or insert an unknown column with `?columns` - @aljungberg
 
 ## [10.1.0] - 2022-10-28
 

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -60,6 +60,7 @@ library
                       PostgREST.Plan.CallPlan
                       PostgREST.Plan.MutatePlan
                       PostgREST.Plan.ReadPlan
+                      PostgREST.Plan.Types
                       PostgREST.RangeQuery
                       PostgREST.ApiRequest
                       PostgREST.ApiRequest.Preferences

--- a/src/PostgREST/ApiRequest/Types.hs
+++ b/src/PostgREST/ApiRequest/Types.hs
@@ -81,7 +81,7 @@ data ApiRequestError
   | SpreadNotToOne Text Text
   | UnacceptableSchema [Text]
   | UnsupportedMethod ByteString
-  | ColumnNotFound Text
+  | ColumnNotFound Text Text
 
 data QPError = QPError Text Text
 data RangeError

--- a/src/PostgREST/ApiRequest/Types.hs
+++ b/src/PostgREST/ApiRequest/Types.hs
@@ -81,6 +81,7 @@ data ApiRequestError
   | SpreadNotToOne Text Text
   | UnacceptableSchema [Text]
   | UnsupportedMethod ByteString
+  | ColumnNotFound Text
 
 data QPError = QPError Text Text
 data RangeError
@@ -144,7 +145,7 @@ type JsonPath = [JsonOperation]
 data JsonOperation
   = JArrow { jOp :: JsonOperand }
   | J2Arrow { jOp :: JsonOperand }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 -- | Represents the key(`->'key'`) or index(`->'1`::int`), the index is Text
 -- because we reuse our escaping functons and let pg do the casting with
@@ -152,7 +153,7 @@ data JsonOperation
 data JsonOperand
   = JKey { jVal :: Text }
   | JIdx { jVal :: Text }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 -- | Boolean logic expression tree e.g. "and(name.eq.N,or(id.eq.1,id.eq.2))" is:
 --

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -199,7 +199,7 @@ instance JSON.ToJSON ApiRequestError where
     "hint"    .= ("Try renaming the parameters or the function itself in the database so function overloading can be resolved" :: Text)]
   toJSON (ColumnNotFound colName) = JSON.object [
     "code"    .= ApiRequestErrorCode18,
-    "message" .= ("Could not find '" <> colName <> "' in the target table" :: Text),
+    "message" .= ("Column '" <> colName <> "' does not exist" :: Text),
     "details" .= JSON.Null,
     "hint"    .= JSON.Null]
 

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -76,6 +76,7 @@ instance PgrstError ApiRequestError where
   status UnacceptableSchema{}    = HTTP.status406
   status UnsupportedMethod{}     = HTTP.status405
   status LimitNoOrderError       = HTTP.status400
+  status ColumnNotFound{}        = HTTP.status400
 
   headers _ = [MediaType.toContentType MTApplicationJSON]
 
@@ -196,6 +197,11 @@ instance JSON.ToJSON ApiRequestError where
     "message" .= ("Could not choose the best candidate function between: " <> T.intercalate ", " [pdSchema p <> "." <> pdName p <> "(" <> T.intercalate ", " [ppName a <> " => " <> ppType a | a <- pdParams p] <> ")" | p <- procs]),
     "details" .= JSON.Null,
     "hint"    .= ("Try renaming the parameters or the function itself in the database so function overloading can be resolved" :: Text)]
+  toJSON (ColumnNotFound colName) = JSON.object [
+    "code"    .= ApiRequestErrorCode18,
+    "message" .= ("Could not find '" <> colName <> "' in the target table" :: Text),
+    "details" .= JSON.Null,
+    "hint"    .= ("If a new column was created in the database with this name, try reloading the schema cache." :: Text)]
 
 compressedRel :: Relationship -> JSON.Value
 -- An ambiguousness error cannot happen for computed relationships TODO refactor so this mempty is not needed

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -197,9 +197,9 @@ instance JSON.ToJSON ApiRequestError where
     "message" .= ("Could not choose the best candidate function between: " <> T.intercalate ", " [pdSchema p <> "." <> pdName p <> "(" <> T.intercalate ", " [ppName a <> " => " <> ppType a | a <- pdParams p] <> ")" | p <- procs]),
     "details" .= JSON.Null,
     "hint"    .= ("Try renaming the parameters or the function itself in the database so function overloading can be resolved" :: Text)]
-  toJSON (ColumnNotFound colName) = JSON.object [
+  toJSON (ColumnNotFound relName colName) = JSON.object [
     "code"    .= ApiRequestErrorCode18,
-    "message" .= ("Column '" <> colName <> "' does not exist" :: Text),
+    "message" .= ("Column '" <> colName <> "' of relation '" <> relName <> "' does not exist" :: Text),
     "details" .= JSON.Null,
     "hint"    .= JSON.Null]
 

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -201,7 +201,7 @@ instance JSON.ToJSON ApiRequestError where
     "code"    .= ApiRequestErrorCode18,
     "message" .= ("Could not find '" <> colName <> "' in the target table" :: Text),
     "details" .= JSON.Null,
-    "hint"    .= ("If a new column was created in the database with this name, try reloading the schema cache." :: Text)]
+    "hint"    .= JSON.Null]
 
 compressedRel :: Relationship -> JSON.Value
 -- An ambiguousness error cannot happen for computed relationships TODO refactor so this mempty is not needed

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -380,9 +380,9 @@ mutatePlan :: Mutation -> QualifiedIdentifier -> ApiRequest -> SchemaCache -> Re
 mutatePlan mutation qi ApiRequest{..} sCache readReq = mapLeft ApiRequestError $
   case mutation of
     MutationCreate ->
-      mapRight (\typedColumns -> Insert qi (S.fromList typedColumns) body ((,) <$> iPreferResolution <*> Just confCols) [] returnings pkCols) typedColumnsOrError
+      mapRight (\typedColumns -> Insert qi typedColumns body ((,) <$> iPreferResolution <*> Just confCols) [] returnings pkCols) typedColumnsOrError
     MutationUpdate ->
-      mapRight (\typedColumns -> Update qi (S.fromList typedColumns) body combinedLogic iTopLevelRange rootOrder returnings) typedColumnsOrError
+      mapRight (\typedColumns -> Update qi typedColumns body combinedLogic iTopLevelRange rootOrder returnings) typedColumnsOrError
     MutationSingleUpsert ->
         if null qsLogic &&
            qsFilterFields == S.fromList pkCols &&
@@ -390,7 +390,7 @@ mutatePlan mutation qi ApiRequest{..} sCache readReq = mapLeft ApiRequestError $
            all (\case
               Filter _ (OpExpr False (Op OpEqual _)) -> True
               _                                      -> False) qsFiltersRoot
-          then mapRight (\typedColumns -> Insert qi (S.fromList typedColumns) body (Just (MergeDuplicates, pkCols)) combinedLogic returnings mempty) typedColumnsOrError
+          then mapRight (\typedColumns -> Insert qi typedColumns body (Just (MergeDuplicates, pkCols)) combinedLogic returnings mempty) typedColumnsOrError
         else
           Left InvalidFilters
     MutationDelete -> Right $ Delete qi combinedLogic iTopLevelRange rootOrder returnings

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -54,7 +54,8 @@ import PostgREST.SchemaCache.Relationship (Cardinality (..),
                                            Relationship (..),
                                            RelationshipsMap,
                                            relIsToOne)
-import PostgREST.SchemaCache.Table        (Table, tablePKCols)
+import PostgREST.SchemaCache.Table        (Table (tableName),
+                                           tablePKCols)
 
 import PostgREST.ApiRequest.Preferences
 import PostgREST.ApiRequest.Types
@@ -413,7 +414,7 @@ resolveOrError :: Maybe Table -> FieldName -> Either ApiRequestError TypedField
 resolveOrError Nothing _ = Left NotFound
 resolveOrError (Just table) field =
   case resolveTableField table field of
-    Nothing         -> Left $ ColumnNotFound field
+    Nothing         -> Left $ ColumnNotFound (tableName table) field
     Just typedField -> Right typedField
 
 callPlan :: ProcDescription -> ApiRequest -> ReadPlanTree -> CallPlan

--- a/src/PostgREST/Plan/MutatePlan.hs
+++ b/src/PostgREST/Plan/MutatePlan.hs
@@ -8,16 +8,18 @@ import qualified Data.Set             as S
 
 import PostgREST.ApiRequest.Preferences  (PreferResolution)
 import PostgREST.ApiRequest.Types        (LogicTree, OrderTerm)
+import PostgREST.Plan.Types              (TypedField)
 import PostgREST.RangeQuery              (NonnegRange)
 import PostgREST.SchemaCache.Identifiers (FieldName,
                                           QualifiedIdentifier)
+
 
 import Protolude
 
 data MutatePlan
   = Insert
       { in_        :: QualifiedIdentifier
-      , insCols    :: S.Set FieldName
+      , insCols    :: S.Set TypedField
       , insBody    :: Maybe LBS.ByteString
       , onConflict :: Maybe (PreferResolution, [FieldName])
       , where_     :: [LogicTree]
@@ -26,7 +28,7 @@ data MutatePlan
       }
   | Update
       { in_       :: QualifiedIdentifier
-      , updCols   :: S.Set FieldName
+      , updCols   :: S.Set TypedField
       , updBody   :: Maybe LBS.ByteString
       , where_    :: [LogicTree]
       , mutRange  :: NonnegRange

--- a/src/PostgREST/Plan/MutatePlan.hs
+++ b/src/PostgREST/Plan/MutatePlan.hs
@@ -4,7 +4,6 @@ module PostgREST.Plan.MutatePlan
 where
 
 import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Set             as S
 
 import PostgREST.ApiRequest.Preferences  (PreferResolution)
 import PostgREST.ApiRequest.Types        (LogicTree, OrderTerm)
@@ -19,7 +18,7 @@ import Protolude
 data MutatePlan
   = Insert
       { in_        :: QualifiedIdentifier
-      , insCols    :: S.Set TypedField
+      , insCols    :: [TypedField]
       , insBody    :: Maybe LBS.ByteString
       , onConflict :: Maybe (PreferResolution, [FieldName])
       , where_     :: [LogicTree]
@@ -28,7 +27,7 @@ data MutatePlan
       }
   | Update
       { in_       :: QualifiedIdentifier
-      , updCols   :: S.Set TypedField
+      , updCols   :: [TypedField]
       , updBody   :: Maybe LBS.ByteString
       , where_    :: [LogicTree]
       , mutRange  :: NonnegRange

--- a/src/PostgREST/Plan/Types.hs
+++ b/src/PostgREST/Plan/Types.hs
@@ -19,7 +19,7 @@ data TypedField = TypedField
    { tfFieldName :: FieldName
    , tfJsonPath  :: JsonPath
    , tfIRType    :: Text
-   } deriving (Eq, Ord)
+   } deriving (Eq)
 
 resolveField :: Field -> Text -> TypedField
 resolveField (fieldName, jsonPath) = TypedField fieldName jsonPath

--- a/src/PostgREST/Plan/Types.hs
+++ b/src/PostgREST/Plan/Types.hs
@@ -1,13 +1,10 @@
 module PostgREST.Plan.Types
   ( TypedField(..)
-  , resolveField
   , resolveTableField
 
   ) where
 
 import qualified Data.HashMap.Strict.InsOrd as HMI
-
-import PostgREST.ApiRequest.Types (Field, JsonPath)
 
 import PostgREST.SchemaCache.Identifiers (FieldName)
 import PostgREST.SchemaCache.Table       (Column (..), Table (..))
@@ -16,16 +13,12 @@ import Protolude
 
 -- | A TypedField is a field with sufficient information to be read from JSON with `json_to_recordset`.
 data TypedField = TypedField
-   { tfFieldName :: FieldName
-   , tfJsonPath  :: JsonPath
-   , tfIRType    :: Text
+   { tfName   :: FieldName
+   , tfIRType :: Text -- ^ The initial type of the field, before any casting.
    } deriving (Eq)
-
-resolveField :: Field -> Text -> TypedField
-resolveField (fieldName, jsonPath) = TypedField fieldName jsonPath
 
 resolveTableField :: Table -> FieldName -> Maybe TypedField
 resolveTableField table fieldName =
   case HMI.lookup fieldName (tableColumns table) of
-    Just column -> Just $ resolveField (colName column, []) (colNominalType column)
+    Just column -> Just $ TypedField (colName column) (colNominalType column)
     Nothing     -> Nothing

--- a/src/PostgREST/Plan/Types.hs
+++ b/src/PostgREST/Plan/Types.hs
@@ -1,0 +1,31 @@
+module PostgREST.Plan.Types
+  ( TypedField(..)
+  , resolveField
+  , resolveTableField
+
+  ) where
+
+import qualified Data.HashMap.Strict.InsOrd as HMI
+
+import PostgREST.ApiRequest.Types (Field, JsonPath)
+
+import PostgREST.SchemaCache.Identifiers (FieldName)
+import PostgREST.SchemaCache.Table       (Column (..), Table (..))
+
+import Protolude
+
+-- | A TypedField is a field with sufficient information to be read from JSON with `json_to_recordset`.
+data TypedField = TypedField
+   { tfFieldName :: FieldName
+   , tfJsonPath  :: JsonPath
+   , tfIRType    :: Text
+   } deriving (Eq, Ord)
+
+resolveField :: Field -> Text -> TypedField
+resolveField (fieldName, jsonPath) = TypedField fieldName jsonPath
+
+resolveTableField :: Table -> FieldName -> Maybe TypedField
+resolveTableField table fieldName =
+  case HMI.lookup fieldName (tableColumns table) of
+    Just column -> Just $ resolveField (colName column, []) (colNominalType column)
+    Nothing     -> Nothing

--- a/src/PostgREST/Query/QueryBuilder.hs
+++ b/src/PostgREST/Query/QueryBuilder.hs
@@ -98,12 +98,12 @@ mutatePlanToQuery (Insert mainQi iCols body onConflct putConditions returnings _
         MergeDuplicates  ->
           if null iCols
              then "DO NOTHING"
-             else "DO UPDATE SET " <> BS.intercalate ", " ((pgFmtIdent . tfFieldName) <> const " = EXCLUDED." <> (pgFmtIdent . tfFieldName) <$> iCols)
+             else "DO UPDATE SET " <> BS.intercalate ", " ((pgFmtIdent . tfName) <> const " = EXCLUDED." <> (pgFmtIdent . tfName) <$> iCols)
       ) onConflct,
     returningF mainQi returnings
     ])
   where
-    cols = BS.intercalate ", " $ pgFmtIdent . tfFieldName <$> iCols
+    cols = BS.intercalate ", " $ pgFmtIdent . tfName <$> iCols
 
 -- An update without a limit is always filtered with a WHERE
 mutatePlanToQuery (Update mainQi uCols body logicForest range ordts returnings)
@@ -138,8 +138,8 @@ mutatePlanToQuery (Update mainQi uCols body logicForest range ordts returnings)
     whereLogic = if null logicForest then mempty else " WHERE " <> intercalateSnippet " AND " (pgFmtLogicTree mainQi <$> logicForest)
     mainTbl = SQL.sql (fromQi mainQi)
     emptyBodyReturnedColumns = if null returnings then "NULL" else BS.intercalate ", " (pgFmtColumn (QualifiedIdentifier mempty $ qiName mainQi) <$> returnings)
-    nonRangeCols = BS.intercalate ", " (pgFmtIdent . tfFieldName <> const " = _." <> pgFmtIdent . tfFieldName <$> uCols)
-    rangeCols = BS.intercalate ", " ((\col -> pgFmtIdent (tfFieldName col) <> " = (SELECT " <> pgFmtIdent (tfFieldName col) <> " FROM pgrst_update_body) ") <$> uCols)
+    nonRangeCols = BS.intercalate ", " (pgFmtIdent . tfName <> const " = _." <> pgFmtIdent . tfName <$> uCols)
+    rangeCols = BS.intercalate ", " ((\col -> pgFmtIdent (tfName col) <> " = (SELECT " <> pgFmtIdent (tfName col) <> " FROM pgrst_update_body) ") <$> uCols)
     (whereRangeIdF, rangeIdF) = mutRangeF mainQi (fst . otTerm <$> ordts)
 
 mutatePlanToQuery (Delete mainQi logicForest range ordts returnings)

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -120,8 +120,8 @@ ftsOperator = \case
   FilterFtsWebsearch -> "@@ websearch_to_tsquery"
 
 -- |
--- These CTEs convert a json object into a json array, this way we can use json_populate_recordset for all json payloads
--- Otherwise we'd have to use json_populate_record for json objects and json_populate_recordset for json arrays
+-- These CTEs convert a json object into a json array, this way we can use json_to_recordset for all json payloads
+-- Otherwise we'd have to use json_to_record for json objects and json_to_recordset for json arrays
 -- We do this in SQL to avoid processing the JSON in application code
 -- TODO: At this stage there shouldn't be a Maybe since ApiRequest should ensure that an INSERT/UPDATE has a body
 normalizedBody :: Maybe LBS.ByteString -> SQL.Snippet

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -255,8 +255,8 @@ pgFmtSelectFromJson fields =
     else SQL.sql ("FROM json_to_recordset (" <> selectBody <> ") AS _ " <> "(" <> typedCols <> ") ")
   )
   where
-    parsedCols = SQL.sql $ BS.intercalate ", " $ pgFmtIdent . tfFieldName <$> fields
-    typedCols = BS.intercalate ", " $ pgFmtIdent . tfFieldName <> const " " <> encodeUtf8 . tfIRType <$> fields
+    parsedCols = SQL.sql $ BS.intercalate ", " $ pgFmtIdent . tfName <$> fields
+    typedCols = BS.intercalate ", " $ pgFmtIdent . tfName <> const " " <> encodeUtf8 . tfIRType <$> fields
 
 pgFmtOrderTerm :: QualifiedIdentifier -> OrderTerm -> SQL.Snippet
 pgFmtOrderTerm qi ot =

--- a/src/PostgREST/Response/OpenAPI.hs
+++ b/src/PostgREST/Response/OpenAPI.hs
@@ -34,7 +34,8 @@ import PostgREST.SchemaCache.Relationship (Cardinality (..),
                                            Relationship (..),
                                            RelationshipsMap)
 import PostgREST.SchemaCache.Table        (Column (..), Table (..),
-                                           TablesMap)
+                                           TablesMap,
+                                           tableColumnsList)
 import PostgREST.Version                  (docsVersion, prettyVersion)
 
 import PostgREST.MediaType
@@ -87,8 +88,8 @@ makeTableDef rels t =
       (tn, (mempty :: Schema)
         & description .~ tableDescription t
         & type_ ?~ SwaggerObject
-        & properties .~ fromList (makeProperty t rels <$> tableColumns t)
-        & required .~ fmap colName (filter (not . colNullable) $ tableColumns t))
+        & properties .~ fromList (makeProperty t rels <$> tableColumnsList t)
+        & required .~ fmap colName (filter (not . colNullable) $ tableColumnsList t))
 
 makeProperty :: Table -> RelationshipsMap -> Column -> (Text, Referenced Schema)
 makeProperty tbl rels col = (colName col, Inline s)
@@ -219,7 +220,7 @@ makeParamDefs ti =
         & in_ .~ ParamQuery
         & type_ ?~ SwaggerString))
   ]
-  <> concat [ makeObjectBody (tableName t) : makeRowFilters (tableName t) (tableColumns t)
+  <> concat [ makeObjectBody (tableName t) : makeRowFilters (tableName t) (tableColumnsList t)
             | t <- ti
             ]
 
@@ -280,7 +281,7 @@ makePathItem t = ("/" ++ T.unpack tn, p $ tableInsertable t || tableUpdatable t 
     p False = pr
     p True  = pw
     tn = tableName t
-    rs = [ T.intercalate "." ["rowFilter", tn, colName c ] | c <- tableColumns t ]
+    rs = [ T.intercalate "." ["rowFilter", tn, colName c ] | c <- tableColumnsList t ]
     ref = Ref . Reference
 
 makeProcPathItem :: ProcDescription -> (FilePath, PathItem)

--- a/src/PostgREST/SchemaCache/Table.hs
+++ b/src/PostgREST/SchemaCache/Table.hs
@@ -1,14 +1,18 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric  #-}
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE FlexibleInstances #-}
 
 module PostgREST.SchemaCache.Table
   ( Column(..)
   , Table(..)
+  , tableColumnsList
   , TablesMap
+  , ColumnMap
   ) where
 
-import qualified Data.Aeson          as JSON
-import qualified Data.HashMap.Strict as HM
+import qualified Data.Aeson                 as JSON
+import qualified Data.HashMap.Strict        as HM
+import qualified Data.HashMap.Strict.InsOrd as HMI
 
 import PostgREST.SchemaCache.Identifiers (FieldName,
                                           QualifiedIdentifier (..),
@@ -28,9 +32,12 @@ data Table = Table
   , tableUpdatable   :: Bool
   , tableDeletable   :: Bool
   , tablePKCols      :: [FieldName]
-  , tableColumns     :: [Column]
+  , tableColumns     :: ColumnMap
   }
-  deriving (Show, Ord, Generic, JSON.ToJSON)
+  deriving (Show, Generic, JSON.ToJSON)
+
+tableColumnsList :: Table -> [Column]
+tableColumnsList = HMI.elems . tableColumns
 
 instance Eq Table where
   Table{tableSchema=s1,tableName=n1} == Table{tableSchema=s2,tableName=n2} = s1 == s2 && n1 == n2
@@ -40,6 +47,7 @@ data Column = Column
   , colDescription :: Maybe Text
   , colNullable    :: Bool
   , colType        :: Text
+  , colNominalType :: Text
   , colMaxLen      :: Maybe Int32
   , colDefault     :: Maybe Text
   , colEnum        :: [Text]
@@ -47,3 +55,4 @@ data Column = Column
   deriving (Eq, Show, Ord, Generic, JSON.ToJSON)
 
 type TablesMap = HM.HashMap QualifiedIdentifier Table
+type ColumnMap = HMI.InsOrdHashMap FieldName Column

--- a/test/spec/Feature/Query/InsertSpec.hs
+++ b/test/spec/Feature/Query/InsertSpec.hs
@@ -420,6 +420,28 @@ spec actualPgVersion = do
           , matchHeaders = []
           }
 
+      it "disallows ?columns which don't exist" $
+        post "/articles?columns=helicopter"
+          [json|[
+            {"id": 204, "body": "yyy"},
+            {"id": 205, "body": "zzz"}]|]
+          `shouldRespondWith`
+          [json|{"code":"PGRST118","details":null,"hint":"If a new column was created in the database with this name, try reloading the schema cache.","message":"Could not find 'helicopter' in the target table"} |]
+          { matchStatus  = 400
+          , matchHeaders = []
+          }
+
+      it "returns missing table error even if also has invalid ?columns" $
+        post "/garlic?columns=helicopter"
+          [json|[
+            {"id": 204, "body": "yyy"},
+            {"id": 205, "body": "zzz"}]|]
+          `shouldRespondWith`
+          [json|{} |]
+          { matchStatus  = 404
+          , matchHeaders = []
+          }
+
       it "disallows array elements that are not json objects" $
         post "/articles?columns=id,body"
           [json|[
@@ -431,7 +453,7 @@ spec actualPgVersion = do
               "code": "22023",
               "details": null,
               "hint": null,
-              "message": "argument of json_populate_recordset must be an array of objects"}|]
+              "message": "argument of json_to_recordset must be an array of objects"}|]
           { matchStatus  = 400
           , matchHeaders = []
           }

--- a/test/spec/Feature/Query/InsertSpec.hs
+++ b/test/spec/Feature/Query/InsertSpec.hs
@@ -426,7 +426,7 @@ spec actualPgVersion = do
             {"id": 204, "body": "yyy"},
             {"id": 205, "body": "zzz"}]|]
           `shouldRespondWith`
-          [json|{"code":"PGRST118","details":null,"hint":null,"message":"Could not find 'helicopter' in the target table"} |]
+          [json|{"code":"PGRST118","details":null,"hint":null,"message":"Column 'helicopter' does not exist"} |]
           { matchStatus  = 400
           , matchHeaders = []
           }

--- a/test/spec/Feature/Query/InsertSpec.hs
+++ b/test/spec/Feature/Query/InsertSpec.hs
@@ -426,7 +426,7 @@ spec actualPgVersion = do
             {"id": 204, "body": "yyy"},
             {"id": 205, "body": "zzz"}]|]
           `shouldRespondWith`
-          [json|{"code":"PGRST118","details":null,"hint":"If a new column was created in the database with this name, try reloading the schema cache.","message":"Could not find 'helicopter' in the target table"} |]
+          [json|{"code":"PGRST118","details":null,"hint":null,"message":"Could not find 'helicopter' in the target table"} |]
           { matchStatus  = 400
           , matchHeaders = []
           }

--- a/test/spec/Feature/Query/InsertSpec.hs
+++ b/test/spec/Feature/Query/InsertSpec.hs
@@ -426,7 +426,7 @@ spec actualPgVersion = do
             {"id": 204, "body": "yyy"},
             {"id": 205, "body": "zzz"}]|]
           `shouldRespondWith`
-          [json|{"code":"PGRST118","details":null,"hint":null,"message":"Column 'helicopter' does not exist"} |]
+          [json|{"code":"PGRST118","details":null,"hint":null,"message":"Column 'helicopter' of relation 'articles' does not exist"} |]
           { matchStatus  = 400
           , matchHeaders = []
           }

--- a/test/spec/Feature/Query/UpdateSpec.hs
+++ b/test/spec/Feature/Query/UpdateSpec.hs
@@ -313,7 +313,7 @@ spec = do
           [("Prefer", "return=representation")]
           [json|{"body": "yyy"}|]
           `shouldRespondWith`
-          [json|{"code":"PGRST118","details":null,"hint":null,"message":"Could not find 'helicopter' in the target table"} |]
+          [json|{"code":"PGRST118","details":null,"hint":null,"message":"Column 'helicopter' does not exist"} |]
           { matchStatus  = 400
           , matchHeaders = []
           }

--- a/test/spec/Feature/Query/UpdateSpec.hs
+++ b/test/spec/Feature/Query/UpdateSpec.hs
@@ -308,6 +308,28 @@ spec = do
         request methodPatch "/articles?id=eq.2001&columns=body" [("Prefer", "return=representation")]
           [json| {"body": "Some real content", "smth": "here", "other": "stuff", "fake_id": 13} |] `shouldRespondWith` 200
 
+      it "disallows ?columns which don't exist" $ do
+        request methodPatch "/articles?id=eq.1&columns=helicopter"
+          [("Prefer", "return=representation")]
+          [json|{"body": "yyy"}|]
+          `shouldRespondWith`
+          [json|{"code":"PGRST118","details":null,"hint":"If a new column was created in the database with this name, try reloading the schema cache.","message":"Could not find 'helicopter' in the target table"} |]
+          { matchStatus  = 400
+          , matchHeaders = []
+          }
+
+      it "returns missing table error even if also has invalid ?columns" $ do
+        request methodPatch "/garlic?columns=helicopter"
+          [("Prefer", "return=representation")]
+          [json|[
+            {"id": 204, "body": "yyy"},
+            {"id": 205, "body": "zzz"}]|]
+          `shouldRespondWith`
+          [json|{} |]
+          { matchStatus  = 404
+          , matchHeaders = []
+          }
+
   context "tables with self reference foreign keys" $ do
     it "embeds children after update" $
       request methodPatch "/web_content?id=eq.0&select=id,name,web_content(name)"

--- a/test/spec/Feature/Query/UpdateSpec.hs
+++ b/test/spec/Feature/Query/UpdateSpec.hs
@@ -313,7 +313,7 @@ spec = do
           [("Prefer", "return=representation")]
           [json|{"body": "yyy"}|]
           `shouldRespondWith`
-          [json|{"code":"PGRST118","details":null,"hint":null,"message":"Column 'helicopter' does not exist"} |]
+          [json|{"code":"PGRST118","details":null,"hint":null,"message":"Column 'helicopter' of relation 'articles' does not exist"} |]
           { matchStatus  = 400
           , matchHeaders = []
           }

--- a/test/spec/Feature/Query/UpdateSpec.hs
+++ b/test/spec/Feature/Query/UpdateSpec.hs
@@ -313,7 +313,7 @@ spec = do
           [("Prefer", "return=representation")]
           [json|{"body": "yyy"}|]
           `shouldRespondWith`
-          [json|{"code":"PGRST118","details":null,"hint":"If a new column was created in the database with this name, try reloading the schema cache.","message":"Could not find 'helicopter' in the target table"} |]
+          [json|{"code":"PGRST118","details":null,"hint":null,"message":"Could not find 'helicopter' in the target table"} |]
           { matchStatus  = 400
           , matchHeaders = []
           }


### PR DESCRIPTION
<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs     - https://github.com/PostgREST/postgrest-docs
-->

Switches from `json_populate_recordset` to `json_to_recordset`, which we will need for data representations. See #2523 for details.

The impossible panic we discussed in #2523 has been eliminated by creating a `TypedField` type which doesn't allow that situation.