### PR TITLE
feat: Allow embedding without selecting any column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + Allows including the join table columns when resource embedding
    + Allows disambiguating a recursive m2m embed
    + Allows disambiguating an embed that has a many-to-many relationship using two foreign keys on a junction
+ - #2340, Allow embedding without selecting any column - @steve-chavez
 
 ### Fixed
 

--- a/src/PostgREST/ApiRequest/QueryParams.hs
+++ b/src/PostgREST/ApiRequest/QueryParams.hs
@@ -323,6 +323,9 @@ pTreePath = do
 -- >>> P.parse pFieldForest "" "*,..client(*),other(*)"
 -- Right [Node {rootLabel = SelectField {selField = ("*",[]), selCast = Nothing, selAlias = Nothing}, subForest = []},Node {rootLabel = SpreadRelation {selRelation = "client", selHint = Nothing, selJoinType = Nothing}, subForest = [Node {rootLabel = SelectField {selField = ("*",[]), selCast = Nothing, selAlias = Nothing}, subForest = []}]},Node {rootLabel = SelectRelation {selRelation = "other", selAlias = Nothing, selHint = Nothing, selJoinType = Nothing}, subForest = [Node {rootLabel = SelectField {selField = ("*",[]), selCast = Nothing, selAlias = Nothing}, subForest = []}]}]
 --
+-- >>> P.parse pFieldForest "" ""
+-- Right []
+--
 -- >>> P.parse pFieldForest "" "id,clients(name[])"
 -- Left (line 1, column 16):
 -- unexpected '['
@@ -338,9 +341,6 @@ pFieldForest = pFieldTree `sepBy` lexeme (char ',')
     pFieldTree =  Node <$> try pSpreadRelationSelect <*> between (char '(') (char ')') pFieldForest <|>
                   Node <$> try pRelationSelect       <*> between (char '(') (char ')') pFieldForest <|>
                   Node <$> pFieldSelect <*> pure []
-
-pStar :: Parser Text
-pStar = string "*" $> "*"
 
 -- |
 -- Parse field names
