### PR TITLE
ci: fixes job caches not producing after recent cabal upgrade

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -262,8 +262,9 @@ jobs:
         run: |
           ghcup install ghc ${{ matrix.ghc }}
           ghcup set ghc ${{ matrix.ghc }}
-      - name: Copy cabal.project
+      - name: Copy cabal.project & fix caching
         run: |
+          mkdir ~/.cabal
           cp cabal.project.non-nix cabal.project
       - name: Cache
         uses: actions/cache@v3


### PR DESCRIPTION
Recent and, more importantly, recommended by `ghcup` cabal adopted XDG guidelines and stores data [across multiple directories under `$HOME`](https://cabal.readthedocs.io/en/stable/config.html#directories). 

Creating `~/.cabal` manually returns old behavior and allows caching single directory again.

UPD: the cache entry is in at https://github.com/PostgREST/postgrest/actions/caches#cache-entry-cache-cabal-Linux-9.2.4-d8460256acb9e907b2ffa2affd3a649ad1c6b6bd6aa4fdaa0cc471f49233e884-5dced405a4da11e069fe31a9ae431e31bacfd4cb6458672788062d7a6a9b8a6e

UPD: caching works again, the "Install dependencies" job takes 23 sec again