### PR TITLE
test: move bad parsing integration tests to doctests

### DIFF
--- a/src/PostgREST/ApiRequest/QueryParams.hs
+++ b/src/PostgREST/ApiRequest/QueryParams.hs
@@ -669,6 +669,46 @@ pDelimiter = char '.' <?> "delimiter (.)"
 --
 -- >>> P.parse pOrder "" "name,clients(name),id"
 -- Right [OrderTerm {otTerm = ("name",[]), otDirection = Nothing, otNullOrder = Nothing},OrderRelationTerm {otRelation = "clients", otRelTerm = ("name",[]), otDirection = Nothing, otNullOrder = Nothing},OrderTerm {otTerm = ("id",[]), otDirection = Nothing, otNullOrder = Nothing}]
+--
+-- >>> P.parse pOrder "" "id.ac"
+-- Left (line 1, column 4):
+-- unexpected "c"
+-- expecting "asc", "desc", "nullsfirst" or "nullslast"
+--
+-- >>> P.parse pOrder "" "id.descc"
+-- Left (line 1, column 8):
+-- unexpected 'c'
+-- expecting delimiter (.), "," or end of input
+--
+-- >>> P.parse pOrder "" "id.nulsfist"
+-- Left (line 1, column 4):
+-- unexpected "n"
+-- expecting "asc", "desc", "nullsfirst" or "nullslast"
+--
+-- >>> P.parse pOrder "" "id.nullslasttt"
+-- Left (line 1, column 13):
+-- unexpected 't'
+-- expecting "," or end of input
+--
+-- >>> P.parse pOrder "" "id.smth34"
+-- Left (line 1, column 4):
+-- unexpected "s"
+-- expecting "asc", "desc", "nullsfirst" or "nullslast"
+--
+-- >>> P.parse pOrder "" "id.asc.nlsfst"
+-- Left (line 1, column 8):
+-- unexpected "l"
+-- expecting "nullsfirst" or "nullslast"
+--
+-- >>> P.parse pOrder "" "id.asc.nullslasttt"
+-- Left (line 1, column 17):
+-- unexpected 't'
+-- expecting "," or end of input
+--
+-- >>> P.parse pOrder "" "id.asc.smth34"
+-- Left (line 1, column 8):
+-- unexpected "s"
+-- expecting "nullsfirst" or "nullslast"
 pOrder :: Parser [OrderTerm]
 pOrder = lexeme (try pOrderRelationTerm <|> pOrderTerm) `sepBy1` char ','
   where

--- a/src/PostgREST/ApiRequest/QueryParams.hs
+++ b/src/PostgREST/ApiRequest/QueryParams.hs
@@ -325,6 +325,11 @@ pTreePath = do
 -- Left (line 1, column 16):
 -- unexpected '['
 -- expecting letter, digit, "-", "!", "(", "->>", "->", "::", ")", "," or end of input
+--
+-- >>> P.parse pFieldForest "" "data->>-78xy"
+-- Left (line 1, column 11):
+-- unexpected 'x'
+-- expecting digit, "->", "::", ".", "," or end of input
 pFieldForest :: Parser [Tree SelectItem]
 pFieldForest = pFieldTree `sepBy1` lexeme (char ',')
   where
@@ -401,6 +406,23 @@ pFieldName =
 --
 -- >>> P.parse pJsonPath "" "->0.desc"
 -- Right [JArrow {jOp = JIdx {jVal = "+0"}}]
+--
+-- Fails on badly formed negatives
+--
+-- >>> P.parse pJsonPath "" "->>-78xy"
+-- Left (line 1, column 7):
+-- unexpected 'x'
+-- expecting digit, "->", "::", ".", "," or end of input
+--
+-- >>> P.parse pJsonPath "" "->>--34"
+-- Left (line 1, column 5):
+-- unexpected "-"
+-- expecting digit
+--
+-- >>> P.parse pJsonPath "" "->>-xy-4"
+-- Left (line 1, column 5):
+-- unexpected "x"
+-- expecting digit
 pJsonPath :: Parser JsonPath
 pJsonPath = many pJsonOperation
   where

--- a/test/spec/Feature/Query/AndOrParamsSpec.hs
+++ b/test/spec/Feature/Query/AndOrParamsSpec.hs
@@ -252,35 +252,3 @@ spec actualPgVersion =
 
     it "can query columns that begin with and/or reserved words" $
       get "/grandchild_entities?or=(and_starting_col.eq.smth, or_starting_col.eq.smth)" `shouldRespondWith` 200
