### PR TITLE
ci: cache Nix store with cache-nix-action

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -20,9 +20,10 @@ runs:
     - name: Restore and cache Nix store
       uses: nix-community/cache-nix-action@v4
       with:
-        key: cache-nix-${{ runner.os }}-${{ inputs.cache-id }}-${{ hashFiles('nix/**/*.nix') }}
+        key: cache-nix-${{ runner.os }}-id-${{ inputs.cache-id }}-${{ hashFiles('nix/**/*.nix') }}
         restore-keys: |
-          cache-nix-${{ runner.os }}-
+          cache-nix-${{ runner.os }}-common-
+        restore-key-hit: true
     - uses: cachix/cachix-action@v12
       with:
         name: postgrest

--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -7,6 +7,9 @@ inputs:
     description: Token to pass to cachix
   tools:
     description: Tools to install with nix-env -iA <tools>
+  cache-id:
+    description: Cache id to use for cache-nix-action
+    default: "default"
 
 runs:
   using: composite
@@ -17,7 +20,7 @@ runs:
     - name: Restore and cache Nix store
       uses: nix-community/cache-nix-action@v4
       with:
-        key: cache-nix-${{ runner.os }}-${{ hashFiles('nix/**/*.nix') }}
+        key: cache-nix-${{ runner.os }}-${{ inputs.cache-id }}-${{ hashFiles('nix/**/*.nix') }}
         restore-keys: |
           cache-nix-${{ runner.os }}-
     - uses: cachix/cachix-action@v12

--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -18,7 +18,7 @@ runs:
       with:
         nix_version: '2.13.6'
     - name: Restore and cache Nix store
-      uses: nix-community/cache-nix-action@v4
+      uses: nix-community/cache-nix-action@v4.0.3
       with:
         key: cache-nix-${{ runner.os }}-id-${{ inputs.cache-id }}-${{ hashFiles('nix/**/*.nix') }}
         restore-keys: |

--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -11,9 +11,15 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: cachix/install-nix-action@v23
+    - uses: nixbuild/nix-quick-install-action@v26
       with:
-        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+        nix_version: '2.13.6'
+    - name: Restore and cache Nix store
+      uses: nix-community/cache-nix-action@v4
+      with:
+        key: cache-nix-${{ runner.os }}-${{ hashFiles('nix/**/*.nix') }}
+        restore-keys: |
+          cache-nix-${{ runner.os }}-
     - uses: cachix/cachix-action@v12
       with:
         name: postgrest

--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -20,7 +20,7 @@ runs:
     - name: Restore and cache Nix store
       uses: nix-community/cache-nix-action@v4
       with:
-        key: cache-nix-${{ runner.os }}-id-${{ inputs.cache-id }}-${{ hashFiles('nix/**/*.nix') }}
+        key: cache-nix-${{ runner.os }}-cid-${{ inputs.cache-id }}-${{ hashFiles('nix/**/*.nix') }}
         restore-keys: |
           cache-nix-${{ runner.os }}-common-
         restore-key-hit: true

--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -20,7 +20,7 @@ runs:
     - name: Restore and cache Nix store
       uses: nix-community/cache-nix-action@v4
       with:
-        key: cache-nix-${{ runner.os }}-cid-${{ inputs.cache-id }}-${{ hashFiles('nix/**/*.nix') }}
+        key: cache-nix-${{ runner.os }}-id-${{ inputs.cache-id }}-${{ hashFiles('nix/**/*.nix') }}
         restore-keys: |
           cache-nix-${{ runner.os }}-common-
         restore-key-hit: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           tools: tests
-          cache-id: test-pgdefault
+          cache-id: test-pg
 
       - name: Run coverage (IO tests and Spec tests against PostgreSQL 15)
         run: postgrest-coverage
@@ -79,7 +79,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           tools: tests withTools
-          cache-id: test-pg${{ matrix.pgVersion }}
+          cache-id: test-pg
 
       - name: Run spec tests
         if: always()
@@ -140,8 +140,9 @@ jobs:
     needs: [Test-Nix, Test-Pg-Nix, Test-Memory-Nix, Build-Static-Nix, Lint-Style]
     runs-on: ubuntu-latest
     strategy:
