### PR TITLE
build: add cabal.project.freeze

### DIFF
--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -1,1 +1,1 @@
-constraints: any.deferred-folds ==0.9.18.3
+index-state: hackage.haskell.org 2023-10-13T13:54:33Z

--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -1,1 +1,1 @@
-index-state: hackage.haskell.org 2023-03-25T00:00:00Z
+index-state: hackage.haskell.org 2023-03-25T23:59:59Z

--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -1,1 +1,1 @@
-index-state: hackage.haskell.org 2023-03-25T23:59:59Z
+index-state: hackage.haskell.org 2023-10-19T09:31:29Z

--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -1,0 +1,1 @@
+constraints: any.deferred-folds ==0.9.18.3

--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -1,1 +1,1 @@
-index-state: hackage.haskell.org 2023-10-19T09:31:29Z
+index-state: hackage.haskell.org 2023-10-13T13:54:33Z

--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -1,1 +1,1 @@
-index-state: hackage.haskell.org 2023-10-13T13:54:33Z
+index-state: hackage.haskell.org 2023-03-25T00:00:00Z


### PR DESCRIPTION
Introduces `cabal.project.freeze` to fix build errors caused by `deferred-folds` upgrade, "GHC on Linux" jobs in particular

fixes #3000