### PR TITLE
Revert "build(deps): bump nix-community/cache-nix-action from 4.0.3 to 5.0.1 in /.github/actions/setup-nix"

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -18,7 +18,7 @@ runs:
       with:
         nix_version: '2.13.6'
     - name: Restore and cache Nix store
-      uses: nix-community/cache-nix-action@v5.0.1
+      uses: nix-community/cache-nix-action@v4.0.3
       with:
         key: cache-nix-${{ runner.os }}-id-${{ inputs.cache-id }}-${{ hashFiles('nix/**/*.nix', '.github/actions/setup-nix/*') }}
         restore-keys: |


### PR DESCRIPTION
Reverts PostgREST/postgrest#3135. It completely broke the CI.