### PR TITLE
fix: replace json parser error with generic msg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
  - #3054, Fix not allowing special characters in JSON keys - @laurenceisla
+ - #3090, Replace JSON parser error with generic message - @develop7
+   + Fixes #2344
 
 ## [12.0.0] - 2023-12-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
  - #3054, Fix not allowing special characters in JSON keys - @laurenceisla
- - #3090, Replace JSON parser error with generic message - @develop7
-   + Fixes #2344
+ - #2344, Replace JSON parser error with a clearer generic message - @develop7
 
 ## [12.0.0] - 2023-12-01
 

--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -259,7 +259,9 @@ getPayload reqBody contentMediaType QueryParams{qsColumns} action PathInfo{pathI
           else note "All object keys must match" . payloadAttributes reqBody
                  =<< if LBS.null reqBody && pathIsProc
                        then Right emptyObject
-                       else first BS.pack $ JSON.eitherDecode reqBody
+                       else first BS.pack $
+                          -- Drop parsing error message in favor of generic one (https://github.com/PostgREST/postgrest/issues/2344)
+                          maybe (Left "Empty or invalid json") Right $ JSON.decode reqBody
       (MTTextCSV, _) -> do
         json <- csvToJson <$> first BS.pack (CSV.decodeByName reqBody)
         note "All lines must have same number of fields" $ payloadAttributes (JSON.encode json) json

--- a/test/spec/Feature/Query/InsertSpec.hs
+++ b/test/spec/Feature/Query/InsertSpec.hs
@@ -287,7 +287,7 @@ spec actualPgVersion = do
       it "fails with 400 and error" $
         post "/simple_pk" "}{ x = 2"
         `shouldRespondWith`
-        [json|{"message":"Error in $: Failed reading: not a valid json value at '}{x=2'","code":"PGRST102","details":null,"hint":null}|]
+        [json|{"message":"Empty or invalid json","code":"PGRST102","details":null,"hint":null}|]
         { matchStatus  = 400
         , matchHeaders = [matchContentTypeJson]
         }
@@ -296,7 +296,7 @@ spec actualPgVersion = do
       it "fails with 400 and error" $
         post "/simple_pk" ""
         `shouldRespondWith`
-        [json|{"message":"Error in $: not enough input","code":"PGRST102","details":null,"hint":null}|]
+        [json|{"message":"Empty or invalid json","code":"PGRST102","details":null,"hint":null}|]
         { matchStatus  = 400
         , matchHeaders = [matchContentTypeJson]
         }

--- a/test/spec/Feature/Query/UpdateSpec.hs
+++ b/test/spec/Feature/Query/UpdateSpec.hs
@@ -44,7 +44,7 @@ spec actualPgVersion = do
       it "fails with 400 and error" $
         request methodPatch "/simple_pk" [] "}{ x = 2"
           `shouldRespondWith`
-          [json|{"message":"Error in $: Failed reading: not a valid json value at '}{x=2'","code":"PGRST102","details":null,"hint":null}|]
+          [json|{"message":"Empty or invalid json","code":"PGRST102","details":null,"hint":null}|]
           { matchStatus  = 400,
             matchHeaders = [matchContentTypeJson]
           }
@@ -53,7 +53,7 @@ spec actualPgVersion = do
       it "fails with 400 and error" $
         request methodPatch "/items" [] ""
           `shouldRespondWith`
-          [json|{"message":"Error in $: not enough input","code":"PGRST102","details":null,"hint":null}|]
+          [json|{"message":"Empty or invalid json","code":"PGRST102","details":null,"hint":null}|]
           { matchStatus  = 400,
             matchHeaders = [matchContentTypeJson]
           }


### PR DESCRIPTION
Drops Aeson's parser error from the output in favor of a generic message, per the suggestion in #2344.

Fixes #2344
<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs     - https://github.com/PostgREST/postgrest-docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `fix`, bug fixes
  + `feat`, new features added
  + `perf`, performance improvements
  + `nix`, related to the Nix development environment
  + `ci`, related to the Continuous Integration modules
  + `test`, related to the testing modules
  + `refactor`, refactoring code
  + `deprecate`, deprecating a feature
  + `chore`, maintenance (changelog, build process, etc.)
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
