### PR TITLE
bump postgresql-libpq

### DIFF
--- a/cabal.project.non-nix
+++ b/cabal.project.non-nix
@@ -17,4 +17,4 @@ packages: .
 source-repository-package
   type: git
   location: https://github.com/PostgREST/postgresql-libpq.git
-  tag: e1eb91e8336ee8bd196faf7a41f87fc6f53f906a
+  tag: 890a0a16cf57dd401420fdc6c7d576fb696003bc

--- a/cabal.project.non-nix
+++ b/cabal.project.non-nix
@@ -17,4 +17,4 @@ packages: .
 source-repository-package
   type: git
   location: https://github.com/PostgREST/postgresql-libpq.git
-  tag: 33ff97db570b5b432255f5f24a68db51453f6eb8
+  tag: e1eb91e8336ee8bd196faf7a41f87fc6f53f906a

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -52,8 +52,8 @@ let
           (super.fetchFromGitHub {
             owner = "PostgREST";
             repo = "postgresql-libpq";
-            rev = "cef92cb4c07b56568dffdbf4b719258b82183119"; # merge-upstream
-            sha256 = "0r59klrz47qcnd22s47h612mlz3jbg40wwalfj3f6djwg0cdyr85";
+            rev = "e1eb91e8336ee8bd196faf7a41f87fc6f53f906a"; # merge-upstream
+            sha256 = "1wmyhldk0k14y8whp1p4akrkqxf5snh8qsbm7fv5f7kz95nyffd0";
           })
           { });
     } // extraOverrides final prev;

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -52,7 +52,7 @@ let
           (super.fetchFromGitHub {
             owner = "PostgREST";
             repo = "postgresql-libpq";
-            rev = "cef92cb4c07b56568dffdbf4b719258b82183119"; # master
+            rev = "cef92cb4c07b56568dffdbf4b719258b82183119"; # merge-upstream
             sha256 = "0r59klrz47qcnd22s47h612mlz3jbg40wwalfj3f6djwg0cdyr85";
           })
           { });

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -52,7 +52,7 @@ let
           (super.fetchFromGitHub {
             owner = "PostgREST";
             repo = "postgresql-libpq";
-            rev = "e1eb91e8336ee8bd196faf7a41f87fc6f53f906a"; # merge-upstream
+            rev = "890a0a16cf57dd401420fdc6c7d576fb696003bc"; # master
             sha256 = "1wmyhldk0k14y8whp1p4akrkqxf5snh8qsbm7fv5f7kz95nyffd0";
           })
           { });

--- a/stack.yaml
+++ b/stack.yaml
@@ -29,4 +29,4 @@ extra-deps:
   - text-builder-0.6.7
   - text-builder-dev-0.3.3
   - git: https://github.com/PostgREST/postgresql-libpq.git
-    commit: e1eb91e8336ee8bd196faf7a41f87fc6f53f906a
+    commit: 890a0a16cf57dd401420fdc6c7d576fb696003bc

--- a/stack.yaml
+++ b/stack.yaml
@@ -29,4 +29,4 @@ extra-deps:
   - text-builder-0.6.7
   - text-builder-dev-0.3.3
   - git: https://github.com/PostgREST/postgresql-libpq.git
-    commit: 33ff97db570b5b432255f5f24a68db51453f6eb8
+    commit: e1eb91e8336ee8bd196faf7a41f87fc6f53f906a

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -7,143 +7,143 @@ packages:
 - completed:
     hackage: HTTP-4000.3.16@sha256:6042643c15a0b43e522a6693f1e322f05000d519543a84149cb80aeffee34f71,5947
     pantry-tree:
-      size: 1428
       sha256: b73a7f6d21cf20bbf819e19039409c9010efb5000d2b72cdd8fd67a9027c14e8
+      size: 1428
   original:
     hackage: HTTP-4000.3.16
 - completed:
     hackage: configurator-pg-0.2.6@sha256:cd9b06a458428e493a4d6def725af7ab1ab0fef678fbd871f9586fc7f9aa70be,2849
     pantry-tree:
-      size: 2463
       sha256: 97efe7a22afc93033bda5adcffdabc0f1c30dc32b2c3ba02114ce7cd74c942fd
+      size: 2463
   original:
     hackage: configurator-pg-0.2.6
 - completed:
     hackage: hashable-1.4.1.0@sha256:50b2f002c68fe67730ee7a3cd8607486197dd99b084255005ad51ecd6970a41b,5019
     pantry-tree:
