### PR TITLE
Display an actual TCP port app is bound to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3019, Transaction-Scoped Settings are now shown clearly in the Postgres logs - @laurenceisla
    + Shows `set_config('pgrst.setting_name', $1)` instead of `setconfig($1, $2)`
    + Does not apply to role settings and `app.settings.*`
+ - #2420, Fix bogus message when listening on port 0 - @develop7
 
 ### Changed
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -1,30 +1,16 @@
-{-# LANGUAGE CPP #-}
-
 module Main (main) where
 
 import System.IO (BufferMode (..), hSetBuffering)
 
-import qualified PostgREST.App as App
 import qualified PostgREST.CLI as CLI
 
 import Protolude
-
-#ifndef mingw32_HOST_OS
-import qualified PostgREST.Unix as Unix
-#endif
 
 main :: IO ()
 main = do
   setBuffering
   opts <- CLI.readCLIShowHelp
-  CLI.main installSignalHandlers opts
-
-installSignalHandlers :: App.SignalHandlerInstaller
-#ifndef mingw32_HOST_OS
-installSignalHandlers = Unix.installSignalHandlers
-#else
-installSignalHandlers _ = pass
-#endif
+  CLI.main opts
 
 setBuffering :: IO ()
 setBuffering = do

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -17,20 +17,13 @@ main :: IO ()
 main = do
   setBuffering
   opts <- CLI.readCLIShowHelp
-  CLI.main installSignalHandlers runAppInSocket opts
+  CLI.main installSignalHandlers opts
 
 installSignalHandlers :: App.SignalHandlerInstaller
 #ifndef mingw32_HOST_OS
 installSignalHandlers = Unix.installSignalHandlers
 #else
 installSignalHandlers _ = pass
-#endif
-
-runAppInSocket :: Maybe App.SocketRunner
-#ifndef mingw32_HOST_OS
-runAppInSocket = Just Unix.runAppWithSocket
-#else
-runAppInSocket = Nothing
 #endif
 
 setBuffering :: IO ()

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -122,7 +122,7 @@ library
                     , time                      >= 1.6 && < 1.12
                     , timeit                    >= 2.0 && < 2.1
                     , unordered-containers      >= 0.2.8 && < 0.3
-                    , unix-compat
+                    , unix-compat >= 0.6 && < 0.7
                     , vault                     >= 0.3.1.5 && < 0.4
                     , vector                    >= 0.11 && < 0.14
                     , wai                       >= 3.2.1 && < 3.3

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -120,7 +120,7 @@ library
                     , time                      >= 1.6 && < 1.12
                     , timeit                    >= 2.0 && < 2.1
                     , unordered-containers      >= 0.2.8 && < 0.3
-                    , unix-compat               >= 0.7 && < 0.8
+                    , unix-compat               == 0.5.4
                     , vault                     >= 0.3.1.5 && < 0.4
                     , vector                    >= 0.11 && < 0.14
                     , wai                       >= 3.2.1 && < 3.3

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -120,6 +120,7 @@ library
                     , time                      >= 1.6 && < 1.12
                     , timeit                    >= 2.0 && < 2.1
                     , unordered-containers      >= 0.2.8 && < 0.3
+                    , unix-compat               >= 0.7 && < 0.8
                     , vault                     >= 0.3.1.5 && < 0.4
                     , vector                    >= 0.11 && < 0.14
                     , wai                       >= 3.2.1 && < 3.3

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -122,7 +122,7 @@ library
                     , time                      >= 1.6 && < 1.12
                     , timeit                    >= 2.0 && < 2.1
                     , unordered-containers      >= 0.2.8 && < 0.3
-                    , unix-compat >= 0.6 && < 0.7
+                    , unix-compat               >= 0.5.4 && < 0.6
                     , vault                     >= 0.3.1.5 && < 0.4
                     , vector                    >= 0.11 && < 0.14
                     , wai                       >= 3.2.1 && < 3.3

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -114,6 +114,7 @@ library
                     , regex-tdfa                >= 1.2.2 && < 1.4
                     , retry                     >= 0.7.4 && < 0.10
                     , scientific                >= 0.3.4 && < 0.4
+                    , streaming-commons         >= 0.1.1 && < 0.3
                     , swagger2                  >= 2.4 && < 2.9
                     , text                      >= 1.2.2 && < 1.3
                     , time                      >= 1.6 && < 1.12

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -162,7 +162,6 @@ executable postgrest
   main-is:            Main.hs
   build-depends:      base                >= 4.9 && < 4.17
                     , containers          >= 0.5.7 && < 0.7
-                    , network                   >= 2.6 && < 3.2
                     , postgrest
                     , protolude           >= 0.3.1 && < 0.4
   ghc-options:        -threaded -rtsopts "-with-rtsopts=-N -I0 -qg"

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -64,6 +64,7 @@ library
                       PostgREST.Plan.ReadPlan
                       PostgREST.Plan.Types
                       PostgREST.RangeQuery
+                      PostgREST.Unix
                       PostgREST.ApiRequest
                       PostgREST.ApiRequest.Preferences
                       PostgREST.ApiRequest.QueryParams
@@ -120,6 +121,7 @@ library
                     , time                      >= 1.6 && < 1.12
                     , timeit                    >= 2.0 && < 2.1
                     , unordered-containers      >= 0.2.8 && < 0.3
+                    -- pinning unix-compat to match one's version in warp
                     , unix-compat               == 0.5.4
                     , vault                     >= 0.3.1.5 && < 0.4
                     , vector                    >= 0.11 && < 0.14
@@ -151,8 +153,6 @@ library
     build-depends:
       unix
       , directory >= 1.2.6 && < 1.4
-    exposed-modules:
-      PostgREST.Unix
 
 executable postgrest
   default-language:   Haskell2010
@@ -162,6 +162,7 @@ executable postgrest
   main-is:            Main.hs
   build-depends:      base                >= 4.9 && < 4.17
                     , containers          >= 0.5.7 && < 0.7
+                    , network                   >= 2.6 && < 3.2
                     , postgrest
                     , protolude           >= 0.3.1 && < 0.4
   ghc-options:        -threaded -rtsopts "-with-rtsopts=-N -I0 -qg"

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -122,8 +122,7 @@ library
                     , time                      >= 1.6 && < 1.12
                     , timeit                    >= 2.0 && < 2.1
                     , unordered-containers      >= 0.2.8 && < 0.3
-                    -- pinning unix-compat to match one's version in warp
-                    , unix-compat               == 0.5.4
+                    , unix-compat
                     , vault                     >= 0.3.1.5 && < 0.4
                     , vector                    >= 0.11 && < 0.14
                     , wai                       >= 3.2.1 && < 3.3

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -90,6 +90,7 @@ library
                     , containers                >= 0.5.7 && < 0.7
                     , contravariant-extras      >= 0.3.3 && < 0.4
                     , cookie                    >= 0.4.2 && < 0.5
+                    , directory                 >= 1.2.6 && < 1.4
                     , either                    >= 4.4.1 && < 5.1
                     , extra                     >= 1.7.0 && < 2.0
                     , fuzzyset                  >= 0.2.3
@@ -152,7 +153,6 @@ library
   if !os(windows)
     build-depends:
       unix
-      , directory >= 1.2.6 && < 1.4
 
 executable postgrest
   default-language:   Haskell2010

--- a/src/PostgREST/Admin.hs
+++ b/src/PostgREST/Admin.hs
@@ -61,7 +61,7 @@ reachMainApp appSock = do
     withSocketsDo $ bracket (pure sock) close sendEmpty
   where
     sendEmpty sock = void $ send sock mempty
-    addrFamily (SockAddrInet _ _)      = AF_INET
-    addrFamily (SockAddrInet6 _ _ _ _) = AF_INET6
-    addrFamily (SockAddrUnix _)        = AF_UNIX
+    addrFamily (SockAddrInet _ _) = AF_INET
+    addrFamily (SockAddrInet6 {}) = AF_INET6
+    addrFamily (SockAddrUnix _)   = AF_UNIX
 

--- a/src/PostgREST/Admin.hs
+++ b/src/PostgREST/Admin.hs
@@ -61,7 +61,7 @@ reachMainApp appSock = do
     withSocketsDo $ bracket (pure sock) close sendEmpty
   where
     sendEmpty sock = void $ send sock mempty
-    addrFamily (SockAddrInet _ _) = AF_INET
+    addrFamily (SockAddrInet _ _)      = AF_INET
     addrFamily (SockAddrInet6 _ _ _ _) = AF_INET6
-    addrFamily (SockAddrUnix _) = AF_UNIX
+    addrFamily (SockAddrUnix _)        = AF_UNIX
 

--- a/src/PostgREST/Admin.hs
+++ b/src/PostgREST/Admin.hs
@@ -50,8 +50,6 @@ admin appState appConfig req respond  = do
 
 -- Try to connect to the main app socket
 -- Note that it doesn't even send a valid HTTP request, we just want to check that the main app is accepting connections
--- The code for resolving the "*4", "!4", "*6", "!6", "*" special values is taken from
--- https://hackage.haskell.org/package/streaming-commons-0.2.2.4/docs/src/Data.Streaming.Network.html#bindPortGenEx
 reachMainApp :: Socket -> IO (Either IOException ())
 reachMainApp appSock = do
   sockAddr <- getSocketName appSock

--- a/src/PostgREST/Admin.hs
+++ b/src/PostgREST/Admin.hs
@@ -22,19 +22,20 @@ import PostgREST.Config   (AppConfig (..))
 import qualified PostgREST.AppState as AppState
 
 import Protolude
+import Protolude.Partial (fromJust)
 
 runAdmin :: AppConfig -> AppState -> Warp.Settings -> IO ()
 runAdmin conf@AppConfig{configAdminServerPort} appState settings =
-  whenJust configAdminServerPort $ \adminPort -> do
-    AppState.logWithZTime appState $ "Admin server listening on port " <> show adminPort
-    void . forkIO $ Warp.runSettings (settings & Warp.setPort adminPort) adminApp
+  whenJust (AppState.getSocketAdmin appState) $ \adminSocket -> do
+    AppState.logWithZTime appState $ "Admin server listening on port " <> show (fromIntegral $ fromJust configAdminServerPort)
+    void . forkIO $ Warp.runSettingsSocket settings adminSocket adminApp
   where
     adminApp = admin appState conf
 
 -- | PostgREST admin application
 admin :: AppState.AppState -> AppConfig -> Wai.Application
 admin appState appConfig req respond  = do
-  isMainAppReachable  <- any isRight <$> reachMainApp appConfig
+  isMainAppReachable  <- isRight <$> reachMainApp appConfig (AppState.getSocketREST appState)
   isSchemaCacheLoaded <- isJust <$> AppState.getSchemaCache appState
   isConnectionUp      <-
     if configDbChannelEnabled appConfig
@@ -53,35 +54,8 @@ admin appState appConfig req respond  = do
 -- Note that it doesn't even send a valid HTTP request, we just want to check that the main app is accepting connections
 -- The code for resolving the "*4", "!4", "*6", "!6", "*" special values is taken from
 -- https://hackage.haskell.org/package/streaming-commons-0.2.2.4/docs/src/Data.Streaming.Network.html#bindPortGenEx
-reachMainApp :: AppConfig -> IO [Either IOException ()]
-reachMainApp AppConfig{..} =
-  case configServerUnixSocket of
-    Just path ->  do
-      sock <- socket AF_UNIX Stream 0
-      (:[]) <$> try (do
-        connect sock $ SockAddrUnix path
-        withSocketsDo $ bracket (pure sock) close sendEmpty)
-    Nothing -> do
-      let
-        host | configServerHost `elem` ["*4", "!4", "*6", "!6", "*"] = Nothing
-             | otherwise                                             = Just configServerHost
-        filterAddrs xs =
-          case configServerHost of
-              "*4" -> ipv4Addrs xs ++ ipv6Addrs xs
-              "!4" -> ipv4Addrs xs
-              "*6" -> ipv6Addrs xs ++ ipv4Addrs xs
-              "!6" -> ipv6Addrs xs
-              _    -> xs
-        ipv4Addrs = filter ((/=) AF_INET6 . addrFamily)
-        ipv6Addrs = filter ((==) AF_INET6 . addrFamily)
-
-      addrs <- getAddrInfo (Just $ defaultHints { addrSocketType = Stream }) (T.unpack <$> host) (Just . show $ configServerPort)
-      tryAddr `traverse` filterAddrs addrs
+reachMainApp :: AppConfig -> Socket -> IO (Either IOException ())
+reachMainApp AppConfig{..} appSock = try $ do
+  withSocketsDo $ bracket (pure appSock) close sendEmpty
   where
     sendEmpty sock = void $ send sock mempty
-    tryAddr :: AddrInfo -> IO (Either IOException ())
-    tryAddr addr = do
-      sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
-      try $ do
-        connect sock $ addrAddress addr
-        withSocketsDo $ bracket (pure sock) close sendEmpty

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -70,7 +70,7 @@ import           System.TimeIt         (timeItT)
 
 type Handler = ExceptT Error
 
-type SignalHandlerInstaller = AppState -> IO()
+type SignalHandlerInstaller = ThreadId -> IO () -> IO ()-> IO()
 
 type SocketRunner = Warp.Settings -> Wai.Application -> FileMode -> FilePath -> IO()
 
@@ -78,7 +78,7 @@ run :: SignalHandlerInstaller -> AppState -> IO ()
 run installHandlers appState = do
   conf@AppConfig{..} <- AppState.getConfig appState
   AppState.connectionWorker appState -- Loads the initial SchemaCache
-  installHandlers appState
+  installHandlers (AppState.getMainThreadId appState) (AppState.connectionWorker appState) (AppState.reReadConfig False appState)
   -- reload schema cache + config on NOTIFY
   AppState.runListener conf appState
 

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -28,7 +28,6 @@ import Network.Wai.Handler.Warp (defaultSettings, setHost, setPort,
 import System.Posix.Types       (FileMode)
 
 import qualified Data.HashMap.Strict        as HM
-import qualified Data.Text                  as T (unpack)
 import qualified Data.Text.Encoding         as T
 import qualified Hasql.Transaction.Sessions as SQL
 import qualified Network.Wai                as Wai
@@ -61,13 +60,11 @@ import PostgREST.SchemaCache          (SchemaCache (..))
 import PostgREST.SchemaCache.Routine  (Routine (..))
 import PostgREST.Version              (docsVersion, prettyVersion)
 
-import qualified Control.Exception     as E
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.List             as L
 import qualified Data.Map              as Map (fromList)
 import qualified Network.HTTP.Types    as HTTP
 import qualified Network.Socket        as NS
-import qualified Network.Socket        as Socket
 import           Protolude             hiding (Handler)
 import           System.TimeIt         (timeItT)
 
@@ -77,8 +74,8 @@ type SignalHandlerInstaller = AppState -> IO()
 
 type SocketRunner = Warp.Settings -> Wai.Application -> FileMode -> FilePath -> IO()
 
-run :: SignalHandlerInstaller -> Maybe SocketRunner -> AppState -> IO ()
-run installHandlers maybeRunWithSocket appState = do
+run :: SignalHandlerInstaller -> AppState -> IO ()
+run installHandlers appState = do
   conf@AppConfig{..} <- AppState.getConfig appState
   AppState.connectionWorker appState -- Loads the initial SchemaCache
   installHandlers appState

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -202,6 +202,7 @@ initSockets AppConfig{..} = do
       deleteSocketFileIfExist path
       sock <- NS.socket NS.AF_UNIX NS.Stream NS.defaultProtocol
       NS.bind sock $ NS.SockAddrUnix path
+      NS.listen sock (max 2048 NS.maxListenQueue)
       setFileMode path mode
       return sock
     deleteSocketFileIfExist path =

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -68,7 +68,7 @@ import PostgREST.Config.PgVersion        (PgVersion (..),
 import PostgREST.SchemaCache             (SchemaCache,
                                           querySchemaCache)
 import PostgREST.SchemaCache.Identifiers (dumpQi)
-import PostgREST.Unix                    (createAndBindSocket)
+import PostgREST.Unix                    (createAndBindDomainSocket)
 
 import Data.Streaming.Network (bindPortTCP, bindRandomPortTCP)
 import Data.String            (IsString (..))
@@ -175,7 +175,7 @@ initSockets AppConfig{..} = do
     Just path -> do
       unless isUnixDomainSocketAvailable $
         panic "Cannot run with unix socket on non-unix platforms. Consider deleting the `server-unix-socket` config entry in order to continue."
-      createAndBindSocket path cfg'uspm
+      createAndBindDomainSocket path cfg'uspm
     Nothing -> do
       (_, sock) <-
         if cfg'port /= 0

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -69,14 +69,13 @@ import PostgREST.SchemaCache             (SchemaCache,
                                           querySchemaCache)
 import PostgREST.SchemaCache.Identifiers (dumpQi)
 
-import Data.Streaming.Network (bindPath, bindPortTCP,
-                               bindRandomPortTCP)
+import Data.Streaming.Network (bindPortTCP, bindRandomPortTCP)
 import Data.String            (IsString (..))
+import Network.Socket         (isUnixDomainSocketAvailable)
 import Protolude
+import System.Directory       (removeFile)
+import System.IO.Error        (isDoesNotExistError)
 import System.Posix.Files     (setFileMode)
-import Network.Socket (isUnixDomainSocketAvailable)
-import System.Directory (removeFile)
-import System.IO.Error (isDoesNotExistError)
 
 data AuthResult = AuthResult
   { authClaims :: KM.KeyMap JSON.Value
@@ -176,7 +175,7 @@ initSockets AppConfig{..} = do
 
   sock <- case cfg'usp of
     Just path -> do
-      unless isUnixDomainSocketAvailable $ 
+      unless isUnixDomainSocketAvailable $
         panic "Cannot run with unix socket on non-unix platforms. Consider deleting the `server-unix-socket` config entry in order to continue."
       createAndBindSocket path cfg'uspm
     Nothing -> do

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -171,7 +171,7 @@ initSockets AppConfig{..} = do
     cfg'adminport = configAdminServerPort
 
   sock <- case cfg'usp of
-    -- I'm not using `streaming-commons`' bindPath function here because it's not defined for Windows, 
+    -- I'm not using `streaming-commons`' bindPath function here because it's not defined for Windows,
     -- but we need to have runtime error if we try to use it in Windows, not compile time error
     Just path -> createAndBindDomainSocket path cfg'uspm
     Nothing -> do

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -17,6 +17,7 @@ module PostgREST.AppState
   , getSocketREST
   , getSocketAdmin
   , init
+  , initSockets
   , initWithPool
   , logWithZTime
   , putSchemaCache

--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -29,8 +29,8 @@ import qualified PostgREST.Config   as Config
 import Protolude hiding (hPutStrLn)
 
 
-main :: App.SignalHandlerInstaller -> CLI -> IO ()
-main installSignalHandlers CLI{cliCommand, cliPath} = do
+main :: CLI -> IO ()
+main CLI{cliCommand, cliPath} = do
   conf@AppConfig{..} <-
     either panic identity <$> Config.readAppConfig mempty cliPath Nothing mempty mempty
 
@@ -45,7 +45,7 @@ main installSignalHandlers CLI{cliCommand, cliPath} = do
         when configDbConfig $ AppState.reReadConfig True appState
         putStr . Config.toText =<< AppState.getConfig appState
       CmdDumpSchema -> putStrLn =<< dumpSchema appState
-      CmdRun -> App.run installSignalHandlers appState)
+      CmdRun -> App.run appState)
 
 -- | Dump SchemaCache schema to JSON
 dumpSchema :: AppState -> IO LBS.ByteString

--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -29,8 +29,8 @@ import qualified PostgREST.Config   as Config
 import Protolude hiding (hPutStrLn)
 
 
-main :: App.SignalHandlerInstaller -> Maybe App.SocketRunner -> CLI -> IO ()
-main installSignalHandlers runAppWithSocket CLI{cliCommand, cliPath} = do
+main :: App.SignalHandlerInstaller -> CLI -> IO ()
+main installSignalHandlers CLI{cliCommand, cliPath} = do
   conf@AppConfig{..} <-
     either panic identity <$> Config.readAppConfig mempty cliPath Nothing mempty mempty
 
@@ -45,7 +45,7 @@ main installSignalHandlers runAppWithSocket CLI{cliCommand, cliPath} = do
         when configDbConfig $ AppState.reReadConfig True appState
         putStr . Config.toText =<< AppState.getConfig appState
       CmdDumpSchema -> putStrLn =<< dumpSchema appState
-      CmdRun -> App.run installSignalHandlers runAppWithSocket appState)
+      CmdRun -> App.run installSignalHandlers appState)
 
 -- | Dump SchemaCache schema to JSON
 dumpSchema :: AppState -> IO LBS.ByteString

