### PR TITLE
nix: add `postgrest-profiled-run`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -134,7 +134,7 @@ rec {
 
   # Script for running memory tests.
   memory =
-    pkgs.callPackage nix/tools/memory.nix { inherit postgrestProfiled postgrest withTools; };
+    pkgs.callPackage nix/tools/memory.nix { inherit postgrestProfiled withTools; };
 
   # Utility for updating the pinned version of Nixpkgs.
   nixpkgsTools =

--- a/default.nix
+++ b/default.nix
@@ -134,7 +134,7 @@ rec {
 
   # Script for running memory tests.
   memory =
-    pkgs.callPackage nix/tools/memory.nix { inherit postgrestProfiled withTools; };
+    pkgs.callPackage nix/tools/memory.nix { inherit postgrestProfiled postgrest withTools; };
 
   # Utility for updating the pinned version of Nixpkgs.
   nixpkgsTools =

--- a/nix/tools/cabalTools.nix
+++ b/nix/tools/cabalTools.nix
@@ -42,7 +42,7 @@ let
           [
             "ARG_USE_ENV([PGRST_DB_ANON_ROLE], [postgrest_test_anonymous], [PostgREST anonymous role])"
             "ARG_USE_ENV([PGRST_DB_POOL], [1], [PostgREST pool size])"
-            "ARG_USE_ENV([PGRST_DB_POOL_ACQUISITION_TIMEOUT], [1], [PostgREST pool size])"
+            "ARG_USE_ENV([PGRST_DB_POOL_ACQUISITION_TIMEOUT], [1], [PostgREST pool timeout])"
             "ARG_LEFTOVERS([PostgREST arguments])"
           ];
         workingDir = "/";

--- a/nix/tools/memory.nix
+++ b/nix/tools/memory.nix
@@ -5,7 +5,6 @@
 , checkedShellScript
 , curl
 , postgrestProfiled
-, postgrest
 , withTools
 }:
 let
@@ -30,12 +29,11 @@ let
           [
             "ARG_USE_ENV([PGRST_DB_ANON_ROLE], [postgrest_test_anonymous], [PostgREST anonymous role])"
             "ARG_USE_ENV([PGRST_DB_POOL], [1], [PostgREST pool size])"
-            "ARG_USE_ENV([PGRST_DB_POOL_ACQUISITION_TIMEOUT], [1], [PostgREST pool size])"
+            "ARG_USE_ENV([PGRST_DB_POOL_ACQUISITION_TIMEOUT], [1], [PostgREST pool timeout])"
             "ARG_LEFTOVERS([PostgREST arguments])"
           ];
         workingDir = "/";
         withPath = [ postgrestProfiled ];
-        withEnv = postgrest.env;
       }
       ''
         export PGRST_DB_ANON_ROLE

--- a/nix/tools/memory.nix
+++ b/nix/tools/memory.nix
@@ -1,6 +1,7 @@
 # The memory tests have large dependencies (a profiled build of PostgREST)
 # and are run less often than the spec tests, so we don't include them in
 # the default test environment. We make them available through a separate module.
+# TODO both of these require reentering the nix-shell if you make a change to the code
 { buildToolbox
 , checkedShellScript
 , curl
@@ -24,7 +25,7 @@ let
     checkedShellScript
       {
         name = "postgrest-profiled-run";
-        docs = "Run a profiled build of postgREST. This will generate a postgrest.prof file that can be used to do optimization.";
+        docs = "Run a profiled build of postgREST. This will generate a postgrest.prof file that can be used to do optimization. Note: if you make a change to the code, you must reenter the nix-shell for an updated profiled build.";
         args =
           [
             "ARG_USE_ENV([PGRST_DB_ANON_ROLE], [postgrest_test_anonymous], [PostgREST anonymous role])"


### PR DESCRIPTION
Runs a profiled build of postgREST that can be used for optimization.