### PR TITLE
feat: log full pg version to stderr on connection

### DIFF
--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -376,7 +376,7 @@ internalConnectionWorker appState = work
           putPgVersion appState actualPgVersion
           when configDbChannelEnabled $
             signalListener appState
-          logWithZTime appState "Connection successful"
+          logWithZTime appState $ "Successfully connected to " <> pgvFullName actualPgVersion
           -- this could be fail because the connection drops, but the loadSchemaCache will pick the error and retry again
           -- We cannot retry after it fails immediately, because db-pre-config could have user errors. We just log the error and continue.
           when configDbConfig $ reReadConfig False appState

--- a/src/PostgREST/Config/Database.hs
+++ b/src/PostgREST/Config/Database.hs
@@ -75,8 +75,8 @@ queryPgVersion prepared = statement mempty $ pgVersionStatement prepared
 pgVersionStatement :: Bool -> SQL.Statement () PgVersion
 pgVersionStatement = SQL.Statement sql HE.noParams versionRow
   where
-    sql = "SELECT current_setting('server_version_num')::integer, current_setting('server_version')"
-    versionRow = HD.singleRow $ PgVersion <$> column HD.int4 <*> column HD.text
+    sql = "SELECT current_setting('server_version_num')::integer, current_setting('server_version'), version()"
+    versionRow = HD.singleRow $ PgVersion <$> column HD.int4 <*> column HD.text <*> column HD.text
 
 -- | Query the in-database configuration. The settings have the following priorities:
 --

--- a/src/PostgREST/Config/PgVersion.hs
+++ b/src/PostgREST/Config/PgVersion.hs
@@ -22,47 +22,48 @@ import Protolude
 
 
 data PgVersion = PgVersion
-  { pgvNum  :: Int32
-  , pgvName :: Text
+  { pgvNum      :: Int32
+  , pgvName     :: Text
+  , pgvFullName :: Text
   }
   deriving (Eq, Generic, JSON.ToJSON)
 
 instance Ord PgVersion where
-  (PgVersion v1 _) `compare` (PgVersion v2 _) = v1 `compare` v2
+  (PgVersion v1 _ _) `compare` (PgVersion v2 _ _) = v1 `compare` v2
 
 -- | Tells the minimum PostgreSQL version required by this version of PostgREST
 minimumPgVersion :: PgVersion
 minimumPgVersion = pgVersion96
 
 pgVersion96 :: PgVersion
-pgVersion96 = PgVersion 90600 "9.6"
+pgVersion96 = PgVersion 90600 "9.6" "9.6"
 
 pgVersion100 :: PgVersion
-pgVersion100 = PgVersion 100000 "10"
+pgVersion100 = PgVersion 100000 "10" "10"
 
 pgVersion109 :: PgVersion
-pgVersion109 = PgVersion 100009 "10.9"
+pgVersion109 = PgVersion 100009 "10.9" "10.9"
 
 pgVersion110 :: PgVersion
-pgVersion110 = PgVersion 110000 "11.0"
+pgVersion110 = PgVersion 110000 "11.0" "11.0"
 
 pgVersion112 :: PgVersion
-pgVersion112 = PgVersion 110002 "11.2"
+pgVersion112 = PgVersion 110002 "11.2" "11.2"
 
 pgVersion114 :: PgVersion
-pgVersion114 = PgVersion 110004 "11.4"
+pgVersion114 = PgVersion 110004 "11.4" "11.4"
 
 pgVersion120 :: PgVersion
-pgVersion120 = PgVersion 120000 "12.0"
+pgVersion120 = PgVersion 120000 "12.0" "12.0"
 
 pgVersion121 :: PgVersion
-pgVersion121 = PgVersion 120001 "12.1"
+pgVersion121 = PgVersion 120001 "12.1" "12.1"
 
 pgVersion130 :: PgVersion
-pgVersion130 = PgVersion 130000 "13.0"
+pgVersion130 = PgVersion 130000 "13.0" "13.0"
 
 pgVersion140 :: PgVersion
-pgVersion140 = PgVersion 140000 "14.0"
+pgVersion140 = PgVersion 140000 "14.0" "14.0"
 
 pgVersion150 :: PgVersion
-pgVersion150 = PgVersion 150000 "15.0"
+pgVersion150 = PgVersion 150000 "15.0" "15.0"


### PR DESCRIPTION
Closes #3184

Logs now show:

```
09/Feb/2024:16:54:47 -0500: Starting PostgREST 11.2.0 (eaa1d81)...
09/Feb/2024:16:54:47 -0500: Admin server listening on port 3001
09/Feb/2024:16:54:47 -0500: Attempting to connect to the database...
09/Feb/2024:16:54:47 -0500: Listening on port 3000
09/Feb/2024:16:54:47 -0500: Successfully connected to PostgreSQL 15.5 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 12.3.0, 64-bit

```