### PR TITLE
Add suggestions with fuzzy text search when no relationship is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
  - #2565, Fix bad M2M embedding on RPC - @steve-chavez
- - #2575, Replace misleading error message by function and parameter name suggestions when no function is found - @laurenceisla
- - #2569, Replace misleading error message by parent and child name suggestions when no relationship is found - @laurenceisla
+ - #2575, Replace misleading error message when no function is found with a hint containing functions/parameters names suggestions - @laurenceisla
+ - #2569, Replace misleading error message when no relationship is found with a hint containing parent/child names suggestions - @laurenceisla
 ## [10.1.1] - 2022-11-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
  - #2565, Fix bad M2M embedding on RPC - @steve-chavez
+ - #2575, Replace misleading error message by function and parameter name suggestions when no function is found - @laurenceisla
  - #2569, Replace misleading error message by parent and child name suggestions when no relationship is found - @laurenceisla
 ## [10.1.1] - 2022-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
  - #2565, Fix bad M2M embedding on RPC - @steve-chavez
-
+ - #2569, Replace misleading error message by parent and child name suggestions when no relationship is found - @laurenceisla
 ## [10.1.1] - 2022-11-08
 
 ### Fixed

--- a/src/PostgREST/ApiRequest/Types.hs
+++ b/src/PostgREST/ApiRequest/Types.hs
@@ -35,7 +35,7 @@ import PostgREST.MediaType                (MediaType (..))
 import PostgREST.SchemaCache.Identifiers  (FieldName,
                                            QualifiedIdentifier)
 import PostgREST.SchemaCache.Proc         (ProcDescription (..))
-import PostgREST.SchemaCache.Relationship (Relationship)
+import PostgREST.SchemaCache.Relationship (Relationship, RelationshipsMap)
 
 import Protolude
 
@@ -72,7 +72,7 @@ data ApiRequestError
   | InvalidRpcMethod ByteString
   | LimitNoOrderError
   | NotFound
-  | NoRelBetween Text Text Text
+  | NoRelBetween Text Text (Maybe Text) Text RelationshipsMap
   | NoRpc Text Text [Text] Bool MediaType Bool [QualifiedIdentifier] [ProcDescription]
   | NotEmbedded Text
   | ParseRequestError Text Text

--- a/src/PostgREST/ApiRequest/Types.hs
+++ b/src/PostgREST/ApiRequest/Types.hs
@@ -35,7 +35,8 @@ import PostgREST.MediaType                (MediaType (..))
 import PostgREST.SchemaCache.Identifiers  (FieldName,
                                            QualifiedIdentifier)
 import PostgREST.SchemaCache.Proc         (ProcDescription (..))
-import PostgREST.SchemaCache.Relationship (Relationship, RelationshipsMap)
+import PostgREST.SchemaCache.Relationship (Relationship,
+                                           RelationshipsMap)
 
 import Protolude
 

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -37,7 +37,8 @@ import           PostgREST.ApiRequest.Types (ApiRequestError (..),
 import           PostgREST.MediaType        (MediaType (..))
 import qualified PostgREST.MediaType        as MediaType
 
-import PostgREST.SchemaCache.Identifiers  (QualifiedIdentifier (..))
+import PostgREST.SchemaCache.Identifiers  (QualifiedIdentifier (..),
+                                           Schema)
 import PostgREST.SchemaCache.Proc         (ProcDescription (..),
                                            ProcParam (..))
 import PostgREST.SchemaCache.Relationship (Cardinality (..),
@@ -248,7 +249,7 @@ instance JSON.ToJSON ApiRequestError where
 -- >>> noRelBetweenHint "films" "noclosealternative" "noclosealternative" rels
 -- Nothing
 --
-noRelBetweenHint :: Text -> Text -> Text -> RelationshipsMap -> Maybe Text
+noRelBetweenHint :: Text -> Text -> Schema -> RelationshipsMap -> Maybe Text
 noRelBetweenHint parent child schema allRels = ("Perhaps you meant '" <>) <$>
   if isJust findParent
     then (<> "' instead of '" <> child <> "'.") <$> suggestChild

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -18,6 +18,7 @@ module PostgREST.Error
 import qualified Data.Aeson                as JSON
 import qualified Data.ByteString.Char8     as BS
 import qualified Data.FuzzySet             as Fuzzy
+import qualified Data.HashMap.Strict       as HM
 import qualified Data.Text                 as T
 import qualified Data.Text.Encoding        as T
 import qualified Data.Text.Encoding.Error  as T
@@ -41,7 +42,8 @@ import PostgREST.SchemaCache.Proc         (ProcDescription (..),
                                            ProcParam (..))
 import PostgREST.SchemaCache.Relationship (Cardinality (..),
                                            Junction (..),
-                                           Relationship (..))
+                                           Relationship (..),
+                                           RelationshipsMap)
 import Protolude
 
 
@@ -174,11 +176,11 @@ instance JSON.ToJSON ApiRequestError where
     "details" .= ("Only is null or not is null filters are allowed on embedded resources":: Text),
     "hint"    .= JSON.Null]
 
