### PR TITLE
refactor: remove character varying and text casting

### DIFF
--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -180,13 +180,13 @@ asCsvF = asCsvHeaderF <> " || '\n' || " <> asCsvBodyF
 
 asJsonF :: Bool -> SqlFragment
 asJsonF returnsScalar
-  | returnsScalar = "coalesce(json_agg(_postgrest_t.pgrst_scalar), '[]')::character varying"
-  | otherwise     = "coalesce(json_agg(_postgrest_t), '[]')::character varying"
+  | returnsScalar = "coalesce(json_agg(_postgrest_t.pgrst_scalar), '[]')"
+  | otherwise     = "coalesce(json_agg(_postgrest_t), '[]')"
 
 asJsonSingleF :: Bool -> SqlFragment
 asJsonSingleF returnsScalar
-  | returnsScalar = "coalesce((json_agg(_postgrest_t.pgrst_scalar)->0)::text, 'null')"
-  | otherwise     = "coalesce((json_agg(_postgrest_t)->0)::text, 'null')"
+  | returnsScalar = "coalesce(json_agg(_postgrest_t.pgrst_scalar)->0, 'null')"
+  | otherwise     = "coalesce(json_agg(_postgrest_t)->0, 'null')"
 
 asXmlF :: FieldName -> SqlFragment
 asXmlF fieldName = "coalesce(xmlagg(_postgrest_t." <> pgFmtIdent fieldName <> "), '')"

--- a/test/spec/Feature/Query/PlanSpec.hs
+++ b/test/spec/Feature/Query/PlanSpec.hs
@@ -55,7 +55,7 @@ spec actualPgVersion = do
         totalCost `shouldBe`
           if actualPgVersion > pgVersion120
             then 24.28
-            else 32.28
+            else 32.27
 
     it "outputs blocks info when using the buffers option" $
       if actualPgVersion >= pgVersion130
@@ -126,8 +126,8 @@ spec actualPgVersion = do
         resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.plan+json; for=\"application/json\"; options=verbose; charset=utf-8")
         aggCol `shouldBe`
           if actualPgVersion >= pgVersion120
-            then Just [aesonQQ| "(COALESCE(json_agg(ROW(projects.id, projects.name, projects.client_id)), '[]'::json))::character varying" |]
-            else Just [aesonQQ| "(COALESCE(json_agg(ROW(pgrst_source.id, pgrst_source.name, pgrst_source.client_id)), '[]'::json))::character varying" |]
+            then Just [aesonQQ| "COALESCE(json_agg(ROW(projects.id, projects.name, projects.client_id)), '[]'::json)" |]
+            else Just [aesonQQ| "COALESCE(json_agg(ROW(pgrst_source.id, pgrst_source.name, pgrst_source.client_id)), '[]'::json)" |]
 
     it "outputs the plan for application/vnd.pgrst.object " $ do
       r <- request methodGet "/projects_view" (acceptHdrs "application/vnd.pgrst.plan+json; for=\"application/vnd.pgrst.object\"; options=verbose") ""
@@ -139,8 +139,8 @@ spec actualPgVersion = do
         resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.plan+json; for=\"application/vnd.pgrst.object+json\"; options=verbose; charset=utf-8")
         aggCol `shouldBe`
           if actualPgVersion >= pgVersion120
-            then Just [aesonQQ| "COALESCE(((json_agg(ROW(projects.id, projects.name, projects.client_id)) -> 0))::text, 'null'::text)" |]
-            else Just [aesonQQ| "COALESCE(((json_agg(ROW(pgrst_source.id, pgrst_source.name, pgrst_source.client_id)) -> 0))::text, 'null'::text)" |]
+            then Just [aesonQQ| "COALESCE((json_agg(ROW(projects.id, projects.name, projects.client_id)) -> 0), 'null'::json)" |]
+            else Just [aesonQQ| "COALESCE((json_agg(ROW(pgrst_source.id, pgrst_source.name, pgrst_source.client_id)) -> 0), 'null'::json)" |]
 
   describe "writes plans" $ do
     it "outputs the total cost for an insert" $ do
@@ -205,7 +205,7 @@ spec actualPgVersion = do
 
       liftIO $ do
         resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.plan+json; for=\"application/vnd.pgrst.object+json\"; options=verbose; charset=utf-8")
-        aggCol `shouldBe` Just [aesonQQ| "COALESCE(((json_agg(ROW(projects.id, projects.name, projects.client_id)) -> 0))::text, 'null'::text)" |]
+        aggCol `shouldBe` Just [aesonQQ| "COALESCE((json_agg(ROW(projects.id, projects.name, projects.client_id)) -> 0), 'null'::json)" |]
 
   describe "function plan" $ do
     it "outputs the total cost for a function call" $ do
@@ -219,7 +219,7 @@ spec actualPgVersion = do
       liftIO $ do
         resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.plan+json; charset=utf-8")
         resStatus `shouldBe` Status { statusCode = 200, statusMessage="OK" }
-        totalCost `shouldBe` 68.57
+        totalCost `shouldBe` 68.56
 
     it "outputs the plan for text/xml" $ do
       r <- request methodGet "/rpc/return_scalar_xml"


### PR DESCRIPTION
Following discussion on https://github.com/PostgREST/postgrest/pull/1582#issuecomment-1488954603.

So our `ResultSet` type(used for all results of our generated queries) has a body which is a ByteString:

https://github.com/PostgREST/postgrest/blob/7629eff51d7df69bfa7dedfabd5beea18cb7a8cc/src/PostgREST/Query/Statements.hs#L38-L55

This is decoded as a `bytea` with Hasql:

https://github.com/PostgREST/postgrest/blob/7629eff51d7df69bfa7dedfabd5beea18cb7a8cc/src/PostgREST/Query/Statements.hs#L177-L187

At some point I assume it was decoded as `text`, but this is no longer the case. I assume that's why it was needed to cast the result body.