-      size: 1248
       sha256: 9af2f7a42674f7effcabbebc043f97057240783f1709338a77f58216f4a5f18c
+      size: 1248
   original:
     hackage: hashable-1.4.1.0
 - completed:
     hackage: hashtables-1.3@sha256:ab21804fdafbbd8ad918b2911dabb729ae0ea891780fe66bf7804cbcd07edadf,10379
     pantry-tree:
-      size: 2895
       sha256: e71f113ad989dbc994e0fb52bcc219d62930de9afa8b3441bf7909e864481b33
+      size: 2895
   original:
     hackage: hashtables-1.3
 - completed:
     hackage: hasql-1.6.1.1@sha256:948a2137308cc5354e4997bc3666753867124cd25db792424cb9614b1c1b44cf,6626
     pantry-tree:
-      size: 2622
       sha256: 28d21bf061522fc513f040e9c383b90532222b7258216cc094e07736add8be10
+      size: 2622
   original:
     hackage: hasql-1.6.1.1
 - completed:
     hackage: hasql-dynamic-statements-0.3.1.2@sha256:417aa533c84f074e2fa16bb2c4d4231326aa512097dd1025d915388e56acd1eb,2675
     pantry-tree:
-      size: 595
       sha256: 91696d3f3e0ef3254772ae5a8e4e89be68285febb49b302ed83d85ac4037a417
+      size: 595
   original:
     hackage: hasql-dynamic-statements-0.3.1.2
 - completed:
     hackage: hasql-implicits-0.1.0.5@sha256:d16aacad6dc21428d72447d3ae8bcc03839a2f0aa1ec29c797ed9aca4609f9af,1361
     pantry-tree:
-      size: 264
       sha256: 0451b99a0a1d02db673d0c40acdf60d4e769e15852eed9e8dc05bffaf43efb70
+      size: 264
   original:
     hackage: hasql-implicits-0.1.0.5
 - completed:
     hackage: hasql-notifications-0.2.0.3@sha256:aca3f7ee847a8f0b7ef6f989dc48f4a094a06c1a34e92aa3c8bb230085966ea6,2027
     pantry-tree:
-      size: 452
       sha256: 999f0f2856a00d21f4498a8a58452bbefc4ea972fe2984fd234a68a5fe61d98b
+      size: 452
   original:
     hackage: hasql-notifications-0.2.0.3
 - completed:
     hackage: hasql-pool-0.8.0.6@sha256:b63bb83409bab5bc20ff24f5d62205e9b117701a0fc24531ddeac20ab8c2a42c,1818
     pantry-tree:
-      size: 346
       sha256: c4100946b7eae44375511e35a393abe2e1db0e5637c68cea8f53176b796bfd5b
+      size: 346
   original:
     hackage: hasql-pool-0.8.0.6
 - completed:
     hackage: hasql-transaction-1.0.1.2@sha256:297b158cd1f0727f9b0e175bd7d3741c1bcb725a8094956d0ee79b41aafdb30a,2890
     pantry-tree:
-      size: 983
       sha256: 3679e6d5c835cc17a8fa0c252b8221e282880044b7219aa1de2531bbd5c40691
+      size: 983
   original:
     hackage: hasql-transaction-1.0.1.2
 - completed:
     hackage: isomorphism-class-0.1.0.6@sha256:d93da31287359c761953b876354de28381f409c5c50e3241c572a443e50c553d,1703
     pantry-tree:
-      size: 465
       sha256: c97f922d1ae8f1a0db4c28fac9383d2716934879e95ff0b2b88ebb861d6fba14
+      size: 465
   original:
     hackage: isomorphism-class-0.1.0.6
 - completed:
     hackage: lens-aeson-1.1.3@sha256:52c8eaecd2d1c2a969c0762277c4a8ee72c339a686727d5785932e72ef9c3050,1764
     pantry-tree:
-      size: 541
       sha256: b31392b78f2a03111c805f4400007778eb93b49f998ab41dfbebaaf9b5526bad
+      size: 541
   original:
     hackage: lens-aeson-1.1.3
 - completed:
     hackage: optparse-applicative-0.16.1.0@sha256:418c22ed6a19124d457d96bc66bd22c93ac22fad0c7100fe4972bbb4ac989731,4982
     pantry-tree:
-      size: 2979
       sha256: dd092d843091c08691485d68a1908517079b1bc6f3d73928f37635a19dc27fc1
