### PR TITLE
fix: Dump media handlers and timezones with --dump-schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3205, Fix wrong subquery error returning a status of 400 Bad Request - @steve-chavez
  - #3224, Return status code 406 for non-accepted media type instead of code 415 - @wolfgangwalther
  - #3160, Fix using select= query parameter for custom media type handlers - @wolfgangwalther
+ - #3237, Dump media handlers and timezones with --dump-schema - @wolfgangwalther
 
 ### Deprecated
 

--- a/nix/tools/tests.nix
+++ b/nix/tools/tests.nix
@@ -67,6 +67,7 @@ let
       ps.pyyaml
       ps.requests
       ps.requests-unixsocket
+      ps.syrupy
     ]);
 
   testIO =

--- a/src/PostgREST/ApiRequest/Preferences.hs
+++ b/src/PostgREST/ApiRequest/Preferences.hs
@@ -163,7 +163,7 @@ fromHeaders allowTxDbOverride acceptedTzNames headers =
     listStripPrefix prefix prefList = listToMaybe $ mapMaybe (BS.stripPrefix prefix) prefList
 
     timezonePref = listStripPrefix "timezone=" prefs
-    isTimezonePrefAccepted = (S.member <$> timezonePref <*> pure acceptedTzNames) == Just True
+    isTimezonePrefAccepted = (S.member <$> (decodeUtf8 <$> timezonePref) <*> pure acceptedTzNames) == Just True
 
     maxAffectedPref = listStripPrefix "max-affected=" prefs >>= readMaybe . BS.unpack
 

--- a/src/PostgREST/Config/Database.hs
+++ b/src/PostgREST/Config/Database.hs
@@ -30,7 +30,7 @@ import Protolude
 
 type RoleSettings     = (HM.HashMap ByteString (HM.HashMap ByteString ByteString))
 type RoleIsolationLvl = HM.HashMap ByteString SQL.IsolationLevel
-type TimezoneNames    = Set ByteString -- cache timezone names for prefer timezone=
+type TimezoneNames    = Set Text -- cache timezone names for prefer timezone=
 
 toIsolationLevel :: (Eq a, IsString a) => a -> SQL.IsolationLevel
 toIsolationLevel a = case a of

--- a/src/PostgREST/SchemaCache.hs
+++ b/src/PostgREST/SchemaCache.hs
@@ -31,7 +31,6 @@ import Control.Monad.Extra (whenJust)
 
 import           Data.Aeson                 ((.=))
 import qualified Data.Aeson                 as JSON
-import qualified Data.Aeson.Types           as JSON
 import qualified Data.HashMap.Strict        as HM
 import qualified Data.HashMap.Strict.InsOrd as HMI
 import qualified Data.Set                   as S
@@ -86,13 +85,13 @@ data SchemaCache = SchemaCache
   }
 
 instance JSON.ToJSON SchemaCache where
