### PR TITLE
feat: add spread embeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
  - #1414, Add related orders - @steve-chavez
-  + On a many-to-one or one-to-one relationship, you can order a parent by a child column `/projects?select=*,clients(*)&order=clients(name).desc.nullsfirst`
+   + On a many-to-one or one-to-one relationship, you can order a parent by a child column `/projects?select=*,clients(*)&order=clients(name).desc.nullsfirst`
+ - #1233, Allow spreading embedded resources - @steve-chavez
+   + On a many-to-one or one-to-one relationship, you can unnest a json object with `/projects?select=*,..clients(client_name:name)`
 
 ### Fixed
 

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -212,6 +212,7 @@ test-suite spec
                       Feature.Query.RelatedQueriesSpec
                       Feature.Query.RpcSpec
                       Feature.Query.SingularSpec
+                      Feature.Query.SpreadQueriesSpec
                       Feature.Query.UnicodeSpec
                       Feature.Query.UpdateSpec
                       Feature.Query.UpsertSpec

--- a/src/PostgREST/ApiRequest/Types.hs
+++ b/src/PostgREST/ApiRequest/Types.hs
@@ -38,16 +38,23 @@ import PostgREST.SchemaCache.Relationship (Relationship)
 
 import Protolude
 
--- | The select value in `/tbl?select=alias:field::cast`
+-- | The value in `/tbl?select=alias:field::cast`
 data SelectItem
   = SelectField
     { selField :: Field
     , selCast  :: Maybe Cast
     , selAlias :: Maybe Alias
     }
+-- | The value in `/tbl?select=alias:another_tbl(*)`
   | SelectRelation
     { selRelation :: FieldName
     , selAlias    :: Maybe Alias
+    , selHint     :: Maybe Hint
+    , selJoinType :: Maybe JoinType
+    }
+-- | The value in `/tbl?select=...another_tbl(*)`
+  | SpreadRelation
+    { selRelation :: FieldName
     , selHint     :: Maybe Hint
     , selJoinType :: Maybe JoinType
     }
@@ -71,6 +78,7 @@ data ApiRequestError
   | ParseRequestError Text Text
   | PutRangeNotAllowedError
   | QueryParamError QPError
+  | SpreadNotToOne Text Text
   | UnacceptableSchema [Text]
   | UnsupportedMethod ByteString
 

--- a/src/PostgREST/ApiRequest/Types.hs
+++ b/src/PostgREST/ApiRequest/Types.hs
@@ -71,13 +71,13 @@ data ApiRequestError
   | InvalidRpcMethod ByteString
   | LimitNoOrderError
   | NotFound
-  | NotToOne Text Text
   | NoRelBetween Text Text Text
   | NoRpc Text Text [Text] Bool MediaType Bool
   | NotEmbedded Text
   | ParseRequestError Text Text
   | PutRangeNotAllowedError
   | QueryParamError QPError
+  | RelatedOrderNotToOne Text Text
   | SpreadNotToOne Text Text
   | UnacceptableSchema [Text]
   | UnsupportedMethod ByteString

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -64,7 +64,6 @@ instance PgrstError ApiRequestError where
   status InvalidRpcMethod{}      = HTTP.status405
   status InvalidRange{}          = HTTP.status416
   status NotFound                = HTTP.status404
-  status NotToOne{}              = HTTP.status400
 
   status NoRelBetween{}          = HTTP.status400
   status NoRpc{}                 = HTTP.status404
@@ -72,6 +71,7 @@ instance PgrstError ApiRequestError where
   status ParseRequestError{}     = HTTP.status400
   status PutRangeNotAllowedError = HTTP.status400
   status QueryParamError{}       = HTTP.status400
+  status RelatedOrderNotToOne{}  = HTTP.status400
   status SpreadNotToOne{}        = HTTP.status400
   status UnacceptableSchema{}    = HTTP.status406
   status UnsupportedMethod{}     = HTTP.status405
@@ -154,10 +154,10 @@ instance JSON.ToJSON ApiRequestError where
     "details" .= JSON.Null,
     "hint"    .= JSON.Null]
 
