### PR TITLE
refactor: make observation messages pure

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -69,7 +69,7 @@ type Handler = ExceptT Error
 
 run :: AppState -> (Observation -> IO ()) -> IO ()
 run appState observer = do
-  observer $ AppStartObs prettyVersion
+  observer $ AppServerStartObs prettyVersion
 
   conf@AppConfig{..} <- AppState.getConfig appState
   AppState.connectionWorker appState -- Loads the initial SchemaCache

--- a/src/PostgREST/Logger.hs
+++ b/src/PostgREST/Logger.hs
@@ -11,16 +11,11 @@ module PostgREST.Logger
 import Control.AutoUpdate (defaultUpdateSettings, mkAutoUpdate,
                            updateAction)
 
-import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Text.Encoding   as T
-import           Data.Time            (ZonedTime, defaultTimeLocale,
-                                       formatTime, getZonedTime)
-import qualified Hasql.Pool           as SQL
+import Data.Time (ZonedTime, defaultTimeLocale, formatTime,
+                  getZonedTime)
 
 import qualified Network.Wai                          as Wai
 import qualified Network.Wai.Middleware.RequestLogger as Wai
-import           Numeric                              (showFFloat)
-
 
 import Network.HTTP.Types.Status (status400, status500)
 import System.IO.Unsafe          (unsafePerformIO)
@@ -28,14 +23,9 @@ import System.IO.Unsafe          (unsafePerformIO)
 import PostgREST.Config      (LogLevel (..))
 import PostgREST.Observation
 
-import qualified PostgREST.Auth  as Auth
-import qualified PostgREST.Error as Error
-
-import PostgREST.SchemaCache (showSummary)
-
+import qualified PostgREST.Auth as Auth
 
 import Protolude
-import Protolude.Partial (fromJust)
 
 newtype LoggerState = LoggerState
   { stateGetZTime                 :: IO ZonedTime -- ^ Time with time zone used for logs
@@ -45,14 +35,6 @@ init :: IO LoggerState
 init = do
   zTime <- mkAutoUpdate defaultUpdateSettings { updateAction = getZonedTime }
   pure $ LoggerState zTime
-
-logWithZTime :: LoggerState -> Text -> IO ()
-logWithZTime loggerState txt = do
-  zTime <- stateGetZTime loggerState
-  hPutStrLn stderr $ toS (formatTime defaultTimeLocale "%d/%b/%Y:%T %z: " zTime) <> txt
-
-logPgrstError :: LoggerState -> SQL.UsageError -> IO ()
-logPgrstError loggerState e = logWithZTime loggerState . T.decodeUtf8 . LBS.toStrict $ Error.errorPayload $ Error.PgError False e
 
 middleware :: LogLevel -> Wai.Middleware
 middleware logLevel = case logLevel of
@@ -69,62 +51,9 @@ middleware logLevel = case logLevel of
       }
 
 logObservation :: LoggerState -> Observation -> IO ()
