### PR TITLE
ci: remove GHC 8.10.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -216,7 +216,7 @@ jobs:
   Build-Cabal:
     strategy:
       matrix:
-        ghc: ['8.10.7', '9.2.4']
+        ghc: ['9.2.4']
       fail-fast: false
     name: Build Linux (Cabal, GHC ${{ matrix.ghc }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
As discussed on https://github.com/PostgREST/postgrest/pull/2671#issuecomment-1435691023.