### PR TITLE
fix: log to stderr on AcquisitionTimeoutUsageError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2648, Fix inaccurate error codes with new ones - @laurenceisla
    + `PGRST204`: Column is not found
    + `PGRST003`: Timed out when acquiring connection to db
+ - #2667, Fix `db-pool-acquisition-timeout` not logging to stderr when the timeout is reached - @steve-chavez
 
 ## [10.1.2] - 2023-02-01
 
@@ -34,7 +35,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
  - #2565, Fix bad M2M embedding on RPC - @steve-chavez
  - #2575, Replace misleading error message when no function is found with a hint containing functions/parameters names suggestions - @laurenceisla
- - #2582, Move explanation about "single parameters" from the `message` to the `details` in the error output - @laurenceisla 
+ - #2582, Move explanation about "single parameters" from the `message` to the `details` in the error output - @laurenceisla
  - #2569, Replace misleading error message when no relationship is found with a hint containing parent/child names suggestions - @laurenceisla
  - #1405, Add the required OpenAPI items object when the parameter is an array - @laurenceisla
  - #2592, Add upsert headers for POST requests to the OpenAPI output - @laurenceisla

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -169,7 +169,6 @@ runDbHandler appState mode authenticated prepared handler = do
 
   liftEither resp
 
-
 handleRequest :: AuthResult -> AppConfig -> AppState.AppState -> Bool -> Bool -> ByteString -> PgVersion -> ApiRequest -> SchemaCache -> Handler IO Wai.Response
 handleRequest AuthResult{..} conf appState authenticated prepared jsonDbS pgVer apiReq@ApiRequest{..} sCache =
   case (iAction, iTarget) of

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -26,6 +26,7 @@ module PostgREST.AppState
   , signalListener
   , usePool
   , waitListener
+  , debounceLogAcquisitionTimeout
   ) where
 
 import qualified Data.ByteString.Lazy as LBS
@@ -36,6 +37,7 @@ import qualified PostgREST.Error      as Error
 
 import Control.AutoUpdate (defaultUpdateSettings, mkAutoUpdate,
                            updateAction)
