### PR TITLE
ci: introduce nightly release job

### DIFF
--- a/.github/actions/release-nightly/action.yaml
+++ b/.github/actions/release-nightly/action.yaml
@@ -1,0 +1,50 @@
+name: Release Nightly
+
+inputs:
+  artifact:
+    description: 'The name of the artifact to process'
+    required: true
+  release:
+    description: 'The name of the release to upload to'
+    required: false
+    default: 'nightly'
+  platform:
+    description: 'The platform to use for the archive name'
+    required: true
+  format:
+    description: 'The format to use for the archive name'
+    required: false
+    default: 'tar'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Download artifact 
+      uses: actions/download-artifact@v2
+      with:
+        name: ${{ inputs.artifact }}
+    - name: Chmod artifact
+      run: 'chmod +x ${{ inputs.artifact }}'
+    - name: Get current date & time
+      id: datetime
+      run: echo "datetime=$(date +%Y-%m-%d-%H-%M)" >> "$GITHUB_OUTPUT"
+    - name: Render archive name
+      id: archive_name
+      run: echo "::set-output name=archive_name::postgresql-nightly-${{ steps.datetime.outputs.datetime }}-${{ github.sha }}-${{ inputs.platform }}.${{ inputs.format }}"
+    - name: Compress tarball
+      if: ${{ inputs.format == 'tar' }}
+      run: 'tar -cJvf ${{ steps.archive_name.outputs.archive_name }}.tar.xz ${{ inputs.artifact }}'
+    - name: Compress zip
+      if: ${{ inputs.format == 'zip' }}
+      run: 'zip ${{ steps.archive_name.outputs.archive_name }}.zip ${{ inputs.artifact }}'
+    - name: Upload to release
+      uses: softprops/action-gh-release@v0.1.15
+      with:
+        files: |
+          ${{ steps.archive_name.outputs.archive_name }}.tar.xz
+          ${{ steps.archive_name.outputs.archive_name }}.zip
+        name: ${{ inputs.release }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/actions/release-nightly/action.yaml
+++ b/.github/actions/release-nightly/action.yaml
@@ -34,7 +34,8 @@ runs:
       shell: bash
     - name: Render archive name
       id: archive_name
-      run: echo "::set-output name=archive_name::postgresql-nightly-${{ steps.datetime.outputs.datetime }}-${{ github.sha }}-${{ inputs.platform }}.${{ inputs.format }}"
+      run: |
+        echo "archive_name=postgresql-nightly-${{ steps.datetime.outputs.datetime }}-${{ github.sha }}-${{ inputs.platform }}" >> "$GITHUB_ENV"
       shell: bash
     - name: Compress tarball
       if: ${{ inputs.format == 'tar' }}

--- a/.github/actions/release-nightly/action.yaml
+++ b/.github/actions/release-nightly/action.yaml
@@ -53,4 +53,5 @@ runs:
           ${{ steps.archive_name.outputs.archive_name }}.tar.xz
           ${{ steps.archive_name.outputs.archive_name }}.zip
         tag_name: ${{ inputs.release }}
-
+        fail_on_unmatched_files: false
+        prerelease: true

--- a/.github/actions/release-nightly/action.yaml
+++ b/.github/actions/release-nightly/action.yaml
@@ -56,7 +56,7 @@ runs:
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ inputs.repo-token }}
-        GH_DEBUG: true
+        GH_DEBUG: 1
       run: |
         gh api \
           --method POST \

--- a/.github/actions/release-nightly/action.yaml
+++ b/.github/actions/release-nightly/action.yaml
@@ -56,6 +56,7 @@ runs:
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ inputs.repo-token }}
+        GH_DEBUG: true
       run: |
         gh api \
           --method POST \

--- a/.github/actions/release-nightly/action.yaml
+++ b/.github/actions/release-nightly/action.yaml
@@ -45,7 +45,7 @@ runs:
       if: ${{ inputs.format == 'tar' }}
       run: |
         echo "asset_name=${{ steps.archive_name.outputs.archive_name }}.tar.xz" >> "$GITHUB_ENV"
-        tar -cJvf ${{ steps.archive_name.outputs.archive_name }}.tar.xz ${{ inputs.artifact }}'
+        tar -cJvf ${{ steps.archive_name.outputs.archive_name }}.tar.xz ${{ inputs.artifact }}
       shell: bash
     - name: Compress zip
       if: ${{ inputs.format == 'zip' }}

