### PR TITLE
Add hint for similar function parameter names when they don't match

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -85,6 +85,7 @@ library
                     , contravariant-extras      >= 0.3.3 && < 0.4
                     , cookie                    >= 0.4.2 && < 0.5
                     , either                    >= 4.4.1 && < 5.1
+                    , fuzzyset                  >= 0.2.3
                     , gitrev                    >= 1.2 && < 1.4
                     , hasql                     >= 1.6.1.1 && < 1.7
                     , hasql-dynamic-statements  >= 0.3.1 && < 0.4

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -461,8 +461,9 @@ findProc qi argumentsKeys paramsAsSingleObject allProcs contentMediaType isInvPo
     ([proc], _)  -> Right proc
     (procs, _)   -> Left $ AmbiguousRpc (toList procs)
   where
-    lookupProcName = HM.lookupDefault mempty qi allProcs -- first find the proc by name
     matchProc = overloadedProcPartition lookupProcName
+    -- First find the proc by name
+    lookupProcName = HM.lookupDefault mempty qi allProcs
     -- The partition obtained has the form (overloadedProcs,fallbackProcs)
     -- where fallbackProcs are functions with a single unnamed parameter
     overloadedProcPartition = foldr select ([],[])

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -453,7 +453,7 @@ requestMediaTypes conf action path =
 findProc :: QualifiedIdentifier -> S.Set Text -> Bool -> ProcsMap -> MediaType -> Bool -> Either ApiRequestError ProcDescription
 findProc qi argumentsKeys paramsAsSingleObject allProcs contentMediaType isInvPost =
   case matchProc of
-    ([], [])     -> Left $ NoRpc (qiSchema qi) (qiName qi) (S.toList argumentsKeys) paramsAsSingleObject contentMediaType isInvPost allProcs lookupProcName
+    ([], [])     -> Left $ NoRpc (qiSchema qi) (qiName qi) (S.toList argumentsKeys) paramsAsSingleObject contentMediaType isInvPost (HM.keys allProcs) lookupProcName
     -- If there are no functions with named arguments, fallback to the single unnamed argument function
     ([], [proc]) -> Right proc
     ([], procs)  -> Left $ AmbiguousRpc (toList procs)

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -453,7 +453,7 @@ requestMediaTypes conf action path =
 findProc :: QualifiedIdentifier -> S.Set Text -> Bool -> ProcsMap -> MediaType -> Bool -> Either ApiRequestError ProcDescription
 findProc qi argumentsKeys paramsAsSingleObject allProcs contentMediaType isInvPost =
   case matchProc of
-    ([], [])     -> Left $ NoRpc (qiSchema qi) (qiName qi) (S.toList argumentsKeys) paramsAsSingleObject contentMediaType isInvPost
+    ([], [])     -> Left $ NoRpc (qiSchema qi) (qiName qi) (S.toList argumentsKeys) paramsAsSingleObject contentMediaType isInvPost allProcs
     -- If there are no functions with named arguments, fallback to the single unnamed argument function
     ([], [proc]) -> Right proc
     ([], procs)  -> Left $ AmbiguousRpc (toList procs)

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -453,7 +453,7 @@ requestMediaTypes conf action path =
 findProc :: QualifiedIdentifier -> S.Set Text -> Bool -> ProcsMap -> MediaType -> Bool -> Either ApiRequestError ProcDescription
 findProc qi argumentsKeys paramsAsSingleObject allProcs contentMediaType isInvPost =
   case matchProc of
-    ([], [])     -> Left $ NoRpc (qiSchema qi) (qiName qi) (S.toList argumentsKeys) paramsAsSingleObject contentMediaType isInvPost allProcs
+    ([], [])     -> Left $ NoRpc (qiSchema qi) (qiName qi) (S.toList argumentsKeys) paramsAsSingleObject contentMediaType isInvPost allProcs lookupProcName
     -- If there are no functions with named arguments, fallback to the single unnamed argument function
     ([], [proc]) -> Right proc
     ([], procs)  -> Left $ AmbiguousRpc (toList procs)
@@ -461,7 +461,8 @@ findProc qi argumentsKeys paramsAsSingleObject allProcs contentMediaType isInvPo
     ([proc], _)  -> Right proc
     (procs, _)   -> Left $ AmbiguousRpc (toList procs)
   where
