### PR TITLE
feat: undefined json keys as defaults when using `?columns` and a `Prefer` header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + When the client sends the request header specified in the config it will be included in the response headers.
  - #2694, Make `db-root-spec` stable. - @steve-chavez
    + This can be used to override the OpenAPI spec with a custom database function
+ - #1567, On bulk inserts with `?columns`, undefined json keys can get columns' DEFAULT values by using the `Prefer: undefined-keys=apply-defaults` header - @steve-chavez
 
 ### Fixed
 

--- a/src/PostgREST/ApiRequest/Preferences.hs
+++ b/src/PostgREST/ApiRequest/Preferences.hs
@@ -9,6 +9,7 @@
 module PostgREST.ApiRequest.Preferences
   ( Preferences(..)
   , PreferCount(..)
+  , PreferDefaults(..)
   , PreferParameters(..)
   , PreferRepresentation(..)
   , PreferResolution(..)
@@ -43,6 +44,7 @@ data Preferences
     , preferParameters     :: Maybe PreferParameters
     , preferCount          :: Maybe PreferCount
     , preferTransaction    :: Maybe PreferTransaction
+    , preferDefaults       :: Maybe PreferDefaults
     }
 
 -- |
@@ -109,6 +111,7 @@ fromHeaders headers =
     , preferParameters = parsePrefs [SingleObject, MultipleObjects]
     , preferCount = parsePrefs [ExactCount, PlannedCount, EstimatedCount]
     , preferTransaction = parsePrefs [Commit, Rollback]
+    , preferDefaults = parsePrefs [ApplyDefaults, IgnoreDefaults]
     }
   where
     prefHeaders = filter ((==) HTTP.hPrefer . fst) headers
@@ -204,3 +207,14 @@ instance ToHeaderValue PreferTransaction where
   toHeaderValue Rollback = "tx=rollback"
 
 instance ToAppliedHeader PreferTransaction
+
+data PreferDefaults
+  = ApplyDefaults
+  | IgnoreDefaults
+  deriving Eq
+
+instance ToHeaderValue PreferDefaults where
+  toHeaderValue ApplyDefaults  = "defaults=apply"
+  toHeaderValue IgnoreDefaults = "defaults=ignore"
+
+instance ToAppliedHeader PreferDefaults

--- a/src/PostgREST/ApiRequest/Preferences.hs
+++ b/src/PostgREST/ApiRequest/Preferences.hs
@@ -94,13 +94,14 @@ data Preferences
 --
 -- Preferences can be separated by arbitrary amounts of space, lower-case header is also recognized:
 --
--- >>> pPrint $ fromHeaders [("prefer", "count=exact,    tx=commit   ,return=representation")]
+-- >>> pPrint $ fromHeaders [("prefer", "count=exact,    tx=commit   ,return=representation , defaults=apply")]
 -- Preferences
 --     { preferResolution = Nothing
 --     , preferRepresentation = Full
 --     , preferParameters = Nothing
 --     , preferCount = Just ExactCount
 --     , preferTransaction = Just Commit
+--     , preferDefaults = Just ApplyDefaults
 --     }
 --
 fromHeaders :: [HTTP.Header] -> Preferences
@@ -208,9 +209,12 @@ instance ToHeaderValue PreferTransaction where
 
 instance ToAppliedHeader PreferTransaction
 
+-- |
+-- How to handle the insertion/update when the keys specified in ?columns are not present
+-- in the json body. 
 data PreferDefaults
