### PR TITLE
ci: bring back freebsd build to release bundle

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -313,7 +313,7 @@ jobs:
       - Test-Memory-Nix
       - Build-Static-Nix
       - Build-Stack
-      #- Get-FreeBSD-CirrusCI
+      - Get-FreeBSD-CirrusCI
       - Build-Cabal-Arm
     outputs:
       version: ${{ steps.Identify-Version.outputs.version }}
@@ -394,9 +394,8 @@ jobs:
           tar cJvf "release-bundle/postgrest-v$VERSION-macos-x64.tar.xz" \
             -C artifacts/postgrest-macos-x64 postgrest
 
-          # TODO: Fix timeouts for FreeBSD builds in Cirrus
-          #tar cJvf "release-bundle/postgrest-v$VERSION-freebsd-x64.tar.xz" \
-          #  -C artifacts/postgrest-freebsd-x64 postgrest
+          tar cJvf "release-bundle/postgrest-v$VERSION-freebsd-x64.tar.xz" \
+            -C artifacts/postgrest-freebsd-x64 postgrest
 
           tar cJvf "release-bundle/postgrest-v$VERSION-ubuntu-aarch64.tar.xz" \
             -C artifacts/postgrest-ubuntu-aarch64 postgrest


### PR DESCRIPTION
Since the MR #2608 fixed the issue with FreeBSD builds in CI, then it should be safe to bring back these builds for the release bundle.