### PR TITLE
Support bulk updates using PATCH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2694, Make `db-root-spec` stable. - @steve-chavez
    + This can be used to override the OpenAPI spec with a custom database function
  - #1567, On bulk inserts with `?columns`, undefined json keys can get columns' DEFAULT values by using the `Prefer: undefined-keys=apply-defaults` header - @steve-chavez
+ - #1959, Add support for bulk updates with PATCH and `Prefer: params=multiple-objects`. - @laurenceisla, @steve-chavez
 
 ### Fixed
 

--- a/src/PostgREST/ApiRequest/Preferences.hs
+++ b/src/PostgREST/ApiRequest/Preferences.hs
@@ -115,7 +115,7 @@ fromHeaders headers =
     , preferParameters = parsePrefs [SingleObject, MultipleObjects]
     , preferCount = parsePrefs [ExactCount, PlannedCount, EstimatedCount]
     , preferTransaction = parsePrefs [Commit, Rollback]
-    , preferUndefinedKeys = parsePrefs [ApplyDefaults, IgnoreDefaults]
+    , preferUndefinedKeys = parsePrefs [ApplyDefaults, IgnoreValues, ApplyNulls]
     }
   where
     prefHeaders = filter ((==) HTTP.hPrefer . fst) headers
@@ -216,12 +216,14 @@ instance ToAppliedHeader PreferTransaction
 -- How to handle the insertion/update when the keys specified in ?columns are not present
 -- in the json body.
 data PreferUndefinedKeys
-  = ApplyDefaults  -- ^ Use the default column value for the unspecified keys.
-  | IgnoreDefaults -- ^ Inserts: null values / Updates: the keys are not SET to any value
+  = ApplyDefaults  -- ^ Inserts and Updates: Use the default column value for the unspecified keys.
+  | IgnoreValues   -- ^ Inserts: null values | Updates: the keys are not SET to any value
+  | ApplyNulls     -- ^ Inserts: null values | Updates: SET the values to null
   deriving Eq
 
 instance ToHeaderValue PreferUndefinedKeys where
-  toHeaderValue ApplyDefaults  = "undefined-keys=apply-defaults"
-  toHeaderValue IgnoreDefaults = "undefined-keys=ignore-defaults"
+  toHeaderValue ApplyDefaults = "undefined-keys=apply-defaults"
+  toHeaderValue IgnoreValues  = "undefined-keys=ignore-values"
+  toHeaderValue ApplyNulls    = "undefined-keys=apply-nulls"
 
 instance ToAppliedHeader PreferUndefinedKeys

--- a/src/PostgREST/ApiRequest/Preferences.hs
+++ b/src/PostgREST/ApiRequest/Preferences.hs
@@ -173,10 +173,10 @@ instance ToHeaderValue PreferRepresentation where
   toHeaderValue None        = "return=minimal"
   toHeaderValue HeadersOnly = "return=headers-only"
 
--- | How to pass parameters to stored procedures.
+-- | How to pass parameters to stored procedures or handle bulk UPDATEs.
 data PreferParameters
   = SingleObject    -- ^ Pass all parameters as a single json object to a stored procedure.
-  | MultipleObjects -- ^ Pass an array of json objects as params to a stored procedure.
+  | MultipleObjects -- ^ Pass an array of json objects as params to a stored procedure or as items in a bulk UPDATE.
   deriving Eq
 
 -- TODO: Deprecate params=multiple-objects in next major version

--- a/src/PostgREST/ApiRequest/Types.hs
+++ b/src/PostgREST/ApiRequest/Types.hs
@@ -66,12 +66,14 @@ data ApiRequestError
   = AmbiguousRelBetween Text Text [Relationship]
   | AmbiguousRpc [ProcDescription]
   | BinaryFieldError MediaType
-  | MediaTypeError [ByteString]
+  | BulkUpdRangeNotAllowedError
+  | ColumnNotFound Text Text
   | InvalidBody ByteString
   | InvalidFilters
   | InvalidRange RangeError
   | InvalidRpcMethod ByteString
   | LimitNoOrderError
