### PR TITLE
refactor: split pre-request function out of setPgLocals

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -223,4 +223,5 @@ handleRequest AuthResult{..} conf appState authenticated prepared jsonDbS pgVer 
     runQuery mode query =
       runDbHandler appState mode authenticated prepared $ do
         Query.setPgLocals conf authClaims authRole apiReq jsonDbS pgVer
+        Query.runPreReq conf
         query


### PR DESCRIPTION
This makes what's happening a bit clearer -- there's no apparent reason why these should be within that one big function.

Any better naming ideas than `runPreReq`?