### PR TITLE
chore: show on ReadPlan and MediaType

### DIFF
--- a/src/PostgREST/ApiRequest/QueryParams.hs
+++ b/src/PostgREST/ApiRequest/QueryParams.hs
@@ -65,23 +65,6 @@ import Protolude hiding (try)
 -- Setup for doctests
 -- >>> import Text.Pretty.Simple (pPrint)
 -- >>> deriving instance Show QPError
--- >>> deriving instance Show TrileanVal
--- >>> deriving instance Show FtsOperator
--- >>> deriving instance Show QuantOperator
--- >>> deriving instance Show SimpleOperator
--- >>> deriving instance Show OpQuantifier
--- >>> deriving instance Show Operation
--- >>> deriving instance Show OpExpr
--- >>> deriving instance Show JsonOperand
--- >>> deriving instance Show JsonOperation
--- >>> deriving instance Show Filter
--- >>> deriving instance Show JoinType
--- >>> deriving instance Show SelectItem
--- >>> deriving instance Show OrderDirection
--- >>> deriving instance Show OrderNulls
--- >>> deriving instance Show OrderTerm
--- >>> deriving instance Show LogicOperator
--- >>> deriving instance Show LogicTree
 
 data QueryParams =
   QueryParams

--- a/src/PostgREST/ApiRequest/Types.hs
+++ b/src/PostgREST/ApiRequest/Types.hs
@@ -62,7 +62,7 @@ data SelectItem
     , selHint     :: Maybe Hint
     , selJoinType :: Maybe JoinType
     }
-  deriving (Eq)
+  deriving (Eq, Show)
 
 data ApiRequestError
   = AmbiguousRelBetween Text Text [Relationship]
@@ -108,17 +108,17 @@ data OrderTerm
     , otDirection :: Maybe OrderDirection
     , otNullOrder :: Maybe OrderNulls
     }
-  deriving Eq
+  deriving (Eq, Show)
 
 data OrderDirection
   = OrderAsc
   | OrderDesc
-  deriving (Eq)
+  deriving (Eq, Show)
 
 data OrderNulls
   = OrderNullsFirst
   | OrderNullsLast
-  deriving (Eq)
+  deriving (Eq, Show)
 
 type Field = (FieldName, JsonPath)
 type Cast = Text
@@ -135,7 +135,7 @@ data EmbedParam
 data JoinType
   = JTInner
   | JTLeft
-  deriving Eq
+  deriving (Eq, Show)
 
 -- | Path of the embedded levels, e.g "clients.projects.name=eq.." gives Path
 -- ["clients", "projects"]
@@ -149,7 +149,7 @@ type JsonPath = [JsonOperation]
 data JsonOperation
   = JArrow { jOp :: JsonOperand }
   | J2Arrow { jOp :: JsonOperand }
