### PR TITLE
nix: add example on how to use a library locally

### DIFF
--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -34,6 +34,11 @@ let
       # - If the library fails its test suite (usually when it runs IO tests), wrap the expression with `lib.dontCheck ()`
       # - <subpath> is usually "."
       # - When adding a new library version here, postgrest.cabal and stack.yaml must also be updated
+      #
+      # Note:
+      # - This should NOT be the first place to start managing dependencies. Check package.cabal and stack.yaml first.
+      # - To modify and try packages locally, see "Working with locally modified Haskell packages" in the Nix README.
+      #
 
 
       configurator-pg =

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -36,7 +36,7 @@ let
       # - When adding a new library version here, postgrest.cabal and stack.yaml must also be updated
       #
       # Note:
-      # - This should NOT be the first place to start managing dependencies. Check package.cabal and stack.yaml first.
+      # - This should NOT be the first place to start managing dependencies. Check postgrest.cabal.
       # - To modify and try packages locally, see "Working with locally modified Haskell packages" in the Nix README.
       #
 


### PR DESCRIPTION
Added an example on how to use a local library for development purposes. Useful to debug said library in the context of PostgREST development.