### PR TITLE
nix: add notices for postgrest-with-* commands

### DIFF
--- a/nix/tools/withTools.nix
+++ b/nix/tools/withTools.nix
@@ -13,9 +13,10 @@
 let
   withTmpDb =
     { name, postgresql }:
+    let commandName = "postgrest-with-${name}"; in
     checkedShellScript
       {
-        name = "postgrest-with-${name}";
+        name = commandName;
         docs = "Run the given command in a temporary database with ${name}";
         args =
           [
@@ -83,6 +84,10 @@ let
         psql -v ON_ERROR_STOP=1 -f "$_arg_fixtures" >> "$setuplog"
 
         log "Done. Running command..."
+
+        echo "${commandName}: You can connect with: psql 'postgres:///$PGDATABASE?host=$tmpdir/socket' -U $PGUSER"
+        echo "${commandName}: You can tail the logs with: tail -f $tmpdir/db.log"
+
         ("$_arg_command" "''${_arg_leftovers[@]}")
       '';
 


### PR DESCRIPTION
For knowing where to connect and how to get logs. Example:

```
$PGRST_DB_ANON_ROLE='postgrest_test_anonymous' postgrest-with-postgresql-15 postgrest-run
postgrest-with-postgresql-15: You can connect with: psql 'postgres:///postgres?host=/run/user/1000/postgrest/postgrest-with-postgresql-15-W6B/socket' -U postgrest_test_authenticator
postgrest-with-postgresql-15: You can tail the logs with: tail -f /run/user/1000/postgrest/postgrest-with-postgresql-15-W6B/db.log
07/Mar/2023:12:11:47 -0500: Attempting to connect to the database...
07/Mar/2023:12:11:47 -0500: Connection successful
07/Mar/2023:12:11:47 -0500: Listening on port 3000
07/Mar/2023:12:11:47 -0500: Config reloaded
07/Mar/2023:12:11:47 -0500: Listening for notifications on the pgrst channel
07/Mar/2023:12:11:47 -0500: Schema cache loaded

```