### PR TITLE
RPC returning table alias now works for pg 11/12

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -198,7 +198,7 @@ handleRequest AuthResult{..} conf appState authenticated prepared pgVer apiReq@A
 
     (ActionInvoke invMethod, TargetProc identifier _) -> do
       cPlan <- liftEither $ Plan.callReadPlan identifier conf sCache apiReq invMethod
-      resultSet <- runQuery (Plan.crTxMode cPlan) $ Query.invokeQuery (Plan.crProc cPlan) cPlan apiReq conf
+      resultSet <- runQuery (Plan.crTxMode cPlan) $ Query.invokeQuery (Plan.crProc cPlan) cPlan apiReq conf pgVer
       return $ Response.invokeResponse invMethod (Plan.crProc cPlan) apiReq resultSet
 
     (ActionInspect headersOnly, TargetDefaultSpec tSchema) -> do

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -56,6 +56,7 @@ import PostgREST.SchemaCache.Identifiers  (FieldName,
                                            Schema)
 import PostgREST.SchemaCache.Proc         (ProcDescription (..),
                                            ProcParam (..), ProcsMap,
+                                           procReturnsCompositeAlias,
                                            procReturnsScalar,
                                            procReturnsSetOfScalar)
 import PostgREST.SchemaCache.Relationship (Cardinality (..),
@@ -550,6 +551,7 @@ callPlan proc ApiRequest{iPreferences=Preferences{..}} paramKeys args readReq = 
 , funCArgs = Just args
 , funCScalar = procReturnsScalar proc
 , funCSetOfScalar = procReturnsSetOfScalar proc
+, funCRetCompositeAlias = procReturnsCompositeAlias proc
 , funCReturning = inferColsEmbedNeeds readReq []
 }
   where

--- a/src/PostgREST/Plan/CallPlan.hs
+++ b/src/PostgREST/Plan/CallPlan.hs
@@ -17,12 +17,13 @@ import           PostgREST.SchemaCache.Proc        (ProcDescription (..),
 import Protolude
 
 data CallPlan = FunctionCall
-  { funCQi          :: QualifiedIdentifier
-  , funCParams      :: CallParams
-  , funCArgs        :: Maybe LBS.ByteString
-  , funCScalar      :: Bool
-  , funCSetOfScalar :: Bool
-  , funCReturning   :: [FieldName]
+  { funCQi                :: QualifiedIdentifier
+  , funCParams            :: CallParams
+  , funCArgs              :: Maybe LBS.ByteString
+  , funCScalar            :: Bool
+  , funCSetOfScalar       :: Bool
+  , funCRetCompositeAlias :: Bool
+  , funCReturning         :: [FieldName]
   }
 
 data CallParams

--- a/src/PostgREST/Query.hs
+++ b/src/PostgREST/Query.hs
@@ -152,15 +152,15 @@ deleteQuery mrPlan apiReq@ApiRequest{..} conf = do
   optionalRollback conf apiReq
   pure resultSet
 
-invokeQuery :: ProcDescription -> CallReadPlan -> ApiRequest -> AppConfig -> DbHandler ResultSet
-invokeQuery proc CallReadPlan{crReadPlan, crCallPlan, crBinField} apiReq@ApiRequest{iPreferences=Preferences{..}, ..} conf@AppConfig{..} = do
+invokeQuery :: ProcDescription -> CallReadPlan -> ApiRequest -> AppConfig -> PgVersion -> DbHandler ResultSet
+invokeQuery proc CallReadPlan{crReadPlan, crCallPlan, crBinField} apiReq@ApiRequest{iPreferences=Preferences{..}, ..} conf@AppConfig{..} pgVer = do
   resultSet <-
     lift . SQL.statement mempty $
       Statements.prepareCall
         (Proc.procReturnsScalar proc)
         (Proc.procReturnsSingleComposite proc)
         (Proc.procReturnsSetOfScalar proc)
-        (QueryBuilder.callPlanToQuery crCallPlan)
+        (QueryBuilder.callPlanToQuery crCallPlan pgVer)
         (QueryBuilder.readPlanToQuery crReadPlan)
         (QueryBuilder.readPlanToCountQuery crReadPlan)
         (shouldCount preferCount)

--- a/src/PostgREST/SchemaCache/Proc.hs
+++ b/src/PostgREST/SchemaCache/Proc.hs
@@ -26,7 +26,7 @@ import Protolude
 
 data PgType
   = Scalar Bool -- True if the type is void
-  | Composite QualifiedIdentifier Bool -- True if the composite is a domain alias(used to workaround a bug in pg 11 and 12, see QueryBuilder.hs)
+  | Composite QualifiedIdentifier Bool -- True if the composite is a domain alias(used to work around a bug in pg 11 and 12, see QueryBuilder.hs)
   deriving (Eq, Ord, Generic, JSON.ToJSON)
 
 data RetType

--- a/test/spec/Feature/Query/RpcSpec.hs
+++ b/test/spec/Feature/Query/RpcSpec.hs
@@ -15,7 +15,7 @@ import Text.Heredoc
 import PostgREST.Config.PgVersion (PgVersion, pgVersion100,
                                    pgVersion109, pgVersion110,
                                    pgVersion112, pgVersion114,
-                                   pgVersion130, pgVersion140)
+                                   pgVersion140)
 
 import Protolude  hiding (get)
 import SpecHelper
@@ -376,8 +376,7 @@ spec actualPgVersion =
           ]|]
           { matchHeaders = [matchContentTypeJson] }
 
-      -- https://github.com/PostgREST/postgrest/pull/2677#issuecomment-1444976849
-      when (actualPgVersion >= pgVersion130) $
+      when (actualPgVersion >= pgVersion110) $
         it "can embed if rpc returns domain of table type" $ do
           post "/rpc/getproject_domain?select=id,name,client:clients(id),tasks(id)"
               [json| { "id": 1} |]


### PR DESCRIPTION
The new LATERAL query used for calling the function, introduced on https://github.com/PostgREST/postgrest/pull/2677, failed on functions that returned a domain like `CREATE DOMAIN projects_domain AS projects`.

Work around that by changing the query conditionally, by obtaining a bool that represents the composite alias on the SchemaCache and only do this on pg 11 and 12.