-logObservation loggerState obs =
-  case obs of
-    AdminStartObs port ->
-      logWithZTime loggerState $ "Admin server listening on port " <> show (fromIntegral (fromJust port) :: Integer)
-    AppStartObs ver ->
-      logWithZTime loggerState $ "Starting PostgREST " <> T.decodeUtf8 ver <> "..."
-    AppServerPortObs port ->
-      logWithZTime loggerState $ "Listening on port " <> show port
-    AppServerUnixObs sock ->
-      logWithZTime loggerState $ "Listening on unix socket " <> show sock
-    AppDBConnectAttemptObs ->
-      logWithZTime loggerState "Attempting to connect to the database..."
-    AppExitFatalObs reason ->
-      logWithZTime loggerState $ "Fatal error encountered. " <> reason
-    AppExitDBNoRecoveryObs ->
-      logWithZTime loggerState "Automatic recovery disabled, exiting."
-    AppDBConnectedObs ver ->
-      logWithZTime loggerState $ "Successfully connected to " <> ver
-    AppSCacheFatalErrorObs usageErr hint -> do
-      logWithZTime loggerState "A fatal error ocurred when loading the schema cache"
-      logPgrstError loggerState usageErr
-      logWithZTime loggerState hint
-    AppSCacheNormalErrorObs usageErr -> do
-      logWithZTime loggerState "An error ocurred when loading the schema cache"
-      logPgrstError loggerState usageErr
-    AppSCacheLoadSuccessObs sCache resultTime -> do
-      logWithZTime loggerState $ "Schema cache queried in " <> showMillis resultTime  <> " milliseconds"
-      logWithZTime loggerState $ "Schema cache loaded " <> showSummary sCache
-    ConnectionRetryObs delay -> do
-      logWithZTime loggerState $ "Attempting to reconnect to the database in " <> (show delay::Text) <> " seconds..."
-    ConnectionPgVersionErrorObs usageErr ->
-      logPgrstError loggerState usageErr
-    DBListenerStart channel -> do
-      logWithZTime loggerState $ "Listening for notifications on the " <> channel <> " channel"
-    DBListenerFailNoRecoverObs ->
-      logWithZTime loggerState "Automatic recovery disabled, exiting."
-    DBListenerFailRecoverObs channel ->
-      logWithZTime loggerState $ "Retrying listening for notifications on the " <> channel <> " channel.."
-    ConfigReadErrorObs ->
-      logWithZTime loggerState "An error ocurred when trying to query database settings for the config parameters"
-    ConfigReadErrorFatalObs usageErr hint -> do
-      logPgrstError loggerState usageErr
-      logWithZTime loggerState hint
-    ConfigReadErrorNotFatalObs usageErr -> do
-      logPgrstError loggerState usageErr
-    QueryRoleSettingsErrorObs usageErr -> do
-      logWithZTime loggerState "An error ocurred when trying to query the role settings"
-      logPgrstError loggerState usageErr
-    QueryErrorCodeHighObs usageErr -> do
-      logPgrstError loggerState usageErr
-    ConfigInvalidObs err -> do
-      logWithZTime loggerState $ "Failed reloading config: " <> err
-    ConfigSucceededObs -> do
-      logWithZTime loggerState "Config reloaded"
-    PoolAcqTimeoutObs usageErr -> do
-      logPgrstError loggerState usageErr
-  where
-    showMillis :: Double -> Text
-    showMillis x = toS $ showFFloat (Just 1) (x * 1000) ""
+logObservation loggerState obs = logWithZTime loggerState $ observationMessage obs
+
+logWithZTime :: LoggerState -> Text -> IO ()
+logWithZTime loggerState txt = do
+  zTime <- stateGetZTime loggerState
+  hPutStrLn stderr $ toS (formatTime defaultTimeLocale "%d/%b/%Y:%T %z: " zTime) <> txt

