### PR TITLE
ci: tweak arm builds using cabal

### DIFF
--- a/.github/scripts/arm/build.sh
+++ b/.github/scripts/arm/build.sh
@@ -10,7 +10,7 @@ PGRST_GITHUB_COMMIT="$1"
 SCRIPT_DIR="$2"
 
 DOCKER_BUILD_DIR="$SCRIPT_DIR/docker-env"
-CABAL_VERSION="recommended"
+CABAL_VERSION="latest"
 GHC_VERSION="$3"
 
 install_packages() {

--- a/.github/scripts/arm/build.sh
+++ b/.github/scripts/arm/build.sh
@@ -4,13 +4,14 @@
 
 [ -z "$1" ] && { echo "Missing 1st argument: PostgREST github commit SHA"; exit 1; }
 [ -z "$2" ] && { echo "Missing 2nd argument: Build environment directory name"; exit 1; }
+[ -z "$3" ] && { echo "Missing 3rd argument: GHC version"; exit 1; }
 
 PGRST_GITHUB_COMMIT="$1"
 SCRIPT_DIR="$2"
 
 DOCKER_BUILD_DIR="$SCRIPT_DIR/docker-env"
-CABAL_VERSION="3.6.0.0"
-GHC_VERSION="9.2.4"
+CABAL_VERSION="recommended"
+GHC_VERSION="$3"
 
 install_packages() {
   sudo apt-get update -y

--- a/.github/scripts/arm/build.sh
+++ b/.github/scripts/arm/build.sh
@@ -10,6 +10,7 @@ PGRST_GITHUB_COMMIT="$1"
 SCRIPT_DIR="$2"
 
 DOCKER_BUILD_DIR="$SCRIPT_DIR/docker-env"
+# latest is a shortcut documented on https://www.haskell.org/ghcup/guide/#tags-and-shortcuts
 CABAL_VERSION="latest"
 GHC_VERSION="$3"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -247,13 +247,18 @@ jobs:
         run: cabal build --enable-tests --enable-benchmarks all
 
   Build-Cabal-Arm:
-    name: Build aarch64 (Cabal)
+    strategy:
+      matrix:
+        ghc: ['9.2.4']
+      fail-fast: false
+    name: Build aarch64 (Cabal, GHC ${{ matrix.ghc }})
     if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/rel-') }}
     runs-on: ubuntu-latest
     outputs:
       remotepath: ${{ steps.Remote-Dir.outputs.remotepath }}
     env:
       GITHUB_COMMIT: ${{ github.sha }}
+      GHC_VERSION: ${{ matrix.ghc }}
     steps:
       - uses: actions/checkout@v3
       - id: Remote-Dir
@@ -280,8 +285,8 @@ jobs:
           fingerprint: ${{ secrets.SSH_ARM_FINGERPRINT }}
           command_timeout: 120m
           script_stop: true
-          envs: GITHUB_COMMIT,REMOTE_DIR
-          script: bash ~/$REMOTE_DIR/build.sh "$GITHUB_COMMIT" "$REMOTE_DIR"
+          envs: GITHUB_COMMIT,REMOTE_DIR,GHC_VERSION
+          script: bash ~/$REMOTE_DIR/build.sh "$GITHUB_COMMIT" "$REMOTE_DIR" "GHC_VERSION"
       - name: Download binaries from remote server
         uses: nicklasfrahm/scp-action@main
         with:


### PR DESCRIPTION
Related to #2834

Makes it similar to the Linux build with cabal:
- Remove the hard coded GHC version from the arm build script and puts it in the yaml file instead.
- Uses the [default cabal version by ghcup](https://www.haskell.org/ghcup/install/#which-versions-get-installed).

[Working in test repo](https://github.com/laurenceisla/github-actions-test/actions/runs/5338068914).