--- a/src/PostgREST/Unix.hs
+++ b/src/PostgREST/Unix.hs
@@ -33,8 +33,12 @@ installSignalHandlers tid usr1 usr2 = do
 installSignalHandlers _ _ _ = pass
 #endif
 
+-- | Create a unix domain socket and bind it to the given path.
+-- | The socket file will be deleted if it already exists.
 createAndBindDomainSocket :: String -> FileMode -> IO NS.Socket
 createAndBindDomainSocket path mode = do
+  unless NS.isUnixDomainSocketAvailable $
+    panic "Cannot run with unix socket on non-unix platforms. Consider deleting the `server-unix-socket` config entry in order to continue."
   deleteSocketFileIfExist path
   sock <- NS.socket NS.AF_UNIX NS.Stream NS.defaultProtocol
   NS.bind sock $ NS.SockAddrUnix path

--- a/src/PostgREST/Unix.hs
+++ b/src/PostgREST/Unix.hs
@@ -1,27 +1,42 @@
 module PostgREST.Unix
   ( installSignalHandlers
+  , createAndBindSocket
   ) where
 
-import qualified System.Posix.Signals as Signals
+import qualified System.Posix.Signals     as Signals
+import           System.Posix.Types       (FileMode)
+import           System.PosixCompat.Files (setFileMode)
 