-  deriving (Eq, Ord)
+  deriving (Eq, Show, Ord)
 
 -- | Represents the key(`->'key'`) or index(`->'1`::int`), the index is Text
 -- because we reuse our escaping functons and let pg do the casting with
@@ -157,7 +157,7 @@ data JsonOperation
 data JsonOperand
   = JKey { jVal :: Text }
   | JIdx { jVal :: Text }
-  deriving (Eq, Ord)
+  deriving (Eq, Show, Ord)
 
 -- | Boolean logic expression tree e.g. "and(name.eq.N,or(id.eq.1,id.eq.2))" is:
 --
@@ -169,12 +169,12 @@ data JsonOperand
 data LogicTree
   = Expr Bool LogicOperator [LogicTree]
   | Stmnt Filter
-  deriving (Eq)
+  deriving (Eq, Show)
 
 data LogicOperator
   = And
   | Or
-  deriving Eq
+  deriving (Eq, Show)
 
 data Filter
   = Filter
@@ -182,15 +182,15 @@ data Filter
   , opExpr :: OpExpr
   }
   | FilterNullEmbed Bool FieldName
-  deriving (Eq)
+  deriving (Eq, Show)
 
 data OpExpr
   = OpExpr Bool Operation
   | NoOpExpr Text
-  deriving (Eq)
+  deriving (Eq, Show)
 
 data OpQuantifier = QuantAny | QuantAll
-  deriving Eq
+  deriving (Eq, Show)
 
 data Operation
   = Op SimpleOperator SingleVal
@@ -199,7 +199,7 @@ data Operation
   | Is TrileanVal
   | IsDistinctFrom SingleVal
   | Fts FtsOperator (Maybe Language) SingleVal
-  deriving (Eq)
+  deriving (Eq, Show)
 
 type Language = Text
 
@@ -215,7 +215,7 @@ data TrileanVal
   | TriFalse
   | TriNull
   | TriUnknown
-  deriving Eq
+  deriving (Eq, Show)
 
 -- Operators that are quantifiable, i.e. they can be used with the any/all modifiers
 data QuantOperator
@@ -228,7 +228,7 @@ data QuantOperator
   | OpILike
   | OpMatch
   | OpIMatch
-  deriving Eq
+  deriving (Eq, Show)
 
 data SimpleOperator
   = OpNotEqual
@@ -240,7 +240,7 @@ data SimpleOperator
   | OpNotExtendsRight
   | OpNotExtendsLeft
   | OpAdjacent
-  deriving Eq
+  deriving (Eq, Show)
 
 --
 -- | Operators for full text search operators
@@ -249,4 +249,4 @@ data FtsOperator
   | FilterFtsPlain
   | FilterFtsPhrase
   | FilterFtsWebsearch
-  deriving Eq
+  deriving (Eq, Show)

--- a/src/PostgREST/MediaType.hs
+++ b/src/PostgREST/MediaType.hs
@@ -17,14 +17,6 @@ import Network.HTTP.Types.Header (Header, hContentType)
 
 import Protolude
 
---
--- $setup
--- Setup for doctests
--- >>> import Text.Pretty.Simple (pPrint)
--- >>> deriving instance Show MTPlanFormat
--- >>> deriving instance Show MTPlanOption
--- >>> deriving instance Show MediaType
-
 -- | Enumeration of currently supported media types
 data MediaType
   = MTApplicationJSON
@@ -39,6 +31,7 @@ data MediaType
   | MTAny
   | MTOther ByteString
   | MTPlan MediaType MTPlanFormat [MTPlanOption]
+  deriving Show
 instance Eq MediaType where
   MTApplicationJSON == MTApplicationJSON = True
   MTSingularJSON    == MTSingularJSON    = True
@@ -56,9 +49,11 @@ instance Eq MediaType where
 
 data MTPlanOption
   = PlanAnalyze | PlanVerbose | PlanSettings | PlanBuffers | PlanWAL
+  deriving (Eq, Show)
 
 data MTPlanFormat
   = PlanJSON | PlanText
+  deriving (Eq, Show)
 
 -- | Convert MediaType to a Content-Type HTTP Header
 toContentType :: MediaType -> Header

--- a/src/PostgREST/Plan/ReadPlan.hs
+++ b/src/PostgREST/Plan/ReadPlan.hs
@@ -25,7 +25,7 @@ data JoinCondition =
   JoinCondition
     (QualifiedIdentifier, FieldName)
     (QualifiedIdentifier, FieldName)
-  deriving (Eq)
+  deriving (Eq, Show)
 
 data ReadPlan = ReadPlan
   { select       :: [(CoercibleField, Maybe Cast, Maybe Alias)]
@@ -45,4 +45,4 @@ data ReadPlan = ReadPlan
   , depth        :: Depth
   -- ^ used for aliasing
   }
-  deriving (Eq)
+  deriving (Eq, Show)

--- a/src/PostgREST/Plan/Types.hs
+++ b/src/PostgREST/Plan/Types.hs
@@ -31,7 +31,7 @@ data CoercibleField = CoercibleField
   , cfIRType    :: Text                  -- ^ The native Postgres type of the field, the intermediate (IR) type before mapping.
   , cfTransform :: Maybe TransformerProc -- ^ The optional mapping from irType -> targetType.
   , cfDefault   :: Maybe Text
-  } deriving Eq
+  } deriving (Eq, Show)
 
 unknownField :: FieldName -> JsonPath -> CoercibleField
 unknownField name path = CoercibleField name path "" Nothing Nothing
@@ -40,11 +40,11 @@ unknownField name path = CoercibleField name path "" Nothing Nothing
 data CoercibleLogicTree
   = CoercibleExpr Bool LogicOperator [CoercibleLogicTree]
   | CoercibleStmnt CoercibleFilter
-  deriving (Eq)
+  deriving (Eq, Show)
 
 data CoercibleFilter = CoercibleFilter
   { field  :: CoercibleField
   , opExpr :: OpExpr
   }
   | CoercibleFilterNullEmbed Bool FieldName
-  deriving (Eq)
+  deriving (Eq, Show)

--- a/src/PostgREST/SchemaCache/Identifiers.hs
+++ b/src/PostgREST/SchemaCache/Identifiers.hs
@@ -24,7 +24,7 @@ data QualifiedIdentifier = QualifiedIdentifier
   { qiSchema :: Schema
   , qiName   :: TableName
   }
-  deriving (Eq, Ord, Generic, JSON.ToJSON, JSON.ToJSONKey)
+  deriving (Eq, Show, Ord, Generic, JSON.ToJSON, JSON.ToJSONKey)
 
 instance Hashable QualifiedIdentifier
 

--- a/src/PostgREST/SchemaCache/Relationship.hs
+++ b/src/PostgREST/SchemaCache/Relationship.hs
@@ -34,7 +34,7 @@ data Relationship = Relationship
   , relToOne        :: Bool
   , relIsSelf       :: Bool
   }
-  deriving (Eq, Ord, Generic, JSON.ToJSON)
+  deriving (Eq, Show, Ord, Generic, JSON.ToJSON)
 
 -- | The relationship cardinality
 -- | https://en.wikipedia.org/wiki/Cardinality_(data_modeling)
@@ -47,7 +47,7 @@ data Cardinality
   -- ^ one-to-one, this is a refinement over M2O so operating on it is pretty much the same as M2O
   | M2M Junction
   -- ^ many-to-many
-  deriving (Eq, Ord, Generic, JSON.ToJSON)
+  deriving (Eq, Show, Ord, Generic, JSON.ToJSON)
 
 type FKConstraint = Text
 
@@ -59,7 +59,7 @@ data Junction = Junction
   , junColsSource  :: [(FieldName, FieldName)]
   , junColsTarget  :: [(FieldName, FieldName)]
   }
-  deriving (Eq, Ord, Generic, JSON.ToJSON)
+  deriving (Eq, Show, Ord, Generic, JSON.ToJSON)
 
 -- | Key based on the source table and the foreign table schema
 type RelationshipsMap = HM.HashMap (QualifiedIdentifier, Schema)  [Relationship]


### PR DESCRIPTION
Closes https://github.com/PostgREST/postgrest/issues/2627.

Now we can take the repro on https://github.com/PostgREST/postgrest/issues/2846, do a couple of `traceShowId` and quickly pinpoint the problem:

```
$ postgrest-with-postgresql-15 postgrest-run

[CoercibleStmnt (CoercibleFilterNullEmbed True "clients_projects_1")]
[Node {rootLabel = ReadPlan {select = [(CoercibleField {cfName = "*", cfJsonPath = [], cfIRType = "", cfTransform = Nothing, cfDefault = Nothing},Nothing,Nothing)], from = QualifiedIdentifier
{qiSchema = "test", qiName = "projects"}, fromAlias = Just "projects_1", where_ = [], order = [], range_ = 0 <= x, relName = "projects", relToParent = Just (Relationship {relTable = QualifiedI
dentifier {qiSchema = "test", qiName = "clients"}, relForeignTable = QualifiedIdentifier {qiSchema = "test", qiName = "projects"}, relIsSelf = False, relCardinality = O2M {relCons = "client",
relColumns = [("id","client_id")]}, relTableIsView = False, relFTableIsView = False}), relJoinConds = [JoinCondition (QualifiedIdentifier {qiSchema = "", qiName = "projects_1"},"client_id") (Q
ualifiedIdentifier {qiSchema = "test", qiName = "clients"},"id")], relAlias = Nothing, relAggAlias = "clients_projects_1", relHint = Nothing, relJoinType = Nothing, relIsSpread = False, depth
= 1}, subForest = []}]

curl 'http://localhost:3000/clients?select=*,projects(*)&projects=is.null'   -H "Prefer: count=planned"
{"code":"42703","details":null,"hint":null,"message":"column \"clients_projects_1\" does not exist"}
```

It's still required to remove the `-Werror` flag (which is actually needed to solve https://github.com/PostgREST/postgrest/issues/2275) but it's still an improvement.