-    matchProc = overloadedProcPartition $ HM.lookupDefault mempty qi allProcs -- first find the proc by name
+    lookupProcName = HM.lookupDefault mempty qi allProcs -- first find the proc by name
+    matchProc = overloadedProcPartition lookupProcName
     -- The partition obtained has the form (overloadedProcs,fallbackProcs)
     -- where fallbackProcs are functions with a single unnamed parameter
     overloadedProcPartition = foldr select ([],[])

--- a/src/PostgREST/ApiRequest/Types.hs
+++ b/src/PostgREST/ApiRequest/Types.hs
@@ -67,7 +67,7 @@ data ApiRequestError
   | NotFound
   | NotToOne Text Text
   | NoRelBetween Text Text Text
-  | NoRpc Text Text [Text] Bool MediaType Bool ProcsMap
+  | NoRpc Text Text [Text] Bool MediaType Bool ProcsMap [ProcDescription]
   | NotEmbedded Text
   | ParseRequestError Text Text
   | PutRangeNotAllowedError

--- a/src/PostgREST/ApiRequest/Types.hs
+++ b/src/PostgREST/ApiRequest/Types.hs
@@ -32,7 +32,8 @@ module PostgREST.ApiRequest.Types
   ) where
 
 import PostgREST.MediaType                (MediaType (..))
-import PostgREST.SchemaCache.Identifiers  (FieldName, QualifiedIdentifier)
+import PostgREST.SchemaCache.Identifiers  (FieldName,
+                                           QualifiedIdentifier)
 import PostgREST.SchemaCache.Proc         (ProcDescription (..))
 import PostgREST.SchemaCache.Relationship (Relationship)
 

--- a/src/PostgREST/ApiRequest/Types.hs
+++ b/src/PostgREST/ApiRequest/Types.hs
@@ -32,9 +32,8 @@ module PostgREST.ApiRequest.Types
   ) where
 
 import PostgREST.MediaType                (MediaType (..))
-import PostgREST.SchemaCache.Identifiers  (FieldName)
-import PostgREST.SchemaCache.Proc         (ProcDescription (..),
-                                           ProcsMap)
+import PostgREST.SchemaCache.Identifiers  (FieldName, QualifiedIdentifier)
+import PostgREST.SchemaCache.Proc         (ProcDescription (..))
 import PostgREST.SchemaCache.Relationship (Relationship)
 
 import Protolude
@@ -67,7 +66,7 @@ data ApiRequestError
   | NotFound
   | NotToOne Text Text
   | NoRelBetween Text Text Text
-  | NoRpc Text Text [Text] Bool MediaType Bool ProcsMap [ProcDescription]
+  | NoRpc Text Text [Text] Bool MediaType Bool [QualifiedIdentifier] [ProcDescription]
   | NotEmbedded Text
   | ParseRequestError Text Text
   | PutRangeNotAllowedError

--- a/src/PostgREST/ApiRequest/Types.hs
+++ b/src/PostgREST/ApiRequest/Types.hs
@@ -33,7 +33,8 @@ module PostgREST.ApiRequest.Types
 
 import PostgREST.MediaType                (MediaType (..))
 import PostgREST.SchemaCache.Identifiers  (FieldName)
-import PostgREST.SchemaCache.Proc         (ProcDescription (..))
+import PostgREST.SchemaCache.Proc         (ProcDescription (..),
+                                           ProcsMap)
 import PostgREST.SchemaCache.Relationship (Relationship)
 
 import Protolude
@@ -66,7 +67,7 @@ data ApiRequestError
   | NotFound
   | NotToOne Text Text
   | NoRelBetween Text Text Text
-  | NoRpc Text Text [Text] Bool MediaType Bool
+  | NoRpc Text Text [Text] Bool MediaType Bool ProcsMap
   | NotEmbedded Text
   | ParseRequestError Text Text
   | PutRangeNotAllowedError

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -187,6 +187,7 @@ instance JSON.ToJSON ApiRequestError where
         _                            -> fmtParams) <>
       " in the schema cache"),
     "details" .= JSON.Null,
