### PR TITLE
ci: Split Lint & Style from Test workflow

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,32 @@
+name: Check
+
+on:
+  workflow_call:
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: false
+  pull_request:
+    branches:
+      - main
+      - v[0-9]+
+
+concurrency:
+  # Terminate all previous runs of the same workflow for pull requests
+  group: style-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint-style:
+    name: Lint & Style
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Nix Environment
+        uses: ./.github/actions/setup-nix
+        with:
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          tools: style
+      - name: Run linter (check locally with `nix-shell --run postgrest-lint`)
+        run: postgrest-lint
+      - name: Run style check (auto-format with `nix-shell --run postgrest-style`)
+        run: postgrest-style-check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check:
+    name: Check
+    uses: ./.github/workflows/check.yaml
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+
   docs:
     name: Docs
     uses: ./.github/workflows/docs.yaml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,22 +30,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint-style:
-    name: Lint & Style
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Nix Environment
-        uses: ./.github/actions/setup-nix
-        with:
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-          tools: style
-      - name: Run linter (check locally with `nix-shell --run postgrest-lint`)
-        run: postgrest-lint
-      - name: Run style check (auto-format with `nix-shell --run postgrest-style`)
-        run: postgrest-style-check
-
-
   coverage:
     name: Coverage
     runs-on: ubuntu-latest


### PR DESCRIPTION
The Lint & Style job needs to run on all PRs, not only when something "test" related changes. Otherwise not all workflow, nix or other files are style-checked and linted.