### PR TITLE
refactor: move txMode to Plan

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -200,8 +200,14 @@ handleRequest AuthResult{..} conf appState authenticated prepared jsonDbS pgVer 
       oaiResult <- runQuery Plan.inspectPlanTxMode $ Query.openApiQuery sCache pgVer conf tSchema
       return $ Response.openApiResponse headersOnly oaiResult conf sCache iSchema iNegotiatedByProfile
 
-    (ActionInfo, _) ->
-      return $ Response.infoResponse iTarget sCache
+    (ActionInfo, TargetIdent identifier) ->
+      return $ Response.infoIdentResponse identifier sCache
+
+    (ActionInfo, TargetProc proc _) ->
+      return $ Response.infoProcResponse proc
+
+    (ActionInfo, TargetDefaultSpec _) ->
+      return Response.infoRootResponse
 
     _ ->
       -- This is unreachable as the ApiRequest.hs rejects it before

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -26,7 +26,7 @@ CREATE SCHEMA "EXTRA ""@/\#~_-";
 COMMENT ON SCHEMA v1 IS 'v1 schema';
 COMMENT ON SCHEMA v2 IS 'v2 schema';
 
-COMMENT ON SCHEMA test IS 
+COMMENT ON SCHEMA test IS
 $$My API title
 
 My API description


### PR DESCRIPTION
A step towards removing the `SchemaCache` dependency from `ApiRequest`(https://github.com/PostgREST/postgrest/issues/1804#issuecomment-1267591660).

Paves the way for removing `ProcDescription` from `Target`.

(Needed for implementing https://github.com/PostgREST/postgrest/pull/1582)