### PR TITLE
ci: Add workflow to seed cachix

### DIFF
--- a/.github/workflows/cachix.yaml
+++ b/.github/workflows/cachix.yaml
@@ -14,10 +14,6 @@ on:
       - rel-*
     tags:
       - v*
-  pull_request:
-    branches:
-      - main
-      - rel-*
 
 jobs:
   Seed-Cachix:

--- a/.github/workflows/cachix.yaml
+++ b/.github/workflows/cachix.yaml
@@ -1,0 +1,81 @@
+name: Cachix
+
+# This workflow serves to
+#   - keep cachix up to date with the main branch
+#   - incrementally update cachix for large dependency
+#     updates, e.g. after running postgrest-nixpkgs-upgrade,
+#     which can cause the main CI workflow to time out
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - rel-*
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - main
+      - rel-*
+
+jobs:
+  Seed-Cachix:
+    strategy:
+      matrix:
+        include:
+          - os: Linux
+            runs-on: ubuntu-latest
+          - os: MacOS
+            runs-on: macos-latest
+    name: Seed ${{ matrix.os }}
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Nix Environment
+        uses: ./.github/actions/setup-nix
+        with:
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: Install cachix tooling
+        run: |
+          nix-env -f default.nix -iA devTools.pushCachix.bin
+          postgrest-push-cachix
+
+      - name: Seed dynamic postgrest build
+        run: |
+          nix-build -A postgrestPackage
+          postgrest-push-cachix
+
+      - name: Seed style tools
+        run: |
+          nix-build -A style
+          postgrest-push-cachix
+
+      - name: Seed test tools
+        run: |
+          nix-build -A tests
+          postgrest-push-cachix
+
+      - name: Seed static toolchain
+        if: matrix.os == 'Linux'
+        run: |
+          nix-build -A packagesStatic.haskellPackages.hello
+          postgrest-push-cachix
+
+      - name: Seed static postgresql build (for libpq)
+        if: matrix.os == 'Linux'
+        run: |
+          nix-build -A packagesStatic.pkgs.postgresql
+          postgrest-push-cachix
+
+      - name: Seed static postgrest build
+        if: matrix.os == 'Linux'
+        run: |
+          nix-build -A postgrestStatic
+          postgrest-push-cachix
+
+      - name: Build and push everything to Cachix
+        run: |
+          nix-build
+          postgrest-push-cachix

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,6 @@ jobs:
       - name: Setup Nix Environment
         uses: ./.github/actions/setup-nix
         with:
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
           tools: tests
 
       - name: Build static executable
@@ -131,13 +130,6 @@ jobs:
           path: postgrest-docker.tar.gz
           if-no-files-found: error
 
-      - name: Build and push everything to Cachix (main branch only)
-        if: ${{ github.ref == 'refs/heads/main' }}
-        run: |
-          nix-build
-          nix-env -f default.nix -iA devTools
-          postgrest-push-cachix
-
 
   Build-Macos-Nix:
     name: Build MacOS (Nix)
@@ -146,18 +138,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup Nix Environment
         uses: ./.github/actions/setup-nix
-        with:
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Build everything
         run: |
           nix-build
-          nix-env -f default.nix -iA devTools
-
-      - name: Push to Cachix (main branch only)
-        if: ${{ github.ref == 'refs/heads/main' }}
-        run: |
-          postgrest-push-cachix
 
 
   Build-Stack:

--- a/default.nix
+++ b/default.nix
@@ -65,10 +65,16 @@ let
   postgrest =
     pkgs.haskell.packages."${compiler}".callCabal2nix name src { };
 
-  # Function that derives a fully static Haskell package based on
+  # Functionality that derives a fully static Haskell package based on
   # nh2/static-haskell-nix
   staticHaskellPackage =
     import nix/static-haskell-package.nix { inherit nixpkgs system compiler patches allOverlays; };
+
+  # Static executable.
+  postgrestStatic =
+    lib.justStaticExecutables (lib.dontCheck (staticHaskellPackage name src).package);
+
+  packagesStatic = (staticHaskellPackage name src).survey;
 
   # Options passed to cabal in dev tools and tests
   devCabalOptions =
@@ -152,8 +158,8 @@ rec {
     pkgs.callPackage nix/tools/withTools.nix { inherit devCabalOptions postgresqlVersions postgrest; };
 } // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux rec {
   # Static executable.
-  postgrestStatic =
-    lib.justStaticExecutables (lib.dontCheck (staticHaskellPackage name src));
+  inherit postgrestStatic;
+  inherit packagesStatic;
 
   # Docker images and loading script.
   docker =

--- a/nix/static-haskell-package.nix
+++ b/nix/static-haskell-package.nix
@@ -59,4 +59,7 @@ let
   survey =
     import "${patched-static-haskell-nix}/survey" { inherit normalPkgs compiler defaultCabalPackageVersionComingWithGhc; };
 in
-survey.haskellPackages."${name}"
+{
+  inherit survey;
+  package = survey.haskellPackages."${name}";
+}

--- a/nix/tools/devTools.nix
+++ b/nix/tools/devTools.nix
@@ -303,4 +303,5 @@ buildToolbox
     hsieGraphModules
     hsieGraphSymbols
   ];
+  extra = { inherit pushCachix; };
 }


### PR DESCRIPTION
This is broken out of #2612; subsumes #2611.

The idea is to have a dedicated workflow to incrementally seed cachix, which can be manually triggered on appropriate pull requests. E.g., when a nixpkgs update or dependency update PR is "ready" but stuck due to CI timing out, we'd manually trigger this workflow to push build results to cachix incrementally.

For the moment, the workflow is run automatically on PR, but that's just for this PR, to be removed before merging.

(There's the same outstanding issue as with #2611, in that building `postgrest-push-cachix` also causes a build of `cabal2nix-postgrest` for no good reason. But currently that justs causes a bit of unnecessary extra work, so maybe we can leave that for later.)