### PR TITLE
feat: null filters on embedded resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + Allows disambiguating a recursive m2m embed
    + Allows disambiguating an embed that has a many-to-many relationship using two foreign keys on a junction
  - #2340, Allow embedding without selecting any column - @steve-chavez
+ - #2563, Allow `is.null` or `not.is.null` on an embedded resource - @steve-chavez
+   + Offers a more flexible replacement for `!inner`, e.g. `/projects?select=*,clients(*)&clients=not.is.null`
+   + Allows doing an anti join, e.g. `/projects?select=*,clients(*)&clients=is.null`
+   + Allows using or across related tables conditions
 
 ### Fixed
 

--- a/src/PostgREST/ApiRequest/Types.hs
+++ b/src/PostgREST/ApiRequest/Types.hs
@@ -80,6 +80,7 @@ data ApiRequestError
   | QueryParamError QPError
   | RelatedOrderNotToOne Text Text
   | SpreadNotToOne Text Text
+  | UnacceptableFilter Text
   | UnacceptableSchema [Text]
   | UnsupportedMethod ByteString
 
@@ -172,10 +173,12 @@ data LogicOperator
   | Or
   deriving Eq
 
-data Filter = Filter
+data Filter
+  = Filter
   { field  :: Field
   , opExpr :: OpExpr
   }
+  | FilterNullEmbed Bool FieldName
   deriving (Eq)
 
 data OpExpr =

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -74,6 +74,7 @@ instance PgrstError ApiRequestError where
   status QueryParamError{}       = HTTP.status400
   status RelatedOrderNotToOne{}  = HTTP.status400
   status SpreadNotToOne{}        = HTTP.status400
+  status UnacceptableFilter{}    = HTTP.status400
   status UnacceptableSchema{}    = HTTP.status406
   status UnsupportedMethod{}     = HTTP.status405
   status LimitNoOrderError       = HTTP.status400
@@ -165,6 +166,12 @@ instance JSON.ToJSON ApiRequestError where
     "code"    .= ApiRequestErrorCode19,
     "message" .= ("A spread operation on '" <> target <> "' is not possible" :: Text),
     "details" .= ("'" <> origin <> "' and '" <> target <> "' do not form a many-to-one or one-to-one relationship" :: Text),
