### PR TITLE
deprecate: target embedding disambiguation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2881, Fix error when a function returns `RECORD` or `SET OF RECORD` - @laurenceisla
  - #2896, Fix applying superuser settings for impersonated role - @steve-chavez
 
+### Deprecated
+
+ - #2863, Deprecate resource embedding target disambiguation - @steve-chavez
+   + The `/table?select=*,other!fk(*)` must be used to disambiguate
+   + The server aids in choosing the `!fk` by sending a `hint` on the error whenever an ambiguous request happens.
+
 ## [11.1.0] - 2023-06-07
 
 ### Added

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -485,7 +485,9 @@ findRel schema allRels origin target hint =
             target == qiName relForeignTable && isO2M relCardinality
             && matchFKRefSingleCol hnt relCardinality -- auditor
         else case hint of
+          -- DEPRECATED(remove after 2 major releases since v11.1.0): remove target
           -- target = table / view / constraint / column-from-origin (constraint/column-from-origin can only come from tables https://github.com/PostgREST/postgrest/issues/2277)
+          -- DEPRECATED(remove after 2 major releases since v11.1.0): remove hint as table/view/columns and only leave it as constraint
           -- hint   = table / view / constraint / column-from-origin / column-from-target (hint can take table / view values to aid in finding the junction in an m2m relationship)
           Nothing ->
               -- /projects?select=clients(*)


### PR DESCRIPTION
Closes #2863 