--- a/.github/actions/release-nightly/action.yaml
+++ b/.github/actions/release-nightly/action.yaml
@@ -45,7 +45,7 @@ runs:
       if: ${{ inputs.format == 'tar' }}
       run: |
         echo "asset_name=${{ steps.archive_name.outputs.archive_name }}.tar.xz" >> "$GITHUB_ENV"
-        tar -cJvf ${{ steps.archive_name.outputs.archive_name }}.tar.xz ${{ inputs.artifact }}
+        tar -cJf ${{ steps.archive_name.outputs.archive_name }}.tar.xz ${{ inputs.artifact }}
       shell: bash
     - name: Compress zip
       if: ${{ inputs.format == 'zip' }}
@@ -63,7 +63,7 @@ runs:
           -H "Authorization: Bearer ${GITHUB_TOKEN}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           -H "Content-Type: application/octet-stream" \
-          "https://uploads.github.com/repos/PostgREST/postgrest/releases/33773182/assets?name=${asset_name}" \
+          "https://uploads.github.com/repos/develop7/postgrest/releases/126613367/assets?name=${asset_name}" \
           --data-binary "@${asset_name}"
       shell: bash
     # - name: Upload to release

--- a/.github/actions/release-nightly/action.yaml
+++ b/.github/actions/release-nightly/action.yaml
@@ -44,13 +44,13 @@ runs:
     - name: Compress tarball
       if: ${{ inputs.format == 'tar' }}
       run: |
-        echo "asset_name=${{ steps.archive_name.outputs.archive_name }}.tar.xz" >> "$GITHUB_ENV" \
+        echo "asset_name=${{ steps.archive_name.outputs.archive_name }}.tar.xz" >> "$GITHUB_ENV"
         tar -cJvf ${{ steps.archive_name.outputs.archive_name }}.tar.xz ${{ inputs.artifact }}'
       shell: bash
     - name: Compress zip
       if: ${{ inputs.format == 'zip' }}
       run: |
-        echo "asset_name=${{ steps.archive_name.outputs.archive_name }}.zip" >> "$GITHUB_ENV" \
+        echo "asset_name=${{ steps.archive_name.outputs.archive_name }}.zip" >> "$GITHUB_ENV"
         zip ${{ steps.archive_name.outputs.archive_name }}.zip ${{ inputs.artifact }}
       shell: bash
     - name: Upload to release

--- a/.github/actions/release-nightly/action.yaml
+++ b/.github/actions/release-nightly/action.yaml
@@ -43,17 +43,26 @@ runs:
       shell: bash
     - name: Compress tarball
       if: ${{ inputs.format == 'tar' }}
-      run: 'tar -cJvf ${{ steps.archive_name.outputs.archive_name }}.tar.xz ${{ inputs.artifact }}'
+      run: |
+        echo "asset_name=${{ steps.archive_name.outputs.archive_name }}.tar.xz" >> "$GITHUB_ENV" \
+        tar -cJvf ${{ steps.archive_name.outputs.archive_name }}.tar.xz ${{ inputs.artifact }}'
       shell: bash
     - name: Compress zip
       if: ${{ inputs.format == 'zip' }}
-      run: 'zip ${{ steps.archive_name.outputs.archive_name }}.zip ${{ inputs.artifact }}'
+      run: |
+        echo "asset_name=${{ steps.archive_name.outputs.archive_name }}.zip" >> "$GITHUB_ENV" \
+        zip ${{ steps.archive_name.outputs.archive_name }}.zip ${{ inputs.artifact }}
       shell: bash
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ inputs.repo-token }}
       run: |
-        find -type f -name "${{ steps.archive_name.outputs.archive_name }}.*" -exec gh release upload nightly {} \;
+        gh api \
+          --method POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /repos/PostgREST/postgrest/releases/33773182/assets?name=${asset_name} \
+          -f "@${asset_name}"
       shell: bash
     # - name: Upload to release
     #   uses: softprops/action-gh-release@v0.1.15

--- a/.github/actions/release-nightly/action.yaml
+++ b/.github/actions/release-nightly/action.yaml
@@ -52,4 +52,5 @@ runs:
         files: |
           ${{ steps.archive_name.outputs.archive_name }}.tar.xz
           ${{ steps.archive_name.outputs.archive_name }}.zip