-import qualified PostgREST.AppState as AppState
-
-import Protolude
-
+import           Data.String      (String)
+import qualified Network.Socket   as NS
+import           Protolude
+import           System.Directory (Permissions, removeFile,
+                                   setOwnerReadable, setPermissions)
+import           System.IO.Error  (isDoesNotExistError)
 
 -- | Set signal handlers, only for systems with signals
-installSignalHandlers :: AppState.AppState -> IO ()
-installSignalHandlers appState = do
-  let interrupt = throwTo (AppState.getMainThreadId appState) UserInterrupt
+installSignalHandlers :: ThreadId -> IO () -> IO () -> IO ()
+installSignalHandlers tid usr1 usr2 = do
+  let interrupt = throwTo tid UserInterrupt
   install Signals.sigINT interrupt
   install Signals.sigTERM interrupt
-
-  -- The SIGUSR1 signal updates the internal 'SchemaCache' by running
-  -- 'connectionWorker' exactly as before.
-  install Signals.sigUSR1 $ AppState.connectionWorker appState
-
-  -- Re-read the config on SIGUSR2
-  install Signals.sigUSR2 $ AppState.reReadConfig False appState
+  install Signals.sigUSR1 usr1
+  install Signals.sigUSR2 usr2
   where
     install signal handler =
       void $ Signals.installHandler signal (Signals.Catch handler) Nothing
