### PR TITLE
fix: skew of 30 seconds for JWT validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
  - #2762, Fixes "permission denied for schema" error during schema cache load - @steve-chavez
  - #2756, Fix bad error message on generated columns when using `Prefer: missing=default` - @steve-chavez
+ - #1139, Allow a 30 second skew for JWT validation - @steve-chavez
+   + It used to be 1 second, which was too strict
 
 ## [11.0.0] - 2023-04-16
 

--- a/src/PostgREST/Auth.hs
+++ b/src/PostgREST/Auth.hs
@@ -63,7 +63,7 @@ parseToken AppConfig{..} token time = do
   liftEither . mapLeft jwtClaimsError $ JSON.toJSON <$> eitherClaims
   where
     validation =
-      JWT.defaultJWTValidationSettings audienceCheck & set JWT.allowedSkew 1
+      JWT.defaultJWTValidationSettings audienceCheck & set JWT.allowedSkew 30
 
     audienceCheck :: JWT.StringOrURI -> Bool
     audienceCheck = maybe (const True) (==) configJwtAudience


### PR DESCRIPTION
Closes https://github.com/PostgREST/postgrest/issues/1139.

Use a 30 seconds skew by default as per google recommendations [here](https://cloud.google.com/iap/docs/signed-headers-howto#verifying_the_jwt_payload). Previous 1 second skew was too strict. 


Hard to test for now. We'll just monitor if #1139 gets more reports.