-  toJSON (NoRelBetween parent child schema) = JSON.object [
+  toJSON (NoRelBetween parent child hint schema allRels) = JSON.object [
     "code"    .= SchemaCacheErrorCode00,
     "message" .= ("Could not find a relationship between '" <> parent <> "' and '" <> child <> "' in the schema cache" :: Text),
-    "details" .= JSON.Null,
-    "hint"    .= ("Verify that '" <> parent <> "' and '" <> child <> "' exist in the schema '" <> schema <> "' and that there is a foreign key relationship between them. If a new relationship was created, try reloading the schema cache." :: Text)]
+    "details" .= ("Searched for a foreign key relationship between '" <> parent <> "' and '" <> child <> maybe "" ("' using the hint '" <>) hint <> "' in the schema '" <> schema <> "', but no matches were found."),
+    "hint"    .= noRelBetweenHint parent child schema allRels]
 
   toJSON (AmbiguousRelBetween parent child rels) = JSON.object [
     "code"    .= SchemaCacheErrorCode01,
@@ -213,6 +215,32 @@ instance JSON.ToJSON ApiRequestError where
     "message" .= ("Could not choose the best candidate function between: " <> T.intercalate ", " [pdSchema p <> "." <> pdName p <> "(" <> T.intercalate ", " [ppName a <> " => " <> ppType a | a <- pdParams p] <> ")" | p <- procs]),
     "details" .= JSON.Null,
     "hint"    .= ("Try renaming the parameters or the function itself in the database so function overloading can be resolved" :: Text)]
+
+noRelBetweenHint :: Text -> Text -> Text -> RelationshipsMap -> Maybe Text
+noRelBetweenHint parent child schema allRels = ("Perhaps you meant '" <>) <$>
+  if isJust (findMatch parent)
+    then (<> "' instead of '" <> child <> "'.") <$> suggestChild
+    else (<> "' instead of '" <> parent <> "'.") <$> suggestParent
+  where
+    findMatch val = HM.lookup (QualifiedIdentifier schema val, schema) allRels
+    fuzzySetOfParents  = Fuzzy.fromList [qiName (fst p) | p <- HM.keys allRels, snd p == schema]
+    fuzzySetOfChildren = Fuzzy.fromList [qiName (relForeignTable c) | c <- fromMaybe [] (findMatch parent)]
+    suggestParent = Fuzzy.getOne fuzzySetOfParents parent
+    -- Do not suggest if the child is found in the relations (weight = 1.0)
+    suggestChild  = headMay [snd k | k <- Fuzzy.get fuzzySetOfChildren child, fst k < 1.0]
+-- TODO: Maybe more complex suggestions are needed? E.g. both parent and child not found
+--noRelBetweenHint parent child schema allRels =
+--  ("Perhaps you meant to select a relationship between '" <>)
+--  (<> ("instead of '" <> parent <> "' and '" <> child <> "'")) <$>
+--  case findMatch parent of
+--        Just rels -> ((parent <> "' and '") <>) <$> suggestChild rels
+--        _         -> findMatch
+--  where
+--    findMatch val = HM.lookup (QualifiedIdentifier schema val, schema) allRels
+--    fuzzySetOfParents  = Fuzzy.fromList [qiName (fst p) | p <- rels, snd p == schema]
+--    fuzzySetOfChildren rels = Fuzzy.fromList [qiName (relForeignTable c) | c <- fromMaybe [] (findMatch parent)]
+--    suggestParent = Fuzzy.getOne fuzzySetOfParents parent
+--    suggestChild rels  = Fuzzy.getOne (fuzzySetOfChildren rels) child
 
 -- |
 -- If no function is found with the given name, it does a fuzzy search to all the functions

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -218,10 +218,11 @@ instance JSON.ToJSON ApiRequestError where
     "hint"    .= ("Try renaming the parameters or the function itself in the database so function overloading can be resolved" :: Text)]
 
 -- |
