### PR TITLE
fix: log on LISTEN notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3237, Dump media handlers and timezones with --dump-schema - @wolfgangwalther
  - #3323, #3324, Don't hide error on LISTEN channel failure - @steve-chavez
  - #3330, Incorrect admin server `/ready` response on slow schema cache loads - @steve-chavez
- - #3327, Fix slow responses on schema cache reloads - @steve-chavez
+ - #3340, Log when the LISTEN channel gets a notification - @steve-chavez
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3237, Dump media handlers and timezones with --dump-schema - @wolfgangwalther
  - #3323, #3324, Don't hide error on LISTEN channel failure - @steve-chavez
  - #3330, Incorrect admin server `/ready` response on slow schema cache loads - @steve-chavez
+ - #3327, Fix slow responses on schema cache reloads - @steve-chavez
  - #3340, Log when the LISTEN channel gets a notification - @steve-chavez
 
 ### Deprecated

--- a/src/PostgREST/Observation.hs
+++ b/src/PostgREST/Observation.hs
@@ -40,6 +40,8 @@ data Observation
   | DBListenerStart Text
   | DBListenerFail Text SQL.ConnectionError
   | DBListenerFailRecoverObs Bool Text (Either SomeException ())
+  | DBListenerGotSCacheMsg ByteString
+  | DBListenerGotConfigMsg ByteString
   | ConfigReadErrorObs
   | ConfigReadErrorFatalObs SQL.UsageError Text
   | ConfigReadErrorNotFatalObs SQL.UsageError
@@ -82,11 +84,15 @@ observationMessage = \case
   ConnectionPgVersionErrorObs usageErr ->
     jsonMessage usageErr
   DBListenerStart channel -> do
-    "Listening for notifications on the " <> channel <> " channel"
+    "Listening for notifications on the " <> show channel <> " channel"
   DBListenerFail channel err -> do
     "Could not listen for notifications on the " <> channel <> " channel. " <> show err
   DBListenerFailRecoverObs recover channel err ->
     "Could not listen for notifications on the " <> channel <> " channel. " <> showListenerError err <> (if recover then " Retrying listening for notifications.." else mempty)
+  DBListenerGotSCacheMsg channel ->
+    "Received a schema cache reload message on the " <> show channel <> " channel"
+  DBListenerGotConfigMsg channel ->
+    "Received a config reload message on the " <> show channel <> " channel"
   ConfigReadErrorObs ->
     "An error ocurred when trying to query database settings for the config parameters"
   ConfigReadErrorFatalObs usageErr hint ->

--- a/test/io/__snapshots__/test_cli/test_schema_cache_snapshot[dbRoutines].yaml
+++ b/test/io/__snapshots__/test_cli/test_schema_cache_snapshot[dbRoutines].yaml
@@ -393,6 +393,23 @@
       pdSchema: public
       pdVolatility: Volatile
 
+- - qiName: notify_do_nothing
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: notify_do_nothing
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: void
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+
 - - qiName: sleep
     qiSchema: public
   - - pdDescription: null

--- a/test/io/fixtures.sql
+++ b/test/io/fixtures.sql
@@ -89,6 +89,10 @@ begin
   perform pg_notify('pgrst', 'reload config');
 end $_$ volatile security definer language plpgsql ;
 
+create function notify_do_nothing() returns void as $_$
+  notify pgrst, 'nothing';
+$_$ language sql;
+
 create function reset_invalid_role_claim_key() returns void as $_$
 begin
   alter role postgrest_test_authenticator reset pgrst.jwt_role_claim_key;

--- a/test/io/test_cli.py
+++ b/test/io/test_cli.py
@@ -246,7 +246,7 @@ def test_invalid_openapi_mode(invalidopenapimodes, defaultenv):
                 print(line)
 
 
-# If this test is failing, run pytest with --snapshot-update.
+# If this test is failing, run postgrest-test-io --snapshot-update -k test_schema_cache_snapshot
 @pytest.mark.parametrize(
     "key",
     [

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -422,6 +422,8 @@ def test_invalid_role_claim_key_notify_reload(defaultenv):
         postgrest.session.post("/rpc/invalid_role_claim_key_reload")
 
         output = postgrest.read_stdout()
+        assert 'Received a config reload message on the "pgrst" channel' in output[0]
+        output = postgrest.read_stdout()
         assert "failed to parse role-claim-key value" in output[0]
 
         response = postgrest.session.post("/rpc/reset_invalid_role_claim_key")

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -430,6 +430,24 @@ def test_invalid_role_claim_key_notify_reload(defaultenv):
         assert response.status_code == 204
 
 
+def test_notify_do_nothing(defaultenv):
+    "NOTIFY with unknown message should do nothing"
+
+    env = {
+        **defaultenv,
+        "PGRST_DB_CONFIG": "true",
+        "PGRST_DB_CHANNEL_ENABLED": "true",
+        "PGRST_LOG_LEVEL": "crit",
+    }
+
+    with run(env=env) as postgrest:
+        response = postgrest.session.post("/rpc/notify_do_nothing")
+        assert response.status_code == 204
+
+        output = postgrest.read_stdout()
+        assert output == []
+
+
 def test_db_prepared_statements_enable(defaultenv):
     "Should use prepared statements when the setting is enabled."
 


### PR DESCRIPTION
Now shows:

```
19/Mar/2024:00:21:18 -0500: The "pgrst" channel got a schema cache reload message
19/Mar/2024:00:21:18 -0500: Attempting to connect to the database...
19/Mar/2024:00:21:18 -0500: Successfully connected to PostgreSQL 16.1 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 12.3.0, 64-bit
19/Mar/2024:00:21:18 -0500: Config reloaded
19/Mar/2024:00:21:18 -0500: Schema cache queried in 10.1 milliseconds
19/Mar/2024:00:21:18 -0500: Schema cache loaded 264 Relations, 221 Relationships, 141 Functions, 15 Domain Representations, 45 Media Type Handlers
19/Mar/2024:00:21:18 -0500: Schema cache loaded in 9.1 milliseconds

19/Mar/2024:00:21:22 -0500: The "pgrst" channel got a config reload message
19/Mar/2024:00:21:22 -0500: Config reloaded
```