-  = ApplyDefaults
-  | IgnoreDefaults
+  = ApplyDefaults  -- ^ Use the default column value for the unspecified keys.
+  | IgnoreDefaults -- ^ Inserts: null values / Updates: the keys are not SET to any value 
   deriving Eq
 
 instance ToHeaderValue PreferDefaults where

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -13,6 +13,7 @@ resource.
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE OverloadedRecordDot   #-}
 {-# LANGUAGE RecordWildCards       #-}
 
 module PostgREST.Plan
@@ -501,10 +502,10 @@ updateNode f (targetNodeName:remainingPath, a) (Right (Node rootNode forest)) =
     findNode = find (\(Node ReadPlan{relName, relAlias} _) -> relName == targetNodeName || relAlias == Just targetNodeName) forest
 
 mutatePlan :: Mutation -> QualifiedIdentifier -> ApiRequest -> SchemaCache -> ReadPlanTree -> Either Error MutatePlan
-mutatePlan mutation qi ApiRequest{iPreferences=Preferences{..}, ..} sCache readReq = mapLeft ApiRequestError $
+mutatePlan mutation qi ApiRequest{iPreferences=preferences, ..} sCache readReq = mapLeft ApiRequestError $
   case mutation of
     MutationCreate ->
-      mapRight (\typedColumns -> Insert qi typedColumns body ((,) <$> preferResolution <*> Just confCols) [] returnings pkCols applyDefaults) typedColumnsOrError
+      mapRight (\typedColumns -> Insert qi typedColumns body ((,) <$> preferences.preferResolution <*> Just confCols) [] returnings pkCols applyDefaults) typedColumnsOrError
     MutationUpdate ->
       mapRight (\typedColumns -> Update qi typedColumns body combinedLogic iTopLevelRange rootOrder returnings applyDefaults) typedColumnsOrError
     MutationSingleUpsert ->
@@ -522,7 +523,7 @@ mutatePlan mutation qi ApiRequest{iPreferences=Preferences{..}, ..} sCache readR
     confCols = fromMaybe pkCols qsOnConflict
     QueryParams.QueryParams{..} = iQueryParams
     returnings =
-      if preferRepresentation == None
+      if preferences.preferRepresentation == None
         then []
         else inferColsEmbedNeeds readReq pkCols
     pkCols = maybe mempty tablePKCols $ HM.lookup qi $ dbTables sCache
@@ -532,7 +533,7 @@ mutatePlan mutation qi ApiRequest{iPreferences=Preferences{..}, ..} sCache readR
     body = payRaw <$> iPayload -- the body is assumed to be json at this stage(ApiRequest validates)
     tbl = HM.lookup qi $ dbTables sCache
     typedColumnsOrError = resolveOrError tbl `traverse` S.toList iColumns
-    applyDefaults = preferUndefinedKeys == Just ApplyDefaults
+    applyDefaults = preferences.preferUndefinedKeys == Just ApplyDefaults
 
 resolveOrError :: Maybe Table -> FieldName -> Either ApiRequestError TypedField
 resolveOrError Nothing _ = Left NotFound

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -504,9 +504,9 @@ mutatePlan :: Mutation -> QualifiedIdentifier -> ApiRequest -> SchemaCache -> Re
 mutatePlan mutation qi ApiRequest{iPreferences=Preferences{..}, ..} sCache readReq = mapLeft ApiRequestError $
   case mutation of
     MutationCreate ->
-      mapRight (\typedColumns -> Insert qi typedColumns body ((,) <$> preferResolution <*> Just confCols) [] returnings pkCols) typedColumnsOrError
+      mapRight (\typedColumns -> Insert qi typedColumns body ((,) <$> preferResolution <*> Just confCols) [] returnings pkCols $ preferDefaults == Just ApplyDefaults) typedColumnsOrError
     MutationUpdate ->
-      mapRight (\typedColumns -> Update qi typedColumns body combinedLogic iTopLevelRange rootOrder returnings) typedColumnsOrError
+      mapRight (\typedColumns -> Update qi typedColumns body combinedLogic iTopLevelRange rootOrder returnings $ preferDefaults == Just ApplyDefaults) typedColumnsOrError
     MutationSingleUpsert ->
         if null qsLogic &&
            qsFilterFields == S.fromList pkCols &&
@@ -514,7 +514,7 @@ mutatePlan mutation qi ApiRequest{iPreferences=Preferences{..}, ..} sCache readR
            all (\case
               Filter _ (OpExpr False (Op OpEqual _)) -> True
               _                                      -> False) qsFiltersRoot
-          then mapRight (\typedColumns -> Insert qi typedColumns body (Just (MergeDuplicates, pkCols)) combinedLogic returnings mempty) typedColumnsOrError
+          then mapRight (\typedColumns -> Insert qi typedColumns body (Just (MergeDuplicates, pkCols)) combinedLogic returnings mempty False) typedColumnsOrError
         else
           Left InvalidFilters
     MutationDelete -> Right $ Delete qi combinedLogic iTopLevelRange rootOrder returnings

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -504,9 +504,9 @@ mutatePlan :: Mutation -> QualifiedIdentifier -> ApiRequest -> SchemaCache -> Re
 mutatePlan mutation qi ApiRequest{iPreferences=Preferences{..}, ..} sCache readReq = mapLeft ApiRequestError $
   case mutation of
     MutationCreate ->
-      mapRight (\typedColumns -> Insert qi typedColumns body ((,) <$> preferResolution <*> Just confCols) [] returnings pkCols $ preferDefaults == Just ApplyDefaults) typedColumnsOrError
+      mapRight (\typedColumns -> Insert qi typedColumns body ((,) <$> preferResolution <*> Just confCols) [] returnings pkCols $ preferUndefinedKeys == Just ApplyDefaults) typedColumnsOrError
     MutationUpdate ->
-      mapRight (\typedColumns -> Update qi typedColumns body combinedLogic iTopLevelRange rootOrder returnings $ preferDefaults == Just ApplyDefaults) typedColumnsOrError
+      mapRight (\typedColumns -> Update qi typedColumns body combinedLogic iTopLevelRange rootOrder returnings $ preferUndefinedKeys == Just ApplyDefaults) typedColumnsOrError
     MutationSingleUpsert ->
         if null qsLogic &&
            qsFilterFields == S.fromList pkCols &&

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -504,9 +504,9 @@ mutatePlan :: Mutation -> QualifiedIdentifier -> ApiRequest -> SchemaCache -> Re
 mutatePlan mutation qi ApiRequest{iPreferences=Preferences{..}, ..} sCache readReq = mapLeft ApiRequestError $
   case mutation of
     MutationCreate ->
-      mapRight (\typedColumns -> Insert qi typedColumns body ((,) <$> preferResolution <*> Just confCols) [] returnings pkCols $ preferUndefinedKeys == Just ApplyDefaults) typedColumnsOrError
+      mapRight (\typedColumns -> Insert qi typedColumns body ((,) <$> preferResolution <*> Just confCols) [] returnings pkCols applyDefaults) typedColumnsOrError
     MutationUpdate ->
-      mapRight (\typedColumns -> Update qi typedColumns body combinedLogic iTopLevelRange rootOrder returnings $ preferUndefinedKeys == Just ApplyDefaults) typedColumnsOrError
+      mapRight (\typedColumns -> Update qi typedColumns body combinedLogic iTopLevelRange rootOrder returnings applyDefaults) typedColumnsOrError
     MutationSingleUpsert ->
         if null qsLogic &&
            qsFilterFields == S.fromList pkCols &&
@@ -532,6 +532,7 @@ mutatePlan mutation qi ApiRequest{iPreferences=Preferences{..}, ..} sCache readR
     body = payRaw <$> iPayload -- the body is assumed to be json at this stage(ApiRequest validates)
     tbl = HM.lookup qi $ dbTables sCache
     typedColumnsOrError = resolveOrError tbl `traverse` S.toList iColumns
+    applyDefaults = preferUndefinedKeys == Just ApplyDefaults
 
 resolveOrError :: Maybe Table -> FieldName -> Either ApiRequestError TypedField
 resolveOrError Nothing _ = Left NotFound

--- a/src/PostgREST/Plan/MutatePlan.hs
+++ b/src/PostgREST/Plan/MutatePlan.hs
@@ -24,6 +24,7 @@ data MutatePlan
       , where_     :: [LogicTree]
       , returning  :: [FieldName]
       , insPkCols  :: [FieldName]
+      , applyDefs  :: Bool
       }
   | Update
       { in_       :: QualifiedIdentifier
@@ -33,6 +34,7 @@ data MutatePlan
       , mutRange  :: NonnegRange
       , mutOrder  :: [OrderTerm]
       , returning :: [FieldName]
+      , applyDefs :: Bool
       }
   | Delete
       { in_       :: QualifiedIdentifier

--- a/src/PostgREST/Plan/Types.hs
+++ b/src/PostgREST/Plan/Types.hs
@@ -13,12 +13,13 @@ import Protolude
 
 -- | A TypedField is a field with sufficient information to be read from JSON with `json_to_recordset`.
 data TypedField = TypedField
-   { tfName   :: FieldName
-   , tfIRType :: Text -- ^ The initial type of the field, before any casting.
+   { tfName    :: FieldName
+   , tfIRType  :: Text -- ^ The initial type of the field, before any casting.
+   , tfDefault :: Maybe Text
    } deriving (Eq)
 
 resolveTableField :: Table -> FieldName -> Maybe TypedField
 resolveTableField table fieldName =
   case HMI.lookup fieldName (tableColumns table) of
-    Just column -> Just $ TypedField (colName column) (colNominalType column)
+    Just column -> Just $ TypedField (colName column) (colNominalType column) (colDefault column)
     Nothing     -> Nothing

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -221,28 +221,37 @@ pgFmtSelectItem table (f@(fName, jp), Nothing, alias) = pgFmtField table f <> SQ
 pgFmtSelectItem table (f@(fName, jp), Just cast, alias) = "CAST (" <> pgFmtField table f <> " AS " <> SQL.sql (encodeUtf8 cast) <> " )" <> SQL.sql (pgFmtAs fName jp alias)
 
 -- TODO: At this stage there shouldn't be a Maybe since ApiRequest should ensure that an INSERT/UPDATE has a body
-fromJsonBodyF :: Maybe LBS.ByteString -> [TypedField] -> Bool -> Bool -> SQL.Snippet
-fromJsonBodyF body fields includeSelect includeLimitOne =
+fromJsonBodyF :: Maybe LBS.ByteString -> [TypedField] -> Bool -> Bool -> Bool -> SQL.Snippet
+fromJsonBodyF body fields includeSelect includeLimitOne includeDefaults =
   SQL.sql
   (if includeSelect then "SELECT " <> parsedCols <> " " else mempty) <>
-  "FROM (SELECT " <> jsonPlaceHolder <> " AS json_data) pgrst_payload, " <>
+  "FROM (SELECT " <> jsonbPlaceHolder <> " AS json_data) pgrst_payload, " <>
   -- convert a json object into a json array, this way we can use json_to_recordset for all json payloads
   -- Otherwise we'd have to use json_to_record for json objects and json_to_recordset for json arrays
   -- We do this in SQL to avoid processing the JSON in application code
-  "LATERAL (SELECT CASE WHEN json_typeof(pgrst_payload.json_data) = 'array' THEN pgrst_payload.json_data ELSE json_build_array(pgrst_payload.json_data) END AS val) pgrst_uniform_json, " <>
+  "LATERAL (SELECT CASE WHEN jsonb_typeof(pgrst_payload.json_data) = 'array' THEN pgrst_payload.json_data ELSE jsonb_build_array(pgrst_payload.json_data) END AS val) pgrst_uniform_json, " <>
+  (if includeDefaults
+    then "LATERAL (SELECT jsonb_agg(" <> defsJsonb <> " || elem) AS val from jsonb_array_elements(pgrst_uniform_json.val) elem) pgrst_json_defs, "
+    else mempty) <>
   "LATERAL (SELECT * FROM " <>
     (if null fields
       -- When we are inserting no columns (e.g. using default values), we can't use our ordinary `json_to_recordset`
       -- because it can't extract records with no columns (there's no valid syntax for the `AS (colName colType,...)`
       -- part). But we still need to ensure as many rows are created as there are array elements.
-      then SQL.sql "json_array_elements(pgrst_uniform_json.val) _ "
-      else SQL.sql ("json_to_recordset(pgrst_uniform_json.val) AS _(" <> typedCols <> ") " <> if includeLimitOne then "LIMIT 1" else mempty)
+      then SQL.sql $ "jsonb_array_elements(" <> finalBody <> ") _ "
+      else SQL.sql $ "jsonb_to_recordset(" <> finalBody <> ") AS _(" <> typedCols <> ") " <> if includeLimitOne then "LIMIT 1" else mempty
     ) <>
   ") pgrst_body "
   where
     parsedCols = BS.intercalate ", " $ fromQi  . QualifiedIdentifier "pgrst_body" . tfName <$> fields
     typedCols = BS.intercalate ", " $ pgFmtIdent . tfName <> const " " <> encodeUtf8 . tfIRType <$> fields
-    jsonPlaceHolder = SQL.encoderAndParam (HE.nullable HE.jsonLazyBytes) body
+    jsonbPlaceHolder = SQL.encoderAndParam (HE.nullable HE.jsonbLazyBytes) body
+    defsJsonb = SQL.sql $ "jsonb_build_object(" <> BS.intercalate "," fieldsWDefaults <> ") "
+    fieldsWDefaults = mapMaybe (\case
+        TypedField{tfName=nam, tfDefault=Just def} -> Just $ encodeUtf8 ("'" <> nam <> "', " <> def)
+        TypedField{tfDefault=Nothing} -> Nothing
+      ) fields
+    finalBody = if includeDefaults then "pgrst_json_defs.val" else "pgrst_uniform_json.val"
 
 pgFmtOrderTerm :: QualifiedIdentifier -> OrderTerm -> SQL.Snippet
 pgFmtOrderTerm qi ot =

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -225,33 +225,36 @@ fromJsonBodyF :: Maybe LBS.ByteString -> [TypedField] -> Bool -> Bool -> Bool ->
 fromJsonBodyF body fields includeSelect includeLimitOne includeDefaults =
   SQL.sql
   (if includeSelect then "SELECT " <> parsedCols <> " " else mempty) <>
-  "FROM (SELECT " <> jsonbPlaceHolder <> " AS json_data) pgrst_payload, " <>
+  "FROM (SELECT " <> jsonPlaceHolder <> " AS json_data) pgrst_payload, " <>
   -- convert a json object into a json array, this way we can use json_to_recordset for all json payloads
   -- Otherwise we'd have to use json_to_record for json objects and json_to_recordset for json arrays
   -- We do this in SQL to avoid processing the JSON in application code
-  "LATERAL (SELECT CASE WHEN jsonb_typeof(pgrst_payload.json_data) = 'array' THEN pgrst_payload.json_data ELSE jsonb_build_array(pgrst_payload.json_data) END AS val) pgrst_uniform_json, " <>
+  "LATERAL (SELECT CASE WHEN " <> jsonTypeofF <> "(pgrst_payload.json_data) = 'array' THEN pgrst_payload.json_data ELSE " <> jsonBuildArrayF <> "(pgrst_payload.json_data) END AS val) pgrst_uniform_json, " <>
   (if includeDefaults
-    then "LATERAL (SELECT jsonb_agg(" <> defsJsonb <> " || elem) AS val from jsonb_array_elements(pgrst_uniform_json.val) elem) pgrst_json_defs, "
+    then "LATERAL (SELECT jsonb_agg(jsonb_build_object(" <> defsJsonb <> ") || elem) AS val from jsonb_array_elements(pgrst_uniform_json.val) elem) pgrst_json_defs, "
     else mempty) <>
   "LATERAL (SELECT * FROM " <>
     (if null fields
       -- When we are inserting no columns (e.g. using default values), we can't use our ordinary `json_to_recordset`
       -- because it can't extract records with no columns (there's no valid syntax for the `AS (colName colType,...)`
       -- part). But we still need to ensure as many rows are created as there are array elements.
-      then SQL.sql $ "jsonb_array_elements(" <> finalBody <> ") _ "
-      else SQL.sql $ "jsonb_to_recordset(" <> finalBody <> ") AS _(" <> typedCols <> ") " <> if includeLimitOne then "LIMIT 1" else mempty
+      then SQL.sql $ jsonArrayElementsF <> "(" <> finalBodyF <> ") _ "
+      else SQL.sql $ jsonToRecordsetF <> "(" <> finalBodyF <> ") AS _(" <> typedCols <> ") " <> if includeLimitOne then "LIMIT 1" else mempty
     ) <>
   ") pgrst_body "
   where
     parsedCols = BS.intercalate ", " $ fromQi  . QualifiedIdentifier "pgrst_body" . tfName <$> fields
     typedCols = BS.intercalate ", " $ pgFmtIdent . tfName <> const " " <> encodeUtf8 . tfIRType <$> fields
