### PR TITLE
docs: limitation when selecting related object that was modified by n after insert trigger

### DIFF
--- a/docs/references/api/resource_embedding.rst
+++ b/docs/references/api/resource_embedding.rst
@@ -830,7 +830,6 @@ Response:
      }
 
   Since PostgREST does the insertion and selection in a single query, the join is done before the changes are made to the related table, that's why ``technical_specs`` is empty.
-  An alternative is to use :ref:`table_functions` instead.
 
 .. _nested_embedding:
 

--- a/docs/references/api/resource_embedding.rst
+++ b/docs/references/api/resource_embedding.rst
@@ -816,6 +816,23 @@ Response:
     }
    }
 
+.. note::
+
+  Selecting a related object right after doing an insert may give unexpected results if said object was modified in a trigger.
+  For example, let's say there's an ``AFTER INSERT`` trigger on ``films`` that inserts a new record to ``technical_specs``.
+  Doing the same ``POST`` request as above, but selecting ``select=title,technical_spec(*)`` instead, it would return:
+
+  .. code-block:: json
+
+     {
+      "title": "127 hours",
+      "techinal_specs": null
+     }
+
+  Since PostgREST does the insertion in a single transaction, the selection is done before the changes are made to the related table, that's why the ``technical_specs`` is empty.
+  In the future we'll implement the insertions of tables and embedded resources at the same time.
+  For now, an alternative is to use :ref:`table_functions` instead.
+
 .. _nested_embedding:
 
 Nested Embedding

--- a/docs/references/api/resource_embedding.rst
+++ b/docs/references/api/resource_embedding.rst
@@ -829,9 +829,8 @@ Response:
       "techinal_specs": null
      }
 
-  Since PostgREST does the insertion in a single transaction, the selection is done before the changes are made to the related table, that's why the ``technical_specs`` is empty.
-  In the future we'll implement the insertions of tables and embedded resources at the same time.
-  For now, an alternative is to use :ref:`table_functions` instead.
+  Since PostgREST does the insertion and selection in a single query, the join is done before the changes are made to the related table, that's why ``technical_specs`` is empty.
+  An alternative is to use :ref:`table_functions` instead.
 
 .. _nested_embedding:
 


### PR DESCRIPTION
A user noted that the after insert query didn't reflect when selecting the modified related table. So I think it would be nice to add this limitation here and inform that a better alternative would be available in the future.

The details are explained in the note I added to the docs. If the explanation is too verbose, then I'll summarize it further.

Info that backs this up:
- "The sub-statements in WITH are executed concurrently with each other and with the main query" ( [PostgreSQL docs](https://www.postgresql.org/docs/current/queries-with.html))
- This PostgreSQL Q/A: https://www.postgresql.org/message-id/CAKFQuwYsCPJwNwSjvsP-FVEiojCgLoWpeir%3Dczuk311MKTs69w%40mail.gmail.com