### PR TITLE
fix: don't hide error on LISTEN channel failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3224, Return status code 406 for non-accepted media type instead of code 415 - @wolfgangwalther
  - #3160, Fix using select= query parameter for custom media type handlers - @wolfgangwalther
  - #3237, Dump media handlers and timezones with --dump-schema - @wolfgangwalther
+ - #3323, Don't hide error on LISTEN channel failure - @steve-chavez
 
 ### Deprecated
 


### PR DESCRIPTION
Related to https://github.com/PostgREST/postgrest/discussions/3313.

Now when the LISTEN channel dies we log:

```
11/Mar/2024:14:11:11 -0500: FatalError {fatalErrorMessage = "Error checking for PostgreSQL notifications"}. Retrying listening for notifications on the pgrst channel..
```

It used to be:

```
11/Mar/2024:12:50:17 -0500: Retrying listening for notifications on the pgrst channel..
```

The lib error is still uninformative but that's another issue https://github.com/PostgREST/postgrest/issues/3320#issuecomment-1989198685