-        name: ${{ inputs.release }}
+        tag_name: ${{ inputs.release }}
+

--- a/.github/actions/release-nightly/action.yaml
+++ b/.github/actions/release-nightly/action.yaml
@@ -47,11 +47,17 @@ runs:
       run: 'zip ${{ steps.archive_name.outputs.archive_name }}.zip ${{ inputs.artifact }}'
       shell: bash
     - name: Upload to release
-      uses: softprops/action-gh-release@v0.1.15
-      with:
-        files: |
-          ${{ steps.archive_name.outputs.archive_name }}.tar.xz
-          ${{ steps.archive_name.outputs.archive_name }}.zip
-        tag_name: ${{ inputs.release }}
-        fail_on_unmatched_files: false
-        prerelease: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release upload nightly ${{ steps.archive_name.outputs.archive_name }}.tar.xz ${{ steps.archive_name.outputs.archive_name }}.zip
+      shell: bash
+    # - name: Upload to release
+    #   uses: softprops/action-gh-release@v0.1.15
+    #   with:
+    #     files: |
+    #       ${{ steps.archive_name.outputs.archive_name }}.tar.xz
+    #       ${{ steps.archive_name.outputs.archive_name }}.zip
+    #     tag_name: ${{ inputs.release }}
+    #     fail_on_unmatched_files: false
+    #     prerelease: true

--- a/.github/actions/release-nightly/action.yaml
+++ b/.github/actions/release-nightly/action.yaml
@@ -36,7 +36,7 @@ runs:
     - name: Render archive name
       id: archive_name
       run: |
-        echo "archive_name=postgresql-nightly-${{ steps.datetime.outputs.datetime }}-${{ github.sha }}-${{ inputs.platform }}" >> "$GITHUB_ENV"
+        echo "archive_name=postgresql-nightly-${{ steps.datetime.outputs.datetime }}-${{ github.sha }}-${{ inputs.platform }}" >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Compress tarball
       if: ${{ inputs.format == 'tar' }}

--- a/.github/actions/release-nightly/action.yaml
+++ b/.github/actions/release-nightly/action.yaml
@@ -63,7 +63,7 @@ runs:
           -H "Accept: application/vnd.github+json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           /repos/PostgREST/postgrest/releases/33773182/assets?name=${asset_name} \
-          -f "@${asset_name}"
+          --field "@${asset_name}"
       shell: bash
     # - name: Upload to release
     #   uses: softprops/action-gh-release@v0.1.15

--- a/.github/actions/release-nightly/action.yaml
+++ b/.github/actions/release-nightly/action.yaml
@@ -53,7 +53,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.repo-token }}
       run: |
-        gh release upload nightly ${{ steps.archive_name.outputs.archive_name }}.tar.xz ${{ steps.archive_name.outputs.archive_name }}.zip
+        find -type f -name "${{ steps.archive_name.outputs.archive_name }}.*" -exec gh release upload nightly {} \;
       shell: bash
     # - name: Upload to release
     #   uses: softprops/action-gh-release@v0.1.15

--- a/.github/actions/release-nightly/action.yaml
+++ b/.github/actions/release-nightly/action.yaml
@@ -27,18 +27,23 @@ runs:
         name: ${{ inputs.artifact }}
     - name: Chmod artifact
       run: 'chmod +x ${{ inputs.artifact }}'
+      shell: bash
     - name: Get current date & time
       id: datetime
       run: echo "datetime=$(date +%Y-%m-%d-%H-%M)" >> "$GITHUB_OUTPUT"
+      shell: bash
     - name: Render archive name
       id: archive_name
       run: echo "::set-output name=archive_name::postgresql-nightly-${{ steps.datetime.outputs.datetime }}-${{ github.sha }}-${{ inputs.platform }}.${{ inputs.format }}"
+      shell: bash
     - name: Compress tarball
       if: ${{ inputs.format == 'tar' }}
       run: 'tar -cJvf ${{ steps.archive_name.outputs.archive_name }}.tar.xz ${{ inputs.artifact }}'
+      shell: bash
     - name: Compress zip
       if: ${{ inputs.format == 'zip' }}
       run: 'zip ${{ steps.archive_name.outputs.archive_name }}.zip ${{ inputs.artifact }}'
