### PR TITLE
refactor: dry RPC param parsing

### DIFF
--- a/src/PostgREST/ApiRequest/Types.hs
+++ b/src/PostgREST/ApiRequest/Types.hs
@@ -76,7 +76,6 @@ data ApiRequestError
   | NoRelBetween Text Text (Maybe Text) Text RelationshipsMap
   | NoRpc Text Text [Text] Bool MediaType Bool [QualifiedIdentifier] [ProcDescription]
   | NotEmbedded Text
-  | ParseRequestError Text Text
   | PutRangeNotAllowedError
   | QueryParamError QPError
   | RelatedOrderNotToOne Text Text
@@ -183,8 +182,9 @@ data Filter
   | FilterNullEmbed Bool FieldName
   deriving (Eq)
 
-data OpExpr =
-  OpExpr Bool Operation
+data OpExpr
+  = OpExpr Bool Operation
+  | NoOpExpr Text
   deriving (Eq)
 
 data Operation

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -72,7 +72,6 @@ instance PgrstError ApiRequestError where
   status NoRelBetween{}          = HTTP.status400
   status NoRpc{}                 = HTTP.status404
   status NotEmbedded{}           = HTTP.status400
-  status ParseRequestError{}     = HTTP.status400
   status PutRangeNotAllowedError = HTTP.status400
   status QueryParamError{}       = HTTP.status400
   status RelatedOrderNotToOne{}  = HTTP.status400
@@ -108,11 +107,6 @@ instance JSON.ToJSON ApiRequestError where
                    NegativeLimit           -> "Limit should be greater than or equal to zero."
                    LowerGTUpper            -> "The lower boundary must be lower than or equal to the upper boundary in the Range header."
                    OutOfBounds lower total -> "An offset of " <> lower <> " was requested, but there are only " <> total <> " rows."),
-    "hint"    .= JSON.Null]
-  toJSON (ParseRequestError message details) = JSON.object [
-    "code"    .= ApiRequestErrorCode04,
-    "message" .= message,
-    "details" .= details,
     "hint"    .= JSON.Null]
   toJSON InvalidFilters = JSON.object [
     "code"    .= ApiRequestErrorCode05,
@@ -586,7 +580,7 @@ data ErrorCode
   | ApiRequestErrorCode01
   | ApiRequestErrorCode02
   | ApiRequestErrorCode03
-  | ApiRequestErrorCode04
+  | ApiRequestErrorCode04 -- no longer used (used to be mapped to ParseRequestError)
   | ApiRequestErrorCode05
   | ApiRequestErrorCode06
   | ApiRequestErrorCode07

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -33,7 +33,6 @@ import Data.Tree               (Tree (..))
 
 import PostgREST.ApiRequest               (Action (..),
                                            ApiRequest (..),
-                                           InvokeMethod (..),
                                            Mutation (..),
                                            Payload (..))
 import PostgREST.Config                   (AppConfig (..))
@@ -291,11 +290,9 @@ addFilters ApiRequest{..} rReq =
     QueryParams.QueryParams{..} = iQueryParams
     flts =
       case iAction of
-        ActionInvoke InvGet  -> qsFilters
-        ActionInvoke InvHead -> qsFilters
-        ActionInvoke _       -> qsFilters
-        ActionRead _         -> qsFilters
-        _                    -> qsFiltersNotRoot
+        ActionInvoke _ -> qsFilters
+        ActionRead _   -> qsFilters
+        _              -> qsFiltersNotRoot
 
     addFilterToNode :: (EmbedPath, Filter) -> Either ApiRequestError ReadPlanTree ->  Either ApiRequestError ReadPlanTree
     addFilterToNode =

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -278,6 +278,7 @@ pgFmtOrderTerm qi ot =
 
 pgFmtFilter :: QualifiedIdentifier -> Filter -> SQL.Snippet
 pgFmtFilter _ (FilterNullEmbed hasNot fld) = SQL.sql (pgFmtIdent fld) <> " IS " <> (if hasNot then "NOT" else mempty) <> " NULL"
+pgFmtFilter _ (Filter _ (NoOpExpr _)) = mempty -- TODO unreachable because NoOpExpr is filtered on QueryParams
 pgFmtFilter table (Filter fld (OpExpr hasNot oper)) = notOp <> " " <> case oper of
    Op op val  -> pgFmtFieldOp op <> " " <> case op of
      OpLike  -> unknownLiteral (T.map star val)

--- a/test/spec/Feature/Query/QuerySpec.hs
+++ b/test/spec/Feature/Query/QuerySpec.hs
@@ -1002,7 +1002,8 @@ spec actualPgVersion = do
         { matchHeaders = [matchContentTypeJson] }
 
     it "fails if an operator is not given" $
-      get "/ghostBusters?id=0" `shouldRespondWith` [json| {"details":"Failed to parse [(\"id\",\"0\")]","message":"Unexpected param or filter missing operator","code":"PGRST104","hint":null} |]
+      get "/ghostBusters?id=0" `shouldRespondWith`
+        [json| {"code":"PGRST100","details":"unexpected end of input expecting operator (eq, gt, ...)","hint":null,"message":"\"failed to parse filter (0)\" (line 1, column 2)"} |]
         { matchStatus  = 400
         , matchHeaders = [matchContentTypeJson]
         }


### PR DESCRIPTION
Some refactoring that makes https://github.com/PostgREST/postgrest/pull/1582 easier to implement.