### PR TITLE
build with nix on macos in CI (and push to cachix)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,6 +139,27 @@ jobs:
           postgrest-push-cachix
 
 
+  Build-Macos-Nix:
+    name: Build MacOS (Nix)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Nix Environment
+        uses: ./.github/actions/setup-nix
+        with:
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: Build everything
+        run: |
+          nix-build
+          nix-env -f default.nix -iA devTools
+
+      - name: Push to Cachix (main branch only)
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          postgrest-push-cachix
+
+
   Build-Stack:
     strategy:
       fail-fast: false

--- a/default.nix
+++ b/default.nix
@@ -94,10 +94,6 @@ rec {
   postgrestPackage =
     lib.dontCheck postgrest;
 
-  # Static executable.
-  postgrestStatic =
-    lib.justStaticExecutables (lib.dontCheck (staticHaskellPackage name src));
-
   # Profiled dynamic executable.
   postgrestProfiled =
     lib.enableExecutableProfiling (
@@ -122,10 +118,6 @@ rec {
   # Development tools.
   devTools =
     pkgs.callPackage nix/tools/devTools.nix { inherit tests style devCabalOptions hsie withTools; };
-
-  # Docker images and loading script.
-  docker =
-    pkgs.callPackage nix/tools/docker { postgrest = postgrestStatic; };
 
   # Load testing tools.
   loadtest =
@@ -158,4 +150,12 @@ rec {
 
   withTools =
     pkgs.callPackage nix/tools/withTools.nix { inherit devCabalOptions postgresqlVersions postgrest; };
+} // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux rec {
+  # Static executable.
+  postgrestStatic =
+    lib.justStaticExecutables (lib.dontCheck (staticHaskellPackage name src));
+
+  # Docker images and loading script.
+  docker =
+    pkgs.callPackage nix/tools/docker { postgrest = postgrestStatic; };
 }


### PR DESCRIPTION
Clone of #2604 within the PostgREST project, to hopefully allow access to the cachix token.

The primary point is to cache the nix environment for macos development, too. Running some tests might be a good idea, too.