+  | MediaTypeError [ByteString]
   | NotFound
   | NoRelBetween Text Text (Maybe Text) Text RelationshipsMap
   | NoRpc Text Text [Text] Bool MediaType Bool [QualifiedIdentifier] [ProcDescription]
@@ -83,7 +85,6 @@ data ApiRequestError
   | UnacceptableFilter Text
   | UnacceptableSchema [Text]
   | UnsupportedMethod ByteString
-  | ColumnNotFound Text Text
 
 data QPError = QPError Text Text
 data RangeError

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -59,28 +59,28 @@ class (JSON.ToJSON a) => PgrstError a where
   errorResponseFor err = responseLBS (status err) (headers err) $ errorPayload err
 
 instance PgrstError ApiRequestError where
-  status AmbiguousRelBetween{}   = HTTP.status300
-  status AmbiguousRpc{}          = HTTP.status300
-  status BinaryFieldError{}      = HTTP.status406
-  status MediaTypeError{}        = HTTP.status415
-  status InvalidBody{}           = HTTP.status400
-  status InvalidFilters          = HTTP.status405
-  status InvalidRpcMethod{}      = HTTP.status405
-  status InvalidRange{}          = HTTP.status416
-  status NotFound                = HTTP.status404
-
-  status NoRelBetween{}          = HTTP.status400
-  status NoRpc{}                 = HTTP.status404
-  status NotEmbedded{}           = HTTP.status400
-  status PutRangeNotAllowedError = HTTP.status400
-  status QueryParamError{}       = HTTP.status400
-  status RelatedOrderNotToOne{}  = HTTP.status400
-  status SpreadNotToOne{}        = HTTP.status400
-  status UnacceptableFilter{}    = HTTP.status400
-  status UnacceptableSchema{}    = HTTP.status406
-  status UnsupportedMethod{}     = HTTP.status405
-  status LimitNoOrderError       = HTTP.status400
-  status ColumnNotFound{}        = HTTP.status400
+  status AmbiguousRelBetween{}       = HTTP.status300
+  status AmbiguousRpc{}              = HTTP.status300
+  status BinaryFieldError{}          = HTTP.status406
+  status BulkUpdRangeNotAllowedError = HTTP.status400
+  status ColumnNotFound{}            = HTTP.status400
+  status InvalidBody{}               = HTTP.status400
+  status InvalidFilters              = HTTP.status405
+  status InvalidRpcMethod{}          = HTTP.status405
+  status InvalidRange{}              = HTTP.status416
+  status LimitNoOrderError           = HTTP.status400
+  status MediaTypeError{}            = HTTP.status415
+  status NotFound                    = HTTP.status404
+  status NoRelBetween{}              = HTTP.status400
+  status NoRpc{}                     = HTTP.status404
+  status NotEmbedded{}               = HTTP.status400
+  status PutRangeNotAllowedError     = HTTP.status400
+  status QueryParamError{}           = HTTP.status400
+  status RelatedOrderNotToOne{}      = HTTP.status400
+  status SpreadNotToOne{}            = HTTP.status400
+  status UnacceptableFilter{}        = HTTP.status400
+  status UnacceptableSchema{}        = HTTP.status406
+  status UnsupportedMethod{}         = HTTP.status405
 
   headers _ = [MediaType.toContentType MTApplicationJSON]
 
@@ -170,6 +170,12 @@ instance JSON.ToJSON ApiRequestError where
     "code"    .= ApiRequestErrorCode20,
     "message" .= ("Bad operator on the '" <> target <> "' embedded resource":: Text),
     "details" .= ("Only is null or not is null filters are allowed on embedded resources":: Text),
