### PR TITLE
fix: unused index on jsonb/jsonb arrow filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2834, Fix compilation on Ubuntu by being compatible with GHC 9.0.2 - @steve-chavez
  - #2840, Fix `Prefer: missing=default` with DOMAIN default values - @steve-chavez
  - #2849, Fix HEAD unnecessarily executing aggregates - @steve-chavez
+ - #2594, Fix unused index on jsonb/jsonb arrow filter and order (``/bets?data->>contractId=eq.1`` and ``/bets?order=data->>contractId``) - @steve-chavez
 
 ## [11.1.0] - 2023-06-07
 

--- a/src/PostgREST/Plan/MutatePlan.hs
+++ b/src/PostgREST/Plan/MutatePlan.hs
@@ -6,9 +6,9 @@ where
 import qualified Data.ByteString.Lazy as LBS
 
 import PostgREST.ApiRequest.Preferences  (PreferResolution)
-import PostgREST.ApiRequest.Types        (OrderTerm)
 import PostgREST.Plan.Types              (CoercibleField,
-                                          CoercibleLogicTree)
+                                          CoercibleLogicTree,
+                                          CoercibleOrderTerm)
 import PostgREST.RangeQuery              (NonnegRange)
 import PostgREST.SchemaCache.Identifiers (FieldName,
                                           QualifiedIdentifier)
@@ -33,7 +33,7 @@ data MutatePlan
       , updBody   :: Maybe LBS.ByteString
       , where_    :: [CoercibleLogicTree]
       , mutRange  :: NonnegRange
-      , mutOrder  :: [OrderTerm]
+      , mutOrder  :: [CoercibleOrderTerm]
       , returning :: [FieldName]
       , applyDefs :: Bool
       }
@@ -41,6 +41,6 @@ data MutatePlan
       { in_       :: QualifiedIdentifier
       , where_    :: [CoercibleLogicTree]
       , mutRange  :: NonnegRange
-      , mutOrder  :: [OrderTerm]
+      , mutOrder  :: [CoercibleOrderTerm]
       , returning :: [FieldName]
       }

--- a/src/PostgREST/Plan/ReadPlan.hs
+++ b/src/PostgREST/Plan/ReadPlan.hs
@@ -7,10 +7,10 @@ module PostgREST.Plan.ReadPlan
 import Data.Tree (Tree (..))
 
 import PostgREST.ApiRequest.Types         (Alias, Cast, Depth, Hint,
-                                           JoinType, NodeName,
-                                           OrderTerm)
+                                           JoinType, NodeName)
 import PostgREST.Plan.Types               (CoercibleField (..),
-                                           CoercibleLogicTree)
+                                           CoercibleLogicTree,
+                                           CoercibleOrderTerm)
 import PostgREST.RangeQuery               (NonnegRange)
 import PostgREST.SchemaCache.Identifiers  (FieldName,
                                            QualifiedIdentifier)
@@ -32,7 +32,7 @@ data ReadPlan = ReadPlan
   , from         :: QualifiedIdentifier
   , fromAlias    :: Maybe Alias
   , where_       :: [CoercibleLogicTree]
-  , order        :: [OrderTerm]
+  , order        :: [CoercibleOrderTerm]
   , range_       :: NonnegRange
   , relName      :: NodeName
   , relToParent  :: Maybe Relationship

--- a/src/PostgREST/Plan/Types.hs
+++ b/src/PostgREST/Plan/Types.hs
@@ -4,9 +4,11 @@ module PostgREST.Plan.Types
   , CoercibleLogicTree(..)
   , CoercibleFilter(..)
   , TransformerProc
+  , CoercibleOrderTerm(..)
   ) where
 
-import PostgREST.ApiRequest.Types (JsonPath, LogicOperator, OpExpr)
+import PostgREST.ApiRequest.Types (Field, JsonPath, LogicOperator,
+                                   OpExpr, OrderDirection, OrderNulls)
 
 import PostgREST.SchemaCache.Identifiers (FieldName)
 
@@ -28,13 +30,14 @@ type TransformerProc = Text
 data CoercibleField = CoercibleField
   { cfName      :: FieldName
   , cfJsonPath  :: JsonPath
+  , cfToJson    :: Bool
   , cfIRType    :: Text                  -- ^ The native Postgres type of the field, the intermediate (IR) type before mapping.
   , cfTransform :: Maybe TransformerProc -- ^ The optional mapping from irType -> targetType.
   , cfDefault   :: Maybe Text
   } deriving (Eq, Show)
 
 unknownField :: FieldName -> JsonPath -> CoercibleField
-unknownField name path = CoercibleField name path "" Nothing Nothing
+unknownField name path = CoercibleField name path False "" Nothing Nothing
 
 -- | Like an API request LogicTree, but with coercible field information.
 data CoercibleLogicTree
@@ -47,4 +50,18 @@ data CoercibleFilter = CoercibleFilter
   , opExpr :: OpExpr
   }
   | CoercibleFilterNullEmbed Bool FieldName
+  deriving (Eq, Show)
+
+data CoercibleOrderTerm
+  = CoercibleOrderTerm
+    { coField     :: CoercibleField
+    , coDirection :: Maybe OrderDirection
+    , coNullOrder :: Maybe OrderNulls
+    }
+  | CoercibleOrderRelationTerm
+    { coRelation  :: FieldName
+    , coRelTerm   :: Field
+    , coDirection :: Maybe OrderDirection
+    , coNullOrder :: Maybe OrderNulls
+    }
   deriving (Eq, Show)

