### PR TITLE
refactor: add observation module

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -54,6 +54,7 @@ library
                       PostgREST.Error
                       PostgREST.Logger
                       PostgREST.MediaType
+                      PostgREST.Observation
                       PostgREST.Query
                       PostgREST.Query.QueryBuilder
                       PostgREST.Query.SqlFragment

--- a/src/PostgREST/Admin.hs
+++ b/src/PostgREST/Admin.hs
@@ -16,32 +16,32 @@ import qualified Data.ByteString.Lazy as LBS
 import Network.Socket
 import Network.Socket.ByteString
 
-import PostgREST.AppState (AppState)
-import PostgREST.Config   (AppConfig (..))
+import PostgREST.AppState    (AppState)
+import PostgREST.Config      (AppConfig (..))
+import PostgREST.Observation (Observation (..))
 
 import qualified PostgREST.AppState as AppState
 import qualified PostgREST.Config   as Config
 
 import Protolude
-import Protolude.Partial (fromJust)
 
-runAdmin :: AppConfig -> AppState -> Warp.Settings -> IO ()
-runAdmin conf@AppConfig{configAdminServerPort} appState settings =
+runAdmin :: AppConfig -> AppState -> Warp.Settings -> (Observation -> IO ()) -> IO ()
+runAdmin conf@AppConfig{configAdminServerPort} appState settings observer =
   whenJust (AppState.getSocketAdmin appState) $ \adminSocket -> do
-    AppState.logWithZTime appState $ "Admin server listening on port " <> show (fromIntegral (fromJust configAdminServerPort) :: Integer)
+    observer $ AdminStartObs configAdminServerPort
     void . forkIO $ Warp.runSettingsSocket settings adminSocket adminApp
   where
-    adminApp = admin appState conf
+    adminApp = admin appState conf observer
 
 -- | PostgREST admin application
-admin :: AppState.AppState -> AppConfig -> Wai.Application
-admin appState appConfig req respond  = do
+admin :: AppState.AppState -> AppConfig -> (Observation -> IO ()) -> Wai.Application
+admin appState appConfig observer req respond  = do
   isMainAppReachable  <- isRight <$> reachMainApp (AppState.getSocketREST appState)
   isSchemaCacheLoaded <- isJust <$> AppState.getSchemaCache appState
   isConnectionUp      <-
     if configDbChannelEnabled appConfig
       then AppState.getIsListenerOn appState
-      else isRight <$> AppState.usePool appState appConfig (SQL.sql "SELECT 1")
+      else isRight <$> AppState.usePool appState appConfig (SQL.sql "SELECT 1") observer
 
   case Wai.pathInfo req of
     ["ready"] ->

--- a/src/PostgREST/Logger.hs
+++ b/src/PostgREST/Logger.hs
@@ -2,18 +2,57 @@
 Module      : PostgREST.Logger
 Description : Wai Middleware to log requests to stdout.
 -}
-module PostgREST.Logger (middleware) where
+module PostgREST.Logger
+  ( middleware
+  , logObservation
+  , init
+  ) where
+
+import Control.AutoUpdate (defaultUpdateSettings, mkAutoUpdate,
+                           updateAction)
+
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Text.Encoding   as T
+import           Data.Time            (ZonedTime, defaultTimeLocale,
+                                       formatTime, getZonedTime)
+import qualified Hasql.Pool           as SQL
 
 import qualified Network.Wai                          as Wai
 import qualified Network.Wai.Middleware.RequestLogger as Wai
+import           Numeric                              (showFFloat)
+
 
 import Network.HTTP.Types.Status (status400, status500)
 import System.IO.Unsafe          (unsafePerformIO)
 
-import qualified PostgREST.Auth   as Auth
-import           PostgREST.Config (LogLevel (..))
+import PostgREST.Config      (LogLevel (..))
+import PostgREST.Observation
+
+import qualified PostgREST.Auth  as Auth
+import qualified PostgREST.Error as Error
+
+import PostgREST.SchemaCache (showSummary)
+
 
 import Protolude
+import Protolude.Partial (fromJust)
+
+newtype LoggerState = LoggerState
+  { stateGetZTime                 :: IO ZonedTime -- ^ Time with time zone used for logs
+  }
+
+init :: IO LoggerState
+init = do
+  zTime <- mkAutoUpdate defaultUpdateSettings { updateAction = getZonedTime }
+  pure $ LoggerState zTime
+
+logWithZTime :: LoggerState -> Text -> IO ()
+logWithZTime loggerState txt = do
+  zTime <- stateGetZTime loggerState
+  hPutStrLn stderr $ toS (formatTime defaultTimeLocale "%d/%b/%Y:%T %z: " zTime) <> txt
+
+logPgrstError :: LoggerState -> SQL.UsageError -> IO ()
+logPgrstError loggerState e = logWithZTime loggerState . T.decodeUtf8 . LBS.toStrict $ Error.errorPayload $ Error.PgError False e
 
 middleware :: LogLevel -> Wai.Middleware
 middleware logLevel = case logLevel of
@@ -28,3 +67,64 @@ middleware logLevel = case logLevel of
             & Wai.setApacheRequestFilter (\_ res -> filterStatus $ Wai.responseStatus res)
             & Wai.setApacheUserGetter Auth.getRole
       }
