### PR TITLE
fix: null filtering on embed when column=relation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2594, Fix unused index on jsonb/jsonb arrow filter and order (``/bets?data->>contractId=eq.1`` and ``/bets?order=data->>contractId``) - @steve-chavez
  - #2861, Fix character and bit columns with fixed length not inserting/updating properly - @laurenceisla
    + Fixes the error "value too long for type character(1)" when the char length of the column was bigger than one.
+ - #2862, Fix null filtering on embedded resource when using a column name equal to the relation name - @steve-chave
 
 ## [11.1.0] - 2023-06-07
 

--- a/test/spec/Feature/Query/RelatedQueriesSpec.hs
+++ b/test/spec/Feature/Query/RelatedQueriesSpec.hs
@@ -233,24 +233,26 @@ spec = describe "related queries" $ do
         , matchHeaders = [matchContentTypeJson]
         }
 
-    it "only works with is null or is not null operators" $
-      get "/projects?select=name,clients(*)&clients=eq.3" `shouldRespondWith`
-        [json|{
-          "code":"PGRST120",
-          "details":"Only is null or not is null filters are allowed on embedded resources",
-          "hint":null,
-          "message":"Bad operator on the 'clients' embedded resource"
-        }|]
-        { matchStatus  = 400
-        , matchHeaders = [matchContentTypeJson]
-        }
-
     it "doesn't interfere filtering when embedding using the column name" $
       get "/projects?select=name,client_id,client:client_id(name)&client_id=eq.2" `shouldRespondWith`
         [json|[
           {"name":"IOS","client_id":2,"client":{"name":"Apple"}},
           {"name":"OSX","client_id":2,"client":{"name":"Apple"}}
         ]|]
+        { matchStatus  = 200
+        , matchHeaders = [matchContentTypeJson]
+        }
+
+    it "doesn't interfere filtering on column names used for disambiguation" $
+      get "/user_friend?select=*,user1(*)&user1=eq.a02fb934-3a4d-469b-a6b6-4fcd88b973cf" `shouldRespondWith`
+        [json|[]|]
+        { matchStatus  = 200
+        , matchHeaders = [matchContentTypeJson]
+        }
+
+    it "doesn't interfere filtering on column names that are the same as the relation name" $
+      get "/tournaments?select=*,status(*)&status=eq.3" `shouldRespondWith`
+        [json|[]|]
         { matchStatus  = 200
         , matchHeaders = [matchContentTypeJson]
         }

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -3308,3 +3308,24 @@ CREATE TABLE bitchar_with_length (
   bit bit(5),
   char char(5)
 );
+
+--- https://github.com/PostgREST/postgrest/issues/2862
+create table profiles (
+  id uuid primary key,
+  username text null
+);
+
+create table user_friend (
+  id bigint primary key,
+  user1 uuid references profiles (id),
+  user2 uuid references profiles (id)
+);
+
+create table status(
+  id bigint primary key
+);
+
+create table tournaments(
+  id bigint primary key,
+  status bigint references status(id)
+);


### PR DESCRIPTION
Fixes https://github.com/PostgREST/postgrest/issues/2862

Basically makes the implementation for https://postgrest.org/en/stable/references/api/resource_embedding.html#null-filtering-on-embedded-resources less strict.

Before it used to enforce only null filters where applied, which caused the errors in #2862. Now it removes he null filter restriction.