-      matrix: 
-        cache-id: ['static-nix', 'test-pgdefault', 'test-pg9.6', 'test-pg10', 'test-pg11', 'test-pg12', 'test-pg13', 'test-pg14', 'test-pg15', 'test-pg16', 'style', 'test-memory']
+      max-parallel: 1
+      matrix:
+        cache-id: ['static-nix', 'test-pg', 'style', 'test-memory']
     steps:
       - uses: actions/checkout@v4
       - uses: nixbuild/nix-quick-install-action@v26

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,6 +135,24 @@ jobs:
           path: postgrest-docker.tar.gz
           if-no-files-found: error
 
+  merge-nix-caches-linux:
+    name: "Merge Nix caches (Linux)"
+    needs: [Test-Nix, Test-Pg-Nix, Test-Memory-Nix, Build-Static-Nix, Lint-Style]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: 
+        cache-id: ['static-nix', 'test-pgdefault', 'test-pg9.6', 'test-pg10', 'test-pg11', 'test-pg12', 'test-pg13', 'test-pg14', 'test-pg15', 'test-pg16', 'style', 'test-memory']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nixbuild/nix-quick-install-action@v26
+        with:
+          nix_version: '2.13.6'
+      - name: Restore and cache Nix store
+        uses: nix-community/cache-nix-action@v4
+        with:
+          key: cache-nix-${{ runner.os }}-${{ matrix.cache-id }}-${{ hashFiles('nix/**/*.nix') }}
+          extra-restore-keys: |
+            cache-nix-${{ runner.os }}-
 
   Build-Macos-Nix:
     name: Build MacOS (Nix)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -185,7 +185,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ matrix.cache }}
-          key: ${{ runner.os }}-${{ hashFiles('stack.yaml.lock') }}
+          key: cache-stack-${{ runner.os }}-${{ hashFiles('stack.yaml.lock') }}
       - name: Install dependencies
         if: ${{ matrix.deps }}
         run: ${{ matrix.deps }}
@@ -241,9 +241,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cabal
-          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+          key: cache-cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.ghc }}-
+            cache-cabal-${{ runner.os }}-${{ matrix.ghc }}-
       - name: Install dependencies
         run: |
           cabal update

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,30 +137,32 @@ jobs:
           path: postgrest-docker.tar.gz
           if-no-files-found: error
 
-  merge-nix-caches-linux:
-    name: "Merge Nix caches (Linux)"
-    needs: [Test-Nix, Test-Pg-Nix, Test-Memory-Nix, Build-Static-Nix, Lint-Style]
-    runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 1
-      matrix:
-        cache-id: ['static-nix', 'test-pg', 'style', 'test-memory']
-    steps:
-      - uses: actions/checkout@v4
-      - uses: nixbuild/nix-quick-install-action@v26
-        with:
-          nix_version: '2.13.6'
-      - name: Restore and cache Nix store
-        uses: nix-community/cache-nix-action@v4
-        with:
-          key: cache-nix-${{ runner.os }}-common-${{ hashFiles('nix/**/*.nix') }}
-          extra-restore-keys: |
-            cache-nix-${{ runner.os }}-cid-
-          purge: true
-          purge-keys: |
-            cache-nix-${{ runner.os }}-cid-
-            cache-nix-${{ runner.os }}-common-
-          purge-created-max-age: 0
+  # TODO: Enable this again in a PR by PostgREST admins, because regular users don't have permission to delete cache entries, which this job does.
+  #
+  # merge-nix-caches-linux:
+  #   name: "Merge Nix caches (Linux)"
+  #   needs: [Test-Nix, Test-Pg-Nix, Test-Memory-Nix, Build-Static-Nix, Lint-Style]
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     max-parallel: 1
+  #     matrix:
+  #       cache-id: ['static-nix', 'test-pg', 'style', 'test-memory']
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: nixbuild/nix-quick-install-action@v26
+  #       with:
+  #         nix_version: '2.13.6'
+  #     - name: Restore and cache Nix store
+  #       uses: nix-community/cache-nix-action@v4
+  #       with:
+  #         key: cache-nix-${{ runner.os }}-common-${{ hashFiles('nix/**/*.nix') }}
+  #         extra-restore-keys: |
+  #           cache-nix-${{ runner.os }}-cid-
+  #         purge: true
+  #         purge-keys: |
+  #           cache-nix-${{ runner.os }}-cid-
+  #           cache-nix-${{ runner.os }}-common-
+  #         purge-created-max-age: 0
 
   Build-Macos-Nix:
     name: Build MacOS (Nix)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           tools: style