-    jsonbPlaceHolder = SQL.encoderAndParam (HE.nullable HE.jsonbLazyBytes) body
-    defsJsonb = SQL.sql $ "jsonb_build_object(" <> BS.intercalate "," fieldsWDefaults <> ") "
+    defsJsonb = SQL.sql $ BS.intercalate "," fieldsWDefaults
     fieldsWDefaults = mapMaybe (\case
         TypedField{tfName=nam, tfDefault=Just def} -> Just $ encodeUtf8 ("'" <> nam <> "', " <> def)
         TypedField{tfDefault=Nothing} -> Nothing
       ) fields
-    finalBody = if includeDefaults then "pgrst_json_defs.val" else "pgrst_uniform_json.val"
+    (finalBodyF, jsonTypeofF, jsonBuildArrayF, jsonArrayElementsF, jsonToRecordsetF) =
+      if includeDefaults
+        then ("pgrst_json_defs.val", "jsonb_typeof", "jsonb_build_array", "jsonb_array_elements", "jsonb_to_recordset")
+        else ("pgrst_uniform_json.val", "json_typeof", "json_build_array", "json_array_elements", "json_to_recordset")
+    jsonPlaceHolder = SQL.encoderAndParam (HE.nullable $ if includeDefaults then HE.jsonbLazyBytes else HE.jsonLazyBytes) body
 
 pgFmtOrderTerm :: QualifiedIdentifier -> OrderTerm -> SQL.Snippet
 pgFmtOrderTerm qi ot =