+
+createAndBindSocket :: String -> FileMode -> IO NS.Socket
+createAndBindSocket path mode = do
+  deleteSocketFileIfExist path
+  sock <- NS.socket NS.AF_UNIX NS.Stream NS.defaultProtocol
+  NS.bind sock $ NS.SockAddrUnix path
+  NS.listen sock (max 2048 NS.maxListenQueue)
+  setFileMode path mode
+  return sock
+  where
+    deleteSocketFileIfExist path =
+      removeFile path `catch` handleDoesNotExist
+    handleDoesNotExist e
+      | isDoesNotExistError e = return ()
+      | otherwise = throwIO e

--- a/src/PostgREST/Unix.hs
+++ b/src/PostgREST/Unix.hs
@@ -10,8 +10,7 @@ import           System.PosixCompat.Files (setFileMode)
 import           Data.String      (String)
 import qualified Network.Socket   as NS
 import           Protolude
-import           System.Directory (Permissions, removeFile,
-                                   setOwnerReadable, setPermissions)
+import           System.Directory (removeFile)
 import           System.IO.Error  (isDoesNotExistError)
 
 -- | Set signal handlers, only for systems with signals
@@ -35,8 +34,8 @@ createAndBindSocket path mode = do
   setFileMode path mode
   return sock
   where