+    "hint"    .= JSON.Null]
+
+  toJSON (UnacceptableFilter target) = JSON.object [
+    "code"    .= ApiRequestErrorCode20,
+    "message" .= ("Bad operator on the '" <> target <> "' embedded resource":: Text),
+    "details" .= ("Only is null or not is null filters are allowed on embedded resources":: Text),
     "hint"    .= JSON.Null]
 
   toJSON (NoRelBetween parent child schema) = JSON.object [
@@ -540,6 +547,7 @@ data ErrorCode
   | ApiRequestErrorCode17
   | ApiRequestErrorCode18
   | ApiRequestErrorCode19
+  | ApiRequestErrorCode20
   -- Schema Cache errors
   | SchemaCacheErrorCode00
   | SchemaCacheErrorCode01
@@ -583,6 +591,7 @@ buildErrorCode code = "PGRST" <> case code of
   ApiRequestErrorCode17  -> "117"
   ApiRequestErrorCode18  -> "118"
   ApiRequestErrorCode19  -> "119"
+  ApiRequestErrorCode20  -> "120"
 
   SchemaCacheErrorCode00 -> "200"
   SchemaCacheErrorCode01 -> "201"

--- a/src/PostgREST/Query.hs
+++ b/src/PostgREST/Query.hs
@@ -76,7 +76,7 @@ readQuery req conf@AppConfig{..} apiReq@ApiRequest{..} = do
   resultSet <-
      lift . SQL.statement mempty $
       Statements.prepareRead
-        (QueryBuilder.readPlanToQuery True req)
+        (QueryBuilder.readPlanToQuery req)
         (if iPreferCount == Just EstimatedCount then
            -- LIMIT maxRows + 1 so we can determine below that maxRows was surpassed
            QueryBuilder.limitedQuery countQuery ((+ 1) <$> configDbMaxRows)
@@ -163,7 +163,7 @@ invokeQuery proc CallReadPlan{crReadPlan, crCallPlan} apiReq@ApiRequest{..} conf
         (Proc.procReturnsScalar proc)
         (Proc.procReturnsSingle proc)
         (QueryBuilder.callPlanToQuery crCallPlan)
-        (QueryBuilder.readPlanToQuery True crReadPlan)
+        (QueryBuilder.readPlanToQuery crReadPlan)
         (QueryBuilder.readPlanToCountQuery crReadPlan)
         (shouldCount iPreferCount)
         iAcceptMediaType
@@ -217,7 +217,7 @@ writeQuery MutateReadPlan{mrReadPlan, mrMutatePlan} apiReq conf =
   in
   lift . SQL.statement mempty $
     Statements.prepareWrite
-      (QueryBuilder.readPlanToQuery True mrReadPlan)
+      (QueryBuilder.readPlanToQuery mrReadPlan)
       (QueryBuilder.mutatePlanToQuery mrMutatePlan)
       isInsert
       (iAcceptMediaType apiReq)

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -261,6 +261,7 @@ pgFmtOrderTerm qi ot =
 
 
 pgFmtFilter :: QualifiedIdentifier -> Filter -> SQL.Snippet
+pgFmtFilter _ (FilterNullEmbed hasNot fld) = SQL.sql (pgFmtIdent fld) <> " IS " <> (if hasNot then "NOT" else mempty) <> " NULL"
 pgFmtFilter table (Filter fld (OpExpr hasNot oper)) = notOp <> " " <> case oper of
    Op op val  -> pgFmtFieldOp op <> " " <> case op of
      OpLike  -> unknownLiteral (T.map star val)

--- a/test/spec/Feature/Query/PlanSpec.hs
+++ b/test/spec/Feature/Query/PlanSpec.hs
@@ -299,6 +299,39 @@ spec actualPgVersion = do
 
       liftIO $ planCost r `shouldSatisfy` (< 70.9)
 
+    context "!inner vs embed not null" $ do
+      it "on an o2m, an !inner has a similar cost to not.null" $ do
+        r1 <- request methodGet "/clients?select=*,projects!inner(*)&id=eq.1"
+               [planHdr] ""
+
+        liftIO $ planCost r1 `shouldSatisfy` (< 33.3)
+
+        r2 <- request methodGet "/clients?select=*,projects(*)&projects=not.is.null&id=eq.1"
+               [planHdr] ""
+
+        liftIO $ planCost r2 `shouldSatisfy` (< 33.3)
+
+      it "on an m2o, an !inner has a similar cost to not.null" $ do
+        r1 <- request methodGet "/projects?select=*,clients!inner(*)&id=eq.1"
+               [planHdr] ""
+
+        liftIO $ planCost r1 `shouldSatisfy` (< 16.42)
+
+        r2 <- request methodGet "/projects?select=*,clients(*)&clients=not.is.null&id=eq.1"
+               [planHdr] ""
+
+        liftIO $ planCost r2 `shouldSatisfy` (< 16.42)
+
+      it "on an m2m, an !inner has a similar cost to not.null" $ do
+        r1 <- request methodGet "/users?select=*,tasks!inner(*)&tasks.id=eq.1"
+               [planHdr] ""
+
+        liftIO $ planCost r1 `shouldSatisfy` (< 20876.14)
+
+        r2 <- request methodGet "/users?select=*,tasks(*)&tasks.id=eq.1&tasks=not.is.null"
+               [planHdr] ""
+
+        liftIO $ planCost r2 `shouldSatisfy` (< 20876.14)
 
   describe "function call costs" $ do
     it "should not exceed cost when calling setof composite proc" $ do


### PR DESCRIPTION
Closes https://github.com/PostgREST/postgrest/issues/2563.

- Offers a more flexible replacement for `!inner`(https://github.com/PostgREST/postgrest/pull/1949):

```bash
curl 'localhost:3000/projects?select=name,clients(*)&clients.id=eq.1&clients=not.is.null'

[{"name":"Windows 7","clients":{"id":1,"name":"Microsoft"}},
 {"name":"Windows 10","clients":{"id":1,"name":"Microsoft"}},
 {"name":"IOS","clients":{"id":2,"name":"Apple"}},
 {"name":"OSX","clients":{"id":2,"name":"Apple"}}]

# Same result as
curl 'localhost:3000/projects?select=name,clients!inner(*)&clients.id=eq.1'
```

-  Allows doing ANTI JOIN(only a LEFT one):

```
curl 'localhost:3000/projects?select=name,clients()&clients=is.null'

[{"name":"Orphan"}]
```

- Allows using `or` across related tables conditions([ref](https://github.com/PostgREST/postgrest/discussions/2014#discussion-3670338))

```bash
curl -G 'localhost:3000/client' \
-d "select=*,clientinfo(),contact()" \
-d "clientinfo.other=ilike.*main*&contact.name=ilike.*tabby*" \
-d "or=(clientinfo.not.is.null,contact.not.is.null)"

[{"id":1,"name":"Walmart"},
 {"id":2,"name":"Target"}]
```