--- a/src/PostgREST/Response.hs
+++ b/src/PostgREST/Response.hs
@@ -109,7 +109,7 @@ createResponse QualifiedIdentifier{..} MutateReadPlan{mrMutatePlan} ctxApiReques
               Nothing
             else
               toAppliedHeader <$> preferResolution
-          , undefinedKeysHeader ctxApiRequest
+          , toAppliedHeader <$> preferUndefinedKeys
           ]
 
     if preferRepresentation == Full then
@@ -128,7 +128,7 @@ updateResponse ctxApiRequest@ApiRequest{iPreferences=Preferences{..}} resultSet 
       contentRangeHeader =
         Just . RangeQuery.contentRangeH 0 (rsQueryTotal - 1) $
           if shouldCount preferCount then Just rsQueryTotal else Nothing
-      headers = catMaybes [contentRangeHeader, undefinedKeysHeader ctxApiRequest]
+      headers = catMaybes [contentRangeHeader, toAppliedHeader <$> preferUndefinedKeys]
 
     if preferRepresentation == Full then
         response HTTP.status200
@@ -262,13 +262,6 @@ profileHeader schema negotiatedByProfile =
     then Just $ (,) "Content-Profile" (toS schema)
   else
     Nothing
-
-undefinedKeysHeader :: ApiRequest -> Maybe HTTP.Header
-undefinedKeysHeader ApiRequest{iPreferences=Preferences{preferUndefinedKeys}, iColumns} =
-  if null iColumns || isNothing preferUndefinedKeys then
-     Nothing
-  else
-     toAppliedHeader <$> preferUndefinedKeys
 
 addRetryHint :: Int -> Wai.Response -> Wai.Response
 addRetryHint delay response = do

