### PR TITLE
fix: HEAD unnecessarily executing aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2821, Fix OPTIONS not accepting all available media types - @steve-chavez
  - #2834, Fix compilation on Ubuntu by being compatible with GHC 9.0.2 - @steve-chavez
  - #2840, Fix `Prefer: missing=default` with DOMAIN default values - @steve-chavez
+ - #2849, Fix HEAD unnecessarily executing aggregates - @steve-chavez
 
 ## [11.1.0] - 2023-06-07
 

--- a/src/PostgREST/MediaType.hs
+++ b/src/PostgREST/MediaType.hs
@@ -30,6 +30,7 @@ data MediaType
   | MTOctetStream
   | MTAny
   | MTOther ByteString
+  -- TODO MTPlan should only have its options as [Text]. Its ResultAggregate should have the typed attributes.
   | MTPlan MediaType MTPlanFormat [MTPlanOption]
   deriving Show
 instance Eq MediaType where

--- a/src/PostgREST/MediaType.hs
+++ b/src/PostgREST/MediaType.hs
@@ -7,7 +7,6 @@ module PostgREST.MediaType
   , toContentType
   , toMime
   , decodeMediaType
-  , getMediaType
   ) where
 
 import qualified Data.ByteString          as BS
@@ -143,8 +142,3 @@ decodeMediaType mt =
         [PlanSettings | inOpts "settings"] ++
         [PlanBuffers  | inOpts "buffers" ] ++
         [PlanWAL      | inOpts "wal"     ]
-
-getMediaType :: MediaType -> MediaType
-getMediaType mt = case mt of
-  MTPlan mType _ _ -> mType
-  other            -> other

--- a/src/PostgREST/SchemaCache/Routine.hs
+++ b/src/PostgREST/SchemaCache/Routine.hs
@@ -14,6 +14,7 @@ module PostgREST.SchemaCache.Routine
   , funcReturnsVoid
   , funcTableName
   , funcReturnsCompositeAlias
+  , ResultAggregate(..)
   ) where
 
 import           Data.Aeson                 ((.=))
@@ -21,7 +22,8 @@ import qualified Data.Aeson                 as JSON
 import qualified Data.HashMap.Strict        as HM
 import qualified Hasql.Transaction.Sessions as SQL
 
-import PostgREST.SchemaCache.Identifiers (QualifiedIdentifier (..),
+import PostgREST.SchemaCache.Identifiers (FieldName,
+                                          QualifiedIdentifier (..),
                                           Schema, TableName)
 
 import Protolude
@@ -84,6 +86,16 @@ instance Ord Routine where
 -- | A map of all procs, all of which can be overloaded(one entry will have more than one Routine).
 -- | It uses a HashMap for a faster lookup.
 type RoutineMap = HM.HashMap QualifiedIdentifier [Routine]
+
+data ResultAggregate
+   = BuiltinAggJson
+   | BuiltinAggSingleJson
+   | BuiltinAggGeoJson
+   | BuiltinAggCsv
+   | BuiltinAggXml    (Maybe FieldName)
+   | BuiltinAggBinary (Maybe FieldName)
+   | NoAgg
+   deriving (Eq, Show)
 
 funcReturnsScalar :: Routine -> Bool
 funcReturnsScalar proc = case proc of


### PR DESCRIPTION
Previously:

```sql
curl -I localhost:3000/projects -H "Prefer: count=exact"

tail -f /run/user/1000/postgrest/postgrest-with-postgresql-15-vGF/db.log

WITH pgrst_source AS ( SELECT "test"."projects".* FROM "test"."projects"     )  SELECT null::bigint AS total_result_set, pg_catalog.count(_postgrest_t) AS page_total,
coalesce(json_agg(_postgrest_t), '[]') AS body, -- note here
nullif(current_setting('response.headers', true), '') AS response_headers, nullif(current_setting('response.status', true), '') AS response_status FROM ( SELECT * FROM pgrst_source ) _postgrest_t
```

Now:

```sql
curl -I localhost:3000/projects -H "Prefer: count=exact"

tail -f /run/user/1000/postgrest/postgrest-with-postgresql-15-N94/db.log

WITH pgrst_source AS ( SELECT "test"."projects".* FROM "test"."projects"     ) , pgrst_source_count AS (SELECT 1 FROM "test"."projects") SELECT (SELECT pg_catalog.count(*) FROM pgrst_source_count) AS total_result_set, pg_catalog.count(_postgrest_t) AS page_total, 
''::text AS body, -- note here
nullif(current_setting('response.headers', true), '') AS response_headers, nullif(current_setting('response.status', true), '') AS response_status FROM ( SELECT * FROM pgrst_source ) _postgrest_t
```

It's a bit hard to test it as mentioned on https://github.com/PostgREST/postgrest/issues/2849#issuecomment-1625883754 but the new types make sure this behavior is clear. I've added a `ResultAggregate`(previously on https://github.com/PostgREST/postgrest/pull/2825) that has a `NoAgg` value.

Closes https://github.com/PostgREST/postgrest/issues/2849.