+          cache-id: style
       - name: Run linter (check locally with `nix-shell --run postgrest-lint`)
         run: postgrest-lint
       - name: Run style check (auto-format with `nix-shell --run postgrest-style`)
@@ -42,6 +43,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           tools: tests
+          cache-id: test-pgdefault
 
       - name: Run coverage (IO tests and Spec tests against PostgreSQL 15)
         run: postgrest-coverage
@@ -77,6 +79,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           tools: tests withTools
+          cache-id: test-pg${{ matrix.pgVersion }}
 
       - name: Run spec tests
         if: always()
@@ -96,6 +99,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           tools: memory
+          cache-id: test-memory
       - name: Run memory tests
         run: postgrest-test-memory
 
@@ -109,6 +113,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           tools: tests
+          cache-id: static-nix
 
       - name: Build static executable
         run: nix-build -A postgrestStatic

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,9 +150,14 @@ jobs:
       - name: Restore and cache Nix store
         uses: nix-community/cache-nix-action@v4
         with:
-          key: cache-nix-${{ runner.os }}-${{ matrix.cache-id }}-${{ hashFiles('nix/**/*.nix') }}
+          key: cache-nix-${{ runner.os }}-common-${{ hashFiles('nix/**/*.nix') }}
           extra-restore-keys: |
-            cache-nix-${{ runner.os }}-
+            cache-nix-${{ runner.os }}-id-
+          purge: true
+          purge-keys: |
+            cache-nix-${{ runner.os }}-id-
+            cache-nix-${{ runner.os }}-common-
+          purge-created-max-age: 0
 
   Build-Macos-Nix:
     name: Build MacOS (Nix)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,9 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           tools: tests withTools
-          cache-id: test-pg
+          # It seems like they are installing the same set of derivations, so we can assign them the same cache id. 
+          # This would decrease the amount of caches dowloaded on merge cache step and will prevent disk space issues.
+          cache-id: test-pg 
 
       - name: Run spec tests
         if: always()
@@ -153,10 +155,10 @@ jobs:
         with:
           key: cache-nix-${{ runner.os }}-common-${{ hashFiles('nix/**/*.nix') }}
           extra-restore-keys: |
-            cache-nix-${{ runner.os }}-id-
+            cache-nix-${{ runner.os }}-cid-
           purge: true
           purge-keys: |
-            cache-nix-${{ runner.os }}-id-
+            cache-nix-${{ runner.os }}-cid-
             cache-nix-${{ runner.os }}-common-
           purge-created-max-age: 0
 

--- a/.github/workflows/loadtest.yaml
+++ b/.github/workflows/loadtest.yaml
@@ -23,6 +23,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           tools: loadtest
+          cache-id: test-pg
       - uses: actions-ecosystem/action-get-latest-tag@v1
         id: get-latest-tag
         with:
@@ -54,6 +55,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           tools: loadtest
+          cache-id: test-pg
       - name: Run loadtest
         run: |
           postgrest-loadtest-against ${{ steps.get-latest-tag.outputs.tag }}


### PR DESCRIPTION
This PR introduces caching of the Nix store for nix-based CI jobs, improving "nix setup" build step 2x to 3x, depending on the job

Closes #2990

Changes introduced:
* Reworked the `setup-nix` action:
	- upgraded Nix to 2.13.6 for CI jobs
	- added [cache-nix-action](https://github.com/nix-community/cache-nix-action) to cache nix store
	- added `cache-id` parameter to be able to fine-tune caches
* unifying cache keys' naming scheme across the workflows, making them easier identifiable
* Introduced the `merge-nix-caches` job, which supposed to merge mostly similar nix-based jobs' caches. Had to uncomment it because it couldn't purge per-job caches (to save space) being run under my account, but the work could be continued right where it stopped

TODO: enable Nix garbage collecting