--- a/test/pgbench/1567/new.sql
+++ b/test/pgbench/1567/new.sql
@@ -1,0 +1,15 @@
+INSERT INTO "test"."complex_items"("arr_data", "field-with_sep", "id", "name")
+SELECT pgrst_body."arr_data", pgrst_body."field-with_sep", pgrst_body."id", pgrst_body."name"
+FROM (
+  SELECT '[{"id": 4, "name": "Vier"}, {"id": 5, "name": "Funf", "arr_data": null}, {"id": 6, "name": "Sechs", "arr_data": [1, 2, 3], "field-with_sep": 6}]'::jsonb as json_data
+) pgrst_payload,
+LATERAL (
+  SELECT CASE WHEN jsonb_typeof(pgrst_payload.json_data) = 'array' THEN pgrst_payload.json_data ELSE jsonb_build_array(pgrst_payload.json_data) END AS val
+) pgrst_uniform_json,
+LATERAL (
+  SELECT jsonb_agg(jsonb_build_object('field-with_sep', 1) || elem) AS vals from jsonb_array_elements(pgrst_uniform_json.val) elem
+) pgrst_json_defs,
+LATERAL (
+  SELECT * FROM jsonb_to_recordset (pgrst_json_defs.vals) AS _ ("arr_data" integer[], "field-with_sep" integer, "id" bigint, "name" text)
+) pgrst_body
+RETURNING "test"."complex_items".*;

--- a/test/pgbench/1567/old.sql
+++ b/test/pgbench/1567/old.sql
@@ -1,0 +1,12 @@
+INSERT INTO "test"."complex_items"("arr_data", "field-with_sep", "id", "name")
+SELECT pgrst_body."arr_data", pgrst_body."field-with_sep", pgrst_body."id", pgrst_body."name"
+FROM (
+  SELECT '[{"id": 4, "name": "Vier"}, {"id": 5, "name": "Funf", "arr_data": null}, {"id": 6, "name": "Sechs", "arr_data": [1, 2, 3], "field-with_sep": 6}]'::jsonb as json_data
+) pgrst_payload,
+LATERAL (
+  SELECT CASE WHEN jsonb_typeof(pgrst_payload.json_data) = 'array' THEN pgrst_payload.json_data ELSE jsonb_build_array(pgrst_payload.json_data) END AS val
+) pgrst_uniform_json,
+LATERAL (
+  SELECT * FROM jsonb_to_recordset (pgrst_uniform_json.val) AS _ ("arr_data" integer[], "field-with_sep" integer, "id" bigint, "name" text)
+) pgrst_body
+RETURNING "test"."complex_items".*

--- a/test/pgbench/README.md
+++ b/test/pgbench/README.md
@@ -3,6 +3,11 @@
 Can be used as:
 
 ```
-postgrest-with-postgresql-15 -f test/pgbench/fixtures.sql pgbench -n -T 10 -f test/pgbench/2677/old.sql
-postgrest-with-postgresql-15 -f test/pgbench/fixtures.sql pgbench -n -T 10 -f test/pgbench/2677/new.sql
+postgrest-with-postgresql-15 -f test/pgbench/fixtures.sql pgbench -n -T 10 -f test/pgbench/1567/old.sql
+
+postgrest-with-postgresql-15 -f test/pgbench/fixtures.sql pgbench -n -T 10 -f test/pgbench/1567/new.sql
 ```
+
+## Directory structure
+
+The directory name is the issue number on github.

--- a/test/spec/Feature/Query/InsertSpec.hs
+++ b/test/spec/Feature/Query/InsertSpec.hs
@@ -455,7 +455,7 @@ spec actualPgVersion = do
         -- inserting the array fails on pg 9.6, but the feature should work normally
         when (actualPgVersion >= pgVersion100) $
           it "inserts table default values(field-with_sep) when json keys are undefined" $
-            request methodPost "/complex_items?columns=id,name,field-with_sep,arr_data" [("Prefer", "return=representation"), ("Prefer", "defaults=apply")]
+            request methodPost "/complex_items?columns=id,name,field-with_sep,arr_data" [("Prefer", "return=representation"), ("Prefer", "undefined-keys=apply-defaults")]
                 [json|[
                   {"id": 4, "name": "Vier"},
                   {"id": 5, "name": "Funf", "arr_data": null},
@@ -468,11 +468,11 @@ spec actualPgVersion = do
                   {"id": 6, "name": "Sechs", "field-with_sep": 6, "settings":null,"arr_data":[1,2,3]}
                 ]|]
                 { matchStatus  = 201
-                , matchHeaders = ["Preference-Applied" <:> "defaults=apply"]
+                , matchHeaders = ["Preference-Applied" <:> "undefined-keys=apply-defaults"]
                 }
 
         it "inserts view default values(field-with_sep) when json keys are undefined" $