-    deleteSocketFileIfExist path =
-      removeFile path `catch` handleDoesNotExist
+    deleteSocketFileIfExist path' =
+      removeFile path' `catch` handleDoesNotExist
     handleDoesNotExist e
       | isDoesNotExistError e = return ()
       | otherwise = throwIO e

--- a/src/PostgREST/Unix.hs
+++ b/src/PostgREST/Unix.hs
@@ -5,9 +5,11 @@ module PostgREST.Unix
   , createAndBindDomainSocket
   ) where
 
-import qualified System.Posix.Signals     as Signals
-import           System.Posix.Types       (FileMode)
-import           System.PosixCompat.Files (setFileMode)
+#ifndef mingw32_HOST_OS
+import qualified System.Posix.Signals as Signals
+#endif
+import System.Posix.Types       (FileMode)
+import System.PosixCompat.Files (setFileMode)
 
 import           Data.String      (String)
 import qualified Network.Socket   as NS

--- a/src/PostgREST/Unix.hs
+++ b/src/PostgREST/Unix.hs
@@ -1,43 +1,13 @@
 module PostgREST.Unix
-  ( runAppWithSocket
-  , installSignalHandlers
+  ( installSignalHandlers
   ) where
 
-import qualified Network.Socket           as Socket
-import qualified Network.Wai.Handler.Warp as Warp
-import qualified System.Posix.Signals     as Signals
-
-import Network.Wai        (Application)
-import System.Directory   (removeFile)
-import System.IO.Error    (isDoesNotExistError)
-import System.Posix.Files (setFileMode)
-import System.Posix.Types (FileMode)
+import qualified System.Posix.Signals as Signals
 
 import qualified PostgREST.AppState as AppState
 
 import Protolude
 
-
--- | Run the PostgREST application with user defined socket.
-runAppWithSocket :: Warp.Settings -> Application -> FileMode -> FilePath -> IO ()
-runAppWithSocket settings app socketFileMode socketFilePath =
-  bracket createAndBindSocket Socket.close $ \socket -> do
-    Socket.listen socket Socket.maxListenQueue
-    Warp.runSettingsSocket settings socket app
-  where
-    createAndBindSocket = do
-      deleteSocketFileIfExist socketFilePath
-      sock <- Socket.socket Socket.AF_UNIX Socket.Stream Socket.defaultProtocol
-      Socket.bind sock $ Socket.SockAddrUnix socketFilePath
-      setFileMode socketFilePath socketFileMode
-      return sock
-
-    deleteSocketFileIfExist path =
-      removeFile path `catch` handleDoesNotExist
-
-    handleDoesNotExist e
-      | isDoesNotExistError e = return ()
-      | otherwise = throwIO e
 
 -- | Set signal handlers, only for systems with signals
 installSignalHandlers :: AppState.AppState -> IO ()

--- a/src/PostgREST/Unix.hs
+++ b/src/PostgREST/Unix.hs
@@ -30,7 +30,7 @@ installSignalHandlers tid usr1 usr2 = do
     install signal handler =
       void $ Signals.installHandler signal (Signals.Catch handler) Nothing
 #else
-installSignalHandlers _ = pass
+installSignalHandlers _ _ _ = pass
 #endif
 
 createAndBindDomainSocket :: String -> FileMode -> IO NS.Socket

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -196,11 +196,13 @@ def test_flush_pool_no_interrupt(defaultenv):
 
         t.join()
 
+
 def test_random_port_bound(defaultenv):
     "PostgREST should bind to a random port when PGRST_SERVER_PORT is 0."
 
     with run(env=defaultenv, port="0") as postgrest:
-        assert True # liveness check is done by run(), so we just need to check that it doesn't fail
+        assert True  # liveness check is done by run(), so we just need to check that it doesn't fail
+
 
 def test_app_settings_reload(tmp_path, defaultenv):
     "App settings should be reloaded from file when PostgREST is sent SIGUSR2."

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -196,6 +196,11 @@ def test_flush_pool_no_interrupt(defaultenv):
 
         t.join()
 
+def test_random_port_bound(defaultenv):
+    "PostgREST should bind to a random port when PGRST_SERVER_PORT is 0."
+
+    with run(env=defaultenv, port="0") as postgrest:
+        assert True # liveness check is done by run(), so we just need to check that it doesn't fail
 
 def test_app_settings_reload(tmp_path, defaultenv):
     "App settings should be reloaded from file when PostgREST is sent SIGUSR2."

--- a/test/spec/Main.hs
+++ b/test/spec/Main.hs
@@ -73,11 +73,12 @@ main = do
 
   -- cached schema cache so most tests run fast
   baseSchemaCache <- loadSchemaCache pool testCfg
+  sockets <- AppState.initSockets testCfg
 
   let
     -- For tests that run with the same refSchemaCache
     app config = do
-      appState <- AppState.initWithPool pool config
+      appState <- AppState.initWithPool sockets pool config
       AppState.putPgVersion appState actualPgVersion
       AppState.putSchemaCache appState (Just baseSchemaCache)
       return ((), postgrest config appState $ pure ())
@@ -85,7 +86,7 @@ main = do
     -- For tests that run with a different SchemaCache(depends on configSchemas)
     appDbs config = do
       customSchemaCache <- loadSchemaCache pool config
-      appState <- AppState.initWithPool pool config
+      appState <- AppState.initWithPool sockets pool config
       AppState.putPgVersion appState actualPgVersion
       AppState.putSchemaCache appState (Just customSchemaCache)
       return ((), postgrest config appState $ pure ())


### PR DESCRIPTION
Documents and properly handles the special value of `0` for `server-port` config. Before this PR, the value was passed through and handled by the platform's `getaddrinfo` implementation, seemingly resulting in binding to a random port. This PR makes it official and binds to random port explicitly.

Other changes it introduces:

* Simplifies app starting logic, moving platform-dependent POSIX-specific code to `PostgREST.Unix`, making it the only file with the `LANGUAGE CPP` pragma and reducing the amount of indirection. Pretty sure the indirection in question was here on purpose, let me know if that's still the case — tests do pass, things work fine, so I've decided to give it a shot.
* Recent releases of `network` and all Windows released since 5 years ago actually do support Unix domain sockets, so I've taken a chance to prepare code for making use of those: replaced `setFileMode` with its twin function from `unix-compat` and used `Network.Socket.isUnixDomainSocketAvailable` to check such sockets'  availability in runtime. All that's left to pull the plug is to upgrade `network`.
* makes `PostgREST.Unix.installSignalHandlers` more explicit, avoiding potential circular dependency between `PostgREST.Unix` and `PostgREST.AppState`
* slightly decreases test coverage. The cases missed seem to be trivial to me and would require considerable effort to be tested properly.

Fixes #2420

<details><summary>Old TODO</summary>
TODO:

- [ ] test 
- [x] document special `server-port` value of `0`; done in https://github.com/PostgREST/postgrest-docs/pull/695
- [x] get runtime error for Unix socket on unsupported platforms back (right now it degraded to compile error)
- [x] fix Windows build
- [x] ~fix the crash in, presumably, `Admin.reachMainApp`~ I was `bind`ing a socket, but didn't `listen` it :confounded: 

</details>