-  toJSON (SchemaCache tabs rels routs reps _ _) = JSON.object [
+  toJSON (SchemaCache tabs rels routs reps hdlers tzs) = JSON.object [
       "dbTables"          .= JSON.toJSON tabs
     , "dbRelationships"   .= JSON.toJSON rels
     , "dbRoutines"        .= JSON.toJSON routs
     , "dbRepresentations" .= JSON.toJSON reps
-    , "dbMediaHandlers"   .= JSON.emptyArray
-    , "dbTimezones"       .= JSON.emptyArray
+    , "dbMediaHandlers"   .= JSON.toJSON hdlers
+    , "dbTimezones"       .= JSON.toJSON tzs
     ]
 
 showSummary :: SchemaCache -> Text
@@ -1222,7 +1221,7 @@ timezones = SQL.Statement sql HE.noParams decodeTimezones
   where
     sql = "SELECT name FROM pg_timezone_names"
     decodeTimezones :: HD.Result TimezoneNames
-    decodeTimezones = S.fromList . map encodeUtf8 <$> HD.rowList (column HD.text)
+    decodeTimezones = S.fromList <$> HD.rowList (column HD.text)
 
 param :: HE.Value a -> HE.Params a
 param = HE.param . HE.nonNullable

--- a/src/PostgREST/SchemaCache/Routine.hs
+++ b/src/PostgREST/SchemaCache/Routine.hs
@@ -110,7 +110,7 @@ data MediaHandler
    -- custom
    | CustomFunc QualifiedIdentifier RelIdentifier
    | NoAgg
-   deriving (Eq, Show)
+   deriving (Eq, Show, Generic, JSON.ToJSON)
 
 funcReturnsSingle :: Routine -> Bool
 funcReturnsSingle proc = case proc of

--- a/test/io/__snapshots__/test_cli/test_schema_cache_snapshot.yaml
+++ b/test/io/__snapshots__/test_cli/test_schema_cache_snapshot.yaml
@@ -1,0 +1,1767 @@
+dbMediaHandlers:
+- - - tag: RelAnyElement
+    - tag: MTGeoJSON
+  - - tag: BuiltinOvAggGeoJson
+    - tag: MTGeoJSON
+- - - tag: RelAnyElement
+    - tag: MTApplicationJSON
+  - - tag: BuiltinOvAggJson
+    - tag: MTApplicationJSON
+- - - tag: RelAnyElement
+    - tag: MTTextCSV
+  - - tag: BuiltinOvAggCsv
+    - tag: MTTextCSV
+- - - tag: RelAnyElement
+    - tag: MTAny
+  - - tag: BuiltinOvAggJson
+    - tag: MTApplicationJSON
+dbRelationships: []
+dbRepresentations: []
+dbRoutines:
+- - qiName: reload_pgrst_config
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: reload_pgrst_config
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: void
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: change_max_rows_config
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: change_max_rows_config
+      pdParams:
+      - ppName: val
+        ppReq: true
+        ppType: integer
+        ppTypeMaxLength: integer
+        ppVar: false
+      - ppName: notify
+        ppReq: false
+        ppType: boolean
+        ppTypeMaxLength: boolean
+        ppVar: false
+      pdReturnType:
+        contents:
+          contents:
+            qiName: void
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: reset_invalid_role_claim_key
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: reset_invalid_role_claim_key
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: void
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: multiple_func_settings_test
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings:
+      - - work_mem
+        - '5000'
+      - - statement_timeout
+        - 10s
+      pdHasVariadic: false
+      pdName: multiple_func_settings_test
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: record
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: SetOf
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: serializable_isolation_level
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: serializable_isolation_level
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: text
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: hello
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: hello
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: text
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: get_pgrst_version
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: get_pgrst_version
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: text
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: terminate_pgrst
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: terminate_pgrst
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: record
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: SetOf
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: default_isolation_level
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: default_isolation_level
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: text
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: set_statement_timeout
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: set_statement_timeout
+      pdParams:
+      - ppName: role
+        ppReq: true
+        ppType: text
+        ppTypeMaxLength: text
+        ppVar: false
+      - ppName: milliseconds
+        ppReq: true
+        ppType: integer
+        ppTypeMaxLength: integer
+        ppVar: false
+      pdReturnType:
+        contents:
+          contents:
+            qiName: void
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: change_db_schema_and_full_reload
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: change_db_schema_and_full_reload
+      pdParams:
+      - ppName: schemas
+        ppReq: true
+        ppType: text
+        ppTypeMaxLength: text
+        ppVar: false
+      pdReturnType:
+        contents:
+          contents:
+            qiName: void
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: work_mem_test
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings:
+      - - work_mem
+        - '6000'
+      pdHasVariadic: false
+      pdName: work_mem_test
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: text
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: invalid_role_claim_key_reload
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: invalid_role_claim_key_reload
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: void
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: reset_max_rows_config
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: reset_max_rows_config
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: void
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: uses_prepared_statements
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: uses_prepared_statements
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: bool
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: migrate_function
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: migrate_function
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: void
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: create_function
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: create_function
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: void
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: change_role_statement_timeout
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: change_role_statement_timeout
+      pdParams:
+      - ppName: timeout
+        ppReq: true
+        ppType: text
+        ppTypeMaxLength: text
+        ppVar: false
+      pdReturnType:
+        contents:
+          contents:
+            qiName: void
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: repeatable_read_isolation_level
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: repeatable_read_isolation_level
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: text
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: drop_change_cats
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: drop_change_cats
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: void
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: one_sec_timeout
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings:
+      - - statement_timeout
+        - 1s
+      pdHasVariadic: false
+      pdName: one_sec_timeout
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: void
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: sleep
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: sleep
+      pdParams:
+      - ppName: seconds
+        ppReq: true
+        ppType: double precision
+        ppTypeMaxLength: double precision
+        ppVar: false
+      pdReturnType:
+        contents:
+          contents:
+            qiName: void
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: get_postgres_version
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: get_postgres_version
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: int4
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: four_sec_timeout
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings:
+      - - statement_timeout
+        - 4s
+      pdHasVariadic: false
+      pdName: four_sec_timeout
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: void
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+- - qiName: get_guc_value
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: get_guc_value
+      pdParams:
+      - ppName: name
+        ppReq: true
+        ppType: text
+        ppTypeMaxLength: text
+        ppVar: false
+      pdReturnType:
+        contents:
+          contents:
+            qiName: text
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+dbTables:
+- - qiName: authors_only
+    qiSchema: public
+  - tableColumns: {}
+    tableDeletable: true
+    tableDescription: null
+    tableInsertable: true
+    tableIsView: false
+    tableName: authors_only
+    tablePKCols: []
+    tableSchema: public
+    tableUpdatable: true
+- - qiName: cats
+    qiSchema: public
+  - tableColumns:
+      id:
+        colDefault: null
+        colDescription: null
+        colEnum: []
+        colMaxLen: null
+        colName: id
+        colNominalType: uuid
+        colNullable: false
+        colType: uuid
+      name:
+        colDefault: null
+        colDescription: null
+        colEnum: []
+        colMaxLen: null
+        colName: name
+        colNominalType: text
+        colNullable: true
+        colType: text
+    tableDeletable: true
+    tableDescription: null
+    tableInsertable: true
+    tableIsView: false
+    tableName: cats
+    tablePKCols:
+    - id
+    tableSchema: public
+    tableUpdatable: true
+- - qiName: projects
+    qiSchema: public
+  - tableColumns: {}
+    tableDeletable: true
+    tableDescription: null
+    tableInsertable: true
+    tableIsView: false
+    tableName: projects
+    tablePKCols: []
+    tableSchema: public
+    tableUpdatable: true
+- - qiName: items_w_isolation_level
+    qiSchema: public
+  - tableColumns:
+      id:
+        colDefault: null
+        colDescription: null
+        colEnum: []
+        colMaxLen: null
+        colName: id
+        colNominalType: integer
+        colNullable: true
+        colType: integer
+      isolation_level:
+        colDefault: null
+        colDescription: null
+        colEnum: []
+        colMaxLen: null
+        colName: isolation_level
+        colNominalType: text
+        colNullable: true
+        colType: text
+    tableDeletable: true
+    tableDescription: null
+    tableInsertable: true
+    tableIsView: true
+    tableName: items_w_isolation_level
+    tablePKCols: []
+    tableSchema: public
+    tableUpdatable: true
+- - qiName: items
+    qiSchema: public
+  - tableColumns:
+      id:
+        colDefault: null
+        colDescription: null
+        colEnum: []
+        colMaxLen: null
+        colName: id
+        colNominalType: integer
+        colNullable: true
+        colType: integer
+    tableDeletable: true
+    tableDescription: null
+    tableInsertable: true
+    tableIsView: false
+    tableName: items
+    tablePKCols: []
+    tableSchema: public
+    tableUpdatable: true
+dbTimezones:
+- Africa/Abidjan
+- Africa/Accra
+- Africa/Addis_Ababa
+- Africa/Algiers
+- Africa/Asmara
+- Africa/Asmera
+- Africa/Bamako
+- Africa/Bangui
+- Africa/Banjul
+- Africa/Bissau
+- Africa/Blantyre
+- Africa/Brazzaville
+- Africa/Bujumbura
+- Africa/Cairo
+- Africa/Casablanca
+- Africa/Ceuta
+- Africa/Conakry
+- Africa/Dakar
+- Africa/Dar_es_Salaam
+- Africa/Djibouti
+- Africa/Douala
+- Africa/El_Aaiun
+- Africa/Freetown
+- Africa/Gaborone
+- Africa/Harare
+- Africa/Johannesburg
+- Africa/Juba
+- Africa/Kampala
+- Africa/Khartoum
+- Africa/Kigali
+- Africa/Kinshasa
+- Africa/Lagos
+- Africa/Libreville
+- Africa/Lome
+- Africa/Luanda
+- Africa/Lubumbashi
+- Africa/Lusaka
+- Africa/Malabo
+- Africa/Maputo
+- Africa/Maseru
+- Africa/Mbabane
+- Africa/Mogadishu
+- Africa/Monrovia
+- Africa/Nairobi
+- Africa/Ndjamena
+- Africa/Niamey
+- Africa/Nouakchott
+- Africa/Ouagadougou
+- Africa/Porto-Novo
+- Africa/Sao_Tome
+- Africa/Timbuktu
+- Africa/Tripoli
+- Africa/Tunis
+- Africa/Windhoek
+- America/Adak
+- America/Anchorage
+- America/Anguilla
+- America/Antigua
+- America/Araguaina
+- America/Argentina/Buenos_Aires
+- America/Argentina/Catamarca
+- America/Argentina/ComodRivadavia
+- America/Argentina/Cordoba
+- America/Argentina/Jujuy
+- America/Argentina/La_Rioja
+- America/Argentina/Mendoza
+- America/Argentina/Rio_Gallegos
+- America/Argentina/Salta
+- America/Argentina/San_Juan
+- America/Argentina/San_Luis
+- America/Argentina/Tucuman
+- America/Argentina/Ushuaia
+- America/Aruba
+- America/Asuncion
+- America/Atikokan
+- America/Atka
+- America/Bahia
+- America/Bahia_Banderas
+- America/Barbados
+- America/Belem
+- America/Belize
+- America/Blanc-Sablon
+- America/Boa_Vista
+- America/Bogota
+- America/Boise
+- America/Buenos_Aires
+- America/Cambridge_Bay
+- America/Campo_Grande
+- America/Cancun
+- America/Caracas
+- America/Catamarca
+- America/Cayenne
+- America/Cayman
+- America/Chicago
+- America/Chihuahua
+- America/Ciudad_Juarez
+- America/Coral_Harbour
+- America/Cordoba
+- America/Costa_Rica
+- America/Creston
+- America/Cuiaba
+- America/Curacao
+- America/Danmarkshavn
+- America/Dawson
+- America/Dawson_Creek
+- America/Denver
+- America/Detroit
+- America/Dominica
+- America/Edmonton
+- America/Eirunepe
+- America/El_Salvador
+- America/Ensenada
+- America/Fort_Nelson
+- America/Fort_Wayne
+- America/Fortaleza
+- America/Glace_Bay
+- America/Godthab
+- America/Goose_Bay
+- America/Grand_Turk
+- America/Grenada
+- America/Guadeloupe
+- America/Guatemala
+- America/Guayaquil
+- America/Guyana
+- America/Halifax
+- America/Havana
+- America/Hermosillo
+- America/Indiana/Indianapolis
+- America/Indiana/Knox
+- America/Indiana/Marengo
+- America/Indiana/Petersburg
+- America/Indiana/Tell_City
+- America/Indiana/Vevay
+- America/Indiana/Vincennes
+- America/Indiana/Winamac
+- America/Indianapolis
+- America/Inuvik
+- America/Iqaluit
+- America/Jamaica
+- America/Jujuy
+- America/Juneau
+- America/Kentucky/Louisville
+- America/Kentucky/Monticello
+- America/Knox_IN
+- America/Kralendijk
+- America/La_Paz
+- America/Lima
+- America/Los_Angeles
+- America/Louisville
+- America/Lower_Princes
+- America/Maceio
+- America/Managua
+- America/Manaus
+- America/Marigot
+- America/Martinique
+- America/Matamoros
+- America/Mazatlan
+- America/Mendoza
+- America/Menominee
+- America/Merida
+- America/Metlakatla
+- America/Mexico_City
+- America/Miquelon
+- America/Moncton
+- America/Monterrey
+- America/Montevideo
+- America/Montreal
+- America/Montserrat
+- America/Nassau
+- America/New_York
+- America/Nipigon
+- America/Nome
+- America/Noronha
+- America/North_Dakota/Beulah
+- America/North_Dakota/Center
+- America/North_Dakota/New_Salem
+- America/Nuuk
+- America/Ojinaga
+- America/Panama
+- America/Pangnirtung
+- America/Paramaribo
+- America/Phoenix
+- America/Port-au-Prince
+- America/Port_of_Spain
+- America/Porto_Acre
+- America/Porto_Velho
+- America/Puerto_Rico
+- America/Punta_Arenas
+- America/Rainy_River
+- America/Rankin_Inlet
+- America/Recife
+- America/Regina
+- America/Resolute
+- America/Rio_Branco
+- America/Rosario
+- America/Santa_Isabel
+- America/Santarem
+- America/Santiago
+- America/Santo_Domingo
+- America/Sao_Paulo
+- America/Scoresbysund
+- America/Shiprock
+- America/Sitka
+- America/St_Barthelemy
+- America/St_Johns
+- America/St_Kitts
+- America/St_Lucia
+- America/St_Thomas
+- America/St_Vincent
+- America/Swift_Current
+- America/Tegucigalpa
+- America/Thule
+- America/Thunder_Bay
+- America/Tijuana
+- America/Toronto
+- America/Tortola
+- America/Vancouver
+- America/Virgin
+- America/Whitehorse
+- America/Winnipeg
+- America/Yakutat
+- America/Yellowknife
+- Antarctica/Casey
+- Antarctica/Davis
+- Antarctica/DumontDUrville
+- Antarctica/Macquarie
+- Antarctica/Mawson
+- Antarctica/McMurdo
+- Antarctica/Palmer
+- Antarctica/Rothera
+- Antarctica/South_Pole
+- Antarctica/Syowa
+- Antarctica/Troll
+- Antarctica/Vostok
+- Arctic/Longyearbyen
+- Asia/Aden
+- Asia/Almaty
+- Asia/Amman
+- Asia/Anadyr
+- Asia/Aqtau
+- Asia/Aqtobe
+- Asia/Ashgabat
+- Asia/Ashkhabad
+- Asia/Atyrau
+- Asia/Baghdad
+- Asia/Bahrain
+- Asia/Baku
+- Asia/Bangkok
+- Asia/Barnaul
+- Asia/Beirut
+- Asia/Bishkek
+- Asia/Brunei
+- Asia/Calcutta
+- Asia/Chita
+- Asia/Choibalsan
+- Asia/Chongqing
+- Asia/Chungking
+- Asia/Colombo
+- Asia/Dacca
+- Asia/Damascus
+- Asia/Dhaka
+- Asia/Dili
+- Asia/Dubai
+- Asia/Dushanbe
+- Asia/Famagusta
+- Asia/Gaza
+- Asia/Harbin
+- Asia/Hebron
+- Asia/Ho_Chi_Minh
+- Asia/Hong_Kong
+- Asia/Hovd
+- Asia/Irkutsk
+- Asia/Istanbul
+- Asia/Jakarta
+- Asia/Jayapura
+- Asia/Jerusalem
+- Asia/Kabul
+- Asia/Kamchatka
+- Asia/Karachi
+- Asia/Kashgar
+- Asia/Kathmandu
+- Asia/Katmandu
+- Asia/Khandyga
+- Asia/Kolkata
+- Asia/Krasnoyarsk
+- Asia/Kuala_Lumpur
+- Asia/Kuching
+- Asia/Kuwait
+- Asia/Macao
+- Asia/Macau
+- Asia/Magadan
+- Asia/Makassar
+- Asia/Manila
+- Asia/Muscat
+- Asia/Nicosia
+- Asia/Novokuznetsk
+- Asia/Novosibirsk
+- Asia/Omsk
+- Asia/Oral
+- Asia/Phnom_Penh
+- Asia/Pontianak
+- Asia/Pyongyang
+- Asia/Qatar
+- Asia/Qostanay
+- Asia/Qyzylorda
+- Asia/Rangoon
+- Asia/Riyadh
+- Asia/Saigon
+- Asia/Sakhalin
+- Asia/Samarkand
+- Asia/Seoul
+- Asia/Shanghai
+- Asia/Singapore
+- Asia/Srednekolymsk
+- Asia/Taipei
+- Asia/Tashkent
+- Asia/Tbilisi
+- Asia/Tehran
+- Asia/Tel_Aviv
+- Asia/Thimbu
+- Asia/Thimphu
+- Asia/Tokyo
+- Asia/Tomsk
+- Asia/Ujung_Pandang
+- Asia/Ulaanbaatar
+- Asia/Ulan_Bator
+- Asia/Urumqi
+- Asia/Ust-Nera
+- Asia/Vientiane
+- Asia/Vladivostok
+- Asia/Yakutsk
+- Asia/Yangon
+- Asia/Yekaterinburg
+- Asia/Yerevan
+- Atlantic/Azores
+- Atlantic/Bermuda
+- Atlantic/Canary
+- Atlantic/Cape_Verde
+- Atlantic/Faeroe
+- Atlantic/Faroe
+- Atlantic/Jan_Mayen
+- Atlantic/Madeira
+- Atlantic/Reykjavik
+- Atlantic/South_Georgia
+- Atlantic/St_Helena
+- Atlantic/Stanley
+- Australia/ACT
+- Australia/Adelaide
+- Australia/Brisbane
+- Australia/Broken_Hill
+- Australia/Canberra
+- Australia/Currie
+- Australia/Darwin
+- Australia/Eucla
+- Australia/Hobart
+- Australia/LHI
+- Australia/Lindeman
+- Australia/Lord_Howe
+- Australia/Melbourne
+- Australia/NSW
+- Australia/North
+- Australia/Perth
+- Australia/Queensland
+- Australia/South
+- Australia/Sydney
+- Australia/Tasmania
+- Australia/Victoria
+- Australia/West
+- Australia/Yancowinna
+- Brazil/Acre
+- Brazil/DeNoronha
+- Brazil/East
+- Brazil/West
+- CET
+- CST6CDT
+- Canada/Atlantic
+- Canada/Central
+- Canada/Eastern
+- Canada/Mountain
+- Canada/Newfoundland
+- Canada/Pacific
+- Canada/Saskatchewan
+- Canada/Yukon
+- Chile/Continental
+- Chile/EasterIsland
+- Cuba
+- EET
+- EST
+- EST5EDT
+- Egypt
+- Eire
+- Etc/GMT
+- Etc/GMT+0
+- Etc/GMT+1
+- Etc/GMT+10
+- Etc/GMT+11
+- Etc/GMT+12
+- Etc/GMT+2
+- Etc/GMT+3
+- Etc/GMT+4
+- Etc/GMT+5
+- Etc/GMT+6
+- Etc/GMT+7
+- Etc/GMT+8
+- Etc/GMT+9
+- Etc/GMT-0
+- Etc/GMT-1
+- Etc/GMT-10
+- Etc/GMT-11
+- Etc/GMT-12
+- Etc/GMT-13
+- Etc/GMT-14
+- Etc/GMT-2
+- Etc/GMT-3
+- Etc/GMT-4
+- Etc/GMT-5
+- Etc/GMT-6
+- Etc/GMT-7
+- Etc/GMT-8
+- Etc/GMT-9
+- Etc/GMT0
+- Etc/Greenwich
+- Etc/UCT
+- Etc/UTC
+- Etc/Universal
+- Etc/Zulu
+- Europe/Amsterdam
+- Europe/Andorra
+- Europe/Astrakhan
+- Europe/Athens
+- Europe/Belfast
+- Europe/Belgrade
+- Europe/Berlin
+- Europe/Bratislava
+- Europe/Brussels
+- Europe/Bucharest
+- Europe/Budapest
+- Europe/Busingen
+- Europe/Chisinau
+- Europe/Copenhagen
+- Europe/Dublin
+- Europe/Gibraltar
+- Europe/Guernsey
+- Europe/Helsinki
+- Europe/Isle_of_Man
+- Europe/Istanbul
+- Europe/Jersey
+- Europe/Kaliningrad
+- Europe/Kiev
+- Europe/Kirov
+- Europe/Kyiv
+- Europe/Lisbon
+- Europe/Ljubljana
+- Europe/London
+- Europe/Luxembourg
+- Europe/Madrid
+- Europe/Malta
+- Europe/Mariehamn
+- Europe/Minsk
+- Europe/Monaco
+- Europe/Moscow
+- Europe/Nicosia
+- Europe/Oslo
+- Europe/Paris
+- Europe/Podgorica
+- Europe/Prague
+- Europe/Riga
+- Europe/Rome
+- Europe/Samara
+- Europe/San_Marino
+- Europe/Sarajevo
+- Europe/Saratov
+- Europe/Simferopol
+- Europe/Skopje
+- Europe/Sofia
+- Europe/Stockholm
+- Europe/Tallinn
+- Europe/Tirane
+- Europe/Tiraspol
+- Europe/Ulyanovsk
+- Europe/Uzhgorod
+- Europe/Vaduz
+- Europe/Vatican
+- Europe/Vienna
+- Europe/Vilnius
+- Europe/Volgograd
+- Europe/Warsaw
+- Europe/Zagreb
+- Europe/Zaporozhye
+- Europe/Zurich
+- Factory
+- GB
+- GB-Eire
+- GMT
+- GMT+0
+- GMT-0
+- GMT0
+- Greenwich
+- HST
+- Hongkong
+- Iceland
+- Indian/Antananarivo
+- Indian/Chagos
+- Indian/Christmas
+- Indian/Cocos
+- Indian/Comoro
+- Indian/Kerguelen
+- Indian/Mahe
+- Indian/Maldives
+- Indian/Mauritius
+- Indian/Mayotte
+- Indian/Reunion
+- Iran
+- Israel
+- Jamaica
+- Japan
+- Kwajalein
+- Libya
+- MET
+- MST
+- MST7MDT
+- Mexico/BajaNorte
+- Mexico/BajaSur
+- Mexico/General
+- NZ
+- NZ-CHAT
+- Navajo
+- PRC
+- PST8PDT
+- Pacific/Apia
+- Pacific/Auckland
+- Pacific/Bougainville
+- Pacific/Chatham
+- Pacific/Chuuk
+- Pacific/Easter
+- Pacific/Efate
+- Pacific/Enderbury
+- Pacific/Fakaofo
+- Pacific/Fiji
+- Pacific/Funafuti
+- Pacific/Galapagos
+- Pacific/Gambier
+- Pacific/Guadalcanal
+- Pacific/Guam
+- Pacific/Honolulu
+- Pacific/Johnston
+- Pacific/Kanton
+- Pacific/Kiritimati
+- Pacific/Kosrae
+- Pacific/Kwajalein
+- Pacific/Majuro
+- Pacific/Marquesas
+- Pacific/Midway
+- Pacific/Nauru
+- Pacific/Niue
+- Pacific/Norfolk
+- Pacific/Noumea
+- Pacific/Pago_Pago
+- Pacific/Palau
+- Pacific/Pitcairn
+- Pacific/Pohnpei
+- Pacific/Ponape
+- Pacific/Port_Moresby
+- Pacific/Rarotonga
+- Pacific/Saipan
+- Pacific/Samoa
+- Pacific/Tahiti
+- Pacific/Tarawa
+- Pacific/Tongatapu
+- Pacific/Truk
+- Pacific/Wake
+- Pacific/Wallis
+- Pacific/Yap
+- Poland
+- Portugal
+- ROC
+- ROK
+- Singapore
+- Turkey
+- UCT
+- US/Alaska
+- US/Aleutian
+- US/Arizona
+- US/Central
+- US/East-Indiana
+- US/Eastern
+- US/Hawaii
+- US/Indiana-Starke
+- US/Michigan
+- US/Mountain
+- US/Pacific
+- US/Samoa
+- UTC
+- Universal
+- W-SU
+- WET
+- Zulu
+- posix/Africa/Abidjan
+- posix/Africa/Accra
+- posix/Africa/Addis_Ababa
+- posix/Africa/Algiers
+- posix/Africa/Asmara
+- posix/Africa/Asmera
+- posix/Africa/Bamako
+- posix/Africa/Bangui
+- posix/Africa/Banjul
+- posix/Africa/Bissau
+- posix/Africa/Blantyre
+- posix/Africa/Brazzaville
+- posix/Africa/Bujumbura
+- posix/Africa/Cairo
+- posix/Africa/Casablanca
+- posix/Africa/Ceuta
+- posix/Africa/Conakry
+- posix/Africa/Dakar
+- posix/Africa/Dar_es_Salaam
+- posix/Africa/Djibouti
+- posix/Africa/Douala
+- posix/Africa/El_Aaiun
+- posix/Africa/Freetown
+- posix/Africa/Gaborone
+- posix/Africa/Harare
+- posix/Africa/Johannesburg
+- posix/Africa/Juba
+- posix/Africa/Kampala
+- posix/Africa/Khartoum
+- posix/Africa/Kigali
+- posix/Africa/Kinshasa
+- posix/Africa/Lagos
+- posix/Africa/Libreville
+- posix/Africa/Lome
+- posix/Africa/Luanda
+- posix/Africa/Lubumbashi
+- posix/Africa/Lusaka
+- posix/Africa/Malabo
+- posix/Africa/Maputo
+- posix/Africa/Maseru
+- posix/Africa/Mbabane
+- posix/Africa/Mogadishu
+- posix/Africa/Monrovia
+- posix/Africa/Nairobi
+- posix/Africa/Ndjamena
+- posix/Africa/Niamey
+- posix/Africa/Nouakchott
+- posix/Africa/Ouagadougou
+- posix/Africa/Porto-Novo
+- posix/Africa/Sao_Tome
+- posix/Africa/Timbuktu
+- posix/Africa/Tripoli
+- posix/Africa/Tunis
+- posix/Africa/Windhoek
+- posix/America/Adak
+- posix/America/Anchorage
+- posix/America/Anguilla
+- posix/America/Antigua
+- posix/America/Araguaina
+- posix/America/Argentina/Buenos_Aires
+- posix/America/Argentina/Catamarca
+- posix/America/Argentina/ComodRivadavia
+- posix/America/Argentina/Cordoba
+- posix/America/Argentina/Jujuy
+- posix/America/Argentina/La_Rioja
+- posix/America/Argentina/Mendoza
+- posix/America/Argentina/Rio_Gallegos
+- posix/America/Argentina/Salta
+- posix/America/Argentina/San_Juan
+- posix/America/Argentina/San_Luis
+- posix/America/Argentina/Tucuman
+- posix/America/Argentina/Ushuaia
+- posix/America/Aruba
+- posix/America/Asuncion
+- posix/America/Atikokan
+- posix/America/Atka
+- posix/America/Bahia
+- posix/America/Bahia_Banderas
+- posix/America/Barbados
+- posix/America/Belem
+- posix/America/Belize
+- posix/America/Blanc-Sablon
+- posix/America/Boa_Vista
+- posix/America/Bogota
+- posix/America/Boise
+- posix/America/Buenos_Aires
+- posix/America/Cambridge_Bay
+- posix/America/Campo_Grande
+- posix/America/Cancun
+- posix/America/Caracas
+- posix/America/Catamarca
+- posix/America/Cayenne
+- posix/America/Cayman
+- posix/America/Chicago
+- posix/America/Chihuahua
+- posix/America/Ciudad_Juarez
+- posix/America/Coral_Harbour
+- posix/America/Cordoba
+- posix/America/Costa_Rica
+- posix/America/Creston
+- posix/America/Cuiaba
+- posix/America/Curacao
+- posix/America/Danmarkshavn
+- posix/America/Dawson
+- posix/America/Dawson_Creek
+- posix/America/Denver
+- posix/America/Detroit
+- posix/America/Dominica
+- posix/America/Edmonton
+- posix/America/Eirunepe
+- posix/America/El_Salvador
+- posix/America/Ensenada
+- posix/America/Fort_Nelson
+- posix/America/Fort_Wayne
+- posix/America/Fortaleza
+- posix/America/Glace_Bay
+- posix/America/Godthab
+- posix/America/Goose_Bay
+- posix/America/Grand_Turk
+- posix/America/Grenada
+- posix/America/Guadeloupe
+- posix/America/Guatemala
+- posix/America/Guayaquil
+- posix/America/Guyana
+- posix/America/Halifax
+- posix/America/Havana
+- posix/America/Hermosillo
+- posix/America/Indiana/Indianapolis
+- posix/America/Indiana/Knox
+- posix/America/Indiana/Marengo
+- posix/America/Indiana/Petersburg
+- posix/America/Indiana/Tell_City
+- posix/America/Indiana/Vevay
+- posix/America/Indiana/Vincennes
+- posix/America/Indiana/Winamac
+- posix/America/Indianapolis
+- posix/America/Inuvik
+- posix/America/Iqaluit
+- posix/America/Jamaica
+- posix/America/Jujuy
+- posix/America/Juneau
+- posix/America/Kentucky/Louisville
+- posix/America/Kentucky/Monticello
+- posix/America/Knox_IN
+- posix/America/Kralendijk
+- posix/America/La_Paz
+- posix/America/Lima
+- posix/America/Los_Angeles
+- posix/America/Louisville
+- posix/America/Lower_Princes
+- posix/America/Maceio
+- posix/America/Managua
+- posix/America/Manaus
+- posix/America/Marigot
+- posix/America/Martinique
+- posix/America/Matamoros
+- posix/America/Mazatlan
+- posix/America/Mendoza
+- posix/America/Menominee
+- posix/America/Merida
+- posix/America/Metlakatla
+- posix/America/Mexico_City
+- posix/America/Miquelon
+- posix/America/Moncton
+- posix/America/Monterrey
+- posix/America/Montevideo
+- posix/America/Montreal
+- posix/America/Montserrat
+- posix/America/Nassau
+- posix/America/New_York
+- posix/America/Nipigon
+- posix/America/Nome
+- posix/America/Noronha
+- posix/America/North_Dakota/Beulah
+- posix/America/North_Dakota/Center
+- posix/America/North_Dakota/New_Salem
+- posix/America/Nuuk
+- posix/America/Ojinaga
+- posix/America/Panama
+- posix/America/Pangnirtung
+- posix/America/Paramaribo
+- posix/America/Phoenix
+- posix/America/Port-au-Prince
+- posix/America/Port_of_Spain
+- posix/America/Porto_Acre
+- posix/America/Porto_Velho
+- posix/America/Puerto_Rico
+- posix/America/Punta_Arenas
+- posix/America/Rainy_River
+- posix/America/Rankin_Inlet
+- posix/America/Recife
+- posix/America/Regina
+- posix/America/Resolute
+- posix/America/Rio_Branco
+- posix/America/Rosario
+- posix/America/Santa_Isabel
+- posix/America/Santarem
+- posix/America/Santiago
+- posix/America/Santo_Domingo
+- posix/America/Sao_Paulo
+- posix/America/Scoresbysund
+- posix/America/Shiprock
+- posix/America/Sitka
+- posix/America/St_Barthelemy
+- posix/America/St_Johns
+- posix/America/St_Kitts
+- posix/America/St_Lucia
+- posix/America/St_Thomas
+- posix/America/St_Vincent
+- posix/America/Swift_Current
+- posix/America/Tegucigalpa
+- posix/America/Thule
+- posix/America/Thunder_Bay
+- posix/America/Tijuana
+- posix/America/Toronto
+- posix/America/Tortola
+- posix/America/Vancouver
+- posix/America/Virgin
+- posix/America/Whitehorse
+- posix/America/Winnipeg
+- posix/America/Yakutat
+- posix/America/Yellowknife
+- posix/Antarctica/Casey
+- posix/Antarctica/Davis
+- posix/Antarctica/DumontDUrville
+- posix/Antarctica/Macquarie
+- posix/Antarctica/Mawson
+- posix/Antarctica/McMurdo
+- posix/Antarctica/Palmer
+- posix/Antarctica/Rothera
+- posix/Antarctica/South_Pole
+- posix/Antarctica/Syowa
+- posix/Antarctica/Troll
+- posix/Antarctica/Vostok
+- posix/Arctic/Longyearbyen
+- posix/Asia/Aden
+- posix/Asia/Almaty
+- posix/Asia/Amman
+- posix/Asia/Anadyr
+- posix/Asia/Aqtau
+- posix/Asia/Aqtobe
+- posix/Asia/Ashgabat
+- posix/Asia/Ashkhabad
+- posix/Asia/Atyrau
+- posix/Asia/Baghdad
+- posix/Asia/Bahrain
+- posix/Asia/Baku
+- posix/Asia/Bangkok
+- posix/Asia/Barnaul
+- posix/Asia/Beirut
+- posix/Asia/Bishkek
+- posix/Asia/Brunei
+- posix/Asia/Calcutta
+- posix/Asia/Chita
+- posix/Asia/Choibalsan
+- posix/Asia/Chongqing
+- posix/Asia/Chungking
+- posix/Asia/Colombo
+- posix/Asia/Dacca
+- posix/Asia/Damascus
+- posix/Asia/Dhaka
+- posix/Asia/Dili
+- posix/Asia/Dubai
+- posix/Asia/Dushanbe
+- posix/Asia/Famagusta
+- posix/Asia/Gaza
+- posix/Asia/Harbin
+- posix/Asia/Hebron
+- posix/Asia/Ho_Chi_Minh
+- posix/Asia/Hong_Kong
+- posix/Asia/Hovd
+- posix/Asia/Irkutsk
+- posix/Asia/Istanbul
+- posix/Asia/Jakarta
+- posix/Asia/Jayapura
+- posix/Asia/Jerusalem
+- posix/Asia/Kabul
+- posix/Asia/Kamchatka
+- posix/Asia/Karachi
+- posix/Asia/Kashgar
+- posix/Asia/Kathmandu
+- posix/Asia/Katmandu
+- posix/Asia/Khandyga
+- posix/Asia/Kolkata
+- posix/Asia/Krasnoyarsk
+- posix/Asia/Kuala_Lumpur
+- posix/Asia/Kuching
+- posix/Asia/Kuwait
+- posix/Asia/Macao
+- posix/Asia/Macau
+- posix/Asia/Magadan
+- posix/Asia/Makassar
+- posix/Asia/Manila
+- posix/Asia/Muscat
+- posix/Asia/Nicosia
+- posix/Asia/Novokuznetsk
+- posix/Asia/Novosibirsk
+- posix/Asia/Omsk
+- posix/Asia/Oral
+- posix/Asia/Phnom_Penh
+- posix/Asia/Pontianak
+- posix/Asia/Pyongyang
+- posix/Asia/Qatar
+- posix/Asia/Qostanay
+- posix/Asia/Qyzylorda
+- posix/Asia/Rangoon
+- posix/Asia/Riyadh
+- posix/Asia/Saigon
+- posix/Asia/Sakhalin
+- posix/Asia/Samarkand
+- posix/Asia/Seoul
+- posix/Asia/Shanghai
+- posix/Asia/Singapore
+- posix/Asia/Srednekolymsk
+- posix/Asia/Taipei
+- posix/Asia/Tashkent
+- posix/Asia/Tbilisi
+- posix/Asia/Tehran
+- posix/Asia/Tel_Aviv
+- posix/Asia/Thimbu
+- posix/Asia/Thimphu
+- posix/Asia/Tokyo
+- posix/Asia/Tomsk
+- posix/Asia/Ujung_Pandang
+- posix/Asia/Ulaanbaatar
+- posix/Asia/Ulan_Bator
+- posix/Asia/Urumqi
+- posix/Asia/Ust-Nera
+- posix/Asia/Vientiane
+- posix/Asia/Vladivostok
+- posix/Asia/Yakutsk
+- posix/Asia/Yangon
+- posix/Asia/Yekaterinburg
+- posix/Asia/Yerevan
+- posix/Atlantic/Azores
+- posix/Atlantic/Bermuda
+- posix/Atlantic/Canary
+- posix/Atlantic/Cape_Verde
+- posix/Atlantic/Faeroe
+- posix/Atlantic/Faroe
+- posix/Atlantic/Jan_Mayen
+- posix/Atlantic/Madeira
+- posix/Atlantic/Reykjavik
+- posix/Atlantic/South_Georgia
+- posix/Atlantic/St_Helena
+- posix/Atlantic/Stanley
+- posix/Australia/ACT
+- posix/Australia/Adelaide
+- posix/Australia/Brisbane
+- posix/Australia/Broken_Hill
+- posix/Australia/Canberra
+- posix/Australia/Currie
+- posix/Australia/Darwin
+- posix/Australia/Eucla
+- posix/Australia/Hobart
+- posix/Australia/LHI
+- posix/Australia/Lindeman
+- posix/Australia/Lord_Howe
+- posix/Australia/Melbourne
+- posix/Australia/NSW
+- posix/Australia/North
+- posix/Australia/Perth
+- posix/Australia/Queensland
+- posix/Australia/South
+- posix/Australia/Sydney
+- posix/Australia/Tasmania
+- posix/Australia/Victoria
+- posix/Australia/West
+- posix/Australia/Yancowinna
+- posix/Brazil/Acre
+- posix/Brazil/DeNoronha
+- posix/Brazil/East
+- posix/Brazil/West
+- posix/CET
+- posix/CST6CDT
+- posix/Canada/Atlantic
+- posix/Canada/Central
+- posix/Canada/Eastern
+- posix/Canada/Mountain
+- posix/Canada/Newfoundland
+- posix/Canada/Pacific
+- posix/Canada/Saskatchewan
+- posix/Canada/Yukon
+- posix/Chile/Continental
+- posix/Chile/EasterIsland
+- posix/Cuba
+- posix/EET
+- posix/EST
+- posix/EST5EDT
+- posix/Egypt
+- posix/Eire
+- posix/Etc/GMT
+- posix/Etc/GMT+0
+- posix/Etc/GMT+1
+- posix/Etc/GMT+10
+- posix/Etc/GMT+11
+- posix/Etc/GMT+12
+- posix/Etc/GMT+2
+- posix/Etc/GMT+3
+- posix/Etc/GMT+4
+- posix/Etc/GMT+5
+- posix/Etc/GMT+6
+- posix/Etc/GMT+7
+- posix/Etc/GMT+8
+- posix/Etc/GMT+9
+- posix/Etc/GMT-0
+- posix/Etc/GMT-1
+- posix/Etc/GMT-10
+- posix/Etc/GMT-11
+- posix/Etc/GMT-12
+- posix/Etc/GMT-13
+- posix/Etc/GMT-14
+- posix/Etc/GMT-2
+- posix/Etc/GMT-3
+- posix/Etc/GMT-4
+- posix/Etc/GMT-5
+- posix/Etc/GMT-6
+- posix/Etc/GMT-7
+- posix/Etc/GMT-8
+- posix/Etc/GMT-9
+- posix/Etc/GMT0
+- posix/Etc/Greenwich
+- posix/Etc/UCT
+- posix/Etc/UTC
+- posix/Etc/Universal
+- posix/Etc/Zulu
+- posix/Europe/Amsterdam
+- posix/Europe/Andorra
+- posix/Europe/Astrakhan
+- posix/Europe/Athens
+- posix/Europe/Belfast
+- posix/Europe/Belgrade
+- posix/Europe/Berlin
+- posix/Europe/Bratislava
+- posix/Europe/Brussels
+- posix/Europe/Bucharest
+- posix/Europe/Budapest
+- posix/Europe/Busingen
+- posix/Europe/Chisinau
+- posix/Europe/Copenhagen
+- posix/Europe/Dublin
+- posix/Europe/Gibraltar
+- posix/Europe/Guernsey
+- posix/Europe/Helsinki
+- posix/Europe/Isle_of_Man
+- posix/Europe/Istanbul
+- posix/Europe/Jersey
+- posix/Europe/Kaliningrad
+- posix/Europe/Kiev
+- posix/Europe/Kirov
+- posix/Europe/Kyiv
+- posix/Europe/Lisbon
+- posix/Europe/Ljubljana
+- posix/Europe/London
+- posix/Europe/Luxembourg
+- posix/Europe/Madrid
+- posix/Europe/Malta
+- posix/Europe/Mariehamn
+- posix/Europe/Minsk
+- posix/Europe/Monaco
+- posix/Europe/Moscow
+- posix/Europe/Nicosia
+- posix/Europe/Oslo
+- posix/Europe/Paris
+- posix/Europe/Podgorica
+- posix/Europe/Prague
+- posix/Europe/Riga
+- posix/Europe/Rome
+- posix/Europe/Samara
+- posix/Europe/San_Marino
+- posix/Europe/Sarajevo
+- posix/Europe/Saratov
+- posix/Europe/Simferopol
+- posix/Europe/Skopje
+- posix/Europe/Sofia
+- posix/Europe/Stockholm
+- posix/Europe/Tallinn
+- posix/Europe/Tirane
+- posix/Europe/Tiraspol
+- posix/Europe/Ulyanovsk
+- posix/Europe/Uzhgorod
+- posix/Europe/Vaduz
+- posix/Europe/Vatican
+- posix/Europe/Vienna
+- posix/Europe/Vilnius
+- posix/Europe/Volgograd
+- posix/Europe/Warsaw
+- posix/Europe/Zagreb
+- posix/Europe/Zaporozhye
+- posix/Europe/Zurich
+- posix/Factory
+- posix/GB
+- posix/GB-Eire
+- posix/GMT
+- posix/GMT+0
+- posix/GMT-0
+- posix/GMT0
+- posix/Greenwich
+- posix/HST
+- posix/Hongkong
+- posix/Iceland
+- posix/Indian/Antananarivo
+- posix/Indian/Chagos
+- posix/Indian/Christmas
+- posix/Indian/Cocos
+- posix/Indian/Comoro
+- posix/Indian/Kerguelen
+- posix/Indian/Mahe
+- posix/Indian/Maldives
+- posix/Indian/Mauritius
+- posix/Indian/Mayotte
+- posix/Indian/Reunion
+- posix/Iran
+- posix/Israel
+- posix/Jamaica
+- posix/Japan
+- posix/Kwajalein
+- posix/Libya
+- posix/MET
+- posix/MST
+- posix/MST7MDT
+- posix/Mexico/BajaNorte
+- posix/Mexico/BajaSur
+- posix/Mexico/General
+- posix/NZ
+- posix/NZ-CHAT
+- posix/Navajo
+- posix/PRC
+- posix/PST8PDT
+- posix/Pacific/Apia
+- posix/Pacific/Auckland
+- posix/Pacific/Bougainville
+- posix/Pacific/Chatham
+- posix/Pacific/Chuuk
+- posix/Pacific/Easter
+- posix/Pacific/Efate
+- posix/Pacific/Enderbury
+- posix/Pacific/Fakaofo
+- posix/Pacific/Fiji
+- posix/Pacific/Funafuti
+- posix/Pacific/Galapagos
+- posix/Pacific/Gambier
+- posix/Pacific/Guadalcanal
+- posix/Pacific/Guam
+- posix/Pacific/Honolulu
+- posix/Pacific/Johnston
+- posix/Pacific/Kanton
+- posix/Pacific/Kiritimati
+- posix/Pacific/Kosrae
+- posix/Pacific/Kwajalein
+- posix/Pacific/Majuro
+- posix/Pacific/Marquesas
+- posix/Pacific/Midway
+- posix/Pacific/Nauru
+- posix/Pacific/Niue
+- posix/Pacific/Norfolk
+- posix/Pacific/Noumea
+- posix/Pacific/Pago_Pago
+- posix/Pacific/Palau
+- posix/Pacific/Pitcairn
+- posix/Pacific/Pohnpei
+- posix/Pacific/Ponape
+- posix/Pacific/Port_Moresby
+- posix/Pacific/Rarotonga
+- posix/Pacific/Saipan
+- posix/Pacific/Samoa
+- posix/Pacific/Tahiti
+- posix/Pacific/Tarawa
+- posix/Pacific/Tongatapu
+- posix/Pacific/Truk
+- posix/Pacific/Wake
+- posix/Pacific/Wallis
+- posix/Pacific/Yap
+- posix/Poland
+- posix/Portugal
+- posix/ROC
+- posix/ROK
+- posix/Singapore
+- posix/Turkey
+- posix/UCT
+- posix/US/Alaska
+- posix/US/Aleutian
+- posix/US/Arizona
+- posix/US/Central
+- posix/US/East-Indiana
+- posix/US/Eastern
+- posix/US/Hawaii
+- posix/US/Indiana-Starke
+- posix/US/Michigan
+- posix/US/Mountain
+- posix/US/Pacific
+- posix/US/Samoa
+- posix/UTC
+- posix/Universal
+- posix/W-SU
+- posix/WET
+- posix/Zulu


### PR DESCRIPTION
Those were left out of the schema dump when the features were introduced, probably because ByteString doesn't have a toJSON instance. Changing the type to Text solves this easily.

Resolves #3237