--- If no relationship is found between a parent and a child, then it looks for the parent first.
--- If the parent is not found then it does a fuzzy search to all the parents in the schema cache and
--- gives the best match as suggestion. Otherwise, it does a fuzzy search to all the corresponding children
--- of that parent and gives the best match as suggestion. If both are found, then no suggestion is given.
+-- If no relationship is found then:
+--
+-- Looks for parent suggestions if parent not found
+-- Looks for child suggestions if parent is found but child is not
+-- Gives no suggestions if both are found (it means that there is a problem with the embed hint)
 --
 -- >>> :set -Wno-missing-fields
 -- >>> let qi t = QualifiedIdentifier "api" t

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -208,7 +208,7 @@ getJoinConditions tblAlias parentAlias Relationship{relTable=qi,relForeignTable=
 findRel :: Schema -> RelationshipsMap -> NodeName -> NodeName -> Maybe Hint -> Either ApiRequestError Relationship
 findRel schema allRels origin target hint =
   case rels of
-    []  -> Left $ NoRelBetween origin target schema
+    []  -> Left $ NoRelBetween origin target hint schema allRels
     [r] -> Right r
     rs  -> Left $ AmbiguousRelBetween origin target rs
   where

--- a/test/spec/Feature/Query/EmbedDisambiguationSpec.hs
+++ b/test/spec/Feature/Query/EmbedDisambiguationSpec.hs
@@ -217,10 +217,10 @@ spec =
         it "fails if the fk is not known" $
           get "/message?select=id,sender:person!space(name)&id=lt.4" `shouldRespondWith`
             [json|{
-              "hint":"Verify that 'message' and 'person' exist in the schema 'test' and that there is a foreign key relationship between them. If a new relationship was created, try reloading the schema cache.",
+              "hint":null,
               "message":"Could not find a relationship between 'message' and 'person' in the schema cache",
               "code": "PGRST200",
-              "details": null}|]
+              "details":"Searched for a foreign key relationship between 'message' and 'person' using the hint 'space' in the schema 'test', but no matches were found."}|]
             { matchStatus = 400
             , matchHeaders = [matchContentTypeJson] }
 
@@ -507,10 +507,10 @@ spec =
       it "doesn't work if the junction is only internal" $
         get "/end_1?select=end_2(*)" `shouldRespondWith`
           [json|{
-            "hint":"Verify that 'end_1' and 'end_2' exist in the schema 'test' and that there is a foreign key relationship between them. If a new relationship was created, try reloading the schema cache.",
+            "hint": null,
             "message":"Could not find a relationship between 'end_1' and 'end_2' in the schema cache",
             "code":"PGRST200",
-            "details": null}|]
+            "details": "Searched for a foreign key relationship between 'end_1' and 'end_2' in the schema 'test', but no matches were found."}|]
           { matchStatus  = 400
           , matchHeaders = [matchContentTypeJson] }
       it "shouldn't try to embed if the private junction has an exposed homonym" $
@@ -518,10 +518,10 @@ spec =
         -- Ref: https://github.com/PostgREST/postgrest/issues/1587#issuecomment-734995669
         get "/schauspieler?select=filme(*)" `shouldRespondWith`
           [json|{
-            "hint":"Verify that 'schauspieler' and 'filme' exist in the schema 'test' and that there is a foreign key relationship between them. If a new relationship was created, try reloading the schema cache.",
+            "hint":null,
             "message":"Could not find a relationship between 'schauspieler' and 'filme' in the schema cache",
             "code":"PGRST200",
-            "details": null}|]
+            "details":"Searched for a foreign key relationship between 'schauspieler' and 'filme' in the schema 'test', but no matches were found."}|]
           { matchStatus  = 400
           , matchHeaders = [matchContentTypeJson] }
 