-  toJSON (NotToOne origin target) = JSON.object [
+  toJSON (RelatedOrderNotToOne origin target) = JSON.object [
     "code"    .= ApiRequestErrorCode18,
-    "message" .= ("'" <> origin <> "' and '" <> target <> "' do not form a many-to-one or one-to-one relationship" :: Text),
-    "details" .= JSON.Null,
+    "message" .= ("A related order on '" <> target <> "' is not possible" :: Text),
+    "details" .= ("'" <> origin <> "' and '" <> target <> "' do not form a many-to-one or one-to-one relationship" :: Text),
     "hint"    .= JSON.Null]
 
   toJSON (SpreadNotToOne origin target) = JSON.object [

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -72,6 +72,7 @@ instance PgrstError ApiRequestError where
   status ParseRequestError{}     = HTTP.status400
   status PutRangeNotAllowedError = HTTP.status400
   status QueryParamError{}       = HTTP.status400
+  status SpreadNotToOne{}        = HTTP.status400
   status UnacceptableSchema{}    = HTTP.status406
   status UnsupportedMethod{}     = HTTP.status405
   status LimitNoOrderError       = HTTP.status400
@@ -157,6 +158,12 @@ instance JSON.ToJSON ApiRequestError where
     "code"    .= ApiRequestErrorCode18,
     "message" .= ("'" <> origin <> "' and '" <> target <> "' do not form a many-to-one or one-to-one relationship" :: Text),
     "details" .= JSON.Null,
+    "hint"    .= JSON.Null]
+
+  toJSON (SpreadNotToOne origin target) = JSON.object [
+    "code"    .= ApiRequestErrorCode19,
+    "message" .= ("A spread operation on '" <> target <> "' is not possible" :: Text),
+    "details" .= ("'" <> origin <> "' and '" <> target <> "' do not form a many-to-one or one-to-one relationship" :: Text),
     "hint"    .= JSON.Null]
 
   toJSON (NoRelBetween parent child schema) = JSON.object [
@@ -471,6 +478,7 @@ data ErrorCode
   | ApiRequestErrorCode16
   | ApiRequestErrorCode17
   | ApiRequestErrorCode18
+  | ApiRequestErrorCode19
   -- Schema Cache errors
   | SchemaCacheErrorCode00
   | SchemaCacheErrorCode01
@@ -513,6 +521,7 @@ buildErrorCode code = "PGRST" <> case code of
   ApiRequestErrorCode16  -> "116"
   ApiRequestErrorCode17  -> "117"
   ApiRequestErrorCode18  -> "118"
+  ApiRequestErrorCode19  -> "119"
 
   SchemaCacheErrorCode00 -> "200"
   SchemaCacheErrorCode01 -> "201"

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -328,7 +328,7 @@ addRelatedOrders (Node rp@ReadPlan{order,from} forest) = do
               name    = fromMaybe relName relAlias in
           if isToOne == Just True
             then Right $ ot{otRelation=relAggAlias}
-            else Left $ NotToOne (qiName from) name
+            else Left $ RelatedOrderNotToOne (qiName from) name
         Nothing ->
           Left $ NotEmbedded otRelation
 

--- a/src/PostgREST/Plan/ReadPlan.hs
+++ b/src/PostgREST/Plan/ReadPlan.hs
@@ -41,6 +41,7 @@ data ReadPlan = ReadPlan
   , relAggAlias  :: Alias
   , relHint      :: Maybe Hint
   , relJoinType  :: Maybe JoinType
+  , relIsSpread  :: Bool
   , depth        :: Depth
   -- ^ used for aliasing
   }

--- a/test/spec/Feature/Query/RelatedQueriesSpec.hs
+++ b/test/spec/Feature/Query/RelatedQueriesSpec.hs
@@ -107,17 +107,32 @@ spec =
 
     it "fails when is not a to-one relationship" $ do
       get "/clients?select=*,projects(*)&order=projects(id)" `shouldRespondWith`
-        [json|{"code":"PGRST118","details":null,"hint":null,"message":"'clients' and 'projects' do not form a many-to-one or one-to-one relationship"}|]
+        [json|{
+          "code":"PGRST118",
+          "details":"'clients' and 'projects' do not form a many-to-one or one-to-one relationship",
+          "hint":null,
+          "message":"A related order on 'projects' is not possible"
+        }|]
         { matchStatus  = 400
         , matchHeaders = [matchContentTypeJson]
         }
       get "/clients?select=*,pros:projects(*)&order=pros(id)" `shouldRespondWith`
-        [json|{"code":"PGRST118","details":null,"hint":null,"message":"'clients' and 'pros' do not form a many-to-one or one-to-one relationship"}|]
+        [json|{
+          "code":"PGRST118",
+          "details":"'clients' and 'pros' do not form a many-to-one or one-to-one relationship",
+          "hint":null,
+          "message":"A related order on 'pros' is not possible"
+        }|]
         { matchStatus  = 400
         , matchHeaders = [matchContentTypeJson]
         }
       get "/designers?select=id,computed_videogames(id)&order=computed_videogames(id).desc" `shouldRespondWith`
-        [json|{"code":"PGRST118","details":null,"hint":null,"message":"'designers' and 'computed_videogames' do not form a many-to-one or one-to-one relationship"}|]
+        [json|{
+          "code":"PGRST118",
+          "details":"'designers' and 'computed_videogames' do not form a many-to-one or one-to-one relationship",
+          "hint":null,
+          "message":"A related order on 'computed_videogames' is not possible"
+        }|]
         { matchStatus  = 400
         , matchHeaders = [matchContentTypeJson]
         }

--- a/test/spec/Feature/Query/SpreadQueriesSpec.hs
+++ b/test/spec/Feature/Query/SpreadQueriesSpec.hs
@@ -1,0 +1,86 @@
+module Feature.Query.SpreadQueriesSpec where
+
+import Network.Wai (Application)
+
+import Test.Hspec
+import Test.Hspec.Wai
+import Test.Hspec.Wai.JSON
+
+import Protolude  hiding (get)
+import SpecHelper
+
+spec :: SpecWith ((), Application)
+spec =
+  describe "spread embeds" $ do
+    it "works on a many-to-one relationship" $ do
+      get "/projects?select=id,..clients(client_name:name)" `shouldRespondWith`
+        [json|[
+          {"id":1,"client_name":"Microsoft"},
+          {"id":2,"client_name":"Microsoft"},
+          {"id":3,"client_name":"Apple"},
+          {"id":4,"client_name":"Apple"},
+          {"id":5,"client_name":null}
+        ]|]
+        { matchStatus  = 200
+        , matchHeaders = [matchContentTypeJson]
+        }
+      get "/grandchild_entities?select=name,..child_entities(parent_name:name,..entities(grandparent_name:name))&limit=3" `shouldRespondWith`
+        [json|[
+          {"name":"grandchild entity 1","parent_name":"child entity 1","grandparent_name":"entity 1"},
+          {"name":"grandchild entity 2","parent_name":"child entity 1","grandparent_name":"entity 1"},
+          {"name":"grandchild entity 3","parent_name":"child entity 2","grandparent_name":"entity 1"}
+        ]|]
+        { matchStatus  = 200
+        , matchHeaders = [matchContentTypeJson]
+        }
+      get "/videogames?select=name,..computed_designers(designer_name:name)" `shouldRespondWith`
+        [json|[
+          {"name":"Civilization I","designer_name":"Sid Meier"},
+          {"name":"Civilization II","designer_name":"Sid Meier"},
+          {"name":"Final Fantasy I","designer_name":"Hironobu Sakaguchi"},
+          {"name":"Final Fantasy II","designer_name":"Hironobu Sakaguchi"}
+        ]|]
+        { matchStatus  = 200
+        , matchHeaders = [matchContentTypeJson]
+        }
+
+    it "works inside a normal embed" $
+      get "/grandchild_entities?select=name,child_entity:child_entities(name,..entities(parent_name:name))&limit=1" `shouldRespondWith`
+        [json|[
+          {"name":"grandchild entity 1","child_entity":{"name":"child entity 1","parent_name":"entity 1"}}
+        ]|]
+        { matchStatus  = 200
+        , matchHeaders = [matchContentTypeJson]
+        }
+
+    it "works on a one-to-one relationship" $
+      get "/country?select=name,..capital(capital:name)" `shouldRespondWith`
+        [json|[
+          {"name":"Afghanistan","capital":"Kabul"},
+          {"name":"Algeria","capital":"Algiers"}
+        ]|]
+        { matchStatus  = 200
+        , matchHeaders = [matchContentTypeJson]
+        }
+
+    it "fails when is not a to-one relationship" $ do
+      get "/clients?select=*,..projects(*)" `shouldRespondWith`
+        [json|{
+          "code":"PGRST119",
+          "details":"'clients' and 'projects' do not form a many-to-one or one-to-one relationship",
+          "hint":null,
+          "message":"A spread operation on 'projects' is not possible"
+        }|]
+        { matchStatus  = 400
+        , matchHeaders = [matchContentTypeJson]
+        }
+      get "/designers?select=*,..computed_videogames(*)" `shouldRespondWith`
+        [json|{
+          "code":"PGRST119",
+          "details":"'designers' and 'computed_videogames' do not form a many-to-one or one-to-one relationship",
+          "hint":null,
+          "message":"A spread operation on 'computed_videogames' is not possible"
+        }|]
+        { matchStatus  = 400
+        , matchHeaders = [matchContentTypeJson]
+        }

--- a/test/spec/Main.hs
+++ b/test/spec/Main.hs
@@ -56,6 +56,7 @@ import qualified Feature.Query.RawOutputTypesSpec
 import qualified Feature.Query.RelatedQueriesSpec
 import qualified Feature.Query.RpcSpec
 import qualified Feature.Query.SingularSpec
+import qualified Feature.Query.SpreadQueriesSpec
 import qualified Feature.Query.UnicodeSpec
 import qualified Feature.Query.UpdateSpec
 import qualified Feature.Query.UpsertSpec
@@ -151,6 +152,7 @@ main = do
         , ("Feature.Query.UpsertSpec"                    , Feature.Query.UpsertSpec.spec actualPgVersion)
         , ("Feature.Query.ComputedRelsSpec"              , Feature.Query.ComputedRelsSpec.spec)
         , ("Feature.Query.RelatedQueriesSpec"            , Feature.Query.RelatedQueriesSpec.spec)
+        , ("Feature.Query.SpreadQueriesSpec"             , Feature.Query.SpreadQueriesSpec.spec)
         ]
 
   hspec $ do


