### PR TITLE
ci: check against GHC 9.0.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -216,7 +216,7 @@ jobs:
   Build-Cabal:
     strategy:
       matrix:
-        ghc: ['9.2.4']
+        ghc: ['9.0.2', '9.2.4']
       fail-fast: false
     name: Build Linux (Cabal, GHC ${{ matrix.ghc }})
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
  - #2821, Fix OPTIONS not accepting all available media types - @steve-chavez
+ - #2834, Fix compilation on Ubuntu by being compatible with GHC 9.0.2 - @steve-chavez
 
 ## [11.1.0] - 2023-06-07
 

--- a/test/spec/Feature/Query/PlanSpec.hs
+++ b/test/spec/Feature/Query/PlanSpec.hs
@@ -8,7 +8,6 @@ import Network.Wai.Test (SResponse (..))
 
 import           Data.Aeson.Lens
 import           Data.Aeson.QQ
-import qualified Data.ByteString      as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text            as T
 import           Network.HTTP.Types
@@ -66,7 +65,7 @@ spec actualPgVersion = do
 
           liftIO $ do
             resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.plan+json; for=\"application/json\"; options=buffers; charset=utf-8")
-            resBody `shouldSatisfy` (\t -> T.isInfixOf "Shared Hit Blocks" (decodeUtf8 $ BS.toStrict t))
+            resBody `shouldSatisfy` (\t -> T.isInfixOf "Shared Hit Blocks" (decodeUtf8 $ LBS.toStrict t))
         else do
           -- analyze is required for buffers on pg < 13
           r <- request methodGet "/projects" (acceptHdrs "application/vnd.pgrst.plan+json; options=analyze|buffers") ""
@@ -338,7 +337,7 @@ spec actualPgVersion = do
         let resBody = simpleBody r
 
         liftIO $ do
-          resBody `shouldSatisfy` (\t -> not $ T.isInfixOf "getallusers" (decodeUtf8 $ BS.toStrict t))
+          resBody `shouldSatisfy` (\t -> not $ T.isInfixOf "getallusers" (decodeUtf8 $ LBS.toStrict t))
 
       it "should inline a function with arguments(the function won't appear in the plan tree)" $ do
         r <- request methodGet "/rpc/getitemrange?min=10&max=15"
@@ -347,7 +346,7 @@ spec actualPgVersion = do
         let resBody = simpleBody r
 
         liftIO $ do
-          resBody `shouldSatisfy` (\t -> not $ T.isInfixOf "getitemrange" (decodeUtf8 $ BS.toStrict t))
+          resBody `shouldSatisfy` (\t -> not $ T.isInfixOf "getitemrange" (decodeUtf8 $ LBS.toStrict t))
 
 disabledSpec :: SpecWith ((), Application)
 disabledSpec =


### PR DESCRIPTION
## Problem

Our custom build for ARM [postgrest-v11.1.0-ubuntu-aarch64.tar.xz](https://github.com/PostgREST/postgrest/releases/download/v11.1.0/postgrest-v11.1.0-ubuntu-aarch64.tar.xz) is not working on Ubuntu 18.04. This because it requires a GLIBC > 2.27. 

[OverloadedRecordDot](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/overloaded_record_dot.html) requires GHC 9.2.0, hence a GLIBC > 2.27.

## Solution

Stick to supporting GHC 9.0.2, which is the latest supported version on Ubuntu: https://packages.ubuntu.com/search?keywords=ghc. This by adding a check on CI and removing `OverloadedRecordDot` usage.

## Notes

- An alternative would be providing a static binary for ARM: https://github.com/PostgREST/postgrest/issues/2408, https://github.com/PostgREST/postgrest/pull/2332.
- Though sticking to the latest supported GHC might help with packaging for Ubuntu: https://github.com/PostgREST/postgrest/issues/2273