### PR TITLE
fix: HTTP status responses for upserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
  - #3015, Fix unnecessary count() on RPC returning single - @steve-chavez
+ - #1070, Fix HTTP status responses for upserts - @taimoorzaeem
+   + `PUT` returns `201` instead of `200` when rows are inserted
+   + `POST` with `Prefer: resolution=merge-duplicates` returns `200` instead of `201` when no rows are inserted
 
 ### Changed
 

--- a/src/PostgREST/ApiRequest/Preferences.hs
+++ b/src/PostgREST/ApiRequest/Preferences.hs
@@ -176,6 +176,7 @@ class ToHeaderValue a where
 data PreferResolution
   = MergeDuplicates
   | IgnoreDuplicates
+  deriving Eq
 
 instance ToHeaderValue PreferResolution where
   toHeaderValue MergeDuplicates  = "resolution=merge-duplicates"

--- a/src/PostgREST/Query.hs
+++ b/src/PostgREST/Query.hs
@@ -190,7 +190,7 @@ openApiQuery sCache pgVer AppConfig{..} tSchema =
 writeQuery :: MutateReadPlan -> ApiRequest -> AppConfig  -> DbHandler ResultSet
 writeQuery MutateReadPlan{..} ApiRequest{iPreferences=Preferences{..}} conf =
   let
-    (isInsert, pkCols) = case mrMutatePlan of {Insert{insPkCols} -> (True, insPkCols); _ -> (False, mempty);}
+    (isPut, isInsert, pkCols) = case mrMutatePlan of {Insert{where_,insPkCols} -> ((not . null) where_, True, insPkCols); _ -> (False,False, mempty);}
   in
   lift . SQL.statement mempty $
     Statements.prepareWrite
@@ -198,9 +198,11 @@ writeQuery MutateReadPlan{..} ApiRequest{iPreferences=Preferences{..}} conf =
       (QueryBuilder.readPlanToQuery mrReadPlan)
       (QueryBuilder.mutatePlanToQuery mrMutatePlan)
       isInsert
+      isPut
       mrMedia
       mrHandler
       preferRepresentation
+      preferResolution
       pkCols
       (configDbPreparedStatements conf)
 

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -24,6 +24,8 @@ module PostgREST.Query.SqlFragment
   , fromJsonBodyF
   , responseHeadersF
   , responseStatusF
+  , addConfigPgrstInserted
+  , currentSettingF
   , returningF
   , singleParameter
   , sourceCTE
@@ -432,6 +434,11 @@ responseHeadersF = currentSettingF "response.headers"
 
 responseStatusF :: SQL.Snippet
 responseStatusF = currentSettingF "response.status"
+
+addConfigPgrstInserted :: Bool -> SQL.Snippet
+addConfigPgrstInserted add =
+  let (symbol, num) =  if add then ("+", "0") else ("-", "-1") in
+  "set_config('pgrst.inserted', (coalesce(" <> currentSettingF "pgrst.inserted" <> "::int, 0) " <> symbol <> " 1)::text, true) <> '" <> num <> "'"
 
 currentSettingF :: SQL.Snippet -> SQL.Snippet
 currentSettingF setting =

--- a/src/PostgREST/Query/Statements.hs
+++ b/src/PostgREST/Query/Statements.hs
@@ -51,7 +51,7 @@ data ResultSet
   , rsGucStatus  :: Maybe Text
   -- ^ the HTTP status to be added to the response
   , rsInserted   :: Maybe Int64
-  -- ^ the number of rows inserted (Only used with PUT)
+  -- ^ the number of rows inserted (Only used for upserts)
   }
   | RSPlan BS.ByteString -- ^ the plan of the query
 

--- a/test/spec/Feature/Query/MultipleSchemaSpec.hs
+++ b/test/spec/Feature/Query/MultipleSchemaSpec.hs
@@ -225,13 +225,11 @@ spec =
 
       it "succeeds on PUT on the v2 schema" $
         request methodPut "/children?id=eq.111" [("Content-Profile", "v2"), ("Prefer", "return=representation")]
-          [json| [ { "id": 111, "name": "child v2-111", "parent_id": null } ]|]
+          [json|[{"id": 111, "name": "child v2-111", "parent_id": null}]|]
           `shouldRespondWith`
-          [json|[{ "id": 111, "name": "child v2-111", "parent_id": null }]|]
-          {
-            matchStatus = 200
-          , matchHeaders = [matchContentTypeJson, "Content-Profile" <:> "v2"]
-          }
+          [json|[{"id": 111, "name": "child v2-111", "parent_id": null}]|]
+          { matchStatus  = 201
+          , matchHeaders = [matchContentTypeJson, "Content-Profile" <:> "v2"]}
 
     context "OpenAPI output" $ do
       it "succeeds in reading table definition from default schema v1 if no schema is selected via header" $ do

