### PR TITLE
fix: fixes server timings' precision

### DIFF
--- a/src/PostgREST/Response/Performance.hs
+++ b/src/PostgREST/Response/Performance.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NumericUnderscores #-}
 module PostgREST.Response.Performance
   ( ServerTiming (..)
   , serverTimingHeader
@@ -8,6 +9,7 @@ import qualified Network.HTTP.Types    as HTTP
 import           Numeric               (showFFloat)
 import           Protolude
 
+-- | ServerTiming represents the timing data for a request, in seconds.
 data ServerTiming =
   ServerTiming
     { jwt         :: Maybe Double
@@ -19,14 +21,15 @@ data ServerTiming =
   deriving (Show)
 
 -- | Render the Server-Timing header from a ServerTimingData
+-- The duration precision is milliseconds, per the docs
 --
 -- >>> serverTimingHeader ServerTiming { plan=Just 0.1, transaction=Just 0.2, response=Just 0.3, jwt=Just 0.4, parse=Just 0.5}
--- ("Server-Timing","jwt;dur=400000.0, parse;dur=500000.0, plan;dur=100000.0, transaction;dur=200000.0, response;dur=300000.0")
+-- ("Server-Timing","jwt;dur=400.0, parse;dur=500.0, plan;dur=100.0, transaction;dur=200.0, response;dur=300.0")
 serverTimingHeader :: ServerTiming -> HTTP.Header
 serverTimingHeader timing =
   ("Server-Timing", renderTiming)
   where
-    renderMetric metric = maybe "" (\dur -> BS.concat [metric, BS.pack $ ";dur=" <> showFFloat (Just 1) (dur * 1000000) ""])
+    renderMetric metric = maybe "" (\dur -> BS.concat [metric, BS.pack $ ";dur=" <> showFFloat (Just 1) (dur * 1_000) ""])
     renderTiming = BS.intercalate ", " $ (\(k, v) -> renderMetric k (v timing)) <$>
       [ ("jwt", jwt)
       , ("parse", parse)

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -1170,9 +1170,9 @@ def test_server_timing_jwt_should_decrease_on_subsequent_requests(defaultenv):
         first_dur = parse_server_timings_header(first_timings)["jwt"]
         second_dur = parse_server_timings_header(second_timings)["jwt"]
 
-        # their difference should be atleast 300, implying
+        # their difference should be atleast 0.3ms, implying
         # that JWT Caching is working as expected
-        assert (first_dur - second_dur) > 300.0
+        assert (first_dur - second_dur) > 0.3
 
 
 # just added to complete code coverage
@@ -1252,9 +1252,9 @@ def test_jwt_cache_with_no_exp_claim(defaultenv):
         first_dur = parse_server_timings_header(first_timings)["jwt"]
         second_dur = parse_server_timings_header(second_timings)["jwt"]
 
-        # their difference should be atleast 300, implying
+        # their difference should be atleast 0.3ms, implying
         # that JWT Caching is working as expected
-        assert (first_dur - second_dur) > 300.0
+        assert (first_dur - second_dur) > 0.3
 
 
 def test_preflight_request_with_cors_allowed_origin_config(defaultenv):


### PR DESCRIPTION
Make `Server-Timing` durations match the documentation (see #3219) and document measurement units in source.

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs     - https://github.com/PostgREST/postgrest-docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `fix`, bug fixes
  + `feat`, new features added
  + `perf`, performance improvements
  + `nix`, related to the Nix development environment
  + `ci`, related to the Continuous Integration modules
  + `test`, related to the testing modules
  + `refactor`, refactoring code
  + `deprecate`, deprecating a feature
  + `chore`, maintenance (changelog, build process, etc.)
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
