### PR TITLE
perf: remove json_typeof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3061, Apply all function settings as transaction-scoped settings - @taimoorzaeem
  - #3171, #3046, Log schema cache stats to stderr - @steve-chavez
  - #3210, Dump schema cache through admin API - @taimoorzaeem
+ - #2677, Performance improvement on bulk json inserts, around 10% increase on requests per second by removing `json_typeof` from write queries - @steve-chavez
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3061, Apply all function settings as transaction-scoped settings - @taimoorzaeem
  - #3171, #3046, Log schema cache stats to stderr - @steve-chavez
  - #3210, Dump schema cache through admin API - @taimoorzaeem
- - #2677, Performance improvement on bulk json inserts, around 10% increase on requests per second by removing `json_typeof` from write queries - @steve-chavez
+ - #2676, Performance improvement on bulk json inserts, around 10% increase on requests per second by removing `json_typeof` from write queries - @steve-chavez
 
 ### Fixed
 

--- a/test/pgbench/2676/new.sql
+++ b/test/pgbench/2676/new.sql
@@ -1,0 +1,16 @@
+WITH pgrst_source AS (
+  INSERT INTO "test"."complex_items"("arr_data", "field-with_sep", "id", "name")
+  SELECT "pgrst_body"."arr_data", "pgrst_body"."field-with_sep", "pgrst_body"."id", "pgrst_body"."name"
+  FROM (SELECT '[{"id": 4, "name": "Vier"}, {"id": 5, "name": "Funf", "arr_data": null}, {"id": 6, "name": "Sechs", "arr_data": [1, 2, 3], "field-with_sep": 6}]'::json AS json_data) pgrst_payload,
+  LATERAL (SELECT "arr_data", "field-with_sep", "id", "name" FROM json_to_recordset(pgrst_payload.json_data) AS _("arr_data" integer[], "field-with_sep" integer, "id" bigint, "name" text) ) pgrst_body
+  RETURNING "test"."complex_items".*
+)
+SELECT
+  '' AS total_result_set,
+  pg_catalog.count(_postgrest_t) AS page_total,
+  array[]::text[] AS header,
+  coalesce(json_agg(_postgrest_t), '[]') AS body,
+  nullif(current_setting('response.headers', true), '') AS response_headers,
+  nullif(current_setting('response.status', true), '') AS response_status,
+  '' AS response_inserted
+FROM (SELECT "complex_items".* FROM "pgrst_source" AS "complex_items") _postgrest_t;

--- a/test/pgbench/2676/old.sql
+++ b/test/pgbench/2676/old.sql
@@ -1,0 +1,17 @@
+WITH pgrst_source AS (
+  INSERT INTO "test"."complex_items"("arr_data", "field-with_sep", "id", "name")
+  SELECT "pgrst_body"."arr_data", "pgrst_body"."field-with_sep", "pgrst_body"."id", "pgrst_body"."name"
+  FROM (SELECT '[{"id": 4, "name": "Vier"}, {"id": 5, "name": "Funf", "arr_data": null}, {"id": 6, "name": "Sechs", "arr_data": [1, 2, 3], "field-with_sep": 6}]'::json AS json_data) pgrst_payload,
+  LATERAL (SELECT CASE WHEN json_typeof(pgrst_payload.json_data) = 'array' THEN pgrst_payload.json_data ELSE json_build_array(pgrst_payload.json_data) END AS val) pgrst_uniform_json,
+  LATERAL (SELECT "arr_data", "field-with_sep", "id", "name" FROM json_to_recordset(pgrst_uniform_json.val) AS _("arr_data" integer[], "field-with_sep" integer, "id" bigint, "name" text) ) pgrst_body
+  RETURNING "test"."complex_items".*
+)
+SELECT
+  '' AS total_result_set,
+  pg_catalog.count(_postgrest_t) AS page_total,
+  array[]::text[] AS header,
+  coalesce(json_agg(_postgrest_t), '[]') AS body,
+  nullif(current_setting('response.headers', true), '') AS response_headers,
+  nullif(current_setting('response.status', true), '') AS response_status,
+  '' AS response_inserted
+FROM (SELECT "complex_items".* FROM "pgrst_source" AS "complex_items") _postgrest_t;

--- a/test/pgbench/README.md
+++ b/test/pgbench/README.md
@@ -3,9 +3,9 @@
 Can be used as:
 
 ```
-postgrest-with-postgresql-15 -f test/pgbench/fixtures.sql pgbench -n -T 10 -f test/pgbench/1567/old.sql
+postgrest-with-postgresql-15 -f test/pgbench/fixtures.sql pgbench -U postgres -n -T 10 -f test/pgbench/1567/old.sql
 
-postgrest-with-postgresql-15 -f test/pgbench/fixtures.sql pgbench -n -T 10 -f test/pgbench/1567/new.sql
+postgrest-with-postgresql-15 -f test/pgbench/fixtures.sql pgbench -U postgres -n -T 10 -f test/pgbench/1567/new.sql
 ```
 
 ## Directory structure

--- a/test/spec/Feature/Query/PlanSpec.hs
+++ b/test/spec/Feature/Query/PlanSpec.hs
@@ -152,7 +152,7 @@ spec actualPgVersion = do
       liftIO $ do
         resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.plan+json; for=\"application/json\"; charset=utf-8")
         resStatus `shouldBe` Status { statusCode = 200, statusMessage="OK" }
-        totalCost `shouldBe` 3.27
+        totalCost `shouldBe` 0.06
 
     it "outputs the total cost for an update" $ do
       r <- request methodPatch "/projects?id=eq.3"
@@ -165,7 +165,7 @@ spec actualPgVersion = do
       liftIO $ do
         resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.plan+json; for=\"application/json\"; charset=utf-8")
         resStatus `shouldBe` Status { statusCode = 200, statusMessage="OK" }
-        totalCost `shouldBe` 12.45
+        totalCost `shouldBe` 8.23
 
     it "outputs the total cost for a delete" $ do
       r <- request methodDelete "/projects?id=in.(1,2,3)"


### PR DESCRIPTION
Closes #2676. Removes `json_typeof/jsonb_typeof` by using some light validation on the json body using lazy bytestring functions.

- grants ~10% perf increase. 
  + can be confirmed with the PlanSpec change.
  + can be confirmed manually with pgbench like:
```
$ postgrest-with-postgresql-16 -f test/pgbench/fixtures.sql pgbench -U postgres -n -T 10 -f test/pgbench/2676/old.sql 
tps = 3480.654744 (without initial connection time)

$ postgrest-with-postgresql-16 -f test/pgbench/fixtures.sql pgbench -U postgres -n -T 10 -f test/pgbench/2676/new.sql 
tps = 3973.138881 (without initial connection time)
```
- memory usage is kept the same
- no need for a new `content-type` as per a previous idea on https://github.com/PostgREST/postgrest/issues/2676. This is an improvement for every write case.