--- a/src/PostgREST/Observation.hs
+++ b/src/PostgREST/Observation.hs
@@ -1,29 +1,37 @@
+{-# LANGUAGE LambdaCase #-}
 {-|
 Module      : PostgREST.Observation
 Description : Module for observability types
 -}
 module PostgREST.Observation
   ( Observation(..)
+  , observationMessage
   ) where
 
+import qualified Data.ByteString.Lazy  as LBS
+import qualified Data.Text.Encoding    as T
 import qualified Hasql.Pool            as SQL
 import qualified Network.Socket        as NS
-import           PostgREST.SchemaCache (SchemaCache)
+import           Numeric               (showFFloat)
+import qualified PostgREST.Error       as Error
+import           PostgREST.SchemaCache (SchemaCache, showSummary)
 
 import Protolude
+import Protolude.Partial (fromJust)
 
 data Observation
   = AdminStartObs (Maybe Int)
-  | AppStartObs ByteString
+  | AppServerStartObs ByteString
   | AppServerPortObs NS.PortNumber
   | AppServerUnixObs FilePath
-  | AppDBConnectAttemptObs
-  | AppExitFatalObs Text
-  | AppExitDBNoRecoveryObs
-  | AppDBConnectedObs Text
-  | AppSCacheFatalErrorObs SQL.UsageError Text
-  | AppSCacheNormalErrorObs SQL.UsageError
-  | AppSCacheLoadSuccessObs SchemaCache Double
+  | DBConnectAttemptObs
+  | ExitFatalObs Text
+  | ExitDBNoRecoveryObs
+  | DBConnectedObs Text
+  | SchemaCacheFatalErrorObs SQL.UsageError Text
+  | SchemaCacheNormalErrorObs SQL.UsageError
+  | SchemaCacheQueriedObs Double
+  | SchemaCacheLoadedObs SchemaCache
   | ConnectionRetryObs Int
   | ConnectionPgVersionErrorObs SQL.UsageError
   | DBListenerStart Text
@@ -37,3 +45,61 @@ data Observation
   | QueryRoleSettingsErrorObs SQL.UsageError
   | QueryErrorCodeHighObs SQL.UsageError
   | PoolAcqTimeoutObs SQL.UsageError
+
+observationMessage :: Observation -> Text
+observationMessage = \case
+  AdminStartObs port ->
+    "Admin server listening on port " <> show (fromIntegral (fromJust port) :: Integer)
+  AppServerStartObs ver ->
+    "Starting PostgREST " <> T.decodeUtf8 ver <> "..."
+  AppServerPortObs port ->
+    "Listening on port " <> show port
+  AppServerUnixObs sock ->
+    "Listening on unix socket " <> show sock
+  DBConnectAttemptObs ->
+    "Attempting to connect to the database..."
+  ExitFatalObs reason ->
+    "Fatal error encountered. " <> reason
+  ExitDBNoRecoveryObs ->
+    "Automatic recovery disabled, exiting."
+  DBConnectedObs ver ->
+    "Successfully connected to " <> ver
+  SchemaCacheFatalErrorObs usageErr hint ->
+    "A fatal error ocurred when loading the schema cache. " <> hint <> ". " <> jsonMessage usageErr
+  SchemaCacheNormalErrorObs usageErr ->
+    "An error ocurred when loading the schema cache. " <> jsonMessage usageErr
+  SchemaCacheQueriedObs resultTime ->
+    "Schema cache queried in " <> showMillis resultTime  <> " milliseconds"
+  SchemaCacheLoadedObs sCache ->
+    "Schema cache loaded " <> showSummary sCache
+  ConnectionRetryObs delay ->
+    "Attempting to reconnect to the database in " <> (show delay::Text) <> " seconds..."
+  ConnectionPgVersionErrorObs usageErr ->
+    jsonMessage usageErr
+  DBListenerStart channel -> do
+    "Listening for notifications on the " <> channel <> " channel"
+  DBListenerFailNoRecoverObs ->
+    "Automatic recovery disabled, exiting."
+  DBListenerFailRecoverObs channel ->
+    "Retrying listening for notifications on the " <> channel <> " channel.."
+  ConfigReadErrorObs ->
+    "An error ocurred when trying to query database settings for the config parameters"
+  ConfigReadErrorFatalObs usageErr hint ->
+    hint <> ". " <> jsonMessage usageErr
+  ConfigReadErrorNotFatalObs usageErr ->
+    jsonMessage usageErr
+  QueryRoleSettingsErrorObs usageErr ->
+    "An error ocurred when trying to query the role settings. " <> jsonMessage usageErr
+  QueryErrorCodeHighObs usageErr ->
+    jsonMessage usageErr
+  ConfigInvalidObs err ->
+    "Failed reloading config: " <> err
+  ConfigSucceededObs ->
+     "Config reloaded"
+  PoolAcqTimeoutObs usageErr ->
+    jsonMessage usageErr
+  where
+    showMillis :: Double -> Text
+    showMillis x = toS $ showFFloat (Just 1) (x * 1000) ""
+
+    jsonMessage err = T.decodeUtf8 . LBS.toStrict . Error.errorPayload $ Error.PgError False err


### PR DESCRIPTION
Removes the observation messages from the Logger.

Also, this makes it possible to test the error messages without IO (using a different `observer` in the tests).