-
-    it "fails when using IN without () and provides meaningful error message" $
-      get "/entities?or=(id.in.1,2,id.eq.3)" `shouldRespondWith`
-        [json|{
-          "details": "unexpected \"1\" expecting \"(\"",
-          "message": "\"failed to parse logic tree ((id.in.1,2,id.eq.3))\" (line 1, column 10)",
-          "code": "PGRST100",
-          "hint": null
-        }|] { matchStatus = 400, matchHeaders = [matchContentTypeJson] }
-
-    it "fails on malformed query params and provides meaningful error message" $ do
-      get "/entities?or=)(" `shouldRespondWith`
-        [json|{
-          "details": "unexpected \")\" expecting \"(\"",
-          "message": "\"failed to parse logic tree ()()\" (line 1, column 3)",
-          "code": "PGRST100",
-          "hint": null
-        }|] { matchStatus = 400, matchHeaders = [matchContentTypeJson] }
-      get "/entities?and=(ord(id.eq.1,id.eq.1),id.eq.2)" `shouldRespondWith`
-        [json|{
-          "details": "unexpected \"d\" expecting \"(\"",
-          "message": "\"failed to parse logic tree ((ord(id.eq.1,id.eq.1),id.eq.2))\" (line 1, column 7)",
-          "code": "PGRST100",
-          "hint": null
-        }|] { matchStatus = 400, matchHeaders = [matchContentTypeJson] }
-      get "/entities?or=(id.eq.1,not.xor(id.eq.2,id.eq.3))" `shouldRespondWith`
-        [json|{
-          "details": "unexpected \"x\" expecting logic operator (and, or)",
-          "message": "\"failed to parse logic tree ((id.eq.1,not.xor(id.eq.2,id.eq.3)))\" (line 1, column 16)",
-          "code": "PGRST100",
-          "hint": null
-        }|] { matchStatus = 400, matchHeaders = [matchContentTypeJson] }

--- a/test/spec/Feature/Query/JsonOperatorSpec.hs
+++ b/test/spec/Feature/Query/JsonOperatorSpec.hs
@@ -292,25 +292,11 @@ spec actualPgVersion = describe "json and jsonb operators" $ do
         [json| [{"data":[{"a": [1,2,3]}, {"b": [4,5]}]}] |]
         { matchHeaders = [matchContentTypeJson] }
 
-    it "should fail on badly formed negatives" $ do
-      get "/json_arr?select=data->>-78xy" `shouldRespondWith`
-        [json|
-          {"details": "unexpected 'x' expecting digit, \"->\", \"::\", \".\", \",\" or end of input",
-           "message": "\"failed to parse select parameter (data->>-78xy)\" (line 1, column 11)",
-           "code": "PGRST100",
-           "hint": null} |]
-        { matchStatus = 400, matchHeaders = [matchContentTypeJson] }
-      get "/json_arr?select=data->>--34" `shouldRespondWith`
-        [json|
-          {"details": "unexpected \"-\" expecting digit",
-           "message": "\"failed to parse select parameter (data->>--34)\" (line 1, column 9)",
-           "code": "PGRST100",
-           "hint": null} |]
-        { matchStatus = 400, matchHeaders = [matchContentTypeJson] }
-      get "/json_arr?select=data->>-xy-4" `shouldRespondWith`
-        [json|
-          {"details":"unexpected \"x\" expecting digit",
-           "message":"\"failed to parse select parameter (data->>-xy-4)\" (line 1, column 9)",
-           "code": "PGRST100",
-           "hint": null} |]
-        { matchStatus = 400, matchHeaders = [matchContentTypeJson] }
+  it "gives a meaningful error on bad syntax" $
+    get "/json_arr?select=data->>--34" `shouldRespondWith`
+      [json|
+        {"details": "unexpected \"-\" expecting digit",
+         "message": "\"failed to parse select parameter (data->>--34)\" (line 1, column 9)",
+         "code": "PGRST100",
+         "hint": null} |]
+      { matchStatus = 400, matchHeaders = [matchContentTypeJson] }