+    "hint"    .= JSON.Null]
+
+  toJSON BulkUpdRangeNotAllowedError = JSON.object [
+    "code"    .= ApiRequestErrorCode21,
+    "message" .= ("Range header and limit/offset querystring parameters are not allowed for PATCH with Prefer: params=multiple-objects" :: Text),
+    "details" .= JSON.Null,
     "hint"    .= JSON.Null]
 
   toJSON (NoRelBetween parent child embedHint schema allRels) = JSON.object [
@@ -598,6 +604,7 @@ data ErrorCode
   | ApiRequestErrorCode18
   | ApiRequestErrorCode19
   | ApiRequestErrorCode20
+  | ApiRequestErrorCode21
   -- Schema Cache errors
   | SchemaCacheErrorCode00
   | SchemaCacheErrorCode01
@@ -644,6 +651,7 @@ buildErrorCode code = "PGRST" <> case code of
   ApiRequestErrorCode18  -> "118"
   ApiRequestErrorCode19  -> "119"
   ApiRequestErrorCode20  -> "120"
+  ApiRequestErrorCode21  -> "121"
 
   SchemaCacheErrorCode00 -> "200"
   SchemaCacheErrorCode01 -> "201"

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -507,7 +507,7 @@ mutatePlan mutation qi ApiRequest{iPreferences=preferences, ..} sCache readReq =
     MutationCreate ->
       mapRight (\typedColumns -> Insert qi typedColumns body ((,) <$> preferences.preferResolution <*> Just confCols) [] returnings pkCols applyDefaults) typedColumnsOrError
     MutationUpdate ->
-      mapRight (\typedColumns -> Update qi typedColumns body combinedLogic iTopLevelRange rootOrder returnings applyDefaults pkCols isBulkUpdate) typedColumnsOrError
+      mapRight (\typedColumns -> Update qi typedColumns body combinedLogic iTopLevelRange rootOrder returnings applyDefaults applyIgnoreValues pkCols isBulkUpdate) typedColumnsOrError
     MutationSingleUpsert ->
         if null qsLogic &&
            qsFilterFields == S.fromList pkCols &&
@@ -534,6 +534,7 @@ mutatePlan mutation qi ApiRequest{iPreferences=preferences, ..} sCache readReq =
     tbl = HM.lookup qi $ dbTables sCache
     typedColumnsOrError = resolveOrError tbl `traverse` S.toList iColumns
     applyDefaults = preferences.preferUndefinedKeys == Just ApplyDefaults
+    applyIgnoreValues = preferences.preferUndefinedKeys == Just IgnoreValues
     isBulkUpdate = preferences.preferParameters == Just MultipleObjects
 
 resolveOrError :: Maybe Table -> FieldName -> Either ApiRequestError TypedField

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -507,7 +507,7 @@ mutatePlan mutation qi ApiRequest{iPreferences=preferences, ..} sCache readReq =
     MutationCreate ->
       mapRight (\typedColumns -> Insert qi typedColumns body ((,) <$> preferences.preferResolution <*> Just confCols) [] returnings pkCols applyDefaults) typedColumnsOrError
     MutationUpdate ->
-      mapRight (\typedColumns -> Update qi typedColumns body combinedLogic iTopLevelRange rootOrder returnings applyDefaults) typedColumnsOrError
+      mapRight (\typedColumns -> Update qi typedColumns body combinedLogic iTopLevelRange rootOrder returnings applyDefaults pkCols isBulkUpdate) typedColumnsOrError
     MutationSingleUpsert ->
         if null qsLogic &&
            qsFilterFields == S.fromList pkCols &&
@@ -534,6 +534,7 @@ mutatePlan mutation qi ApiRequest{iPreferences=preferences, ..} sCache readReq =
     tbl = HM.lookup qi $ dbTables sCache
     typedColumnsOrError = resolveOrError tbl `traverse` S.toList iColumns
     applyDefaults = preferences.preferUndefinedKeys == Just ApplyDefaults
+    isBulkUpdate = preferences.preferParameters == Just MultipleObjects
 
 resolveOrError :: Maybe Table -> FieldName -> Either ApiRequestError TypedField
 resolveOrError Nothing _ = Left NotFound

--- a/src/PostgREST/Plan/MutatePlan.hs
+++ b/src/PostgREST/Plan/MutatePlan.hs
@@ -27,16 +27,17 @@ data MutatePlan
       , applyDefs  :: Bool
       }
   | Update
