### PR TITLE
demo: We have not been testing against pg 9.6 and pg 10 for a while

### DIFF
--- a/nix/overlays/postgis.nix
+++ b/nix/overlays/postgis.nix
@@ -15,12 +15,12 @@ in
       postgis = prev.postgresql_11.pkgs.postgis.overrideAttrs (_: postgis_3_2_3);
     };
   };
-  postgresql_10 = prev.postgresql_10.override { this = final.postgresql_11; } // {
+  postgresql_10 = prev.postgresql_10.override { this = final.postgresql_10; } // {
     pkgs = prev.postgresql_10.pkgs // {
       postgis = prev.postgresql_10.pkgs.postgis.overrideAttrs (_: postgis_3_2_3);
     };
   };
-  postgresql_9_6 = prev.postgresql_9_6.override { this = final.postgresql_11; } // {
+  postgresql_9_6 = prev.postgresql_9_6.override { this = final.postgresql_9_6; } // {
     pkgs = prev.postgresql_9_6.pkgs // {
       postgis = prev.postgresql_9_6.pkgs.postgis.overrideAttrs (_: postgis_3_2_3);
     };


### PR DESCRIPTION
This was introduced in #2479 and ever since the following is happening:

```
% postgrest-with-postgresql-9.6 psql -c 'SELECT version()'
                                    version
--------------------------------------------------------------------------------
 PostgreSQL 11.21 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 12.3.0, 64-bit
(1 row)

% postgrest-with-postgresql-10 psql -c 'SELECT version()'
                                    version
-------------------------------------------------------------------------------
 PostgreSQL 11.21 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 12.3.0, 64-bit
(1 row)
```

So we have not been testing against v9.6 or v10.0 for more than a year now, but instead tested against v11 3x as much.

Locally, tests for both version started to fail after the change. It looks like there are only test-related failures, but I don't plan on fixing them. This PR is to serve as a demonstration only and I will pick up #2052 again. 