+    -- The hint will be null in the case of single unnamed parameter functions
     "hint"    .= if hasPreferSingleObject || (isInvPost && contentType `elem` [MTTextPlain, MTTextXML, MTOctetStream])
                  then Nothing
                  else noRpcHint schema procName argumentKeys allProcs overloadedProcs ]

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -45,8 +45,6 @@ import PostgREST.SchemaCache.Relationship (Cardinality (..),
                                            Relationship (..))
 import Protolude
 
--- >>>
--- >>>
 
 class (JSON.ToJSON a) => PgrstError a where
   status   :: a -> HTTP.Status
@@ -215,7 +213,7 @@ instance JSON.ToJSON ApiRequestError where
 -- >>> noRpcHint "api" "noclosealternative" "()" procsMap []
 -- Nothing
 --
--- If a function is found with the given name, but no params match, then it does a fuzzy searh
+-- If a function is found with the given name, but no params match, then it does a fuzzy search
 -- to all the overloaded functions' params using the form "(param1, param2, param3, ...)"
 -- and shows the best match as hint.
 --

--- a/test/doc/Main.hs
+++ b/test/doc/Main.hs
@@ -15,4 +15,5 @@ main =
     , "src/PostgREST/Query/SqlFragment.hs"
     , "src/PostgREST/ApiRequest/Preferences.hs"
     , "src/PostgREST/ApiRequest/QueryParams.hs"
+    , "src/PostgREST/Error.hs"
     ]

--- a/test/spec/Feature/Query/RpcSpec.hs
+++ b/test/spec/Feature/Query/RpcSpec.hs
@@ -120,17 +120,31 @@ spec actualPgVersion =
       it "should fail with 404 on unknown proc name" $
         get "/rpc/fake" `shouldRespondWith` 404
 
-      it "should fail with 404 on unknown proc args" $ do
-        get "/rpc/sayhello" `shouldRespondWith`
+      it "should fail with 404 and hint the closest proc on unknown proc name" $
+        get "/rpc/sayhell" `shouldRespondWith`
           [json| {
-            "hint":null,
-            "message":"Could not find the test.sayhello function without parameters in the schema cache",
+            "hint":"Perhaps you meant to call the function test.sayhello",
+            "message":"Could not find the test.sayhell function without parameters in the schema cache",
             "code":"PGRST202",
             "details":null} |]
           { matchStatus  = 404
           , matchHeaders = [matchContentTypeJson]
-          } 
+          }
+
+      it "should fail with 404 on unknown proc args" $ do
+        get "/rpc/sayhello" `shouldRespondWith` 404
         get "/rpc/sayhello?any_arg=value" `shouldRespondWith` 404
+
+      it "should fail with 404 and hint the closest args on unknown proc args" $
+        get "/rpc/sayhello?nam=Peter" `shouldRespondWith`
+          [json| {
+            "hint":"Perhaps you meant to call the function test.sayhello(name)",
+            "message":"Could not find the test.sayhello(nam) function in the schema cache",
+            "code":"PGRST202",
+            "details":null} |]
+          { matchStatus  = 404
+          , matchHeaders = [matchContentTypeJson]
+          }
 
       it "should not ignore unknown args and fail with 404" $
         get "/rpc/add_them?a=1&b=2&smthelse=blabla" `shouldRespondWith`

--- a/test/spec/Feature/Query/RpcSpec.hs
+++ b/test/spec/Feature/Query/RpcSpec.hs
@@ -121,7 +121,15 @@ spec actualPgVersion =
         get "/rpc/fake" `shouldRespondWith` 404
 
       it "should fail with 404 on unknown proc args" $ do
-        get "/rpc/sayhello" `shouldRespondWith` 404
+        get "/rpc/sayhello" `shouldRespondWith`
+          [json| {
+            "hint":null,
+            "message":"Could not find the test.sayhello function without parameters in the schema cache",
+            "code":"PGRST202",
+            "details":null} |]
+          { matchStatus  = 404
+          , matchHeaders = [matchContentTypeJson]
+          } 
         get "/rpc/sayhello?any_arg=value" `shouldRespondWith` 404
 
       it "should not ignore unknown args and fail with 404" $