-          request methodPost "/complex_items_view?columns=id,name" [("Prefer", "return=representation"), ("Prefer", "defaults=apply")]
+          request methodPost "/complex_items_view?columns=id,name" [("Prefer", "return=representation"), ("Prefer", "undefined-keys=apply-defaults")]
               [json|[
                 {"id": 7, "name": "Sieben"},
                 {"id": 8}
@@ -483,7 +483,7 @@ spec actualPgVersion = do
                 {"id": 8, "name": "Default", "field-with_sep": 1, "settings":null,"arr_data":null}
               ]|]
               { matchStatus  = 201
-              , matchHeaders = ["Preference-Applied" <:> "defaults=apply"]
+              , matchHeaders = ["Preference-Applied" <:> "undefined-keys=apply-defaults"]
               }
 
     context "with unicode values" $ do

--- a/test/spec/Feature/Query/InsertSpec.hs
+++ b/test/spec/Feature/Query/InsertSpec.hs
@@ -11,8 +11,9 @@ import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 import Text.Heredoc
 
-import PostgREST.Config.PgVersion (PgVersion, pgVersion110,
-                                   pgVersion112, pgVersion130)
+import PostgREST.Config.PgVersion (PgVersion, pgVersion100,
+                                   pgVersion110, pgVersion112,
+                                   pgVersion130)
 
 import Protolude  hiding (get)
 import SpecHelper
@@ -448,15 +449,42 @@ spec actualPgVersion = do
             {"id": 204, "body": "yyy"},
             333,
             "asdf",
-            {"id": 205, "body": "zzz"}]|] `shouldRespondWith`
-          [json|{
-              "code": "22023",
-              "details": null,
-              "hint": null,
-              "message": "argument of json_to_recordset must be an array of objects"}|]
-          { matchStatus  = 400
-          , matchHeaders = []
-          }
+            {"id": 205, "body": "zzz"}]|] `shouldRespondWith` 400
+
+      context "apply defaults on undefined keys" $ do
+        -- inserting the array fails on pg 9.6, but the feature should work normally
+        when (actualPgVersion >= pgVersion100) $
+          it "inserts table default values(field-with_sep) when json keys are undefined" $
+            request methodPost "/complex_items?columns=id,name,field-with_sep,arr_data" [("Prefer", "return=representation"), ("Prefer", "defaults=apply")]
+                [json|[
+                  {"id": 4, "name": "Vier"},
+                  {"id": 5, "name": "Funf", "arr_data": null},
+                  {"id": 6, "name": "Sechs", "field-with_sep": 6, "arr_data": "{1,2,3}"}
+                ]|]
+              `shouldRespondWith`
+                [json|[
+                  {"id": 4, "name": "Vier", "field-with_sep": 1, "settings":null,"arr_data":null},
+                  {"id": 5, "name": "Funf", "field-with_sep": 1, "settings":null,"arr_data":null},
+                  {"id": 6, "name": "Sechs", "field-with_sep": 6, "settings":null,"arr_data":[1,2,3]}
+                ]|]
+                { matchStatus  = 201
+                , matchHeaders = []
+                }
+
+        it "inserts view default values(field-with_sep) when json keys are undefined" $
+          request methodPost "/complex_items_view?columns=id,name" [("Prefer", "return=representation"), ("Prefer", "defaults=apply")]
+              [json|[
+                {"id": 7, "name": "Sieben"},
+                {"id": 8}
+              ]|]
+            `shouldRespondWith`
+              [json|[
+                {"id": 7, "name": "Sieben", "field-with_sep": 1, "settings":null,"arr_data":null},
+                {"id": 8, "name": "Default", "field-with_sep": 1, "settings":null,"arr_data":null}
+              ]|]
+              { matchStatus  = 201
+              , matchHeaders = []
+              }
 
     context "with unicode values" $ do
       it "succeeds and returns full representation" $

--- a/test/spec/Feature/Query/InsertSpec.hs
+++ b/test/spec/Feature/Query/InsertSpec.hs
@@ -468,7 +468,7 @@ spec actualPgVersion = do
                   {"id": 6, "name": "Sechs", "field-with_sep": 6, "settings":null,"arr_data":[1,2,3]}
                 ]|]
                 { matchStatus  = 201
-                , matchHeaders = []
+                , matchHeaders = ["Preference-Applied" <:> "defaults=apply"]
                 }
 
         it "inserts view default values(field-with_sep) when json keys are undefined" $
@@ -483,7 +483,7 @@ spec actualPgVersion = do
                 {"id": 8, "name": "Default", "field-with_sep": 1, "settings":null,"arr_data":null}
               ]|]
               { matchStatus  = 201
-              , matchHeaders = []
+              , matchHeaders = ["Preference-Applied" <:> "defaults=apply"]
               }
 
     context "with unicode values" $ do

--- a/test/spec/Feature/Query/QuerySpec.hs
+++ b/test/spec/Feature/Query/QuerySpec.hs
@@ -327,11 +327,11 @@ spec actualPgVersion = do
   describe "Shaping response with select parameter" $ do
     it "selectStar works in absense of parameter" $
       get "/complex_items?id=eq.3" `shouldRespondWith`
-        [json|[{"id":3,"name":"Three","settings":{"foo":{"int":1,"bar":"baz"}},"arr_data":[1,2,3],"field-with_sep":1}]|]
+        [json|[{"id":3,"name":"Three","settings":{"foo":{"int":1,"bar":"baz"}},"arr_data":[1,2,3],"field-with_sep":3}]|]
 
     it "dash `-` in column names is accepted" $
       get "/complex_items?id=eq.3&select=id,field-with_sep" `shouldRespondWith`
