### PR TITLE
nix: Make postgrest-with-postgresql-xxx postgrest-test-io work better

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Run IO tests
         if: always()
-        run: postgrest-with-postgresql-${{ matrix.pgVersion }} -f test/io/fixtures.sql postgrest-test-io -vv
+        run: postgrest-with-postgresql-${{ matrix.pgVersion }} postgrest-test-io -vv
 
 
   Test-Memory-Nix:

--- a/nix/tools/loadtest.nix
+++ b/nix/tools/loadtest.nix
@@ -60,7 +60,7 @@ let
         abs_output="$(realpath "$_arg_output")"
 
         # shellcheck disable=SC2145
-        ${withTools.withPg} --fixtures "$_arg_testdir"/fixtures.sql \
+        ${withTools.withPg} -f "$_arg_testdir"/fixtures.sql \
         ${withTools.withSlowPg} \
         ${withTools.withPgrst} \
         ${withTools.withSlowPgrst} \

--- a/nix/tools/memory.nix
+++ b/nix/tools/memory.nix
@@ -17,7 +17,7 @@ let
         withPath = [ postgrestProfiled curl ];
       }
       ''
-        ${withTools.withPg} test/memory/memory-tests.sh
+        ${withTools.withPg} -f test/spec/fixtures/load.sql test/memory/memory-tests.sh
       '';
 
 in

--- a/nix/tools/tests.nix
+++ b/nix/tools/tests.nix
@@ -28,8 +28,8 @@ let
         withEnv = postgrest.env;
       }
       ''
-        ${withTools.withPg} ${cabal-install}/bin/cabal v2-run ${devCabalOptions} \
-          test:spec -- "''${_arg_leftovers[@]}"
+        ${withTools.withPg} -f test/spec/fixtures/load.sql \
+          ${cabal-install}/bin/cabal v2-run ${devCabalOptions} test:spec -- "''${_arg_leftovers[@]}"
       '';
 
   testDoctests =
@@ -59,9 +59,10 @@ let
         withEnv = postgrest.env;
       }
       ''
-        ${withTools.withPg} ${runtimeShell} -c " \
-          ${cabal-install}/bin/cabal v2-run ${devCabalOptions} test:spec && \
-          ${cabal-install}/bin/cabal v2-run ${devCabalOptions} test:spec"
+        ${withTools.withPg} -f test/spec/fixtures/load.sql \
+          ${runtimeShell} -c " \
+            ${cabal-install}/bin/cabal v2-run ${devCabalOptions} test:spec && \
+            ${cabal-install}/bin/cabal v2-run ${devCabalOptions} test:spec"
       '';
 
   ioTestPython =
@@ -99,7 +100,7 @@ let
         withPath = [ jq ];
       }
       ''
-        ${withTools.withPg} \
+        ${withTools.withPg} -f test/spec/fixtures.sql \
             ${cabal-install}/bin/cabal v2-run ${devCabalOptions} --verbose=0 -- \
             postgrest --dump-schema \
             | ${yq}/bin/yq -y .
@@ -137,11 +138,12 @@ let
 
           # collect all tests
           HPCTIXFILE="$tmpdir"/io.tix \
-            ${withTools.withPg} -f test/io/fixtures.sql ${cabal-install}/bin/cabal v2-exec ${devCabalOptions} -- \
-            ${ioTestPython}/bin/pytest -v test/io
+            ${withTools.withPg} -f test/io/fixtures.sql \
+            ${cabal-install}/bin/cabal v2-exec ${devCabalOptions} -- ${ioTestPython}/bin/pytest -v test/io
 
           HPCTIXFILE="$tmpdir"/spec.tix \
-            ${withTools.withPg} ${cabal-install}/bin/cabal v2-run ${devCabalOptions} test:spec
+            ${withTools.withPg} -f test/spec/fixtures/load.sql \
+            ${cabal-install}/bin/cabal v2-run ${devCabalOptions} test:spec
 
           # Note: No coverage for doctests, as doctests leverage GHCi and GHCi does not support hpc
 


### PR DESCRIPTION
The upside is that postgrest-with-postgresql-xxx postgrest-test-io works as expected now. The downside is, that postgrest-with-postgresql-xxx psql now starts without any schema. This now needs an explicit postgrest-with-postgresql-xxx -f path/to.sql to do anything useful.

Resolves #2864
