### PR TITLE
nix: use similar config to tests on postgrest-run 

### DIFF
--- a/nix/tools/cabalTools.nix
+++ b/nix/tools/cabalTools.nix
@@ -41,6 +41,8 @@ let
         args =
           [
             "ARG_USE_ENV([PGRST_DB_ANON_ROLE], [postgrest_test_anonymous], [PostgREST anonymous role])"
+            "ARG_USE_ENV([PGRST_DB_POOL], [1], [PostgREST pool size])"
+            "ARG_USE_ENV([PGRST_DB_POOL_ACQUISITION_TIMEOUT], [1], [PostgREST pool size])"
             "ARG_LEFTOVERS([PostgREST arguments])"
           ];
         inRootDir = true;
@@ -48,6 +50,8 @@ let
       }
       ''
         export PGRST_DB_ANON_ROLE
+        export PGRST_DB_POOL
+        export PGRST_DB_POOL_ACQUISITION_TIMEOUT
 
         exec ${cabal-install}/bin/cabal v2-run ${devCabalOptions} --verbose=0 -- \
           postgrest "''${_arg_leftovers[@]}"

--- a/test/io/fixtures.sql
+++ b/test/io/fixtures.sql
@@ -90,7 +90,7 @@ create or replace function sleep(seconds double precision) returns void as $$
 $$ language sql;
 
 create or replace function hello() returns text as $$
-  select 'hello';
+  select 'hello'::text;
 $$ language sql;
 
 create table cats(id uuid primary key, name text);

--- a/test/io/fixtures.sql
+++ b/test/io/fixtures.sql
@@ -1,4 +1,4 @@
-\ir big_schema.sql
+-- \ir big_schema.sql big schema test currently skipped, see test_io.py
 \ir db_config.sql
 
 set search_path to public;

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -308,13 +308,11 @@ def test_db_schema_reload(tmp_path, defaultenv):
 
         # reload config
         postgrest.process.send_signal(signal.SIGUSR2)
+        time.sleep(0.1)
 
         # reload schema cache to verify that the config reload actually happened
         postgrest.process.send_signal(signal.SIGUSR1)
-
-        # takes max 1 second to load the internal cache(big_schema.sql included now)
-        # TODO this could go back to time.sleep(0.1) if the big_schema is put in another test suite
-        time.sleep(1)
+        time.sleep(0.1)
 
         response = postgrest.session.get("/rpc/get_guc_value?name=search_path")
         assert response.text == '"\\"v1\\", \\"public\\""'


### PR DESCRIPTION
Otherwise manual tests can be deceiving. As commented on https://github.com/PostgREST/postgrest/pull/2810#discussion_r1213841669.