@@ -141,7 +149,7 @@ spec actualPgVersion =
           [json|{}|]
         `shouldRespondWith`
           [json| {
-            "hint":"If a new function was created in the database with this name and parameters, try reloading the schema cache.",
+            "hint":null,
             "message":"Could not find the test.sayhello function with a single json or jsonb parameter in the schema cache",
             "code":"PGRST202",
             "details":null} |]
@@ -152,7 +160,7 @@ spec actualPgVersion =
       it "should fail with 404 for overloaded functions with unknown args" $ do
         get "/rpc/overloaded?wrong_arg=value" `shouldRespondWith`
           [json| {
-            "hint":"If a new function was created in the database with this name and parameters, try reloading the schema cache.",
+            "hint":null,
             "message":"Could not find the test.overloaded(wrong_arg) function in the schema cache",
             "code":"PGRST202",
             "details":null} |]
@@ -161,7 +169,7 @@ spec actualPgVersion =
           }
         get "/rpc/overloaded?a=1&b=2&wrong_arg=value" `shouldRespondWith`
           [json| {
-            "hint":"If a new function was created in the database with this name and parameters, try reloading the schema cache.",
+            "hint":"Perhaps you meant to call the function test.overloaded(a, b, c)",
             "message":"Could not find the test.overloaded(a, b, wrong_arg) function in the schema cache",
             "code":"PGRST202",
             "details":null} |]
@@ -1247,7 +1255,7 @@ spec actualPgVersion =
               [json|{"x": 1, "y": 2}|]
             `shouldRespondWith`
               [json|{
-                "hint": "If a new function was created in the database with this name and parameters, try reloading the schema cache.",
+                "hint": "Perhaps you meant to call the function test.unnamed_text_param",
                 "message": "Could not find the test.unnamed_int_param(x, y) function or the test.unnamed_int_param function with a single unnamed json or jsonb parameter in the schema cache",
                 "code":"PGRST202",
                 "details":null
@@ -1262,7 +1270,7 @@ spec actualPgVersion =
               [str|a simple text|]
             `shouldRespondWith`
               [json|{
-                "hint": "If a new function was created in the database with this name and parameters, try reloading the schema cache.",
+                "hint": null,
                 "message": "Could not find the test.unnamed_int_param function with a single unnamed text parameter in the schema cache",
                 "code":"PGRST202",
                 "details":null
@@ -1277,7 +1285,7 @@ spec actualPgVersion =
               [str|a simple text|]
             `shouldRespondWith`
               [json|{
-                "hint": "If a new function was created in the database with this name and parameters, try reloading the schema cache.",
+                "hint": null,
                 "message": "Could not find the test.unnamed_int_param function with a single unnamed xml parameter in the schema cache",
                 "code":"PGRST202",
                 "details":null
@@ -1293,7 +1301,7 @@ spec actualPgVersion =
               file
           `shouldRespondWith`
             [json|{
-              "hint": "If a new function was created in the database with this name and parameters, try reloading the schema cache.",
+              "hint": null,
               "message": "Could not find the test.unnamed_int_param function with a single unnamed bytea parameter in the schema cache",
               "code":"PGRST202",
               "details":null
@@ -1353,7 +1361,7 @@ spec actualPgVersion =
               "a,b\n1,2\n4,6\n100,200"
             `shouldRespondWith`
               [json| {
-                "hint":"If a new function was created in the database with this name and parameters, try reloading the schema cache.",
+                "hint":"Perhaps you meant to call the function test.overloaded_unnamed_param(x, y)",
                 "message":"Could not find the test.overloaded_unnamed_param(a, b) function in the schema cache",
                 "code":"PGRST202",
                 "details":null

--- a/test/spec/Feature/Query/RpcSpec.hs
+++ b/test/spec/Feature/Query/RpcSpec.hs
@@ -127,7 +127,7 @@ spec actualPgVersion =
       it "should not ignore unknown args and fail with 404" $
         get "/rpc/add_them?a=1&b=2&smthelse=blabla" `shouldRespondWith`
         [json| {
-          "hint":"If a new function was created in the database with this name and parameters, try reloading the schema cache.",
+          "hint":"Perhaps you meant to call the function test.add_them(a, b)",
           "message":"Could not find the test.add_them(a, b, smthelse) function in the schema cache",
           "code":"PGRST202",
           "details":null} |]


### PR DESCRIPTION
Related to #2571 and #2451.