### PR TITLE
test: fix result path for load test

### DIFF
--- a/nix/tools/loadtest.nix
+++ b/nix/tools/loadtest.nix
@@ -56,11 +56,12 @@ let
         export PGRST_LOG_LEVEL="crit"
 
         mkdir -p "$(dirname "$_arg_output")"
+        abs_output="$(realpath "$_arg_output")"
 
         # shellcheck disable=SC2145
         ${withTools.withPg} --fixtures "$_arg_testdir"/fixtures.sql \
         ${withTools.withPgrst} \
-        sh -c "cd \"$_arg_testdir\" && ${runner} -targets targets.http -output \"$_arg_output\" \"''${_arg_leftovers[@]}\""
+        sh -c "cd \"$_arg_testdir\" && ${runner} -targets targets.http -output \"$abs_output\" \"''${_arg_leftovers[@]}\""
         ${vegeta}/bin/vegeta report -type=text "$_arg_output"
       '';
 


### PR DESCRIPTION
Before this, `postgrest-loadtest` was failing for me locally on macOS with

```
error opening ./loadtest/result.bin: open ./loadtest/result.bin: no such file or directory
```

which makes sense with the relative path `./loadtest/result.bin` while `vegeta` is run in `./test/load`. Not sure why that wasn't caught in CI.