-      { in_       :: QualifiedIdentifier
-      , updCols   :: [TypedField]
-      , updBody   :: Maybe LBS.ByteString
-      , where_    :: [LogicTree]
-      , mutRange  :: NonnegRange
-      , mutOrder  :: [OrderTerm]
-      , returning :: [FieldName]
-      , applyDefs :: Bool
-      , updPkFlts :: [FieldName]
-      , isBulk    :: Bool
+      { in_           :: QualifiedIdentifier
+      , updCols       :: [TypedField]
+      , updBody       :: Maybe LBS.ByteString
+      , where_        :: [LogicTree]
+      , mutRange      :: NonnegRange
+      , mutOrder      :: [OrderTerm]
+      , returning     :: [FieldName]
+      , applyDefs     :: Bool
+      , applyIgnrVals :: Bool
+      , updPkFlts     :: [FieldName]
+      , isBulk        :: Bool
       }
   | Delete
       { in_       :: QualifiedIdentifier

--- a/src/PostgREST/Plan/MutatePlan.hs
+++ b/src/PostgREST/Plan/MutatePlan.hs
@@ -35,6 +35,8 @@ data MutatePlan
       , mutOrder  :: [OrderTerm]
       , returning :: [FieldName]
       , applyDefs :: Bool
+      , updPkFlts :: [FieldName]
+      , isBulk    :: Bool
       }
   | Delete
       { in_       :: QualifiedIdentifier

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -26,6 +26,7 @@ module PostgREST.Query.SqlFragment
   , pgFmtIdent
   , pgFmtIdentList
   , pgFmtJoinCondition
+  , pgFmtLit
   , pgFmtLogicTree
   , pgFmtOrderTerm
   , pgFmtSelectItem
@@ -231,8 +232,8 @@ pgFmtSelectItem table (f@(fName, jp), Nothing, alias) = pgFmtField table f <> SQ
 pgFmtSelectItem table (f@(fName, jp), Just cast, alias) = "CAST (" <> pgFmtField table f <> " AS " <> SQL.sql (encodeUtf8 cast) <> " )" <> SQL.sql (pgFmtAs fName jp alias)
 
 -- TODO: At this stage there shouldn't be a Maybe since ApiRequest should ensure that an INSERT/UPDATE has a body
-fromJsonBodyF :: Maybe LBS.ByteString -> [TypedField] -> Bool -> Bool -> Bool -> SQL.Snippet
-fromJsonBodyF body fields includeSelect includeLimitOne includeDefaults =
+fromJsonBodyF :: Maybe LBS.ByteString -> [TypedField] -> Bool -> Bool -> Bool -> Bool -> SQL.Snippet
+fromJsonBodyF body fields includeSelect includeLimitOne includeDefaults includeIgnoreVals =
   SQL.sql
   (if includeSelect then "SELECT " <> parsedCols <> " " else mempty) <>
   "FROM (SELECT " <> jsonPlaceHolder <> " AS json_data) pgrst_payload, " <>
@@ -242,6 +243,9 @@ fromJsonBodyF body fields includeSelect includeLimitOne includeDefaults =
   "LATERAL (SELECT CASE WHEN " <> jsonTypeofF <> "(pgrst_payload.json_data) = 'array' THEN pgrst_payload.json_data ELSE " <> jsonBuildArrayF <> "(pgrst_payload.json_data) END AS val) pgrst_uniform_json, " <>
   (if includeDefaults
     then "LATERAL (SELECT jsonb_agg(jsonb_build_object(" <> defsJsonb <> ") || elem) AS val from jsonb_array_elements(pgrst_uniform_json.val) elem) pgrst_json_defs, "
+    else mempty) <>
+  (if includeIgnoreVals
+    then "jsonb_array_elements(pgrst_uniform_json.val) pgrst_json_old_vals, "
     else mempty) <>
   "LATERAL (SELECT * FROM " <>
     (if null fields
@@ -260,11 +264,14 @@ fromJsonBodyF body fields includeSelect includeLimitOne includeDefaults =
         TypedField{tfName=nam, tfDefault=Just def} -> Just $ encodeUtf8 (pgFmtLit nam <> ", " <> def)
         TypedField{tfDefault=Nothing} -> Nothing
       ) fields
-    (finalBodyF, jsonTypeofF, jsonBuildArrayF, jsonArrayElementsF, jsonToRecordsetF) =
-      if includeDefaults
-        then ("pgrst_json_defs.val", "jsonb_typeof", "jsonb_build_array", "jsonb_array_elements", "jsonb_to_recordset")
-        else ("pgrst_uniform_json.val", "json_typeof", "json_build_array", "json_array_elements", "json_to_recordset")
-    jsonPlaceHolder = SQL.encoderAndParam (HE.nullable $ if includeDefaults then HE.jsonbLazyBytes else HE.jsonLazyBytes) body
+    (finalBodyF, jsonTypeofF, jsonBuildArrayF, jsonArrayElementsF, jsonToRecordsetF)
+      | includeDefaults =
+        ("pgrst_json_defs.val", "jsonb_typeof", "jsonb_build_array", "jsonb_array_elements", "jsonb_to_recordset")
+      | includeIgnoreVals =
+        ("pgrst_json_old_vals", "jsonb_typeof", "jsonb_build_array", "jsonb_array_elements", "jsonb_to_record")
+      | otherwise =
+        ("pgrst_uniform_json.val", "json_typeof", "json_build_array", "json_array_elements", "json_to_recordset")
+    jsonPlaceHolder = SQL.encoderAndParam (HE.nullable $ if includeDefaults || includeIgnoreVals then HE.jsonbLazyBytes else HE.jsonLazyBytes) body
 
 pgFmtOrderTerm :: QualifiedIdentifier -> OrderTerm -> SQL.Snippet
 pgFmtOrderTerm qi ot =

--- a/test/spec/Feature/Query/DeleteSpec.hs
+++ b/test/spec/Feature/Query/DeleteSpec.hs
@@ -154,7 +154,7 @@ spec =
       it "works with the limit and offset query params" $
         baseTable "limited_delete_items" "id" tblDataBefore
         `mutatesWith`
-        requestMutation methodDelete "/limited_delete_items?order=id&limit=1&offset=1" mempty
+        requestMutation methodDelete "/limited_delete_items?order=id&limit=1&offset=1" mempty mempty
         `shouldMutateInto`
         [json|[
           { "id": 1, "name": "item-1" }
@@ -164,7 +164,7 @@ spec =
       it "works with the limit query param plus a filter" $
         baseTable "limited_delete_items" "id" tblDataBefore
         `mutatesWith`
-        requestMutation methodDelete "/limited_delete_items?order=id&limit=1&id=gt.1" mempty
+        requestMutation methodDelete "/limited_delete_items?order=id&limit=1&id=gt.1" mempty mempty
         `shouldMutateInto`
         [json|[
           { "id": 1, "name": "item-1" }
@@ -200,7 +200,7 @@ spec =
       it "works with views with an explicit order by unique col" $
         baseTable "limited_delete_items_view" "id" tblDataBefore
         `mutatesWith`
-        requestMutation methodDelete "/limited_delete_items_view?order=id&limit=1&offset=1" mempty
+        requestMutation methodDelete "/limited_delete_items_view?order=id&limit=1&offset=1" mempty mempty
         `shouldMutateInto`
         [json|[
           { "id": 1, "name": "item-1" }
@@ -210,7 +210,7 @@ spec =
       it "works with views with an explicit order by composite pk" $
         baseTable "limited_delete_items_cpk_view" "id" tblDataBefore
         `mutatesWith`
-        requestMutation methodDelete "/limited_delete_items_cpk_view?order=id,name&limit=1&offset=1" mempty
+        requestMutation methodDelete "/limited_delete_items_cpk_view?order=id,name&limit=1&offset=1" mempty mempty
         `shouldMutateInto`
         [json|[
           { "id": 1, "name": "item-1" }
@@ -220,7 +220,7 @@ spec =
       it "works on a table without a pk by ordering by 'ctid'" $
         baseTable "limited_delete_items_no_pk" "id" tblDataBefore
         `mutatesWith`
-        requestMutation methodDelete "/limited_delete_items_no_pk?order=ctid&limit=1&offset=1" mempty
+        requestMutation methodDelete "/limited_delete_items_no_pk?order=ctid&limit=1&offset=1" mempty mempty
         `shouldMutateInto`
         [json|[
           { "id": 1, "name": "item-1" }

--- a/test/spec/Feature/Query/PgSafeUpdateSpec.hs
+++ b/test/spec/Feature/Query/PgSafeUpdateSpec.hs
@@ -38,7 +38,7 @@ spec =
       it "allows full table update if a filter is present" $
         baseTable "safe_update_items" "id" tblDataBefore
         `mutatesWith`
-        requestMutation methodPatch "/safe_update_items?id=gt.0" [json| {"name": "updated-item"} |]
+        requestMutation methodPatch "/safe_update_items?id=gt.0" mempty [json| {"name": "updated-item"} |]
         `shouldMutateInto`
         [json|[
           { "id": 1, "name": "updated-item", "observation": null }
@@ -61,7 +61,7 @@ spec =
       it "allows full table delete if a filter is present" $
         baseTable "safe_delete_items" "id" tblDataBefore
         `mutatesWith`
-        requestMutation methodDelete "/safe_delete_items?id=gt.0" mempty
+        requestMutation methodDelete "/safe_delete_items?id=gt.0" mempty mempty
         `shouldMutateInto`
         [json|[]|]
 
@@ -72,7 +72,7 @@ disabledSpec =
       it "works if no condition is present" $
         baseTable "unsafe_update_items" "id" tblDataBefore
         `mutatesWith`
-        requestMutation methodPatch "/unsafe_update_items" [json| {"name": "updated-item"} |]
+        requestMutation methodPatch "/unsafe_update_items" mempty [json| {"name": "updated-item"} |]
         `shouldMutateInto`
         [json|[
           { "id": 1, "name": "updated-item", "observation": null }
@@ -84,6 +84,6 @@ disabledSpec =
       it "works if no condition is present" $
         baseTable "unsafe_delete_items" "id" tblDataBefore
         `mutatesWith`
-        requestMutation methodDelete "/unsafe_delete_items" mempty
+        requestMutation methodDelete "/unsafe_delete_items" mempty mempty
         `shouldMutateInto`
         [json|[]|]

--- a/test/spec/Feature/Query/UpdateSpec.hs
+++ b/test/spec/Feature/Query/UpdateSpec.hs
@@ -757,10 +757,43 @@ spec = do
       , { "id": 3, "name": "item-3", "observation": null }
       ]|]
 
+    it "updates with ?columns when the json array body has objects with different keys, updating to a null value when the key is not specified" $
+      baseTable "bulk_update_items" "id" tblDataBeforeBulk
+      `mutatesWith`
+      requestMutation methodPatch "/bulk_update_items?columns=id,name,observation"
+        [("Prefer", "params=multiple-objects")]
+        [json|[
+          { "id": 1, "name": "item-1 - 1st", "observation": "Lost item" }
+        , { "id": 2, "observation": "new item" }
+        ]|]
+      `shouldMutateInto`
+      [json|[
+        { "id": 1, "name": "item-1 - 1st", "observation": "Lost item" }
+      , { "id": 2, "name": null, "observation": "new item" }
+      , { "id": 3, "name": "item-3", "observation": null }
+      ]|]
+
     it "updates with ?columns when the json array body has objects with different keys, ignoring the value when the key is not specified" $
       baseTable "bulk_update_items" "id" tblDataBeforeBulk
       `mutatesWith`
-      requestMutation methodPatch "/bulk_update_items?columns=id,name,observation" [("Prefer", "params=multiple-objects")]
+      requestMutation methodPatch "/bulk_update_items?columns=id,name,observation"
+        [("Prefer", "params=multiple-objects"), ("Prefer", "undefined-keys=ignore-values")]
+        [json|[
+          { "id": 1, "name": "item-1 - 1st", "observation": "Lost item" }
+        , { "id": 2, "observation": "new item" }
+        ]|]
+      `shouldMutateInto`
+      [json|[
+        { "id": 1, "name": "item-1 - 1st", "observation": "Lost item" }
+      , { "id": 2, "name": "item-2", "observation": "new item" }
+      , { "id": 3, "name": "item-3", "observation": null }
+      ]|]
+
+    it "updates with ?columns when the json array body has objects with different keys, updating to the default column value when the key is not specified" $
+      baseTable "bulk_update_items" "id" tblDataBeforeBulk
+      `mutatesWith`
+      requestMutation methodPatch "/bulk_update_items?columns=id,name,observation"
+        [("Prefer", "params=multiple-objects"), ("Prefer", "undefined-keys=apply-defaults")]
         [json|[
           { "id": 1, "name": "item-1 - 1st", "observation": "Lost item" }
         , { "id": 2, "name": "item-2 - 2nd" }
@@ -768,6 +801,6 @@ spec = do
       `shouldMutateInto`
       [json|[
         { "id": 1, "name": "item-1 - 1st", "observation": "Lost item" }
-      , { "id": 2, "name": "item-2 - 2nd", "observation": null }
+      , { "id": 2, "name": "item-2 - 2nd", "observation": "New!" }
       , { "id": 3, "name": "item-3", "observation": null }
       ]|]

--- a/test/spec/SpecHelper.hs
+++ b/test/spec/SpecHelper.hs
@@ -280,9 +280,9 @@ baseTable :: ByteString -> ByteString -> Value -> BaseTable
 baseTable = BaseTable
 
 -- | The mutation (update/delete) that will be applied to the base table
-requestMutation :: Method -> ByteString -> BL.ByteString -> WaiExpectation ()
-requestMutation method path body =
-  request method path [("Prefer", "tx=commit")] body `shouldRespondWith` 204
+requestMutation :: Method -> ByteString -> [Header] -> BL.ByteString -> WaiExpectation ()
+requestMutation method path headers body =
+  request method path ([("Prefer", "tx=commit")] <> headers) body `shouldRespondWith` 204
 
 data BaseTable = BaseTable ByteString ByteString Value
 data MutationCheck = MutationCheck BaseTable (WaiExpectation ())

--- a/test/spec/fixtures/data.sql
+++ b/test/spec/fixtures/data.sql
@@ -838,3 +838,8 @@ INSERT INTO posters(id,name) VALUES (1,'Mark'), (2,'Elon'), (3,'Bill'), (4,'Jeff
 
 TRUNCATE TABLE subscriptions CASCADE;
 INSERT INTO subscriptions(subscriber,subscribed) VALUES (3,1), (4,1), (1,2);
+
+TRUNCATE TABLE test.bulk_update_items CASCADE;
+INSERT INTO test.bulk_update_items (id, name, observation) VALUES (1, 'item-1', NULL), (2, 'item-2', NULL), (3, 'item-3', NULL);
+TRUNCATE TABLE test.bulk_update_items_cpk CASCADE;
+INSERT INTO test.bulk_update_items_cpk (id, name, observation) VALUES (1, 'item-1', NULL), (2, 'item-2', NULL), (3, 'item-3', NULL);

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -3110,3 +3110,18 @@ create table test.tbl_w_json(
   id int,
   data json
 );
+
+-- Tables to test bulk updates
+
+CREATE TABLE test.bulk_update_items (
+  id INT PRIMARY KEY,
+  name TEXT,
+  observation TEXT DEFAULT 'New!'
+);
+
+CREATE TABLE test.bulk_update_items_cpk (
+  id INT,
+  name TEXT,
+  observation TEXT,
+  PRIMARY KEY (id, name)
+);


### PR DESCRIPTION
Closes #1959. It allows bulk updates using PATCH only when the header `Prefer: params=multiple-objects` is applied as suggested here https://github.com/PostgREST/postgrest/issues/1959#issuecomment-1428789816.

- [x] Allow bulk updates
- [x] Allow different keys in the body 
  Needs: https://github.com/PostgREST/postgrest/pull/2672
- [ ] Clean and refactor
- [x] Add tests
- [x] Add changelog