+      shell: bash
     - name: Upload to release
       uses: softprops/action-gh-release@v0.1.15
       with:
@@ -46,5 +51,3 @@ runs:
           ${{ steps.archive_name.outputs.archive_name }}.tar.xz
           ${{ steps.archive_name.outputs.archive_name }}.zip
         name: ${{ inputs.release }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/actions/release-nightly/action.yaml
+++ b/.github/actions/release-nightly/action.yaml
@@ -25,8 +25,9 @@ runs:
       uses: actions/download-artifact@v2
       with:
         name: ${{ inputs.artifact }}
-    - name: Chmod artifact
-      run: 'chmod +x ${{ inputs.artifact }}'
+    - name: "Fix artifact name & perms"
+      run: |
+        mv postgrest ${{ inputs.artifact }} && chmod +x ${{ inputs.artifact }}
       shell: bash
     - name: Get current date & time
       id: datetime

--- a/.github/actions/release-nightly/action.yaml
+++ b/.github/actions/release-nightly/action.yaml
@@ -15,6 +15,9 @@ inputs:
     description: 'The format to use for the archive name'
     required: false
     default: 'tar'
+  repo-token:
+    description: 'The token to use for the upload'
+    required: true
 
 runs:
   using: "composite"
@@ -48,7 +51,7 @@ runs:
       shell: bash
     - name: Upload to release
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ inputs.repo-token }}
       run: |
         gh release upload nightly ${{ steps.archive_name.outputs.archive_name }}.tar.xz ${{ steps.archive_name.outputs.archive_name }}.zip
       shell: bash

--- a/.github/actions/release-nightly/action.yaml
+++ b/.github/actions/release-nightly/action.yaml
@@ -56,14 +56,15 @@ runs:
     - name: Upload to release
       env:
         GITHUB_TOKEN: ${{ inputs.repo-token }}
-        GH_DEBUG: 1
       run: |
-        gh api \
-          --method POST \
+        curl -L \
+          -X POST \
           -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${GITHUB_TOKEN}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          /repos/PostgREST/postgrest/releases/33773182/assets?name=${asset_name} \
-          --field "@${asset_name}"
+          -H "Content-Type: application/octet-stream" \
+          "https://uploads.github.com/repos/PostgREST/postgrest/releases/33773182/assets?name=${asset_name}" \
+          --data-binary "@${asset_name}"
       shell: bash
     # - name: Upload to release
     #   uses: softprops/action-gh-release@v0.1.15

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,6 +125,7 @@ jobs:
         with:
           artifact: postgrest-linux-static-x64
           platform: linux-static-x64
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Docker image
         run: nix-build -A docker.image --out-link postgrest-docker.tar.gz
       - name: Save built Docker image as artifact
