### PR TITLE
chore: fix server-timing metric order and doctest

### DIFF
--- a/src/PostgREST/Response/Performance.hs
+++ b/src/PostgREST/Response/Performance.hs
@@ -13,24 +13,24 @@ import           Protolude
 data ServerMetric =
     SMJwt
   | SMParse
-  | SMResp
   | SMPlan
   | SMTransaction
+  | SMResp
   deriving (Show, Eq, Ord)
 type ServerTimingData = Map ServerMetric (Maybe Double)
 
 -- | Render the Server-Timing header from a ServerTimingData
 --
--- >>> renderServerTimingHeader $ Map.fromList [(SMPlan, 0.1), (SMTransaction, 0.2), (SMResp, 0.3), (SMJwt, 0.4)]
--- ("Server-Timing","jwt;dur=400000.0, render;dur=300000.0, plan;dur=100000.0, query;dur=200000.0")
+-- >>> renderServerTimingHeader $ Map.fromList [(SMPlan, Just 0.1), (SMTransaction, Just 0.2), (SMResp, Just 0.3), (SMJwt, Just 0.4), (SMParse, Just 0.5)]
+-- ("Server-Timing","jwt;dur=400000.0, parse;dur=500000.0, plan;dur=100000.0, transaction;dur=200000.0, response;dur=300000.0")
 renderServerTimingHeader :: ServerTimingData -> HTTP.Header
 renderServerTimingHeader timingData =
   ("Server-Timing", BS.intercalate ", " $ map renderTiming $ Map.toList timingData)
 renderTiming :: (ServerMetric, Maybe Double) -> BS.ByteString
 renderTiming (metric, time) = maybe "" (\x -> BS.concat [renderMetric metric, BS.pack $ ";dur=" <> showFFloat (Just 1) (x * 1000000) ""]) time
   where
+    renderMetric SMJwt         = "jwt"
+    renderMetric SMParse       = "parse"
     renderMetric SMPlan        = "plan"
     renderMetric SMTransaction = "transaction"
     renderMetric SMResp        = "response"
-    renderMetric SMJwt         = "jwt"
-    renderMetric SMParse       = "parse"

--- a/test/doc/Main.hs
+++ b/test/doc/Main.hs
@@ -16,6 +16,7 @@ main =
     , "src/PostgREST/Query/SqlFragment.hs"
     , "src/PostgREST/ApiRequest/Preferences.hs"
     , "src/PostgREST/ApiRequest/QueryParams.hs"
+    , "src/PostgREST/Response/Performance.hs"
     , "src/PostgREST/Error.hs"
     , "src/PostgREST/MediaType.hs"
     , "src/PostgREST/Config.hs"


### PR DESCRIPTION
Sends the `response` metric to the end of the `Server-Timing` header and makes the doctest work.