### PR TITLE
ci: nix: more concurrent downloads

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -18,7 +18,7 @@ runs:
       with:
         nix_version: '2.13.6'
         nix_conf: |
-          http-connections = 40
+          http-connections = 30
     - name: Restore and cache Nix store
       uses: nix-community/cache-nix-action@v4.0.3
       with:

--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -17,6 +17,8 @@ runs:
     - uses: nixbuild/nix-quick-install-action@v26
       with:
         nix_version: '2.13.6'
+        nix_conf: |
+          http-connections = 40
     - name: Restore and cache Nix store
       uses: nix-community/cache-nix-action@v4.0.3
       with:


### PR DESCRIPTION
Playing with nix.conf's [`http-connections`](https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-http-connections) parameter, might improve the downloading time of many small files.
<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs     - https://github.com/PostgREST/postgrest-docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `fix`, bug fixes
  + `feat`, new features added
  + `perf`, performance improvements
  + `nix`, related to the Nix development environment
  + `ci`, related to the Continuous Integration modules
  + `test`, related to the testing modules
  + `refactor`, refactoring code
  + `deprecate`, deprecating a feature
  + `chore`, maintenance (changelog, build process, etc.)
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
