### PR TITLE
refactor: use a data type instead of Map for Server Timing

### DIFF
--- a/src/PostgREST/Response/Performance.hs
+++ b/src/PostgREST/Response/Performance.hs
@@ -1,36 +1,36 @@
 module PostgREST.Response.Performance
-  ( ServerMetric(..)
-  , ServerTimingData
-  , renderServerTimingHeader
+  ( ServerTiming (..)
+  , serverTimingHeader
   )
 where
 import qualified Data.ByteString.Char8 as BS
-import qualified Data.Map              as Map
 import qualified Network.HTTP.Types    as HTTP
 import           Numeric               (showFFloat)
 import           Protolude
 
-data ServerMetric =
-    SMJwt
-  | SMParse
-  | SMPlan
-  | SMTransaction
-  | SMResp
-  deriving (Show, Eq, Ord)
-type ServerTimingData = Map ServerMetric (Maybe Double)
+data ServerTiming =
+  ServerTiming
+    { jwt         :: Maybe Double
+    , parse       :: Maybe Double
+    , plan        :: Maybe Double
+    , transaction :: Maybe Double
+    , response    :: Maybe Double
+    }
+  deriving (Show)
 
 -- | Render the Server-Timing header from a ServerTimingData
 --
--- >>> renderServerTimingHeader $ Map.fromList [(SMPlan, Just 0.1), (SMTransaction, Just 0.2), (SMResp, Just 0.3), (SMJwt, Just 0.4), (SMParse, Just 0.5)]
+-- >>> serverTimingHeader ServerTiming { plan=Just 0.1, transaction=Just 0.2, response=Just 0.3, jwt=Just 0.4, parse=Just 0.5}
 -- ("Server-Timing","jwt;dur=400000.0, parse;dur=500000.0, plan;dur=100000.0, transaction;dur=200000.0, response;dur=300000.0")
-renderServerTimingHeader :: ServerTimingData -> HTTP.Header
-renderServerTimingHeader timingData =
-  ("Server-Timing", BS.intercalate ", " $ map renderTiming $ Map.toList timingData)
-renderTiming :: (ServerMetric, Maybe Double) -> BS.ByteString
-renderTiming (metric, time) = maybe "" (\x -> BS.concat [renderMetric metric, BS.pack $ ";dur=" <> showFFloat (Just 1) (x * 1000000) ""]) time
+serverTimingHeader :: ServerTiming -> HTTP.Header
+serverTimingHeader timing =
+  ("Server-Timing", renderTiming)
   where
-    renderMetric SMJwt         = "jwt"
-    renderMetric SMParse       = "parse"
-    renderMetric SMPlan        = "plan"
-    renderMetric SMTransaction = "transaction"
-    renderMetric SMResp        = "response"
+    renderMetric metric = maybe "" (\dur -> BS.concat [metric, BS.pack $ ";dur=" <> showFFloat (Just 1) (dur * 1000000) ""])
+    renderTiming = BS.intercalate ", " $ (\(k, v) -> renderMetric k (v timing)) <$>
+      [ ("jwt", jwt)
+      , ("parse", parse)
+      , ("plan", plan)
+      , ("transaction", transaction)
+      , ("response", response)
+      ]


### PR DESCRIPTION
Refactor the `Performance.hs` module.
