### PR TITLE
changelog: clarify breaking change about dropping legacy gucs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - Removed `application/octet-stream`, `text/plain`, `text/xml` [builtin support for scalar results](https://postgrest.org/en/v11.1/references/api/resource_representation.html#scalar-function-response-format) - @steve-chavez
  - Removed default `application/openapi+json` media type for [db-root-spec](https://postgrest.org/en/v11.1/references/configuration.html#db-root-spec) - @steve-chavez
  - Removed [db-use-legacy-gucs](https://postgrest.org/en/v11.2/references/configuration.html#db-use-legacy-gucs) - @laurenceisla
+   + All PostgreSQL versions now use GUCs in JSON format for [Headers, Cookies and JWT claims](https://postgrest.org/en/v12/references/transactions.html#request-headers-cookies-and-jwt-claims).
 
 ## [11.2.2] - 2023-10-25
 


### PR DESCRIPTION
As it was mentioned here: https://github.com/PostgREST/postgrest/issues/3019#issuecomment-1965268047, the breaking change for dropping legacy gucs is not clear enough.

After merging this, I'll do the same change to the release log.