+      size: 2979
   original:
     hackage: optparse-applicative-0.16.1.0
 - completed:
     hackage: postgresql-binary-0.12.5@sha256:de9da3cba9be541d6c75ae8da2858c33d83dc1b2e0c639b0b9781816b78a91f4,5594
     pantry-tree:
-      size: 1619
       sha256: b392337f91031a5b3407393e2f04dfe4e7a28019e88eae6a9370538b90e28c51
+      size: 1619
   original:
     hackage: postgresql-binary-0.12.5
 - completed:
     hackage: protolude-0.3.2@sha256:2a38b3dad40d238ab644e234b692c8911423f9d3ed0e36b62287c4a698d92cd1,2240
     pantry-tree:
-      size: 1594
       sha256: a36d2912ac552d950ba4476de7d950b56b82dd28e48b9f4d0efee938f10bc525
+      size: 1594
   original:
     hackage: protolude-0.3.2
 - completed:
     hackage: ptr-0.16.8.2@sha256:708ebb95117f2872d2c5a554eb6804cf1126e86abe793b2673f913f14e5eb1ac,3959
     pantry-tree:
-      size: 1303
       sha256: 557c438345de19f82bf01d676100da2a191ef06f624e7a4b90b09ac17cbb52a5
+      size: 1303
   original:
     hackage: ptr-0.16.8.2
 - completed:
     hackage: text-builder-0.6.7@sha256:efbb3e06107e9c8d1cfe85c963938ca9f375a74379af03da3173be4ef5c37bcf,2364
     pantry-tree:
-      size: 425
       sha256: cd0ae197e6f9f3860a8ab71f5b87c4a8452ed1fce2fdfd35e36d68ded6e6648e
+      size: 425
   original:
     hackage: text-builder-0.6.7
 - completed:
     hackage: text-builder-dev-0.3.3@sha256:79ec422defcc2e5b34f94129c72b98d34b2efc1ed8bbd945ccb8f4f535a892c3,2784
     pantry-tree:
-      size: 724
       sha256: 8883631a132438e7892fcb13e89d6bbcdc0ac76c56fbea8df8d7aa482ce81f73
+      size: 724
   original:
     hackage: text-builder-dev-0.3.3
 - completed:
+    commit: 890a0a16cf57dd401420fdc6c7d576fb696003bc
+    git: https://github.com/PostgREST/postgresql-libpq.git
     name: postgresql-libpq
-    version: 0.9.4.3
-    git: https://github.com/PostgREST/postgresql-libpq.git
     pantry-tree:
-      size: 1414
       sha256: 074668b9669b9c49f3c522c8af5c608799a1965e203c463b188b2632995beac2
-    commit: e1eb91e8336ee8bd196faf7a41f87fc6f53f906a
+      size: 1414
+    version: 0.9.4.3
   original:
+    commit: 890a0a16cf57dd401420fdc6c7d576fb696003bc
     git: https://github.com/PostgREST/postgresql-libpq.git
-    commit: e1eb91e8336ee8bd196faf7a41f87fc6f53f906a
 snapshots:
 - completed:
+    sha256: 4c31d4ef975b0211078862566aedf3b82b6cea569fc2cde4c72a51e5a8d236ce
     size: 618951
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/14.yaml
-    sha256: 4c31d4ef975b0211078862566aedf3b82b6cea569fc2cde4c72a51e5a8d236ce
   original: lts-19.14

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -135,12 +135,12 @@ packages:
     version: 0.9.4.3
     git: https://github.com/PostgREST/postgresql-libpq.git
     pantry-tree:
-      size: 1081
-      sha256: 0df271e48af32eb8292a45301af45e114110d54099ee73dbc609d39770e8175e
-    commit: 33ff97db570b5b432255f5f24a68db51453f6eb8
+      size: 1414
+      sha256: 074668b9669b9c49f3c522c8af5c608799a1965e203c463b188b2632995beac2
+    commit: e1eb91e8336ee8bd196faf7a41f87fc6f53f906a
   original:
     git: https://github.com/PostgREST/postgresql-libpq.git
-    commit: 33ff97db570b5b432255f5f24a68db51453f6eb8
+    commit: e1eb91e8336ee8bd196faf7a41f87fc6f53f906a
 snapshots:
 - completed:
     size: 618951


### PR DESCRIPTION
This pulls in updated postgreql-libpq from https://github.com/PostgREST/postgresql-libpq/pull/2, compare that PR for details.

~~Once https://github.com/PostgREST/postgresql-libpq/pull/2 is merged, I'll update this PR to reference the updated PostgREST/postgresql-libpq master branch.~~ Done