-        [json|[{"id":3,"field-with_sep":1}]|]
+        [json|[{"id":3,"field-with_sep":3}]|]
 
     it "one simple column" $
       get "/complex_items?select=id" `shouldRespondWith`

--- a/test/spec/Feature/Query/UpdateSpec.hs
+++ b/test/spec/Feature/Query/UpdateSpec.hs
@@ -330,6 +330,57 @@ spec = do
           , matchHeaders = []
           }
 
+      context "apply defaults on undefined keys" $ do
+        it "updates table using default values(field-with_sep) when json keys are undefined" $ do
+          request methodPatch "/complex_items?id=eq.3&columns=name,field-with_sep"
+            [("Prefer", "return=representation"), ("Prefer", "defaults=apply")]
+            [json|{"name": "Tres"}|]
+            `shouldRespondWith`
+            [json|[
+              {"id":3,"name":"Tres","settings":{"foo":{"int":1,"bar":"baz"}},"arr_data":[1,2,3],"field-with_sep":1}
+            ]|]
+            { matchStatus  = 200
+            , matchHeaders = []
+            }
+
+        it "updates with limit/offset using table default values(field-with_sep) when json keys are undefined" $ do
+          request methodPatch "/complex_items?select=id,name&columns=name,field-with_sep&limit=1&offset=2&order=id"
+            [("Prefer", "return=representation"), ("Prefer", "defaults=apply")]
+            [json|{"name": "Tres"}|]
+            `shouldRespondWith`
+            [json|[
+              {"id":3,"name":"Tres"}
+            ]|]
+            { matchStatus  = 200
+            , matchHeaders = []
+            }
+
+        it "updates table default values(field-with_sep) when json keys are undefined" $ do
+          request methodPatch "/complex_items?id=eq.3&columns=name,field-with_sep"
+            [("Prefer", "return=representation"), ("Prefer", "defaults=apply")]
+            [json|{"name": "Tres"}|]
+            `shouldRespondWith`
+            [json|[
+              {"id":3,"name":"Tres","settings":{"foo":{"int":1,"bar":"baz"}},"arr_data":[1,2,3],"field-with_sep":1}
+            ]|]
+            { matchStatus  = 200
+            , matchHeaders = []
+            }
+
+        it "updates view default values(field-with_sep) when json keys are undefined" $
+          request methodPatch "/complex_items_view?id=eq.3&columns=arr_data,name"
+            [("Prefer", "return=representation"), ("Prefer", "defaults=apply")]
+            [json|
+              {"arr_data":null}
+            |]
+            `shouldRespondWith`
+            [json|[
+              {"id":3,"name":"Default","settings":{"foo":{"int":1,"bar":"baz"}},"arr_data":null,"field-with_sep":3}
+            ]|]
+            { matchStatus  = 200
+            , matchHeaders = []
+            }
+
   context "tables with self reference foreign keys" $ do
     it "embeds children after update" $
       request methodPatch "/web_content?id=eq.0&select=id,name,web_content(name)"

--- a/test/spec/Feature/Query/UpdateSpec.hs
+++ b/test/spec/Feature/Query/UpdateSpec.hs
@@ -340,7 +340,7 @@ spec = do
               {"id":3,"name":"Tres","settings":{"foo":{"int":1,"bar":"baz"}},"arr_data":[1,2,3],"field-with_sep":1}
             ]|]
             { matchStatus  = 200
-            , matchHeaders = []
+            , matchHeaders = ["Preference-Applied" <:> "defaults=apply"]
             }
 
         it "updates with limit/offset using table default values(field-with_sep) when json keys are undefined" $ do
@@ -352,7 +352,7 @@ spec = do
               {"id":3,"name":"Tres"}
             ]|]
             { matchStatus  = 200
-            , matchHeaders = []
+            , matchHeaders = ["Preference-Applied" <:> "defaults=apply"]
             }
 
         it "updates table default values(field-with_sep) when json keys are undefined" $ do
@@ -364,7 +364,7 @@ spec = do
               {"id":3,"name":"Tres","settings":{"foo":{"int":1,"bar":"baz"}},"arr_data":[1,2,3],"field-with_sep":1}
             ]|]
             { matchStatus  = 200
-            , matchHeaders = []
+            , matchHeaders = ["Preference-Applied" <:> "defaults=apply"]
             }
 
         it "updates view default values(field-with_sep) when json keys are undefined" $
@@ -378,7 +378,7 @@ spec = do
               {"id":3,"name":"Default","settings":{"foo":{"int":1,"bar":"baz"}},"arr_data":null,"field-with_sep":3}
             ]|]
             { matchStatus  = 200
-            , matchHeaders = []
+            , matchHeaders = ["Preference-Applied" <:> "defaults=apply"]
             }
 
   context "tables with self reference foreign keys" $ do

--- a/test/spec/Feature/Query/UpdateSpec.hs
+++ b/test/spec/Feature/Query/UpdateSpec.hs
@@ -333,43 +333,43 @@ spec = do
       context "apply defaults on undefined keys" $ do
         it "updates table using default values(field-with_sep) when json keys are undefined" $ do
           request methodPatch "/complex_items?id=eq.3&columns=name,field-with_sep"
-            [("Prefer", "return=representation"), ("Prefer", "defaults=apply")]
+            [("Prefer", "return=representation"), ("Prefer", "undefined-keys=apply-defaults")]
             [json|{"name": "Tres"}|]
             `shouldRespondWith`
             [json|[
               {"id":3,"name":"Tres","settings":{"foo":{"int":1,"bar":"baz"}},"arr_data":[1,2,3],"field-with_sep":1}
             ]|]
             { matchStatus  = 200
-            , matchHeaders = ["Preference-Applied" <:> "defaults=apply"]
+            , matchHeaders = ["Preference-Applied" <:> "undefined-keys=apply-defaults"]
             }
 
         it "updates with limit/offset using table default values(field-with_sep) when json keys are undefined" $ do
           request methodPatch "/complex_items?select=id,name&columns=name,field-with_sep&limit=1&offset=2&order=id"
