### PR TITLE
fix: wrong subquery error returning as 400 status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
  - #3149, Misleading "Starting PostgREST.." logs on schema cache reloading - @steve-chavez
  - #2815, Build static executable with GSSAPI support - @wolfgangwalther
+ - #3205, Fix wrong subquery error returning a status of 400 Bad Request - @steve-chavez
 
 ### Deprecated
 

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -464,6 +464,10 @@ pgErrorStatus authed (SQL.SessionUsageError (SQL.QueryError _ _ (SQL.ResultError
         "23503"   -> HTTP.status409 -- foreign_key_violation
         "23505"   -> HTTP.status409 -- unique_violation
         "25006"   -> HTTP.status405 -- read_only_sql_transaction
+        "21000"   -> -- cardinality_violation
+          if BS.isSuffixOf "requires a WHERE clause" m
+            then HTTP.status400 -- special case for pg-safeupdate, which we consider as client error
+            else HTTP.status500 -- generic function or view server error, e.g. "more than one row returned by a subquery used as an expression"
         '2':'5':_ -> HTTP.status500 -- invalid tx state
         '2':'8':_ -> HTTP.status403 -- invalid auth specification
         '2':'D':_ -> HTTP.status500 -- invalid tx termination

--- a/test/spec/Feature/Query/ErrorSpec.hs
+++ b/test/spec/Feature/Query/ErrorSpec.hs
@@ -9,8 +9,8 @@ import Test.Hspec.Wai.JSON
 
 import Protolude hiding (get)
 
-spec :: SpecWith ((), Application)
-spec = do
+nonExistentSchema :: SpecWith ((), Application)
+nonExistentSchema = do
   describe "Non existent api schema" $ do
     it "succeeds when requesting root path" $
       get "/" `shouldRespondWith` 200
@@ -61,3 +61,9 @@ spec = do
              "code": "PGRST117",
              "message":"Unsupported HTTP method: OTHER"}|]
           { matchStatus = 405 }
+
+pgErrorCodeMapping :: SpecWith ((), Application)
+pgErrorCodeMapping = do
+  describe "PostreSQL error code mappings" $ do
+    it "should return 500 for cardinality_violation" $
+      get "/bad_subquery" `shouldRespondWith` 500

--- a/test/spec/Main.hs
+++ b/test/spec/Main.hs
@@ -152,6 +152,7 @@ main = do
         , ("Feature.Query.RelatedQueriesSpec"            , Feature.Query.RelatedQueriesSpec.spec)
         , ("Feature.Query.SpreadQueriesSpec"             , Feature.Query.SpreadQueriesSpec.spec)
         , ("Feature.NoSuperuserSpec"                     , Feature.NoSuperuserSpec.spec)
+        , ("Feature.Query.PgErrorCodeMappingSpec"        , Feature.Query.ErrorSpec.pgErrorCodeMapping)
         ]
 
   hspec $ do
@@ -211,7 +212,7 @@ main = do
 
     -- this test runs with a nonexistent db-schema
     parallel $ before nonexistentSchemaApp $
-      describe "Feature.Query.ErrorSpec" Feature.Query.ErrorSpec.spec
+      describe "Feature.Query.NonExistentSchemaErrorSpec" Feature.Query.ErrorSpec.nonExistentSchema
 
     -- this test runs with an extra search path
     parallel $ before extraSearchPathApp $ do

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -3752,3 +3752,6 @@ create aggregate test.some_agg (some_numbers) (
 , sfunc = some_trans
 , finalfunc = some_final
 );
+
+create view bad_subquery as
+select * from projects where id = (select id from projects);


### PR DESCRIPTION
Closes #3205.

Also considers that pg-safeupdate uses the `cardinality_violation`([ref](https://github.com/eradman/pg-safeupdate/blob/master/safeupdate.c#L38-L46)) code for reporting an error and in this case we want to keep `400 Bad Request`. This is done by checking the pg-safeupdate error message.