### PR TITLE
fix: selecting overloaded computed columns alongside `*` when returing tables from INSERT and RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3149, Misleading "Starting PostgREST.." logs on schema cache reloading - @steve-chavez
  - #2815, Build static executable with GSSAPI support - @wolfgangwalther
  - #3205, Fix wrong subquery error returning a status of 400 Bad Request - @steve-chavez
+ - #2688, #3145 Fix selecting overloaded computed columns alongside `*` when returning tables from INSERT and RPC - @wolfgangwalther, @laurenceisla
 
 ### Deprecated
 

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -947,7 +947,7 @@ inferColsEmbedNeeds :: ReadPlanTree -> [FieldName] -> [FieldName]
 inferColsEmbedNeeds (Node ReadPlan{select} forest) pkCols
   -- if * is part of the select, we must not add pk or fk columns manually -
   -- otherwise those would be selected and output twice
-  | "*" `elem` fldNames = ["*"]
+  | "*" `elem` fldNames = fldNames
   | otherwise           = returnings
   where
     fldNames = cfName . csField <$> select

--- a/test/spec/Feature/Query/QuerySpec.hs
+++ b/test/spec/Feature/Query/QuerySpec.hs
@@ -533,9 +533,15 @@ spec actualPgVersion = do
         get "/items2?id=eq.1&select=id,computed_overload" `shouldRespondWith`
           [json|[{"id":1,"computed_overload":true}]|]
           { matchHeaders = [matchContentTypeJson] }
+        get "items?id=eq.1&select=*,computed_overload" `shouldRespondWith`
+          [json|[{"id":1,"computed_overload":true}]|]
+          { matchHeaders = [matchContentTypeJson] }
 
-      it "overloaded computed column on rpc" $
+      it "overloaded computed column on rpc" $ do
         get "/rpc/search?id=1&select=id,computed_overload" `shouldRespondWith`
+          [json|[{"id":1,"computed_overload":true}]|]
+          { matchHeaders = [matchContentTypeJson] }
+        get "/rpc/search?id=1&select=*,computed_overload" `shouldRespondWith`
           [json|[{"id":1,"computed_overload":true}]|]
           { matchHeaders = [matchContentTypeJson] }
 

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -3755,3 +3755,15 @@ create aggregate test.some_agg (some_numbers) (
 
 create view bad_subquery as
 select * from projects where id = (select id from projects);
+
+CREATE FUNCTION is_orphan(test.projects) RETURNS boolean
+  LANGUAGE sql IMMUTABLE
+AS $$ SELECT $1.client_id IS NULL $$;
+
+CREATE FUNCTION created_at(test.projects) RETURNS date
+  LANGUAGE sql IMMUTABLE
+AS $$ SELECT '20240101'::date $$;
+
+CREATE FUNCTION created_at(test.articles) RETURNS date
+  LANGUAGE sql IMMUTABLE
+AS $$ SELECT '20240101'::date $$;


### PR DESCRIPTION
Closes #3145
It should also work for #2688 (needs confirmation)