### PR TITLE
ci: cabal+GHC: tweak caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -269,8 +269,11 @@ jobs:
       - name: Cache
         uses: actions/cache@v3
         with:
-          path: ~/.cabal
-          key: cache-cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+            dist-newstyle
+          key: cache-cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('**/*.cabal', '**/cabal.project') }}
           restore-keys: |
             cache-cabal-${{ runner.os }}-${{ matrix.ghc }}-
       - name: Install dependencies


### PR DESCRIPTION
Makes it to cache only relevant directories, adds `dist-newstyle` to prevent needless rebuilding even harder and shortens cache key name by supplying `hashFiles`multiple arguments. Reference: https://github.com/actions/cache/blob/main/examples.md#haskell---cabal
