### PR TITLE
ci: merge cached Nix stores

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -20,10 +20,9 @@ runs:
     - name: Restore and cache Nix store
       uses: nix-community/cache-nix-action@v4.0.3
       with:
-        key: cache-nix-${{ runner.os }}-id-${{ inputs.cache-id }}-${{ hashFiles('nix/**/*.nix') }}
+        key: cache-nix-${{ runner.os }}-id-${{ inputs.cache-id }}-${{ hashFiles('nix/**/*.nix', '.github/actions/setup-nix/*') }}
         restore-keys: |
           cache-nix-${{ runner.os }}-common-
-        restore-key-hit: true
     - uses: cachix/cachix-action@v13
       with:
         name: postgrest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,16 +13,32 @@ on:
       - rel-*
 
 jobs:
-  Lint-Style:
-    name: Lint & check code style
+  Prepopulate-Nix-Cache-Linux:
+    name: Prepopulate Nix cache for Linux runners
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Setup Nix Environment
         uses: ./.github/actions/setup-nix
         with:
+          cache-id: common
+      - name: Put all tools to store to be cached afterwards
+        run: |
+          # shellcheck disable=SC2046
+          nix-store -v --realize $( nix-instantiate default.nix )
+        shell: bash
+    
+  Lint-Style:
+    name: Lint & check code style
+    runs-on: ubuntu-latest
+    needs: [Prepopulate-Nix-Cache-Linux]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Nix Environment
+        uses: ./.github/actions/setup-nix
+        with:
           tools: style
-          cache-id: style
+          cache-id: common
       - name: Run linter (check locally with `nix-shell --run postgrest-lint`)
         run: postgrest-lint
       - name: Run style check (auto-format with `nix-shell --run postgrest-style`)
@@ -32,6 +48,7 @@ jobs:
   Test-Nix:
     name: Test (Nix)
     runs-on: ubuntu-latest
+    needs: [Prepopulate-Nix-Cache-Linux]
     defaults:
       run:
         # Hack for enabling color output, see:
@@ -43,7 +60,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           tools: tests
-          cache-id: test-pg
+          cache-id: common
 
       - name: Run coverage (IO tests and Spec tests against PostgreSQL 15)
         run: postgrest-coverage
@@ -68,6 +85,7 @@ jobs:
         pgVersion: [9.6, 10, 11, 12, 13, 14, 15, 16]
     name: Test PG ${{ matrix.pgVersion }} (Nix)
     runs-on: ubuntu-latest
+    needs: [Prepopulate-Nix-Cache-Linux]
     defaults:
       run:
         # Hack for enabling color output, see:
@@ -81,7 +99,7 @@ jobs:
           tools: tests withTools
           # It seems like they are installing the same set of derivations, so we can assign them the same cache id. 
           # This would decrease the amount of caches dowloaded on merge cache step and will prevent disk space issues.
-          cache-id: test-pg 
+          cache-id: common 
 
       - name: Run spec tests
         if: always()
@@ -95,13 +113,14 @@ jobs:
   Test-Memory-Nix:
     name: Test memory (Nix)
     runs-on: ubuntu-latest
+    needs: [Prepopulate-Nix-Cache-Linux]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Nix Environment
         uses: ./.github/actions/setup-nix
         with:
           tools: memory
-          cache-id: test-memory
+          cache-id: common
       - name: Run memory tests
         run: postgrest-test-memory
 
@@ -109,13 +128,14 @@ jobs:
   Build-Static-Nix:
     name: Build Linux static (Nix)
     runs-on: ubuntu-latest
+    needs: [Prepopulate-Nix-Cache-Linux]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Nix Environment
         uses: ./.github/actions/setup-nix
         with:
           tools: tests
-          cache-id: static-nix
+          cache-id: common
 
       - name: Build static executable
         run: nix-build -A postgrestStatic
@@ -136,33 +156,6 @@ jobs:
           name: postgrest-docker-x64
           path: postgrest-docker.tar.gz
           if-no-files-found: error
-
-  # TODO: Enable this again in a PR by PostgREST admins, because regular users don't have permission to delete cache entries, which this job does.
-  #
-  # merge-nix-caches-linux:
-  #   name: "Merge Nix caches (Linux)"
-  #   needs: [Test-Nix, Test-Pg-Nix, Test-Memory-Nix, Build-Static-Nix, Lint-Style]
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     max-parallel: 1
-  #     matrix:
-  #       cache-id: ['static-nix', 'test-pg', 'style', 'test-memory']
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: nixbuild/nix-quick-install-action@v26
-  #       with:
-  #         nix_version: '2.13.6'
-  #     - name: Restore and cache Nix store
-  #       uses: nix-community/cache-nix-action@v4
-  #       with:
-  #         key: cache-nix-${{ runner.os }}-common-${{ hashFiles('nix/**/*.nix') }}
-  #         extra-restore-keys: |
-  #           cache-nix-${{ runner.os }}-cid-
-  #         purge: true
-  #         purge-keys: |
-  #           cache-nix-${{ runner.os }}-cid-
-  #           cache-nix-${{ runner.os }}-common-
-  #         purge-created-max-age: 0
 
   Build-Macos-Nix:
     name: Build MacOS (Nix)

--- a/.github/workflows/loadtest.yaml
+++ b/.github/workflows/loadtest.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           tools: loadtest
-          cache-id: test-pg
+          cache-id: test-loadtest
       - uses: actions-ecosystem/action-get-latest-tag@v1
         id: get-latest-tag
         with:
@@ -55,7 +55,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           tools: loadtest
-          cache-id: test-pg
+          cache-id: test-loadtest
       - name: Run loadtest
         run: |
           postgrest-loadtest-against ${{ steps.get-latest-tag.outputs.tag }}


### PR DESCRIPTION
Introduces a nix cache warm-up job, which prefetches all the derivations we ever need to the Nix store, which is cached right away. Such cache is reused then in further actions, reducing in-job downloads to zero.

Before this PR every nix-involving job (13 of them on Linux) took 3 to 4 minutes to do "nix setup" due to downloading 121 to 1409 paths, 300 to 1360 MB big. While these jobs cache Nix store here and there, there's a handful of them, multiplied by 2.3-ish GB in size, and thus they exceed the upper cache limit for GH Actions of 10 GB. 
After merging this PR, a cold run takes ~6 minutes to warm up the cache, then every nix-involving job takes 1:30 mins to unpack the cache and have all the derivations installed. A warm run takes 1 minute of a no-op cache warm up step and the same 1:30 to unpack the cache. This produces one Nix store cache per OS of 2.3 GB in size, which fit the storage nicely and would probably be a benefit for every build, for `main` and PR branches as well.

TODO: make the `loadtest` workflow use a common cache as well, maybe by extracting the "warm up" job to a separate workflow. 

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs     - https://github.com/PostgREST/postgrest-docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `fix`, bug fixes
  + `feat`, new features added
  + `perf`, performance improvements
  + `nix`, related to the Nix development environment
  + `ci`, related to the Continuous Integration modules
  + `test`, related to the testing modules
  + `refactor`, refactoring code
  + `deprecate`, deprecating a feature
  + `chore`, maintenance (changelog, build process, etc.)
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
