### PR TITLE
fix: bump hasql-pool to 0.8.0.6

### DIFF
--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -32,7 +32,14 @@ let
       hashtables = lib.dontCheck prev.hashtables_1_3_1;
       hasql = lib.dontCheck prev.hasql_1_6_1_4;
       hasql-dynamic-statements = lib.dontCheck prev.hasql-dynamic-statements_0_3_1_2;
-      hasql-pool = lib.dontCheck prev.hasql-pool_0_8_0_4;
+      hasql-pool = lib.dontCheck
+        (prev.callHackageDirect
+          {
+            pkg = "hasql-pool";
+            ver = "0.8.0.6";
+            sha256 = "sha256-2u/cwPk8XfXffaDRzGeyzhL+9k2+2T4b8bGOZwz8AX0=";
+          }
+          { });
       hasql-transaction = lib.dontCheck prev.hasql-transaction_1_0_1_2;
       isomorphism-class = lib.unmarkBroken prev.isomorphism-class;
       lens = lib.dontCheck prev.lens_5_2;

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -89,7 +89,7 @@ library
                     , hasql                     >= 1.6.1.1 && < 1.7
                     , hasql-dynamic-statements  >= 0.3.1 && < 0.4
                     , hasql-notifications       >= 0.1 && < 0.3
-                    , hasql-pool                >= 0.8.0.2 && < 0.9
+                    , hasql-pool                >= 0.8.0.6 && < 0.9
                     , hasql-transaction         >= 1.0.1 && < 1.1
                     , heredoc                   >= 0.2 && < 0.3
                     , http-types                >= 0.12.2 && < 0.13

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@ extra-deps:
   - hasql-dynamic-statements-0.3.1.2
   - hasql-implicits-0.1.0.5
   - hasql-notifications-0.2.0.3
-  - hasql-pool-0.8.0.2
+  - hasql-pool-0.8.0.6
   - hasql-transaction-1.0.1.2
   - isomorphism-class-0.1.0.6
   - lens-aeson-1.1.3

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -61,12 +61,12 @@ packages:
   original:
     hackage: hasql-notifications-0.2.0.3
 - completed:
-    hackage: hasql-pool-0.8.0.2@sha256:15473f336c2bd1da161cd03635841f38b0c177d7b8662762c8708c239a428f04,1907
+    hackage: hasql-pool-0.8.0.6@sha256:b63bb83409bab5bc20ff24f5d62205e9b117701a0fc24531ddeac20ab8c2a42c,1818
     pantry-tree:
-      size: 505
-      sha256: 495dfdf8b7f7d910e2e8a7a7e8d71c8dbf9d439e048de5bc2a66a762011cbdc2
+      size: 346
+      sha256: c4100946b7eae44375511e35a393abe2e1db0e5637c68cea8f53176b796bfd5b
   original:
-    hackage: hasql-pool-0.8.0.2
+    hackage: hasql-pool-0.8.0.6
 - completed:
     hackage: hasql-transaction-1.0.1.2@sha256:297b158cd1f0727f9b0e175bd7d3741c1bcb725a8094956d0ee79b41aafdb30a,2890
     pantry-tree:


### PR DESCRIPTION
This update ensures that connections aren't lost if they throw an exception. Compare #2558.