--- a/test/spec/Feature/Query/JsonOperatorSpec.hs
+++ b/test/spec/Feature/Query/JsonOperatorSpec.hs
@@ -103,7 +103,7 @@ spec actualPgVersion = describe "json and jsonb operators" $ do
 
       it "can get array of objects" $ do
         get "/json_arr?select=data->0->>a&id=in.(5,6)" `shouldRespondWith`
-          [json| [{"a":"A"}, {"a":"[1, 2, 3]"}] |]
+          [json|[{"a":"A"}, {"a":"[1,2,3]"}]|]
           { matchHeaders = [matchContentTypeJson] }
         get "/json_arr?select=data->0->a->>2&id=in.(5,6)" `shouldRespondWith`
           [json| [{"a":null}, {"a":"3"}] |]
@@ -275,7 +275,7 @@ spec actualPgVersion = describe "json and jsonb operators" $ do
         [json| [{"data":8}, {"data":7}] |]
         { matchHeaders = [matchContentTypeJson] }
       get "/json_arr?select=data->-2->>a&id=in.(5,6)" `shouldRespondWith`
-        [json| [{"a":"A"}, {"a":"[1, 2, 3]"}] |]
+        [json| [{"a":"A"}, {"a":"[1,2,3]"}] |]
         { matchHeaders = [matchContentTypeJson] }
 
     it "can filter with negative indexes" $ do

--- a/test/spec/Feature/Query/PlanSpec.hs
+++ b/test/spec/Feature/Query/PlanSpec.hs
@@ -348,6 +348,43 @@ spec actualPgVersion = do
         liftIO $ do
           resBody `shouldSatisfy` (\t -> not $ T.isInfixOf "getitemrange" (decodeUtf8 $ LBS.toStrict t))
 
+    context "index usage" $ do
+      it "should use an index for a json arrow operator filter" $ do
+        r <- request methodGet "/bets?data_json->>contractId=eq.1"
+               [(hAccept, "application/vnd.pgrst.plan")] ""
+
+        let resBody = simpleBody r
+
+        liftIO $ do
+          resBody `shouldSatisfy` (\t -> T.isInfixOf "Index Cond" (decodeUtf8 $ LBS.toStrict t))
+
+      it "should use an index for a jsonb arrow operator filter" $ do
+        r <- request methodGet "/bets?data_jsonb->>contractId=eq.1"
+               [(hAccept, "application/vnd.pgrst.plan")] ""
+
+        let resBody = simpleBody r
+
+        liftIO $ do
+          resBody `shouldSatisfy` (\t -> T.isInfixOf "Index" (decodeUtf8 $ LBS.toStrict t))
+
+      it "should use an index for ordering on a json arrow operator" $ do
+        r <- request methodGet "/bets?order=data_json->>contractId"
+               [(hAccept, "application/vnd.pgrst.plan")] ""
+
+        let resBody = simpleBody r
+
+        liftIO $ do
+          resBody `shouldSatisfy` (\t -> T.isInfixOf "Index" (decodeUtf8 $ LBS.toStrict t))
+
+      it "should use an index for ordering on a jsonb arrow operator" $ do
+        r <- request methodGet "/bets?order=data_jsonb->>contractId"
+               [(hAccept, "application/vnd.pgrst.plan")] ""
+
+        let resBody = simpleBody r
+
+        liftIO $ do
+          resBody `shouldSatisfy` (\t -> T.isInfixOf "Index" (decodeUtf8 $ LBS.toStrict t))
+
 disabledSpec :: SpecWith ((), Application)
 disabledSpec =
   it "doesn't work if db-plan-enabled=false(the default)" $ do

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -3293,3 +3293,12 @@ create table evil_friends(
   id   devil_int
 , name text
 );
+
+create table bets (
+  id int
+, data_json  json
+, data_jsonb jsonb
+);
+
+create index bets_data_json  on bets ((data_json  ->>'contractId'));
+create index bets_data_jsonb on bets ((data_jsonb ->>'contractId'));


### PR DESCRIPTION
Closes https://github.com/PostgREST/postgrest/issues/2594

Before:
```
curl "localhost:3000/bets?data_jsonb->>contractId=eq.1" -H "Accept: application/vnd.pgrst.plan"

Aggregate  (cost=32.26..32.28 rows=1 width=112)
  ->  Seq Scan on bets  (cost=0.00..32.23 rows=6 width=36)
        Filter: ((to_jsonb(data_jsonb) ->> 'contractId'::text) = '1'::text)
```

Now:

```
curl "localhost:3000/bets?data_jsonb->>contractId=eq.1" -H "Accept: application/vnd.pgrst.plan"

Aggregate  (cost=12.67..12.69 rows=1 width=112)
  ->  Bitmap Heap Scan on bets  (cost=4.18..12.65 rows=4 width=68)
        Recheck Cond: ((data_jsonb ->> 'contractId'::text) = '1'::text)
        ->  Bitmap Index Scan on bets_data_jsonb  (cost=0.00..4.18 rows=4 width=0)
              Index Cond: ((data_jsonb ->> 'contractId'::text) = '1'::text)
```