### PR TITLE
fix: upgrade hasql-notifications to show error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3224, Return status code 406 for non-accepted media type instead of code 415 - @wolfgangwalther
  - #3160, Fix using select= query parameter for custom media type handlers - @wolfgangwalther
  - #3237, Dump media handlers and timezones with --dump-schema - @wolfgangwalther
- - #3323, Don't hide error on LISTEN channel failure - @steve-chavez
+ - #3323, #3324, Don't hide error on LISTEN channel failure - @steve-chavez
 
 ### Deprecated
 

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -19,15 +19,18 @@ let
       #
       # To temporarily pin unreleased versions from GitHub:
       #   <name> =
-      #     prev.callCabal2nixWithOptions "<name>" (super.fetchFromGitHub {
+      #     lib.dontCheck (prev.callCabal2nixWithOptions "<name>" (super.fetchFromGitHub {
       #       owner = "<owner>";
       #       repo  = "<repo>";
       #       rev = "<commit>";
       #       sha256 = "<sha256>";
-      #    }) "--subpath=<subpath>" {};
+      #    }) "--subpath=." {});
       #
       # To fill in the sha256:
       #   update-nix-fetchgit nix/overlays/haskell-packages.nix
+      #
+      # Nowadays you can just delete the sha256 attribute above and nix will assume a fake sha.
+      # Once you build the derivation it will suggest the correct sha.
 
       configurator-pg =
         prev.callHackageDirect
@@ -47,6 +50,15 @@ let
         });
 
       hasql-pool = lib.dontCheck prev.hasql-pool_0_10;
+
+      hasql-notifications = lib.dontCheck (prev.callHackageDirect
+        {
+          pkg = "hasql-notifications";
+          ver = "0.2.1.0";
+          sha256 = "sha256-MEIirDKR81KpiBOnWJbVInWevL6Kdb/XD1Qtd8e6KsQ=";
+        }
+        { }
+      );
 
     };
 in

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -492,11 +492,11 @@ listener appState observer = do
         exitFailure
   where
     handleFinally dbChannel False err = do
-      observer $ DBListenerFailNoRecoverObs dbChannel err
+      observer $ DBListenerFailRecoverObs False dbChannel err
       killThread (getMainThreadId appState)
     handleFinally dbChannel True err = do
       -- if the thread dies, we try to recover
-      observer $ DBListenerFailRecoverObs dbChannel err
+      observer $ DBListenerFailRecoverObs True dbChannel err
       putIsListenerOn appState False
       -- assume the pool connection was also lost, call the connection worker
       connectionWorker appState


### PR DESCRIPTION
Based on https://github.com/diogob/hasql-notifications/pull/21

The logs now show:

```
13/Mar/2024:10:52:54 -0500: Could not listen for notifications on the pgrst channel. server closed the connection unexpectedly This probably means the server terminated abnormally before or while processing the request. Retrying listening for notifications..
```