--- a/test/spec/Feature/Query/QuerySpec.hs
+++ b/test/spec/Feature/Query/QuerySpec.hs
@@ -590,8 +590,8 @@ spec actualPgVersion = do
           it "cannot request partitions as children from a partitioned table" $
             get "/car_models?id=in.(1,2,4)&select=id,name,car_model_sales_202101(id)&order=id.asc" `shouldRespondWith`
               [json|
-                {"hint":"Verify that 'car_models' and 'car_model_sales_202101' exist in the schema 'test' and that there is a foreign key relationship between them. If a new relationship was created, try reloading the schema cache.",
-                 "details":null,
+                {"hint":"Perhaps you meant 'car_model_sales' instead of 'car_model_sales_202101'.",
+                 "details":"Searched for a foreign key relationship between 'car_models' and 'car_model_sales_202101' in the schema 'test', but no matches were found.",
                  "code":"PGRST200",
                  "message":"Could not find a relationship between 'car_models' and 'car_model_sales_202101' in the schema cache"} |]
               { matchStatus  = 400

--- a/test/spec/Feature/Query/QuerySpec.hs
+++ b/test/spec/Feature/Query/QuerySpec.hs
@@ -601,8 +601,8 @@ spec actualPgVersion = do
           it "cannot request a partitioned table as parent from a partition" $
             get "/car_model_sales_202101?select=id,name,car_models(id,name)&order=id.asc" `shouldRespondWith`
               [json|
-                {"hint":"Verify that 'car_model_sales_202101' and 'car_models' exist in the schema 'test' and that there is a foreign key relationship between them. If a new relationship was created, try reloading the schema cache.",
-                 "details":null,
+                {"hint":"Perhaps you meant 'car_model_sales' instead of 'car_model_sales_202101'.",
+                 "details":"Searched for a foreign key relationship between 'car_model_sales_202101' and 'car_models' in the schema 'test', but no matches were found.",
                  "code":"PGRST200",
                  "message":"Could not find a relationship between 'car_model_sales_202101' and 'car_models' in the schema cache"} |]
               { matchStatus  = 400
@@ -612,8 +612,8 @@ spec actualPgVersion = do
           it "cannot request a partition as parent from a partitioned table" $
             get "/car_model_sales?id=in.(1,3,4)&select=id,name,car_models_default(id,name)&order=id.asc" `shouldRespondWith`
               [json|
-                {"hint":"Verify that 'car_model_sales' and 'car_models_default' exist in the schema 'test' and that there is a foreign key relationship between them. If a new relationship was created, try reloading the schema cache.",
-                 "details":null,
+                {"hint":"Perhaps you meant 'car_models' instead of 'car_models_default'.",
+                 "details":"Searched for a foreign key relationship between 'car_model_sales' and 'car_models_default' in the schema 'test', but no matches were found.",
                  "code":"PGRST200",
                  "message":"Could not find a relationship between 'car_model_sales' and 'car_models_default' in the schema cache"} |]
               { matchStatus  = 400
@@ -623,8 +623,8 @@ spec actualPgVersion = do
           it "cannot request partitioned tables as children from a partition" $
             get "/car_models_default?select=id,name,car_model_sales(id,name)&order=id.asc" `shouldRespondWith`
               [json|
-                {"hint":"Verify that 'car_models_default' and 'car_model_sales' exist in the schema 'test' and that there is a foreign key relationship between them. If a new relationship was created, try reloading the schema cache.",
-                 "details":null,
+                {"hint":"Perhaps you meant 'car_model_sales' instead of 'car_models_default'.",
+                 "details":"Searched for a foreign key relationship between 'car_models_default' and 'car_model_sales' in the schema 'test', but no matches were found.",
                  "code":"PGRST200",
                  "message":"Could not find a relationship between 'car_models_default' and 'car_model_sales' in the schema cache"} |]
               { matchStatus  = 400


### PR DESCRIPTION
Closes #2569 

Contemplating two options:

- Suggest either the `parent` or `child` one at a time. If no parent is found, then suggest the closest match and stop there, otherwise, continue  looking for the child and suggest its closest match.
- ~Suggest both `parent` and `child`, if neither is found then suggest the closest relationship between them.~

Done so far:

- [x] Simple suggestions for parents or children (one at a time)
- [x] Doctests
- [x] Spectests