@@ -210,6 +211,7 @@ jobs:
           artifact: postgrest-${{ matrix.platform }}${{ matrix.ext }}
           platform: ${{ matrix.platform }}
           format: ${{ matrix.release_format }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
   
   Get-FreeBSD-CirrusCI:
     name: Get FreeBSD build from CirrusCI
@@ -233,6 +235,7 @@ jobs:
         with:
           artifact: postgrest-freebsd-x64
           platform: freebsd-x64
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
   
   Build-Cabal:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -322,11 +322,6 @@ jobs:
           name: postgrest-ubuntu-aarch64
           path: result/postgrest
           if-no-files-found: error
-      - name: Upload executable to nightly release
-        uses: ./.github/actions/release-nightly
-        with:
-          artifact: postgrest-ubuntu-aarch64
-          platform: ubuntu-aarch64
   
   Prepare-Release:
     name: Prepare release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -306,6 +306,65 @@ jobs:
           path: result/postgrest
           if-no-files-found: error
 
+  release-nightly:
+    name: Upload Nightly Build
+    # if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    needs:
+      - Lint-Style
+      - Test-Nix
+      - Test-Pg-Nix
+      - Test-Memory-Nix
+      - Build-Static-Nix
+      - Build-Stack
+      - Get-FreeBSD-CirrusCI
+      - Build-Cabal-Arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+      - name: Get current date & time
+        id: datetime
+        run: echo "datetime=$(date +%Y-%m-%d-%H-%M-%S)" >> "$GITHUB_OUTPUT"
+      - name: Create release bundle with archives for all builds
+        env:
+          VERSION: "${{ steps.datetime.outputs.datetime }}-${{ github.sha }}"
+        run: |
+          find artifacts -type f -iname postgrest -exec chmod +x {} \;
+
+          mkdir -p release-bundle
+
+          tar cJvf "release-bundle/postgrest-nightly-$VERSION-linux-static-x64.tar.xz" \
+            -C artifacts/postgrest-linux-static-x64 postgrest
+
+          tar cJvf "release-bundle/postgrest-nightly-$VERSION-macos-x64.tar.xz" \
+            -C artifacts/postgrest-macos-x64 postgrest
+
+          # TODO: Fix timeouts for FreeBSD builds in Cirrus
+          tar cJvf "release-bundle/postgrest-nightly-$VERSION-freebsd-x64.tar.xz" \
+            -C artifacts/postgrest-freebsd-x64 postgrest
+
+          tar cJvf "release-bundle/postgrest-nightly-$VERSION-ubuntu-aarch64.tar.xz" \
+            -C artifacts/postgrest-ubuntu-aarch64 postgrest
+
+          zip "release-bundle/postgrest-nightly-$VERSION-windows-x64.zip" \
+            artifacts/postgrest-windows-x64/postgrest.exe
+
+      - name: Save release bundle
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-bundle
+          path: release-bundle
+          if-no-files-found: error
+      - name: Publish release on GitHub
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Releasing version $VERSION on GitHub..."
+          gh release upload "nightly" \
+            release-bundle/*
 
   Prepare-Release:
     name: Prepare release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,10 +12,6 @@ on:
       - main
       - rel-*
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   Lint-Style:
     name: Lint & check code style

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,10 @@ on:
       - main
       - rel-*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Lint-Style:
     name: Lint & check code style

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,6 +160,7 @@ jobs:
               .stack-work
             platform: ubuntu-x64
             ext: ''
+            release_format: tar
 
           - name: MacOS
             runs-on: macos-latest
@@ -168,6 +169,7 @@ jobs:
               .stack-work
             platform: macos-x64
             ext: ''
+            release_format: tar
 
           - name: Windows
             runs-on: windows-latest
@@ -178,6 +180,7 @@ jobs:
             deps: Add-Content $env:GITHUB_PATH $env:PGBIN
             platform: windows-x64
             ext: '.exe'
+            release_format: zip
 
     name: Build ${{ matrix.name }} (Stack)
     runs-on: ${{ matrix.runs-on }}
@@ -206,6 +209,7 @@ jobs:
         with:
           artifact: postgrest-${{ matrix.platform }}${{ matrix.ext }}
           platform: ${{ matrix.platform }}
+          format: ${{ matrix.release_format }}
   
   Get-FreeBSD-CirrusCI:
     name: Get FreeBSD build from CirrusCI

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,7 +120,11 @@ jobs:
           name: postgrest-linux-static-x64
           path: result/bin/postgrest
           if-no-files-found: error
-
+      - name: Upload executable to nightly release
+        uses: ./.github/actions/release-nightly
+        with:
+          artifact: postgrest-linux-static-x64
+          platform: linux-static-x64
       - name: Build Docker image
         run: nix-build -A docker.image --out-link postgrest-docker.tar.gz
       - name: Save built Docker image as artifact
@@ -129,7 +133,7 @@ jobs:
           name: postgrest-docker-x64
           path: postgrest-docker.tar.gz
           if-no-files-found: error
-
+# TODO: Upload Docker image to nightly release
 
   Build-Macos-Nix:
     name: Build MacOS (Nix)
@@ -154,14 +158,16 @@ jobs:
             cache: |
               ~/.stack
               .stack-work
-            artifact: postgrest-ubuntu-x64
+            platform: ubuntu-x64
+            ext: ''
 
           - name: MacOS
             runs-on: macos-latest
             cache: |
               ~/.stack
               .stack-work
-            artifact: postgrest-macos-x64
+            platform: macos-x64
+            ext: ''
 
           - name: Windows
             runs-on: windows-latest
@@ -170,7 +176,8 @@ jobs:
               ~\AppData\Local\Programs\stack
               .stack-work
             deps: Add-Content $env:GITHUB_PATH $env:PGBIN
-            artifact: postgrest-windows-x64
+            platform: windows-x64
+            ext: '.exe'
 
     name: Build ${{ matrix.name }} (Stack)
     runs-on: ${{ matrix.runs-on }}
@@ -189,12 +196,17 @@ jobs:
       - name: Save built executable as artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.artifact }}
+          name: postgrest-${{ matrix.platform }}${{ matrix.ext }}
           path: |
             result/postgrest
             result/postgrest.exe
           if-no-files-found: error
-
+      - name: Upload executable to nightly release
+        uses: ./.github/actions/release-nightly
+        with:
+          artifact: postgrest-${{ matrix.platform }}${{ matrix.ext }}
+          platform: ${{ matrix.platform }}
+  
   Get-FreeBSD-CirrusCI:
     name: Get FreeBSD build from CirrusCI
     runs-on: ubuntu-latest
@@ -212,7 +224,12 @@ jobs:
           name: postgrest-freebsd-x64
           path: postgrest
           if-no-files-found: error
-
+      - name: Upload executable to nightly release
+        uses: ./.github/actions/release-nightly
+        with:
+          artifact: postgrest-freebsd-x64
+          platform: freebsd-x64
+  
   Build-Cabal:
     strategy:
       matrix:
@@ -305,67 +322,12 @@ jobs:
           name: postgrest-ubuntu-aarch64
           path: result/postgrest
           if-no-files-found: error
-
-  release-nightly:
-    name: Upload Nightly Build
-    # if: ${{ github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-latest
-    needs:
-      - Lint-Style
-      - Test-Nix
-      - Test-Pg-Nix
-      - Test-Memory-Nix
-      - Build-Static-Nix
-      - Build-Stack
-      - Get-FreeBSD-CirrusCI
-      - Build-Cabal-Arm
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download all artifacts
-        uses: actions/download-artifact@v3
+      - name: Upload executable to nightly release
+        uses: ./.github/actions/release-nightly
         with:
-          path: artifacts
-      - name: Get current date & time
-        id: datetime
-        run: echo "datetime=$(date +%Y-%m-%d-%H-%M-%S)" >> "$GITHUB_OUTPUT"
-      - name: Create release bundle with archives for all builds
-        env:
-          VERSION: "${{ steps.datetime.outputs.datetime }}-${{ github.sha }}"
-        run: |
-          find artifacts -type f -iname postgrest -exec chmod +x {} \;
-
-          mkdir -p release-bundle
-
-          tar cJvf "release-bundle/postgrest-nightly-$VERSION-linux-static-x64.tar.xz" \
-            -C artifacts/postgrest-linux-static-x64 postgrest
-
-          tar cJvf "release-bundle/postgrest-nightly-$VERSION-macos-x64.tar.xz" \
-            -C artifacts/postgrest-macos-x64 postgrest
-
-          # TODO: Fix timeouts for FreeBSD builds in Cirrus
-          tar cJvf "release-bundle/postgrest-nightly-$VERSION-freebsd-x64.tar.xz" \
-            -C artifacts/postgrest-freebsd-x64 postgrest
-
-          tar cJvf "release-bundle/postgrest-nightly-$VERSION-ubuntu-aarch64.tar.xz" \
-            -C artifacts/postgrest-ubuntu-aarch64 postgrest
-
-          zip "release-bundle/postgrest-nightly-$VERSION-windows-x64.zip" \
-            artifacts/postgrest-windows-x64/postgrest.exe
-
-      - name: Save release bundle
-        uses: actions/upload-artifact@v3
-        with:
-          name: release-bundle
-          path: release-bundle
-          if-no-files-found: error
-      - name: Publish release on GitHub
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Releasing version $VERSION on GitHub..."
-          gh release upload "nightly" \
-            release-bundle/*
-
+          artifact: postgrest-ubuntu-aarch64
+          platform: ubuntu-aarch64
+  
   Prepare-Release:
     name: Prepare release
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,6 +103,8 @@ jobs:
   Build-Static-Nix:
     name: Build Linux static (Nix)
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Setup Nix Environment
@@ -185,6 +187,8 @@ jobs:
 
     name: Build ${{ matrix.name }} (Stack)
     runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Stack working files cache


### PR DESCRIPTION
This PR introduces packaging and uploading successfully built artifacts to `nightly` GitHub release right away, before/without passing test suite.

fixes #2997 