### PR TITLE
feat: any/all modifiers for operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + New option `db-pool-max-lifetime` (default 30m)
    + `db-pool-acquisition-timeout` is no longer optional and defaults to 10s
    + Fixes postgresql resource leak with long-lived connections (#2638)
+ - #1569, Allow `any/all` modifiers on the `eq,like,ilike,gt,gte,lt,lte,match,imatch` operators, e.g. `/tbl?id=eq(any).{1,2,3}` - @steve-chavez
+   - This converts the input into an array type
 
 ### Fixed
 
@@ -42,7 +44,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2705, Fix bug when using the `Range` header on `PATCH/DELETE` - @laurenceisla
    + Fix the`"message": "syntax error at or near \"RETURNING\""` error
    + Fix doing a limited update/delete when an `order` query parameter was present
-    
+
 ### Changed
 
  - #2705, The `Range` header is now only considered on `GET` requests and is ignored for any other method - @laurenceisla

--- a/src/PostgREST/ApiRequest/Types.hs
+++ b/src/PostgREST/ApiRequest/Types.hs
@@ -19,6 +19,7 @@ module PostgREST.ApiRequest.Types
   , NodeName
   , OpExpr(..)
   , Operation (..)
+  , OpQuantifier(..)
   , OrderDirection(..)
   , OrderNulls(..)
   , OrderTerm(..)
@@ -27,6 +28,7 @@ module PostgREST.ApiRequest.Types
   , SingleVal
   , TrileanVal(..)
   , SimpleOperator(..)
+  , QuantOperator(..)
   , FtsOperator(..)
   , SelectItem(..)
   ) where
@@ -187,8 +189,12 @@ data OpExpr
   | NoOpExpr Text
   deriving (Eq)
 
+data OpQuantifier = QuantAny | QuantAll
+  deriving Eq
+
 data Operation
   = Op SimpleOperator SingleVal
+  | OpQuant QuantOperator (Maybe OpQuantifier) SingleVal
   | In ListVal
   | Is TrileanVal
   | IsDistinctFrom SingleVal
@@ -211,15 +217,21 @@ data TrileanVal
   | TriUnknown
   deriving Eq
 
-data SimpleOperator
+-- Operators that are quantifiable, i.e. they can be used with the any/all modifiers
+data QuantOperator
   = OpEqual
   | OpGreaterThanEqual
   | OpGreaterThan
   | OpLessThanEqual
   | OpLessThan
-  | OpNotEqual
   | OpLike
   | OpILike
+  | OpMatch
+  | OpIMatch
+  deriving Eq
+
+data SimpleOperator
+  = OpNotEqual
   | OpContains
   | OpContained
   | OpOverlap
@@ -228,10 +240,9 @@ data SimpleOperator
   | OpNotExtendsRight
   | OpNotExtendsLeft
   | OpAdjacent
-  | OpMatch
-  | OpIMatch
   deriving Eq
 
+--
 -- | Operators for full text search operators
 data FtsOperator
   = FilterFts

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -515,8 +515,8 @@ mutatePlan mutation qi ApiRequest{iPreferences=preferences, ..} sCache readReq =
            qsFilterFields == S.fromList pkCols &&
            not (null (S.fromList pkCols)) &&
            all (\case
-              Filter _ (OpExpr False (Op OpEqual _)) -> True
-              _                                      -> False) qsFiltersRoot
+              Filter _ (OpExpr False (OpQuant OpEqual Nothing _)) -> True
+              _                                                   -> False) qsFiltersRoot
           then mapRight (\typedColumns -> Insert qi typedColumns body (Just (MergeDuplicates, pkCols)) combinedLogic returnings mempty False) typedColumnsOrError
         else
           Left InvalidFilters


### PR DESCRIPTION
Closes #1569.

**Edit**: This only works for the `eq,like,ilike,gt,gte,lt,lte,match,imatch` operators.

The `cs/cd` operators don't work for an array type:

```sql
select '{3,4}'::int[] @> ANY('{{3,4,5},{2,3}}');
ERROR:  could not find array type for data type integer[]
LINE 1: select '{3,4}'::int[] @> ANY('{{3,4,5},{2,3}}');

select '{3,4}'::int[] @> ANY('{3,4,5}');
ERROR:  could not find array type for data type integer[]
LINE 1: select '{3,4}'::int[] @> ANY('{3,4,5}');
```

Same for the `ov, sl, sr, nxl, nxr, adj` operators, which operate against range types. For the `fts` operators, it's not a direct translation because `to_tsquery` would have to be done for every element on the array.

### Pending

- [x] Tests
- [x] Changelog