### PR TITLE
ci: use postgrest-push-cachix independently of other tools

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,7 +135,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           nix-build
-          nix-env -f default.nix -iA devTools
+          nix-env -f default.nix -iA devTools.pushCachix.bin
           postgrest-push-cachix
 
 
@@ -152,7 +152,7 @@ jobs:
       - name: Build everything
         run: |
           nix-build
-          nix-env -f default.nix -iA devTools
+          nix-env -f default.nix -iA devTools.pushCachix.bin
 
       - name: Push to Cachix (main branch only)
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/nix/tools/devTools.nix
+++ b/nix/tools/devTools.nix
@@ -303,4 +303,5 @@ buildToolbox
     hsieGraphModules
     hsieGraphSymbols
   ];
+  extra = { inherit pushCachix; };
 }


### PR DESCRIPTION
This cuts down the dependency footprint of postgrest-push-cachix massively, allowing us to invoke it for incrementally updating cachix from CI.

This fixes #2609 (in a sense -- it doesn't really make anything simpler and things still feel a bit overengineered, but...).