@@ -536,6 +536,8 @@ pFieldSelect = lexeme $ try (do
     pEnd = try (void $ lookAhead (string ")")) <|>
            try (void $ lookAhead (string ",")) <|>
            try eof
+    pStar = string "*" $> "*"
+
 
 -- |
 -- Parse spread relations in select

--- a/src/PostgREST/ApiRequest/QueryParams.hs
+++ b/src/PostgREST/ApiRequest/QueryParams.hs
@@ -36,8 +36,8 @@ import Text.ParserCombinators.Parsec (GenParser, ParseError, Parser,
                                       eof, errorPos, letter,
                                       lookAhead, many1, noneOf,
                                       notFollowedBy, oneOf,
-                                      optionMaybe, sepBy1, string,
-                                      try, (<?>))
+                                      optionMaybe, sepBy, sepBy1,
+                                      string, try, (<?>))
 
 import PostgREST.RangeQuery              (NonnegRange, allRange,
                                           rangeGeq, rangeLimit,
@@ -333,7 +333,7 @@ pTreePath = do
 -- unexpected 'x'
 -- expecting digit, "->", "::", ".", "," or end of input
 pFieldForest :: Parser [Tree SelectItem]
-pFieldForest = pFieldTree `sepBy1` lexeme (char ',')
+pFieldForest = pFieldTree `sepBy` lexeme (char ',')
   where
     pFieldTree :: Parser (Tree SelectItem)
     pFieldTree =  try (Node <$> pSpreadRelationSelect <*> between (char '(') (char ')') pFieldForest) <|>

--- a/src/PostgREST/Query.hs
+++ b/src/PostgREST/Query.hs
@@ -76,7 +76,7 @@ readQuery req conf@AppConfig{..} apiReq@ApiRequest{..} = do
   resultSet <-
      lift . SQL.statement mempty $
       Statements.prepareRead
-        (QueryBuilder.readPlanToQuery req)
+        (QueryBuilder.readPlanToQuery True req)
         (if iPreferCount == Just EstimatedCount then
            -- LIMIT maxRows + 1 so we can determine below that maxRows was surpassed
            QueryBuilder.limitedQuery countQuery ((+ 1) <$> configDbMaxRows)
@@ -163,7 +163,7 @@ invokeQuery proc CallReadPlan{crReadPlan, crCallPlan} apiReq@ApiRequest{..} conf
         (Proc.procReturnsScalar proc)
         (Proc.procReturnsSingle proc)
         (QueryBuilder.callPlanToQuery crCallPlan)
-        (QueryBuilder.readPlanToQuery crReadPlan)
+        (QueryBuilder.readPlanToQuery True crReadPlan)
         (QueryBuilder.readPlanToCountQuery crReadPlan)
         (shouldCount iPreferCount)
         iAcceptMediaType
@@ -217,7 +217,7 @@ writeQuery MutateReadPlan{mrReadPlan, mrMutatePlan} apiReq conf =
   in
   lift . SQL.statement mempty $
     Statements.prepareWrite
-      (QueryBuilder.readPlanToQuery mrReadPlan)
+      (QueryBuilder.readPlanToQuery True mrReadPlan)
       (QueryBuilder.mutatePlanToQuery mrMutatePlan)
       isInsert
       (iAcceptMediaType apiReq)

--- a/src/PostgREST/Query/QueryBuilder.hs
+++ b/src/PostgREST/Query/QueryBuilder.hs
@@ -57,7 +57,7 @@ readPlanToQuery (Node ReadPlan{select,from=mainQi,fromAlias,where_=logicForest,o
 
 getSelectsJoins :: ReadPlanTree -> ([SQL.Snippet], [SQL.Snippet]) -> ([SQL.Snippet], [SQL.Snippet])
 getSelectsJoins (Node ReadPlan{relToParent=Nothing} _) _ = ([], [])
-getSelectsJoins rr@(Node ReadPlan{relName, relToParent=Just rel, relAggAlias, relAlias, relJoinType, relIsSpread} _) (selects,joins) =
+getSelectsJoins rr@(Node ReadPlan{select, relName, relToParent=Just rel, relAggAlias, relAlias, relJoinType, relIsSpread} forest) (selects,joins) =
   let
     subquery = readPlanToQuery rr
     aliasOrName = pgFmtIdent $ fromMaybe relName relAlias
@@ -77,7 +77,7 @@ getSelectsJoins rr@(Node ReadPlan{relName, relToParent=Just rel, relAggAlias, re
             "FROM (" <> subquery <> " ) AS " <> SQL.sql aggAlias
           ) aggAlias $ if relJoinType == Just JTInner then SQL.sql aggAlias <> " IS NOT NULL" else "TRUE")
   in
-  (sel:selects, joi:joins)
+  (if null select && null forest then selects else sel:selects, joi:joins)
 
 mutatePlanToQuery :: MutatePlan -> SQL.Snippet
 mutatePlanToQuery (Insert mainQi iCols body onConflct putConditions returnings _) =

--- a/test/spec/Feature/Query/QuerySpec.hs
+++ b/test/spec/Feature/Query/QuerySpec.hs
@@ -1256,3 +1256,22 @@ spec actualPgVersion = do
       get "/users?select=*,tasks!inner()&tasks.id=eq.3" `shouldRespondWith`
         [json|[{"id":1,"name":"Angela Martin"}]|]
         { matchHeaders = [matchContentTypeJson] }
+
+  context "empty root select" $
+    it "gives all columns" $ do
+      get "/projects?select=" `shouldRespondWith`
+        [json|[
+          {"id":1,"name":"Windows 7","client_id":1},
+          {"id":2,"name":"Windows 10","client_id":1},
+          {"id":3,"name":"IOS","client_id":2},
+          {"id":4,"name":"OSX","client_id":2},
+          {"id":5,"name":"Orphan","client_id":null}]|]
+        { matchHeaders = [matchContentTypeJson] }
+      get "/rpc/getallprojects?select=" `shouldRespondWith`
+        [json|[
+          {"id":1,"name":"Windows 7","client_id":1},
+          {"id":2,"name":"Windows 10","client_id":1},
+          {"id":3,"name":"IOS","client_id":2},
+          {"id":4,"name":"OSX","client_id":2},
+          {"id":5,"name":"Orphan","client_id":null}]|]
+        { matchHeaders = [matchContentTypeJson] }

--- a/test/spec/Feature/Query/QuerySpec.hs
+++ b/test/spec/Feature/Query/QuerySpec.hs
@@ -1224,3 +1224,35 @@ spec actualPgVersion = do
     liftIO $ do
       let respHeaders = simpleHeaders r
       respHeaders `shouldSatisfy` noProfileHeader
+
+  context "empty embed" $ do
+    it "works on a many-to-one relationship" $ do
+      get "/projects?select=id,name,clients()" `shouldRespondWith`
+        [json| [
+          {"id":1,"name":"Windows 7"},
+          {"id":2,"name":"Windows 10"},
+          {"id":3,"name":"IOS"},
+          {"id":4,"name":"OSX"},
+          {"id":5,"name":"Orphan"}]|]
+        { matchHeaders = [matchContentTypeJson] }
+      get "/projects?select=id,name,clients!inner()&clients.id=eq.2" `shouldRespondWith`
+        [json|[
+          {"id":3,"name":"IOS"},
+          {"id":4,"name":"OSX"}]|]
+        { matchHeaders = [matchContentTypeJson] }
+
+    it "works on a one-to-many relationship" $ do
+      get "/clients?select=id,name,projects()" `shouldRespondWith`
+        [json| [{"id":1,"name":"Microsoft"}, {"id":2,"name":"Apple"}]|]
+        { matchHeaders = [matchContentTypeJson] }
+      get "/clients?select=id,name,projects!inner()&projects.name=eq.IOS" `shouldRespondWith`
+        [json|[{"id":2,"name":"Apple"}]|]
+        { matchHeaders = [matchContentTypeJson] }
+
+    it "works on a many-to-many relationship" $ do
+      get "/users?select=*,tasks!inner()" `shouldRespondWith`
+        [json| [{"id":1,"name":"Angela Martin"}, {"id":2,"name":"Michael Scott"}, {"id":3,"name":"Dwight Schrute"}]|]
+        { matchHeaders = [matchContentTypeJson] }
+      get "/users?select=*,tasks!inner()&tasks.id=eq.3" `shouldRespondWith`
+        [json|[{"id":1,"name":"Angela Martin"}]|]
+        { matchHeaders = [matchContentTypeJson] }


### PR DESCRIPTION
Closes https://github.com/PostgREST/postgrest/issues/2340

Allows doing

```http
GET /clients?select=id,name,projects!inner()&projects.name=eq.IOS

[{"id":2,"name":"Apple"}]
```

i.e. filtering on a related table without it showing on the result.

## Tasks

- [x] Implement and tests
- [x] Fix parsers for correct errors
- [x] `GET /projects` should give the same result as `GET /projects?select=`