### PR TITLE
Add more data to `Server-Timing` header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2824, Fix range request with 0 rows and 0 offset return status 416 - @strengthless
 
 ## [11.2.1] - 2023-10-03
+ - #2983, Add more data to `Server-Timing` header - @develop7
 
 ### Fixed
 

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -71,6 +71,7 @@ library
                       PostgREST.Response
                       PostgREST.Response.OpenAPI
                       PostgREST.Response.GucHeader
+                      PostgREST.Response.Performance
                       PostgREST.Version
   other-modules:      Paths_postgrest
   build-depends:      base                      >= 4.9 && < 4.17

--- a/src/PostgREST/Response/Performance.hs
+++ b/src/PostgREST/Response/Performance.hs
@@ -1,0 +1,34 @@
+module PostgREST.Response.Performance
+  ( ServerMetric(..)
+  , ServerTimingData
+  , renderServerTimingHeader
+  )
+where
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.Map              as Map
+import qualified Network.HTTP.Types    as HTTP
+import           Numeric               (showFFloat)
+import           Protolude
+
+data ServerMetric =
+    SMJwt
+  | SMRender
+  | SMPlan
+  | SMQuery
+  deriving (Show, Eq, Ord)
+type ServerTimingData = Map ServerMetric (Maybe Double)
+
+-- | Render the Server-Timing header from a ServerTimingData
+--
+-- >>> renderServerTimingHeader $ Map.fromList [(SMPlan, 0.1), (SMQuery, 0.2), (SMRender, 0.3), (SMJwt, 0.4)]
+-- ("Server-Timing","jwt;dur=400000.0, render;dur=300000.0, plan;dur=100000.0, query;dur=200000.0")
+renderServerTimingHeader :: ServerTimingData -> HTTP.Header
+renderServerTimingHeader timingData =
+  ("Server-Timing", BS.intercalate ", " $ map renderTiming $ Map.toList timingData)
+renderTiming :: (ServerMetric, Maybe Double) -> BS.ByteString
+renderTiming (metric, time) = maybe "" (\x -> BS.concat [renderMetric metric, BS.pack $ ";dur=" <> showFFloat (Just 1) (x * 1000000) ""]) time
+  where
+    renderMetric SMPlan   = "plan"
+    renderMetric SMQuery  = "query"
+    renderMetric SMRender = "render"
+    renderMetric SMJwt    = "jwt"

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -1119,15 +1119,15 @@ def test_server_timing_jwt_should_decrease_on_subsequent_requests(defaultenv):
     )
 
     with run(stdin=SECRET.encode(), env=env) as postgrest:
-        first_dur_text = postgrest.session.get(
-            "/authors_only", headers=headers
-        ).headers["Server-Timing"]
-        second_dur_text = postgrest.session.get(
+        first_timings = postgrest.session.get("/authors_only", headers=headers).headers[
+            "Server-Timing"
+        ]
+        second_timings = postgrest.session.get(
             "/authors_only", headers=headers
         ).headers["Server-Timing"]
 
-        first_dur = float(first_dur_text[8:])  # skip "jwt;dur="
-        second_dur = float(second_dur_text[8:])
+        first_dur = parse_server_timings_header(first_timings)["jwt"]
+        second_dur = parse_server_timings_header(second_timings)["jwt"]
 
         # their difference should be atleast 300, implying
         # that JWT Caching is working as expected
@@ -1172,15 +1172,15 @@ def test_server_timing_jwt_should_not_decrease_when_caching_disabled(defaultenv)
 
     with run(stdin=SECRET.encode(), env=env) as postgrest:
         warmup_req = postgrest.session.get("/authors_only", headers=headers)
-        first_dur_text = postgrest.session.get(
-            "/authors_only", headers=headers
-        ).headers["Server-Timing"]
-        second_dur_text = postgrest.session.get(
+        first_timings = postgrest.session.get("/authors_only", headers=headers).headers[
+            "Server-Timing"
+        ]
+        second_timings = postgrest.session.get(
             "/authors_only", headers=headers
         ).headers["Server-Timing"]
 
-        first_dur = float(first_dur_text[8:])  # skip "jwt;dur="
-        second_dur = float(second_dur_text[8:])
+        first_dur = parse_server_timings_header(first_timings)["jwt"]
+        second_dur = parse_server_timings_header(second_timings)["jwt"]
 
         # their difference should be less than 150
         # implying that token is not cached
@@ -1201,15 +1201,15 @@ def test_jwt_cache_with_no_exp_claim(defaultenv):
     headers = jwtauthheader({"role": "postgrest_test_author"}, SECRET)  # no exp
 
     with run(stdin=SECRET.encode(), env=env) as postgrest:
-        first_dur_text = postgrest.session.get(
-            "/authors_only", headers=headers
-        ).headers["Server-Timing"]
-        second_dur_text = postgrest.session.get(
+        first_timings = postgrest.session.get("/authors_only", headers=headers).headers[
+            "Server-Timing"
+        ]
+        second_timings = postgrest.session.get(
             "/authors_only", headers=headers
         ).headers["Server-Timing"]
 
-        first_dur = float(first_dur_text[8:])  # skip "jwt;dur="
-        second_dur = float(second_dur_text[8:])
+        first_dur = parse_server_timings_header(first_timings)["jwt"]
+        second_dur = parse_server_timings_header(second_timings)["jwt"]
 
         # their difference should be atleast 300, implying
         # that JWT Caching is working as expected

--- a/test/io/util.py
+++ b/test/io/util.py
@@ -40,3 +40,20 @@ def authheader(token):
 def jwtauthheader(claim, secret):
     "Authorization header with signed JWT."
     return authheader(jwt.encode(claim, secret))
+
+
+def parse_server_timings_header(header):
+    """Parse the Server-Timing header into a dict of metric names to values.
+
+    The header is a comma-separated list of metrics, each of which has a name
+    and a duration. The duration may be followed by a semicolon and a list of
+    parameters, but we ignore those.
+
+    See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing
+    """
+    timings = {}
+    for timing in header.split(","):
+        name, duration_text, *_ = timing.split(";")
+        _, duration = duration_text.split("=")
+        timings[name] = float(duration)
+    return timings

--- a/test/spec/Feature/Query/ServerTimingSpec.hs
+++ b/test/spec/Feature/Query/ServerTimingSpec.hs
@@ -22,8 +22,7 @@ spec =
           `shouldRespondWith`
           [json|[{"id":6,"name":"Oscorp","referee":3,"auditor":4,"manager_id":6}]|]
           { matchStatus  = 200
-          , matchHeaders = [ matchContentTypeJson
-                           , matchHeaderPresent "Server-Timing"]
+          , matchHeaders = matchContentTypeJson : map matchServerTimingHasTiming ["jwt", "plan", "query", "render"]
           }
 
       it "works with post request" $
@@ -33,8 +32,7 @@ spec =
           `shouldRespondWith`
           [json|[{"id":7,"name":"John","referee":null,"auditor":null,"manager_id":6}]|]
           { matchStatus  = 201
-          , matchHeaders = [ matchContentTypeJson
-                           , matchHeaderPresent "Server-Timing"]
+          , matchHeaders = matchContentTypeJson : map matchServerTimingHasTiming ["jwt", "plan", "query", "render"]
           }
 
       it "works with patch request" $
@@ -43,8 +41,7 @@ spec =
           `shouldRespondWith`
             ""
             { matchStatus  = 204
-            , matchHeaders = [ matchHeaderAbsent hContentType
-                             , matchHeaderPresent "Server-Timing" ]
+            , matchHeaders = matchHeaderAbsent hContentType : map matchServerTimingHasTiming ["jwt", "plan", "query", "render"]
             }
 
       it "works with put request" $
@@ -54,7 +51,7 @@ spec =
           `shouldRespondWith`
             [json| [ { "name": "Go", "rank": 19 } ]|]
             { matchStatus  = 200
-            , matchHeaders = [ matchHeaderPresent "Server-Timing" ]
+            , matchHeaders = map matchServerTimingHasTiming ["jwt", "plan", "query", "render"]
             }
 
       it "works with delete request" $
@@ -64,8 +61,7 @@ spec =
           `shouldRespondWith`
             ""
             { matchStatus  = 204
-            , matchHeaders = [ matchHeaderAbsent hContentType
-                             , matchHeaderPresent "Server-Timing" ]
+            , matchHeaders = matchHeaderAbsent hContentType : map matchServerTimingHasTiming ["jwt", "plan", "query", "render"]
             }
 
       it "works with rpc call" $
@@ -75,5 +71,5 @@ spec =
           `shouldRespondWith`
           [json|{"x": 1, "y": 2}|]
           { matchStatus  = 200
-          , matchHeaders = [ matchHeaderPresent "Server-Timing" ]
+          , matchHeaders = map matchServerTimingHasTiming ["jwt", "plan", "query", "render"]
           }


### PR DESCRIPTION
Introduces the performance metrics' collection and rendering in `Server-Timing` header 

fixes #2771 

- [x] metrics
	* `query`
	* `jwt`
	* `plan`
	* `render`
- [x] tests 
- [x] CHANGELOG