--- a/test/spec/Feature/Query/QuerySpec.hs
+++ b/test/spec/Feature/Query/QuerySpec.hs
@@ -921,50 +921,12 @@ spec actualPgVersion = do
       get "/projects?id=eq.1&select=id, name, clients(id, name)&clients.order=name.asc" `shouldRespondWith`
         [json|[{"id":1,"name":"Windows 7","clients":{"id":1,"name":"Microsoft"}}]|]
 
-    context "order syntax errors" $ do
-      it "gives meaningful error messages when asc/desc/nulls{first,last} are misspelled" $ do
-        get "/items?order=id.ac" `shouldRespondWith`
-          [json|{"details":"unexpected \"c\" expecting \"asc\", \"desc\", \"nullsfirst\" or \"nullslast\"","message":"\"failed to parse order (id.ac)\" (line 1, column 4)","code":"PGRST100","hint":null}|]
-          { matchStatus  = 400
-          , matchHeaders = [matchContentTypeJson]
-          }
-        get "/items?order=id.descc" `shouldRespondWith`
-          [json|{"details":"unexpected 'c' expecting delimiter (.), \",\" or end of input","message":"\"failed to parse order (id.descc)\" (line 1, column 8)","code":"PGRST100","hint":null}|]
-          { matchStatus  = 400
-          , matchHeaders = [matchContentTypeJson]
-          }
-        get "/items?order=id.nulsfist" `shouldRespondWith`
-          [json|{"details":"unexpected \"n\" expecting \"asc\", \"desc\", \"nullsfirst\" or \"nullslast\"","message":"\"failed to parse order (id.nulsfist)\" (line 1, column 4)","code":"PGRST100","hint":null}|]
-          { matchStatus  = 400
-          , matchHeaders = [matchContentTypeJson]
-          }
-        get "/items?order=id.nullslasttt" `shouldRespondWith`
-          [json|{"details":"unexpected 't' expecting \",\" or end of input","message":"\"failed to parse order (id.nullslasttt)\" (line 1, column 13)","code":"PGRST100","hint":null}|]
-          { matchStatus  = 400
-          , matchHeaders = [matchContentTypeJson]
-          }
-        get "/items?order=id.smth34" `shouldRespondWith`
-          [json|{"details":"unexpected \"s\" expecting \"asc\", \"desc\", \"nullsfirst\" or \"nullslast\"","message":"\"failed to parse order (id.smth34)\" (line 1, column 4)","code":"PGRST100","hint":null}|]
-          { matchStatus  = 400
-          , matchHeaders = [matchContentTypeJson]
-          }
-
-      it "gives meaningful error messages when nulls{first,last} are misspelled after asc/desc" $ do
-        get "/items?order=id.asc.nlsfst" `shouldRespondWith`
-          [json|{"details":"unexpected \"l\" expecting \"nullsfirst\" or \"nullslast\"","message":"\"failed to parse order (id.asc.nlsfst)\" (line 1, column 8)","code":"PGRST100","hint":null}|]
-          { matchStatus  = 400
-          , matchHeaders = [matchContentTypeJson]
-          }
-        get "/items?order=id.asc.nullslasttt" `shouldRespondWith`
-          [json|{"details":"unexpected 't' expecting \",\" or end of input","message":"\"failed to parse order (id.asc.nullslasttt)\" (line 1, column 17)","code":"PGRST100","hint":null}|]
-          { matchStatus  = 400
-          , matchHeaders = [matchContentTypeJson]
-          }
-        get "/items?order=id.asc.smth34" `shouldRespondWith`
-          [json|{"details":"unexpected \"s\" expecting \"nullsfirst\" or \"nullslast\"","message":"\"failed to parse order (id.asc.smth34)\" (line 1, column 8)","code":"PGRST100","hint":null}|]
-          { matchStatus  = 400
-          , matchHeaders = [matchContentTypeJson]
-          }
+    it "gives meaningful error message on bad syntax" $ do
+      get "/items?order=id.asc.nullslasttt" `shouldRespondWith`
+        [json|{"details":"unexpected 't' expecting \",\" or end of input","message":"\"failed to parse order (id.asc.nullslasttt)\" (line 1, column 17)","code":"PGRST100","hint":null}|]
+        { matchStatus  = 400
+        , matchHeaders = [matchContentTypeJson]
+        }
 
   describe "Accept headers" $ do
     it "should respond an unknown accept type with 415" $


### PR DESCRIPTION
The parsing tests are more visible and maintainable this way.