### PR TITLE
perf: make the Null Filtering query more performant

### DIFF
--- a/src/PostgREST/Plan/Types.hs
+++ b/src/PostgREST/Plan/Types.hs
@@ -49,7 +49,7 @@ data CoercibleFilter = CoercibleFilter
   { field  :: CoercibleField
   , opExpr :: OpExpr
   }
-  | CoercibleFilterNullEmbed Bool FieldName
+  | CoercibleFilterNullEmbed Bool FieldName [FieldName]
   deriving (Eq, Show)
 
 data CoercibleOrderTerm

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -337,7 +337,11 @@ pgFmtArrayLiteralForField values _ = unknownLiteral (pgBuildArrayLiteral values)
 
 
 pgFmtFilter :: QualifiedIdentifier -> CoercibleFilter -> SQL.Snippet
-pgFmtFilter _ (CoercibleFilterNullEmbed hasNot fld) = pgFmtIdent fld <> " IS " <> (if not hasNot then "NOT " else mempty) <> "DISTINCT FROM NULL"
+pgFmtFilter _ (CoercibleFilterNullEmbed hasNot fld joins) =
+  (if null joins
+  then pgFmtIdent fld
+  else intercalateSnippet " AND " $ (\j -> pgFmtIdent fld <> "." <> pgFmtIdent j) <$> joins)
+  <> " IS " <> (if hasNot then "NOT " else mempty) <> "NULL"
 pgFmtFilter _ (CoercibleFilter _ (NoOpExpr _)) = mempty -- TODO unreachable because NoOpExpr is filtered on QueryParams
 pgFmtFilter table (CoercibleFilter fld (OpExpr hasNot oper)) = notOp <> " " <> pgFmtField table fld <> case oper of
    Op op val  -> " " <> simpleOperator op <> " " <> pgFmtUnknownLiteralForField (unknownLiteral val) fld

--- a/test/spec/Feature/Query/RelatedQueriesSpec.hs
+++ b/test/spec/Feature/Query/RelatedQueriesSpec.hs
@@ -258,8 +258,10 @@ spec = describe "related queries" $ do
         , matchHeaders = [matchContentTypeJson]
         }
 
-    -- "?table=not.is.null" does a "table IS DISTINCT FROM NULL" instead of a "table IS NOT NULL"
-    -- https://github.com/PostgREST/postgrest/issues/2800#issuecomment-1720315818
+    -- "?table=not.is.null" translates to:
+    -- * "table.join_column IS NOT NULL" for to-one relationships
+    -- * "table IS NOT NULL" for to-many relationships
+    -- https://github.com/PostgREST/postgrest/issues/2961
     it "embeds verifying that the entire target table row is not null" $ do
       get "/table_b?select=name,table_a(name)&table_a=not.is.null" `shouldRespondWith`
         [json|[


### PR DESCRIPTION
Closes #2961

- [x] Convert 'table is distinct from null' to 'join_col is not null' 
- [ ] Adapt subquery to new filter
- [ ] Verify if it can only be done for `to-one` relationships