### PR TITLE
feat: log schema cache load time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2887, Add Preference `max-affected` to limit affected resources - @taimoorzaeem
  - #3171, Add an ability to dump config via admin API - @skywriter
  - #3061, Apply all function settings as transaction-scoped settings - @taimoorzaeem
- - #3171, Log schema cache stats to stderr - @steve-chavez
+ - #3171, #3046, Log schema cache stats to stderr - @steve-chavez
  - #3210, Dump schema cache through admin API - @taimoorzaeem
 
 ### Fixed

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -310,7 +310,8 @@ loadSchemaCache appState observer = do
     Right sCache -> do
       putSchemaCache appState $ Just sCache
       observer $ SchemaCacheQueriedObs resultTime
-      observer $ SchemaCacheLoadedObs sCache
+      (t, _) <- timeItT $ observer $ SchemaCacheSummaryObs sCache
+      observer $ SchemaCacheLoadedObs t
       return SCLoaded
 
 -- | Current database connection status data ConnectionStatus

--- a/src/PostgREST/Observation.hs
+++ b/src/PostgREST/Observation.hs
@@ -31,7 +31,8 @@ data Observation
   | SchemaCacheFatalErrorObs SQL.UsageError Text
   | SchemaCacheNormalErrorObs SQL.UsageError
   | SchemaCacheQueriedObs Double
-  | SchemaCacheLoadedObs SchemaCache
+  | SchemaCacheSummaryObs SchemaCache
+  | SchemaCacheLoadedObs Double
   | ConnectionRetryObs Int
   | ConnectionPgVersionErrorObs SQL.UsageError
   | DBListenerStart Text
@@ -70,8 +71,10 @@ observationMessage = \case
     "An error ocurred when loading the schema cache. " <> jsonMessage usageErr
   SchemaCacheQueriedObs resultTime ->
     "Schema cache queried in " <> showMillis resultTime  <> " milliseconds"
-  SchemaCacheLoadedObs sCache ->
+  SchemaCacheSummaryObs sCache ->
     "Schema cache loaded " <> showSummary sCache
+  SchemaCacheLoadedObs resultTime ->
+    "Schema cache loaded in " <> showMillis resultTime <> " milliseconds"
   ConnectionRetryObs delay ->
     "Attempting to reconnect to the database in " <> (show delay::Text) <> " seconds..."
   ConnectionPgVersionErrorObs usageErr ->


### PR DESCRIPTION
Helps with https://github.com/PostgREST/postgrest/issues/3046. Logs now show:

```
21/Feb/2024:15:48:37 -0500: Starting PostgREST 12.1 (160caaf)...
...
21/Feb/2024:15:48:37 -0500: Schema cache queried in 18.3 milliseconds
21/Feb/2024:15:48:37 -0500: Schema cache loaded 264 Relations, 221 Relationships, 141 Functions, 15 Domain Representations, 45 Media Type Handlers
21/Feb/2024:15:48:37 -0500: Schema cache loaded in 12.2 milliseconds
```