--- a/test/spec/Feature/Query/PlanSpec.hs
+++ b/test/spec/Feature/Query/PlanSpec.hs
@@ -192,7 +192,7 @@ spec actualPgVersion = do
       liftIO $ do
         resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.plan+json; for=\"application/json\"; charset=utf-8")
         resStatus `shouldBe` Status { statusCode = 200, statusMessage="OK" }
-        totalCost `shouldBe` 1.29
+        totalCost `shouldBe` 3.55
 
     it "outputs the total cost for 2 upserts" $ do
       r <- request methodPost "/tiobe_pls"
@@ -206,7 +206,7 @@ spec actualPgVersion = do
       liftIO $ do
         resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.plan+json; for=\"application/json\"; charset=utf-8")
         resStatus `shouldBe` Status { statusCode = 200, statusMessage="OK" }
-        totalCost `shouldBe` 3.27
+        totalCost `shouldBe` 5.53
 
     it "outputs the total cost for an upsert with 10 rows" $ do
       r <- request methodPost "/tiobe_pls"
@@ -220,7 +220,7 @@ spec actualPgVersion = do
       liftIO $ do
         resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.plan+json; for=\"application/json\"; charset=utf-8")
         resStatus `shouldBe` Status { statusCode = 200, statusMessage="OK" }
-        totalCost `shouldBe` 3.27
+        totalCost `shouldBe` 5.53
 
     it "outputs the total cost for an upsert with 100 rows" $ do
       r <- request methodPost "/tiobe_pls"
@@ -234,7 +234,7 @@ spec actualPgVersion = do
       liftIO $ do
         resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.plan+json; for=\"application/json\"; charset=utf-8")
         resStatus `shouldBe` Status { statusCode = 200, statusMessage="OK" }
-        totalCost `shouldBe` 3.27
+        totalCost `shouldBe` 5.53
 
     it "outputs the total cost for an upsert with 1000 rows" $ do
       r <- request methodPost "/tiobe_pls"
@@ -248,7 +248,7 @@ spec actualPgVersion = do
       liftIO $ do
         resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.plan+json; for=\"application/json\"; charset=utf-8")
         resStatus `shouldBe` Status { statusCode = 200, statusMessage="OK" }
-        totalCost `shouldBe` 3.27
+        totalCost `shouldBe` 5.53
 
     it "outputs the plan for application/vnd.pgrst.object" $ do
       r <- request methodDelete "/projects?id=eq.6"

--- a/test/spec/Feature/Query/ServerTimingSpec.hs
+++ b/test/spec/Feature/Query/ServerTimingSpec.hs
@@ -45,11 +45,11 @@ spec =
             }
 
       it "works with put request" $
-        request methodPut "/tiobe_pls?name=eq.Go"
+        request methodPut "/tiobe_pls?name=eq.Python"
             [("Prefer", "return=representation")]
-            [json| [ { "name": "Go", "rank": 19 } ]|]
+            [json| [ { "name": "Python", "rank": 19 } ]|]
           `shouldRespondWith`
-            [json| [ { "name": "Go", "rank": 19 } ]|]
+            [json| [ { "name": "Python", "rank": 19 } ]|]
             { matchStatus  = 200
             , matchHeaders = map matchServerTimingHasTiming ["jwt", "plan", "query", "render"]
             }

--- a/test/spec/Feature/RollbackSpec.hs
+++ b/test/spec/Feature/RollbackSpec.hs
@@ -118,11 +118,12 @@ shouldPersistMutations reqHeaders respHeaders = do
 
   it "does persist put" $ do
     request methodPut "/items?id=eq.0"
-        reqHeaders
-        [json|{"id":0}|]
+      reqHeaders
+      [json|{"id":0}|]
       `shouldRespondWith`
-        [json|[{"id":0}]|]
-        { matchHeaders = respHeaders }
+      [json|[{"id":0}]|]
+      { matchStatus  = 201
+      , matchHeaders = respHeaders }
     get "/items?id=eq.0"
       `shouldRespondWith`
         [json|[{"id":0}]|]
@@ -175,7 +176,8 @@ shouldNotPersistMutations reqHeaders respHeaders = do
         [json|{"id":0}|]
       `shouldRespondWith`
         [json|[{"id":0}]|]
-        { matchHeaders = respHeaders }
+        { matchStatus  = 201
+        , matchHeaders = respHeaders }
     get "/items?id=eq.0"
       `shouldRespondWith`
         [json|[]|]


### PR DESCRIPTION
This might fix #1070.

#### Fixed

- `PUT` returns `201` instead of `200` when rows are inserted
- `POST` with `Prefer: resolution=merge-duplicates` returns `200` instead of `201` when no rows are inserted