### PR DESCRIPTION
Allows unnesting json objects. Closes https://github.com/PostgREST/postgrest/issues/1233.

Instead of getting

```http
GET /grandchild_entities?select=name,child_entities(parent_name:name,entities(grandparent_name:name))&limit=3'

[
{"name":"grandchild entity 1","child_entities":{"parent_name":"child entity 1","entities":{"grandparent_name":"entity 1"}}},
{"name":"grandchild entity 2","child_entities":{"parent_name":"child entity 1","entities":{"grandparent_name":"entity 1"}}},
{"name":"grandchild entity 3","child_entities":{"parent_name":"child entity 2","entities":{"grandparent_name":"entity 1"}}}
]
```

You can get

```http
GET /grandchild_entities?select=name,..child_entities(parent_name:name,..entities(grandparent_name:name))&limit=3

[
{"name":"grandchild entity 1","parent_name":"child entity 1","grandparent_name":"entity 1"},
{"name":"grandchild entity 2","parent_name":"child entity 1","grandparent_name":"entity 1"},
{"name":"grandchild entity 3","parent_name":"child entity 2","grandparent_name":"entity 1"}
]
```

Only for many-to-one and one-to-one relationships.

### Tasks

- [x] Initial implementation and test
- [x] Refactor - DRY
- [x] Validate to-one relationship
- [x] More tests