+import Control.Debounce
 import Data.IORef         (IORef, atomicWriteIORef, newIORef,
                            readIORef)
 import Data.Time          (ZonedTime, defaultTimeLocale, formatTime,
@@ -51,29 +53,30 @@ import Protolude
 
 data AppState = AppState
   -- | Database connection pool
-  { statePool         :: SQL.Pool
+  { statePool                     :: SQL.Pool
   -- | Database server version, will be updated by the connectionWorker
-  , statePgVersion    :: IORef PgVersion
+  , statePgVersion                :: IORef PgVersion
   -- | No schema cache at the start. Will be filled in by the connectionWorker
-  , stateSchemaCache  :: IORef (Maybe SchemaCache)
+  , stateSchemaCache              :: IORef (Maybe SchemaCache)
   -- | Cached SchemaCache in json
-  , stateJsonDbS      :: IORef ByteString
+  , stateJsonDbS                  :: IORef ByteString
   -- | Binary semaphore to make sure just one connectionWorker can run at a time
-  , stateWorkerSem    :: MVar ()
+  , stateWorkerSem                :: MVar ()
   -- | Binary semaphore used to sync the listener(NOTIFY reload) with the connectionWorker.
-  , stateListener     :: MVar ()
+  , stateListener                 :: MVar ()
   -- | State of the LISTEN channel, used for the admin server checks
-  , stateIsListenerOn :: IORef Bool
+  , stateIsListenerOn             :: IORef Bool
   -- | Config that can change at runtime
-  , stateConf         :: IORef AppConfig
+  , stateConf                     :: IORef AppConfig
   -- | Time used for verifying JWT expiration
-  , stateGetTime      :: IO UTCTime
+  , stateGetTime                  :: IO UTCTime
   -- | Time with time zone used for worker logs
-  , stateGetZTime     :: IO ZonedTime
+  , stateGetZTime                 :: IO ZonedTime
   -- | Used for killing the main thread in case a subthread fails
-  , stateMainThreadId :: ThreadId
+  , stateMainThreadId             :: ThreadId
   -- | Keeps track of when the next retry for connecting to database is scheduled
-  , stateRetryNextIn  :: IORef Int
+  , stateRetryNextIn              :: IORef Int
+  , debounceLogAcquisitionTimeout :: IO ()
   }
 
 init :: AppConfig -> IO AppState
@@ -82,8 +85,8 @@ init conf = do
   initWithPool pool conf
 
 initWithPool :: SQL.Pool -> AppConfig -> IO AppState
-initWithPool pool conf =
-  AppState pool
+initWithPool pool conf = do
+  appState <- AppState pool
     <$> newIORef minimumPgVersion -- assume we're in a supported version when starting, this will be corrected on a later step
     <*> newIORef Nothing
     <*> newIORef mempty
@@ -95,6 +98,17 @@ initWithPool pool conf =
     <*> mkAutoUpdate defaultUpdateSettings { updateAction = getZonedTime }
     <*> myThreadId
     <*> newIORef 0
+    <*> pure (pure ())
+
+  deb <-
+    let oneSecond = 1000000 in
+    mkDebounce defaultDebounceSettings
+       { debounceAction =  logPgrstError appState SQL.AcquisitionTimeoutUsageError
+       , debounceFreq = 5*oneSecond
+       , debounceEdge = trailingEdge
+       }
+
+  return appState { debounceLogAcquisitionTimeout = deb }
 
 destroy :: AppState -> IO ()
 destroy = destroyPool

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -76,6 +76,7 @@ data AppState = AppState
   , stateMainThreadId             :: ThreadId
   -- | Keeps track of when the next retry for connecting to database is scheduled
   , stateRetryNextIn              :: IORef Int
+  -- | Logs a pool error with a debounce
   , debounceLogAcquisitionTimeout :: IO ()
   }
 
@@ -105,7 +106,7 @@ initWithPool pool conf = do
     mkDebounce defaultDebounceSettings
        { debounceAction =  logPgrstError appState SQL.AcquisitionTimeoutUsageError
        , debounceFreq = 5*oneSecond
-       , debounceEdge = trailingEdge
+       , debounceEdge = leadingEdge -- logs at the start and the end
        }
 
   return appState { debounceLogAcquisitionTimeout = deb }

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -104,7 +104,7 @@ initWithPool pool conf = do
   deb <-
     let oneSecond = 1000000 in
     mkDebounce defaultDebounceSettings
-       { debounceAction =  logPgrstError appState SQL.AcquisitionTimeoutUsageError
+       { debounceAction = logPgrstError appState SQL.AcquisitionTimeoutUsageError
        , debounceFreq = 5*oneSecond
        , debounceEdge = leadingEdge -- logs at the start and the end
        }

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -446,13 +446,13 @@ pgErrorStatus authed (SQL.SessionUsageError (SQL.QueryError _ _ (SQL.ResultError
 
     _                       -> HTTP.status500
 
-checkIsFatal :: PgError -> Maybe Text
-checkIsFatal (PgError _ (SQL.ConnectionUsageError e))
+checkIsFatal :: SQL.UsageError -> Maybe Text
+checkIsFatal (SQL.ConnectionUsageError e)
   | isAuthFailureMessage = Just $ toS failureMessage
   | otherwise = Nothing
   where isAuthFailureMessage = "FATAL:  password authentication failed" `isInfixOf` failureMessage
         failureMessage = BS.unpack $ fromMaybe mempty e
-checkIsFatal (PgError _ (SQL.SessionUsageError (SQL.QueryError _ _ (SQL.ResultError serverError))))
+checkIsFatal(SQL.SessionUsageError (SQL.QueryError _ _ (SQL.ResultError serverError)))
   = case serverError of
       -- Check for a syntax error (42601 is the pg code). This would mean the error is on our part somehow, so we treat it as fatal.
       SQL.ServerError "42601" _ _ _ _

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -572,6 +572,16 @@ def test_pool_acquisition_timeout(defaultenv, metapostgrest):
         data = response.json()
         assert data["message"] == "Timed out acquiring connection from connection pool."
 
+        # ensure the message appears on the logs as well
+        output = None
+        for _ in range(10):
+            output = postgrest.process.stdout.readline()
+            if output:
+                break
+            time.sleep(0.1)
+
+        assert "Timed out acquiring connection from connection pool." in output.decode()
+
 
 def test_change_statement_timeout_held_connection(defaultenv, metapostgrest):
     "Statement timeout changes take effect immediately, even with a request outliving the reconfiguration"


### PR DESCRIPTION
When reaching the timeout on `db-pool-acquisition-timeout`, we don't log an error to stderr. This is useful for admins since they will know that the pool size has to be increased or that queries are taking too long.

- [x] Debounce(since many requests could trigger this error)
- [x] Test