### PR TITLE
feat: Build against libpq 15

### DIFF
--- a/nix/overlays/postgresql-default.nix
+++ b/nix/overlays/postgresql-default.nix
@@ -1,5 +1,5 @@
 self: super:
 # Overlay that sets the default version of PostgreSQL.
 {
-  postgresql = super.postgresql_14;
+  postgresql = super.postgresql_15;
 }


### PR DESCRIPTION
This is the part of #2545 that made the static build fail.

It throws:

```
libpq.so.5.15:                 U atexit
libpq must not be calling any function which invokes exit
make[3]: *** [Makefile:121: libpq-refs-stamp] Error 1
make[3]: Leaving directory '/build/postgresql-15.0/src/interfaces/libpq'
make[2]: *** [Makefile:17: all-libpq-recurse] Error 2
make[2]: Leaving directory '/build/postgresql-15.0/src/interfaces'
make[1]: *** [Makefile:42: all-interfaces-recurse] Error 2
make[1]: Leaving directory '/build/postgresql-15.0/src'
make: *** [GNUmakefile:16: world-src-recurse] Error 2
builder for '/nix/store/43x2c5japzcfn8iimpjnjz7w0vsvki9j-postgresql-15.0.drv' failed with exit code 2
```

This seems to be related to: https://www.postgresql.org/message-id/flat/3128896.1624742969%40sss.pgh.pa.us