+
+logObservation :: LoggerState -> Observation -> IO ()
+logObservation loggerState obs =
+  case obs of
+    AdminStartObs port ->
+      logWithZTime loggerState $ "Admin server listening on port " <> show (fromIntegral (fromJust port) :: Integer)
+    AppStartObs ver ->
+      logWithZTime loggerState $ "Starting PostgREST " <> T.decodeUtf8 ver <> "..."
+    AppServerPortObs port ->
+      logWithZTime loggerState $ "Listening on port " <> show port
+    AppServerUnixObs sock ->
+      logWithZTime loggerState $ "Listening on unix socket " <> show sock
+    AppDBConnectAttemptObs ->
+      logWithZTime loggerState "Attempting to connect to the database..."
+    AppExitFatalObs reason ->
+      logWithZTime loggerState $ "Fatal error encountered. " <> reason
+    AppExitDBNoRecoveryObs ->
+      logWithZTime loggerState "Automatic recovery disabled, exiting."
+    AppDBConnectedObs ver ->
+      logWithZTime loggerState $ "Successfully connected to " <> ver
+    AppSCacheFatalErrorObs usageErr hint -> do
+      logWithZTime loggerState "A fatal error ocurred when loading the schema cache"
+      logPgrstError loggerState usageErr
+      logWithZTime loggerState hint
+    AppSCacheNormalErrorObs usageErr -> do
+      logWithZTime loggerState "An error ocurred when loading the schema cache"
+      logPgrstError loggerState usageErr
+    AppSCacheLoadSuccessObs sCache resultTime -> do
+      logWithZTime loggerState $ "Schema cache queried in " <> showMillis resultTime  <> " milliseconds"
+      logWithZTime loggerState $ "Schema cache loaded " <> showSummary sCache
+    ConnectionRetryObs delay -> do
+      logWithZTime loggerState $ "Attempting to reconnect to the database in " <> (show delay::Text) <> " seconds..."
+    ConnectionPgVersionErrorObs usageErr ->
+      logPgrstError loggerState usageErr
+    DBListenerStart channel -> do
+      logWithZTime loggerState $ "Listening for notifications on the " <> channel <> " channel"
+    DBListenerFailNoRecoverObs ->
+      logWithZTime loggerState "Automatic recovery disabled, exiting."
+    DBListenerFailRecoverObs channel ->
+      logWithZTime loggerState $ "Retrying listening for notifications on the " <> channel <> " channel.."
+    ConfigReadErrorObs ->
+      logWithZTime loggerState "An error ocurred when trying to query database settings for the config parameters"
+    ConfigReadErrorFatalObs usageErr hint -> do
+      logPgrstError loggerState usageErr
+      logWithZTime loggerState hint
+    ConfigReadErrorNotFatalObs usageErr -> do
+      logPgrstError loggerState usageErr
+    QueryRoleSettingsErrorObs usageErr -> do
+      logWithZTime loggerState "An error ocurred when trying to query the role settings"
+      logPgrstError loggerState usageErr
+    QueryErrorCodeHighObs usageErr -> do
+      logPgrstError loggerState usageErr
+    ConfigInvalidObs err -> do
+      logWithZTime loggerState $ "Failed reloading config: " <> err
+    ConfigSucceededObs -> do
+      logWithZTime loggerState "Config reloaded"
+    PoolAcqTimeoutObs usageErr -> do
+      logPgrstError loggerState usageErr
+  where
+    showMillis :: Double -> Text
+    showMillis x = toS $ showFFloat (Just 1) (x * 1000) ""

--- a/src/PostgREST/Observation.hs
+++ b/src/PostgREST/Observation.hs
@@ -1,0 +1,39 @@
+{-|
+Module      : PostgREST.Observation
+Description : Module for observability types
+-}
+module PostgREST.Observation
+  ( Observation(..)
+  ) where
+
+import qualified Hasql.Pool            as SQL
+import qualified Network.Socket        as NS
+import           PostgREST.SchemaCache (SchemaCache)
+
+import Protolude
+
+data Observation
+  = AdminStartObs (Maybe Int)
+  | AppStartObs ByteString
+  | AppServerPortObs NS.PortNumber
+  | AppServerUnixObs FilePath
+  | AppDBConnectAttemptObs
+  | AppExitFatalObs Text
+  | AppExitDBNoRecoveryObs
+  | AppDBConnectedObs Text
+  | AppSCacheFatalErrorObs SQL.UsageError Text
+  | AppSCacheNormalErrorObs SQL.UsageError
+  | AppSCacheLoadSuccessObs SchemaCache Double
+  | ConnectionRetryObs Int
+  | ConnectionPgVersionErrorObs SQL.UsageError
+  | DBListenerStart Text
+  | DBListenerFailNoRecoverObs
+  | DBListenerFailRecoverObs Text
+  | ConfigReadErrorObs
+  | ConfigReadErrorFatalObs SQL.UsageError Text
+  | ConfigReadErrorNotFatalObs SQL.UsageError
+  | ConfigInvalidObs Text
+  | ConfigSucceededObs
+  | QueryRoleSettingsErrorObs SQL.UsageError
+  | QueryErrorCodeHighObs SQL.UsageError
+  | PoolAcqTimeoutObs SQL.UsageError


### PR DESCRIPTION
- Centralizes log traces into a single module. Which improves maintainability and removes some complexity from `AppState`.
- Will enable handling verbosity on log traces (required for https://github.com/PostgREST/postgrest/pull/3229)
- Might also help with opentelemetry (https://github.com/PostgREST/postgrest/pull/3140)
- Got the structure from https://github.com/nikita-volkov/hasql-pool/pull/40.
 
## Next steps

- Move the messages from the Logger to Observation (`showObservation`).
- There are more improvements to make but it will involve changing the messages. Wanted to keep the behavior as is for now.