### PR TITLE
ci: less strict conditions for loadtest in main

### DIFF
--- a/.github/workflows/loadtest.yaml
+++ b/.github/workflows/loadtest.yaml
@@ -36,7 +36,7 @@ jobs:
 
   Loadtest-Merge-Nix:
     name: Loadtest Merge (Nix)
-    if: ${{ github.event_name == 'merge' && github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Prevents the loadtest on merge to main being skipped since whole workflow is already triggered by pushes to `main` only

related to #2946 

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs     - https://github.com/PostgREST/postgrest-docs
-->
