### PR TITLE
ci: merge more nix caches

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -20,9 +20,7 @@ runs:
     - name: Restore and cache Nix store
       uses: nix-community/cache-nix-action@v4.0.3
       with:
-        key: cache-nix-${{ runner.os }}-id-${{ inputs.cache-id }}-${{ hashFiles('nix/**/*.nix', '.github/actions/setup-nix/*') }}
-        restore-keys: |
-          cache-nix-${{ runner.os }}-common-
+        key: cache-nix-${{ runner.os }}-${{ hashFiles('nix/**/*.nix', '.github/actions/setup-nix/*') }}
     - uses: cachix/cachix-action@v13
       with:
         name: postgrest

--- a/.github/workflows/cachix.yaml
+++ b/.github/workflows/cachix.yaml
@@ -33,6 +33,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          cache-id: 'common'
 
       - name: Install cachix tooling
         run: |

--- a/.github/workflows/loadtest.yaml
+++ b/.github/workflows/loadtest.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           tools: loadtest
-          cache-id: test-loadtest
+          cache-id: common
       - uses: actions-ecosystem/action-get-latest-tag@v1
         id: get-latest-tag
         with:
@@ -58,7 +58,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           tools: loadtest
-          cache-id: test-loadtest
+          cache-id: common
       - name: Run loadtest
         run: |
           postgrest-loadtest-against ${{ steps.get-latest-tag.outputs.tag }}


### PR DESCRIPTION
merge `loadtest` & `default` cache from `Loadtest` & `Cachix` workflows to the `common` one
<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs     - https://github.com/PostgREST/postgrest-docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `fix`, bug fixes
  + `feat`, new features added
  + `perf`, performance improvements
  + `nix`, related to the Nix development environment
  + `ci`, related to the Continuous Integration modules
  + `test`, related to the testing modules
  + `refactor`, refactoring code
  + `deprecate`, deprecating a feature
  + `chore`, maintenance (changelog, build process, etc.)
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
