### PR TITLE
Add the -v/--version option to show the version information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + Data representations preserve the ability to write to the original column and require no extra storage or complex triggers (compared to using `GENERATED ALWAYS` columns)
    + Note: data representations require Postgres 10 (Postgres 11 if using `IN` predicates); data representations are not implemented for RPC
  - #2647, Allow to verify the PostgREST version in SQL: `select distinct application_name from pg_stat_activity`. - @laurenceisla
+ - #2856, Add the `--version` CLI option that prints the version information - @laurenceisla
 
 ### Fixed
 

--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -80,13 +80,19 @@ readCLIShowHelp =
   where
     prefs = O.prefs $ O.showHelpOnError <> O.showHelpOnEmpty
     opts = O.info parser $ O.fullDesc <> progDesc
-    parser = O.helper <*> exampleParser <*> cliParser
+    parser = O.helper <*> versionParser <*> exampleParser <*> cliParser
 
     progDesc =
       O.progDesc $
         "PostgREST "
         <> BS.unpack prettyVersion
         <> " / create a REST API to an existing Postgres database"
+
+    versionParser =
+      O.infoOption ("PostgREST " <> BS.unpack prettyVersion) $
+        O.long "version"
+        <> O.short 'v'
+        <> O.help "Show the version information"
 
     exampleParser =
       O.infoOption exampleConfigFile $

--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -80,7 +80,7 @@ readCLIShowHelp =
   where
     prefs = O.prefs $ O.showHelpOnError <> O.showHelpOnEmpty
     opts = O.info parser $ O.fullDesc <> progDesc
-    parser = O.helper <*> versionParser <*> exampleParser <*> cliParser
+    parser = O.helper <*> versionFlag <*> exampleParser <*> cliParser
 
     progDesc =
       O.progDesc $
@@ -88,7 +88,7 @@ readCLIShowHelp =
         <> BS.unpack prettyVersion
         <> " / create a REST API to an existing Postgres database"
 
-    versionParser =
+    versionFlag =
       O.infoOption ("PostgREST " <> BS.unpack prettyVersion) $
         O.long "version"
         <> O.short 'v'

--- a/test/io/fixtures.yaml
+++ b/test/io/fixtures.yaml
@@ -4,6 +4,10 @@ cli:
     args: ['--help']
   - name: help short
     args: ['-h']
+  - name: version long
+    args: ['--version']
+  - name: version short
+    args: ['-v']
   - name: example long
     args: ['--example']
   - name: example short


### PR DESCRIPTION
Now that we can check the version from many sources, it makes sense to also allow it from the command line. This PR adds the `-v` / `--version` option and changes the following:

```bash
$ postgrest --version
Invalid option `--version'

...
```

To:

```bash
$ postgrest --version
PostgREST 11.1.0 (e752224)
```