-            [("Prefer", "return=representation"), ("Prefer", "defaults=apply")]
+            [("Prefer", "return=representation"), ("Prefer", "undefined-keys=apply-defaults")]
             [json|{"name": "Tres"}|]
             `shouldRespondWith`
             [json|[
               {"id":3,"name":"Tres"}
             ]|]
             { matchStatus  = 200
-            , matchHeaders = ["Preference-Applied" <:> "defaults=apply"]
+            , matchHeaders = ["Preference-Applied" <:> "undefined-keys=apply-defaults"]
             }
 
         it "updates table default values(field-with_sep) when json keys are undefined" $ do
           request methodPatch "/complex_items?id=eq.3&columns=name,field-with_sep"
-            [("Prefer", "return=representation"), ("Prefer", "defaults=apply")]
+            [("Prefer", "return=representation"), ("Prefer", "undefined-keys=apply-defaults")]
             [json|{"name": "Tres"}|]
             `shouldRespondWith`
             [json|[
               {"id":3,"name":"Tres","settings":{"foo":{"int":1,"bar":"baz"}},"arr_data":[1,2,3],"field-with_sep":1}
             ]|]
             { matchStatus  = 200
-            , matchHeaders = ["Preference-Applied" <:> "defaults=apply"]
+            , matchHeaders = ["Preference-Applied" <:> "undefined-keys=apply-defaults"]
             }
 
         it "updates view default values(field-with_sep) when json keys are undefined" $
           request methodPatch "/complex_items_view?id=eq.3&columns=arr_data,name"
-            [("Prefer", "return=representation"), ("Prefer", "defaults=apply")]
+            [("Prefer", "return=representation"), ("Prefer", "undefined-keys=apply-defaults")]
             [json|
               {"arr_data":null}
             |]
@@ -378,7 +378,7 @@ spec = do
               {"id":3,"name":"Default","settings":{"foo":{"int":1,"bar":"baz"}},"arr_data":null,"field-with_sep":3}
             ]|]
             { matchStatus  = 200
-            , matchHeaders = ["Preference-Applied" <:> "defaults=apply"]
+            , matchHeaders = ["Preference-Applied" <:> "undefined-keys=apply-defaults"]
             }
 
   context "tables with self reference foreign keys" $ do

--- a/test/spec/fixtures/data.sql
+++ b/test/spec/fixtures/data.sql
@@ -168,7 +168,7 @@ INSERT INTO touched_files VALUES
 TRUNCATE TABLE complex_items CASCADE;
 INSERT INTO complex_items VALUES (1, 'One', '{"foo":{"int":1,"bar":"baz"}}', '{1}');
 INSERT INTO complex_items VALUES (2, 'Two', '{"foo":{"int":1,"bar":"baz"}}', '{1,2}');
-INSERT INTO complex_items VALUES (3, 'Three', '{"foo":{"int":1,"bar":"baz"}}', '{1,2,3}');
+INSERT INTO complex_items VALUES (3, 'Three', '{"foo":{"int":1,"bar":"baz"}}', '{1,2,3}', 3);
 
 
 --

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -3100,3 +3100,8 @@ create view test.alpha_projects as
 create view test.zeta_projects as
   select c.id, p.name as pro_name, c.name as cli_name
   from projects p join clients c on p.client_id = c.id;
+
+CREATE VIEW test.complex_items_view AS
+SELECT * FROM test.complex_items;
+
+ALTER VIEW test.complex_items_view ALTER COLUMN name SET DEFAULT 'Default';

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -3105,3 +3105,8 @@ CREATE VIEW test.complex_items_view AS
 SELECT * FROM test.complex_items;
 
 ALTER VIEW test.complex_items_view ALTER COLUMN name SET DEFAULT 'Default';
+
+create table test.tbl_w_json(
+  id int,
+  data json
+);


### PR DESCRIPTION
Closes #1567.

(`field-with_sep` has default 1 on the following)

- Allows bulk insert with defaults

```bash
http POST "localhost:3000/complex_items?columns=id,name,field-with_sep,arr_data" "Prefer: return=representation" <<JSON
[
  {"id": 4, "name": "Vier"},
  {"id": 5, "name": "Funf", "arr_data": null},
  {"id": 6, "name": "Sechs", "field-with_sep": 6, "arr_data": [1,2,3]}
]
JSON

[
    { "arr_data": null, "field-with_sep": 1, "id": 4, "name": "Vier", "settings": null },
    { "arr_data": null, "field-with_sep": 1, "id": 5, "name": "Funf", "settings": null },
    { "arr_data": [ 1, 2, 3 ], "field-with_sep": 6, "id": 6, "name": "Sechs", "settings": null }
]
```

- Allows updating with defaults

```bash
http PATCH "/complex_items?id=eq.3&columns=name,field-with_sep" "Prefer: return=representation" <<JSON
{"name": "Tres"}
JSON


[ { "arr_data": [ 1, 2, 3 ], "field-with_sep": 1, "id": 3, "name": "Tres", "settings": { "foo": { "bar": "baz", "int": 1 } } } ]
```

- It works on views as well assuming they have a default set up using: `ALTER VIEW test.complex_items_view ALTER COLUMN name SET DEFAULT 'Default'`

## Pending

- [x] Optionally apply the feature with a Prefer header(since this new insert query is more expensive)
- [x] CHANGELOG