### PR TITLE
refactor: remove MTPlanAttrs to doctest

### DIFF
--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -51,9 +51,7 @@ import PostgREST.ApiRequest.Types        (ApiRequestError (..),
                                           RangeError (..))
 import PostgREST.Config                  (AppConfig (..),
                                           OpenAPIMode (..))
-import PostgREST.MediaType               (MTPlanAttrs (..),
-                                          MTPlanFormat (..),
-                                          MediaType (..))
+import PostgREST.MediaType               (MediaType (..))
 import PostgREST.RangeQuery              (NonnegRange, allRange,
                                           convertToLimitZeroRange,
                                           hasLimitZero,
@@ -375,5 +373,5 @@ producedMediaTypes conf action path =
         ++ [MTOpenAPI | pathIsRootSpec path]
     defaultMediaTypes =
       [MTApplicationJSON, MTSingularJSON, MTGeoJSON, MTTextCSV] ++
-      [MTPlan $ MTPlanAttrs Nothing PlanJSON mempty | configDbPlanEnabled conf] ++ [MTAny]
+      [MTPlan Nothing Nothing mempty | configDbPlanEnabled conf] ++ [MTAny]
     rawMediaTypes = configRawMediaTypes conf `union` [MTOctetStream, MTTextPlain, MTTextXML]

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -57,8 +57,7 @@ import PostgREST.Config.JSPath           (JSPath, JSPathExp (..),
                                           dumpJSPath, pRoleClaimKey)
 import PostgREST.Config.Proxy            (Proxy (..),
                                           isMalformedProxyUri, toURI)
-import PostgREST.MediaType               (MediaType (..),
-                                          NormalMedia (..), toMime)
+import PostgREST.MediaType               (MediaType (..), toMime)
 import PostgREST.SchemaCache.Identifiers (QualifiedIdentifier, dumpQi,
                                           toQi)
 
@@ -263,7 +262,7 @@ parser optPath env dbSettings roleSettings roleIsolationLvl =
     <*> parseOpenAPIMode "openapi-mode"
     <*> (fromMaybe False <$> optBool "openapi-security-active")
     <*> parseOpenAPIServerProxyURI "openapi-server-proxy-uri"
-    <*> (maybe [] (fmap (MTNormal . MTOther . encodeUtf8) . splitOnCommas) <$> optValue "raw-media-types")
+    <*> (maybe [] (fmap (MTOther . encodeUtf8) . splitOnCommas) <$> optValue "raw-media-types")
     <*> (fromMaybe "!4" <$> optString "server-host")
     <*> (fromMaybe 3000 <$> optInt "server-port")
     <*> (fmap (CI.mk . encodeUtf8) <$> optString "server-trace-header")

--- a/src/PostgREST/MediaType.hs
+++ b/src/PostgREST/MediaType.hs
@@ -1,9 +1,7 @@
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE LambdaCase            #-}
 
 module PostgREST.MediaType
   ( MediaType(..)
-  , NormalMedia(..)
   , MTPlanOption (..)
   , MTPlanFormat (..)
   , MTPlanAttrs(..)
@@ -15,29 +13,14 @@ module PostgREST.MediaType
 
 import qualified Data.ByteString          as BS
 import qualified Data.ByteString.Internal as BS (c2w)
-import qualified Data.List                as L
 import           Data.Maybe               (fromJust)
 
 import Network.HTTP.Types.Header (Header, hContentType)
 
 import Protolude
---
--- $setup
--- Setup for doctests
--- >>> import Text.Pretty.Simple (pPrint)
--- >>> deriving instance Show NormalMedia
--- >>> deriving instance Show MTPlanFormat
--- >>> deriving instance Show MTPlanOption
--- >>> deriving instance Show MTPlanAttrs
--- >>> deriving instance Show MediaType
 
 -- | Enumeration of currently supported media types
 data MediaType
-  = MTNormal NormalMedia
-  | MTPlan   MTPlanAttrs
-  deriving Eq
-
-data NormalMedia
   = MTApplicationJSON
   | MTSingularJSON
   | MTGeoJSON
@@ -49,95 +32,83 @@ data NormalMedia
   | MTOctetStream
   | MTAny
   | MTOther ByteString
+  | MTPlan MTPlanAttrs
   deriving Eq
 
-
-data MTPlanAttrs = MTPlanAttrs (Maybe NormalMedia) MTPlanFormat [MTPlanOption]
+data MTPlanAttrs = MTPlanAttrs (Maybe MediaType) MTPlanFormat [MTPlanOption]
 instance Eq MTPlanAttrs where
   MTPlanAttrs {} == MTPlanAttrs {} = True -- we don't care about the attributes when comparing two MTPlan media types
 
 data MTPlanOption
   = PlanAnalyze | PlanVerbose | PlanSettings | PlanBuffers | PlanWAL
-  deriving Eq
 
 data MTPlanFormat
   = PlanJSON | PlanText
-  deriving Eq
 
 -- | Convert MediaType to a Content-Type HTTP Header
 toContentType :: MediaType -> Header
 toContentType ct = (hContentType, toMime ct <> charset)
   where
     charset = case ct of
-      MTNormal MTOctetStream -> mempty
-      MTNormal (MTOther _)   -> mempty
-      _                      -> "; charset=utf-8"
+      MTOctetStream -> mempty
+      MTOther _     -> mempty
+      _             -> "; charset=utf-8"
 
 -- | Convert from MediaType to a ByteString representing the mime type
 toMime :: MediaType -> ByteString
-toMime (MTNormal x) = toMimeNormal x
+toMime MTApplicationJSON = "application/json"
+toMime MTGeoJSON         = "application/geo+json"
+toMime MTTextCSV         = "text/csv"
+toMime MTTextPlain       = "text/plain"
+toMime MTTextXML         = "text/xml"
+toMime MTOpenAPI         = "application/openapi+json"
+toMime MTSingularJSON    = "application/vnd.pgrst.object+json"
+toMime MTUrlEncoded      = "application/x-www-form-urlencoded"
+toMime MTOctetStream     = "application/octet-stream"
+toMime MTAny             = "*/*"
+toMime (MTOther ct)      = ct
 toMime (MTPlan (MTPlanAttrs mt fmt opts)) =
   "application/vnd.pgrst.plan+" <> toMimePlanFormat fmt <>
-  (if isNothing mt then mempty else "; for=\"" <> toMimeNormal (fromJust mt) <> "\"") <>
+  (if isNothing mt then mempty else "; for=\"" <> toMime (fromJust mt) <> "\"") <>
   (if null opts then mempty else "; options=" <> BS.intercalate "|" (toMimePlanOption <$> opts))
 
-toMimeNormal :: NormalMedia -> ByteString
-toMimeNormal = \case
-  MTApplicationJSON -> "application/json"
-  MTGeoJSON         -> "application/geo+json"
-  MTTextCSV         -> "text/csv"
-  MTTextPlain       -> "text/plain"
-  MTTextXML         -> "text/xml"
-  MTOpenAPI         -> "application/openapi+json"
-  MTSingularJSON    -> "application/vnd.pgrst.object+json"
-  MTUrlEncoded      -> "application/x-www-form-urlencoded"
-  MTOctetStream     -> "application/octet-stream"
-  MTAny             -> "*/*"
-  (MTOther ct)      -> ct
-
 toMimePlanOption :: MTPlanOption -> ByteString
-toMimePlanOption = \case
-  PlanAnalyze  -> "analyze"
-  PlanVerbose  -> "verbose"
-  PlanSettings -> "settings"
-  PlanBuffers  -> "buffers"
-  PlanWAL      -> "wal"
+toMimePlanOption PlanAnalyze  = "analyze"
+toMimePlanOption PlanVerbose  = "verbose"
+toMimePlanOption PlanSettings = "settings"
+toMimePlanOption PlanBuffers  = "buffers"
+toMimePlanOption PlanWAL      = "wal"
 
 toMimePlanFormat :: MTPlanFormat -> ByteString
 toMimePlanFormat PlanJSON = "json"
 toMimePlanFormat PlanText = "text"
 
--- | Convert from ByteString to MediaType.
---
--- >>> decodeMediaType "application/json"
--- MTNormal MTApplicationJSON
---
--- >>> decodeMediaType "application/vnd.pgrst.plan;"
--- MTPlan (MTPlanAttrs Nothing PlanText [])
---
--- >>> decodeMediaType "application/vnd.pgrst.plan;for=\"application/json\""
--- MTPlan (MTPlanAttrs (Just MTApplicationJSON) PlanText [])
---
--- >>> decodeMediaType "application/vnd.pgrst.plan;for=\"text/csv\""
--- MTPlan (MTPlanAttrs (Just MTTextCSV) PlanText [])
---
--- A plan media type inside "for" shouldn't recurse
---
--- >>> decodeMediaType "application/vnd.pgrst.plan;for=\"application/vnd.pgrst.plan\""
--- MTPlan (MTPlanAttrs (Just (MTOther "application/vnd.pgrst.plan")) PlanText [])
+-- | Convert from ByteString to MediaType. Warning: discards MIME parameters
 decodeMediaType :: BS.ByteString -> MediaType
-decodeMediaType bs =
-  case BS.split (BS.c2w ';') bs of
+decodeMediaType mt =
+  case BS.split (BS.c2w ';') mt of
+    "application/json":_                   -> MTApplicationJSON
+    "application/geo+json":_               -> MTGeoJSON
+    "text/csv":_                           -> MTTextCSV
+    "text/plain":_                         -> MTTextPlain
+    "text/xml":_                           -> MTTextXML
+    "application/openapi+json":_           -> MTOpenAPI
+    "application/vnd.pgrst.object+json":_  -> MTSingularJSON
+    "application/vnd.pgrst.object":_       -> MTSingularJSON
+    "application/x-www-form-urlencoded":_  -> MTUrlEncoded
+    "application/octet-stream":_           -> MTOctetStream
     "application/vnd.pgrst.plan":rest      -> getPlan PlanText rest
     "application/vnd.pgrst.plan+text":rest -> getPlan PlanText rest
     "application/vnd.pgrst.plan+json":rest -> getPlan PlanJSON rest
-    mt                                     -> MTNormal $ decodeNormalMediaType mt
+    "*/*":_                                -> MTAny
+    other:_                                -> MTOther other
+    _                                      -> MTAny
   where
     getPlan fmt rest =
      let
        opts         = BS.split (BS.c2w '|') $ fromMaybe mempty (BS.stripPrefix "options=" =<< find (BS.isPrefixOf "options=") rest)
        inOpts str   = str `elem` opts
-       mtFor        = decodeNormalMediaType . L.singleton . dropAround (== BS.c2w '"') <$> (BS.stripPrefix "for=" =<< find (BS.isPrefixOf "for=") rest)
+       mtFor        = decodeMediaType . dropAround (== BS.c2w '"') <$> (BS.stripPrefix "for=" =<< find (BS.isPrefixOf "for=") rest)
        dropAround p = BS.dropWhile p . BS.dropWhileEnd p in
      MTPlan $ MTPlanAttrs mtFor fmt $
       [PlanAnalyze  | inOpts "analyze" ] ++
@@ -146,26 +117,8 @@ decodeMediaType bs =
       [PlanBuffers  | inOpts "buffers" ] ++
       [PlanWAL      | inOpts "wal"     ]
 
--- | Convert from ByteString to MediaType. Warning: discards MIME parameters
-decodeNormalMediaType :: [BS.ByteString] -> NormalMedia
-decodeNormalMediaType bs =
-  case bs of
-    "application/json":_                  -> MTApplicationJSON
-    "application/geo+json":_              -> MTGeoJSON
-    "text/csv":_                          -> MTTextCSV
-    "text/plain":_                        -> MTTextPlain
-    "text/xml":_                          -> MTTextXML
-    "application/openapi+json":_          -> MTOpenAPI
-    "application/vnd.pgrst.object+json":_ -> MTSingularJSON
-    "application/vnd.pgrst.object":_      -> MTSingularJSON
-    "application/x-www-form-urlencoded":_ -> MTUrlEncoded
-    "application/octet-stream":_          -> MTOctetStream
-    "*/*":_                               -> MTAny
-    other:_                               -> MTOther other
-    _                                     -> MTAny
-
-getMediaType :: MediaType -> NormalMedia
+getMediaType :: MediaType -> MediaType
 getMediaType mt = case mt of
   MTPlan (MTPlanAttrs (Just mType) _ _) -> mType
   MTPlan (MTPlanAttrs Nothing _ _)      -> MTApplicationJSON
-  MTNormal x                            -> x
+  other                                 -> other

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -45,8 +45,7 @@ import PostgREST.ApiRequest               (Action (..),
 import PostgREST.Config                   (AppConfig (..))
 import PostgREST.Error                    (Error (..))
 import PostgREST.MediaType                (MTPlanAttrs (..),
-                                           MediaType (..),
-                                           NormalMedia (..))
+                                           MediaType (..))
 import PostgREST.Query.SqlFragment        (sourceCTEName)
 import PostgREST.RangeQuery               (NonnegRange, allRange,
                                            convertToLimitZeroRange,
@@ -123,10 +122,10 @@ callReadPlan identifier conf sCache apiRequest invMethod = do
   let relIdentifier = QualifiedIdentifier pdSchema (fromMaybe pdName $ Routine.funcTableName proc) -- done so a set returning function can embed other relations
   rPlan <- readPlan relIdentifier conf sCache apiRequest
   let args = case (invMethod, iContentMediaType apiRequest) of
-        (InvGet, _)                      -> jsonRpcParams proc qsParams'
-        (InvHead, _)                     -> jsonRpcParams proc qsParams'
-        (InvPost, MTNormal MTUrlEncoded) -> maybe mempty (jsonRpcParams proc . payArray) $ iPayload apiRequest
-        (InvPost, _)                     -> maybe mempty payRaw $ iPayload apiRequest
+        (InvGet, _)             -> jsonRpcParams proc qsParams'
+        (InvHead, _)            -> jsonRpcParams proc qsParams'
+        (InvPost, MTUrlEncoded) -> maybe mempty (jsonRpcParams proc . payArray) $ iPayload apiRequest
+        (InvPost, _)            -> maybe mempty payRaw $ iPayload apiRequest
       txMode = case (invMethod, pdVolatility) of
           (InvGet,  _)                 -> SQL.Read
           (InvHead, _)                 -> SQL.Read
@@ -168,12 +167,12 @@ findProc qi argumentsKeys paramsAsSingleObject allProcs contentMediaType isInvPo
     -- If the function is called with post and has a single unnamed parameter
     -- it can be called depending on content type and the parameter type
     hasSingleUnnamedParam Function{pdParams=[RoutineParam{ppType}]} = isInvPost && case (contentMediaType, ppType) of
-      (MTNormal MTApplicationJSON, "json")  -> True
-      (MTNormal MTApplicationJSON, "jsonb") -> True
-      (MTNormal MTTextPlain, "text")        -> True
-      (MTNormal MTTextXML, "xml")           -> True
-      (MTNormal MTOctetStream, "bytea")     -> True
-      _                                     -> False
+      (MTApplicationJSON, "json")  -> True
+      (MTApplicationJSON, "jsonb") -> True
+      (MTTextPlain, "text")        -> True
+      (MTTextXML, "xml")           -> True
+      (MTOctetStream, "bytea")     -> True
+      _                            -> False
     hasSingleUnnamedParam _ = False
     matchesParams proc =
       let
@@ -185,7 +184,7 @@ findProc qi argumentsKeys paramsAsSingleObject allProcs contentMediaType isInvPo
         then length params == 1 && (firstType == Just "json" || firstType == Just "jsonb")
       -- If the function has no parameters, the arguments keys must be empty as well
       else if null params
-        then null argumentsKeys && not (isInvPost && contentMediaType `elem` [MTNormal MTOctetStream, MTNormal MTTextPlain, MTNormal MTTextXML])
+        then null argumentsKeys && not (isInvPost && contentMediaType `elem` [MTOctetStream, MTTextPlain, MTTextXML])
       -- A function has optional and required parameters. Optional parameters have a default value and
       -- don't require arguments for the function to be executed, required parameters must have an argument present.
       else case L.partition ppReq params of
@@ -633,7 +632,7 @@ binaryField AppConfig{configRawMediaTypes} acceptMediaType proc rpTree
   | otherwise =
       Right Nothing
   where
-    isRawMediaType = acceptMediaType `elem` configRawMediaTypes `L.union` [MTNormal MTOctetStream, MTNormal MTTextPlain, MTNormal MTTextXML] || isRawPlan acceptMediaType
+    isRawMediaType = acceptMediaType `elem` configRawMediaTypes `L.union` [MTOctetStream, MTTextPlain, MTTextXML] || isRawPlan acceptMediaType
     isRawPlan mt = case mt of
       MTPlan (MTPlanAttrs (Just MTOctetStream) _ _) -> True
       MTPlan (MTPlanAttrs (Just MTTextPlain) _ _)   -> True

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -44,8 +44,7 @@ import PostgREST.ApiRequest               (Action (..),
                                            Payload (..))
 import PostgREST.Config                   (AppConfig (..))
 import PostgREST.Error                    (Error (..))
-import PostgREST.MediaType                (MTPlanAttrs (..),
-                                           MediaType (..))
+import PostgREST.MediaType                (MediaType (..))
 import PostgREST.Query.SqlFragment        (sourceCTEName)
 import PostgREST.RangeQuery               (NonnegRange, allRange,
                                            convertToLimitZeroRange,
@@ -634,10 +633,10 @@ binaryField AppConfig{configRawMediaTypes} acceptMediaType proc rpTree
   where
     isRawMediaType = acceptMediaType `elem` configRawMediaTypes `L.union` [MTOctetStream, MTTextPlain, MTTextXML] || isRawPlan acceptMediaType
     isRawPlan mt = case mt of
-      MTPlan (MTPlanAttrs (Just MTOctetStream) _ _) -> True
-      MTPlan (MTPlanAttrs (Just MTTextPlain) _ _)   -> True
-      MTPlan (MTPlanAttrs (Just MTTextXML) _ _)     -> True
-      _                                             -> False
+      MTPlan (Just MTOctetStream) _ _ -> True
+      MTPlan (Just MTTextPlain) _ _   -> True
+      MTPlan (Just MTTextXML) _ _     -> True
+      _                               -> False
 
     fstFieldName :: ReadPlanTree -> Maybe FieldName
     fstFieldName (Node ReadPlan{select=(("*", []), _, _):_} [])  = Nothing

--- a/src/PostgREST/Query.hs
+++ b/src/PostgREST/Query.hs
@@ -46,8 +46,7 @@ import PostgREST.Config                  (AppConfig (..),
 import PostgREST.Config.PgVersion        (PgVersion (..),
                                           pgVersion140)
 import PostgREST.Error                   (Error)
-import PostgREST.MediaType               (MediaType (..),
-                                          NormalMedia (..))
+import PostgREST.MediaType               (MediaType (..))
 import PostgREST.Plan                    (CallReadPlan (..),
                                           MutateReadPlan (..),
                                           WrappedReadPlan (..))
@@ -208,7 +207,7 @@ writeQuery MutateReadPlan{mrReadPlan, mrMutatePlan} apiReq@ApiRequest{iPreferenc
 failNotSingular :: MediaType -> ResultSet -> DbHandler ()
 failNotSingular _ RSPlan{} = pure ()
 failNotSingular mediaType RSStandard{rsQueryTotal=queryTotal} =
-  when (mediaType == MTNormal MTSingularJSON && queryTotal /= 1) $ do
+  when (mediaType == MTSingularJSON && queryTotal /= 1) $ do
     lift SQL.condemn
     throwError $ Error.singularityError queryTotal
 

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -431,7 +431,7 @@ intercalateSnippet :: ByteString -> [SQL.Snippet] -> SQL.Snippet
 intercalateSnippet _ [] = mempty
 intercalateSnippet frag snippets = foldr1 (\a b -> a <> SQL.sql frag <> b) snippets
 
-explainF :: MTPlanFormat -> [MTPlanOption] -> SQL.Snippet -> SQL.Snippet
+explainF :: Maybe MTPlanFormat -> [MTPlanOption] -> SQL.Snippet -> SQL.Snippet
 explainF fmt opts snip =
   "EXPLAIN (" <>
     SQL.sql (BS.intercalate ", " (fmtPlanFmt fmt : (fmtPlanOpt <$> opts))) <>
@@ -444,8 +444,9 @@ explainF fmt opts snip =
     fmtPlanOpt PlanBuffers  = "BUFFERS"
     fmtPlanOpt PlanWAL      = "WAL"
 
-    fmtPlanFmt PlanJSON = "FORMAT JSON"
-    fmtPlanFmt PlanText = "FORMAT TEXT"
+    fmtPlanFmt Nothing         = "FORMAT TEXT"
+    fmtPlanFmt (Just PlanJSON) = "FORMAT JSON"
+    fmtPlanFmt (Just PlanText) = "FORMAT TEXT"
 
 -- | Do a pg set_config(setting, value, true) call. This is equivalent to a SET LOCAL.
 setConfigLocal :: ByteString -> (ByteString, ByteString) -> SQL.Snippet

--- a/src/PostgREST/Query/Statements.hs
+++ b/src/PostgREST/Query/Statements.hs
@@ -26,8 +26,7 @@ import Control.Lens ((^?))
 import Data.Maybe   (fromJust)
 
 import PostgREST.ApiRequest.Preferences
-import PostgREST.MediaType               (MTPlanAttrs (..),
-                                          MTPlanFormat (..),
+import PostgREST.MediaType               (MTPlanFormat (..),
                                           MediaType (..),
                                           getMediaType)
 import PostgREST.Query.SqlFragment
@@ -168,7 +167,7 @@ preparePlanRows :: SQL.Snippet -> Bool -> SQL.Statement () (Maybe Int64)
 preparePlanRows countQuery =
   SQL.dynamicallyParameterized snippet decodeIt
   where
-    snippet = explainF PlanJSON mempty countQuery
+    snippet = explainF (Just PlanJSON) mempty countQuery
     decodeIt :: HD.Result (Maybe Int64)
     decodeIt =
       let row = HD.singleRow $ column HD.bytea in
@@ -188,8 +187,8 @@ standardRow noLocation =
 
 mtSnippet :: MediaType -> SQL.Snippet -> SQL.Snippet
 mtSnippet mediaType snippet = case mediaType of
-  MTPlan (MTPlanAttrs _ fmt opts) -> explainF fmt opts snippet
-  _                               -> snippet
+  MTPlan _ fmt opts -> explainF fmt opts snippet
+  _                 -> snippet
 
 -- | We use rowList because when doing EXPLAIN (FORMAT TEXT), the result comes as many rows. FORMAT JSON comes as one.
 planRow :: HD.Result ResultSet

--- a/src/PostgREST/Query/Statements.hs
+++ b/src/PostgREST/Query/Statements.hs
@@ -29,7 +29,6 @@ import PostgREST.ApiRequest.Preferences
 import PostgREST.MediaType               (MTPlanAttrs (..),
                                           MTPlanFormat (..),
                                           MediaType (..),
-                                          NormalMedia (..),
                                           getMediaType)
 import PostgREST.Query.SqlFragment
 import PostgREST.SchemaCache.Identifiers (FieldName)
@@ -190,7 +189,7 @@ standardRow noLocation =
 mtSnippet :: MediaType -> SQL.Snippet -> SQL.Snippet
 mtSnippet mediaType snippet = case mediaType of
   MTPlan (MTPlanAttrs _ fmt opts) -> explainF fmt opts snippet
-  MTNormal _                      -> snippet
+  _                               -> snippet
 
 -- | We use rowList because when doing EXPLAIN (FORMAT TEXT), the result comes as many rows. FORMAT JSON comes as one.
 planRow :: HD.Result ResultSet

--- a/src/PostgREST/Response.hs
+++ b/src/PostgREST/Response.hs
@@ -42,8 +42,7 @@ import PostgREST.ApiRequest.Preferences  (PreferRepresentation (..),
                                           toAppliedHeader)
 import PostgREST.ApiRequest.QueryParams  (QueryParams (..))
 import PostgREST.Config                  (AppConfig (..))
-import PostgREST.MediaType               (MediaType (..),
-                                          NormalMedia (..))
+import PostgREST.MediaType               (MediaType (..))
 import PostgREST.Plan                    (MutateReadPlan (..))
 import PostgREST.Plan.MutatePlan         (MutatePlan (..))
 import PostgREST.Query.Statements        (ResultSet (..))
@@ -227,7 +226,7 @@ invokeResponse invMethod proc ctxApiRequest@ApiRequest{..} resultSet = case resu
 openApiResponse :: Bool -> Maybe (TablesMap, RoutineMap, Maybe Text) -> AppConfig -> SchemaCache -> Schema -> Bool -> Wai.Response
 openApiResponse headersOnly body conf sCache schema negotiatedByProfile =
   Wai.responseLBS HTTP.status200
-    (MediaType.toContentType (MTNormal MTOpenAPI) : maybeToList (profileHeader schema negotiatedByProfile))
+    (MediaType.toContentType MTOpenAPI : maybeToList (profileHeader schema negotiatedByProfile))
     (maybe mempty (\(x, y, z) -> if headersOnly then mempty else OpenAPI.encode conf sCache x y z) body)
 
 -- | Response with headers and status overridden from GUCs.

--- a/src/PostgREST/Response/OpenAPI.hs
+++ b/src/PostgREST/Response/OpenAPI.hs
@@ -351,7 +351,7 @@ makeProcPathItem pd = ("/rpc/" ++ toS (pdName pd), pe)
       & summary .~ pSum
       & description .~ mfilter (/="") pDesc
       & tags .~ Set.fromList ["(rpc) " <> pdName pd]
-      & produces ?~ makeMimeList [MTNormal MTApplicationJSON, MTNormal MTSingularJSON]
+      & produces ?~ makeMimeList [MTApplicationJSON, MTSingularJSON]
       & at 200 ?~ "OK"
     getOp = procOp
       & parameters .~ makeProcGetParams (pdParams pd)
@@ -367,7 +367,7 @@ makeRootPathItem = ("/", p)
     getOp = (mempty :: Operation)
       & tags .~ Set.fromList ["Introspection"]
       & summary ?~ "OpenAPI description (this document)"
-      & produces ?~ makeMimeList [MTNormal MTOpenAPI, MTNormal MTApplicationJSON]
+      & produces ?~ makeMimeList [MTOpenAPI, MTApplicationJSON]
       & at 200 ?~ "OK"
     pr = (mempty :: PathItem) & get ?~ getOp
     p = pr
@@ -407,8 +407,8 @@ postgrestSpec rels pds ti (s, h, p, b) sd allowSecurityDef = (mempty :: Swagger)
   & definitions .~ fromList (makeTableDef rels <$> ti)
   & parameters .~ fromList (makeParamDefs ti)
   & paths .~ makePathItems pds ti
-  & produces .~ makeMimeList mediaTypes
-  & consumes .~ makeMimeList mediaTypes
+  & produces .~ makeMimeList [MTApplicationJSON, MTSingularJSON, MTTextCSV]
+  & consumes .~ makeMimeList [MTApplicationJSON, MTSingularJSON, MTTextCSV]
   & securityDefinitions .~ makeSecurityDefinitions securityDefName allowSecurityDef
   & security .~ [SecurityRequirement (fromList [(securityDefName, [])]) | allowSecurityDef]
     where
@@ -417,7 +417,6 @@ postgrestSpec rels pds ti (s, h, p, b) sd allowSecurityDef = (mempty :: Swagger)
       securityDefName = "JWT"
       (dTitle, dDesc) = fmap fst &&& fmap (T.dropWhile (=='\n') . snd) $
                     T.breakOn "\n" <$> sd
-      mediaTypes = [MTNormal MTApplicationJSON, MTNormal MTSingularJSON, MTNormal MTTextCSV]
 
 pickProxy :: Maybe Text -> Maybe Proxy
 pickProxy proxy

--- a/test/doc/Main.hs
+++ b/test/doc/Main.hs
@@ -16,5 +16,4 @@ main =
     , "src/PostgREST/ApiRequest/Preferences.hs"
     , "src/PostgREST/ApiRequest/QueryParams.hs"
     , "src/PostgREST/Error.hs"
-    , "src/PostgREST/MediaType.hs"
     ]

--- a/test/doc/Main.hs
+++ b/test/doc/Main.hs
@@ -16,4 +16,5 @@ main =
     , "src/PostgREST/ApiRequest/Preferences.hs"
     , "src/PostgREST/ApiRequest/QueryParams.hs"
     , "src/PostgREST/Error.hs"
+    , "src/PostgREST/MediaType.hs"
     ]

--- a/test/spec/Feature/Query/PlanSpec.hs
+++ b/test/spec/Feature/Query/PlanSpec.hs
@@ -254,7 +254,7 @@ spec actualPgVersion = do
           resStatus  = simpleStatus r
 
       liftIO $ do
-        resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.plan+text; charset=utf-8")
+        resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.plan; charset=utf-8")
         resStatus `shouldBe` Status { statusCode = 200, statusMessage="OK" }
         resBody `shouldSatisfy` (\t -> LBS.take 9 t == "Aggregate")
 

--- a/test/spec/SpecHelper.hs
+++ b/test/spec/SpecHelper.hs
@@ -29,8 +29,7 @@ import PostgREST.Config                  (AppConfig (..),
                                           LogLevel (..),
                                           OpenAPIMode (..),
                                           parseSecret)
-import PostgREST.MediaType               (MediaType (..),
-                                          NormalMedia (..))
+import PostgREST.MediaType               (MediaType (..))
 import PostgREST.SchemaCache.Identifiers (QualifiedIdentifier (..))
 import Protolude                         hiding (get, toS)
 import Protolude.Conv                    (toS)
@@ -197,7 +196,7 @@ testCfgRootSpec :: AppConfig
 testCfgRootSpec = baseCfg { configDbRootSpec = Just $ QualifiedIdentifier mempty "root"}
 
 testCfgHtmlRawOutput :: AppConfig
-testCfgHtmlRawOutput = baseCfg { configRawMediaTypes = [MTNormal $ MTOther "text/html"] }
+testCfgHtmlRawOutput = baseCfg { configRawMediaTypes = [MTOther "text/html"] }
 
 testCfgResponseHeaders :: AppConfig
 testCfgResponseHeaders = baseCfg { configDbPreRequest = Just $ QualifiedIdentifier mempty "custom_headers" }


### PR DESCRIPTION
Reverts https://github.com/PostgREST/postgrest/pull/2828, that change made https://github.com/PostgREST/postgrest/pull/2825 more difficult to implement.

doctests remain by removing `MTPlanAttrs`.