### PR TITLE
ci: Switch action-get-latest-tag to github-action-get-previous-tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,8 @@ jobs:
   docs:
     name: Docs
     uses: ./.github/workflows/docs.yaml
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
 
   test:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,6 +2,9 @@ name: Docs
 
 on:
   workflow_call:
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: false
   pull_request:
     branches:
       - main
@@ -28,6 +31,7 @@ jobs:
     - name: Setup Nix Environment
       uses: ./.github/actions/setup-nix
       with:
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         tools: docs
     - run: postgrest-docs-build
     - run: git diff --exit-code HEAD locales || echo "Please commit changes to the locales/ folder after running postgrest-docs-build."
@@ -41,6 +45,7 @@ jobs:
     - name: Setup Nix Environment
       uses: ./.github/actions/setup-nix
       with:
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         tools: docs
     - name: Run spellcheck
       run: postgrest-docs-spellcheck
@@ -57,5 +62,6 @@ jobs:
     - name: Setup Nix Environment
       uses: ./.github/actions/setup-nix
       with:
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         tools: docs
     - run: postgrest-docs-linkcheck

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -132,6 +132,7 @@ jobs:
       - name: Setup Nix Environment
         uses: ./.github/actions/setup-nix
         with:
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
           tools: loadtest
       - uses: WyriHaximus/github-action-get-previous-tag@04e8485ecb6487243907e330d522ff60f02283ce # v1.4.0
         id: get-latest-tag


### PR DESCRIPTION
The former is not maintained anymore and produces deprecation warnings in CI.