### PR TITLE
refactor: observation handler to AppConfig

### DIFF
--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -64,6 +64,8 @@ import PostgREST.Config.Proxy            (Proxy (..),
 import PostgREST.SchemaCache.Identifiers (QualifiedIdentifier, dumpQi,
                                           toQi)
 
+import PostgREST.Observation
+
 import Protolude hiding (Proxy, toList)
 
 
@@ -112,6 +114,7 @@ data AppConfig = AppConfig
   , configRoleSettings             :: RoleSettings
   , configRoleIsoLvl               :: RoleIsolationLvl
   , configInternalSCSleep          :: Maybe Int32
+  , configObserver                 :: ObservationHandler
   }
 
 data LogLevel = LogCrit | LogError | LogWarn | LogInfo
@@ -210,13 +213,13 @@ instance JustIfMaybe a (Maybe a) where
 
 -- | Reads and parses the config and overrides its parameters from env vars,
 -- files or db settings.
-readAppConfig :: [(Text, Text)] -> Maybe FilePath -> Maybe Text -> RoleSettings -> RoleIsolationLvl -> IO (Either Text AppConfig)
-readAppConfig dbSettings optPath prevDbUri roleSettings roleIsolationLvl = do
+readAppConfig :: [(Text, Text)] -> Maybe FilePath -> Maybe Text -> RoleSettings -> RoleIsolationLvl -> ObservationHandler -> IO (Either Text AppConfig)
+readAppConfig dbSettings optPath prevDbUri roleSettings roleIsolationLvl observer = do
   env <- readPGRSTEnvironment
   -- if no filename provided, start with an empty map to read config from environment
   conf <- maybe (return $ Right M.empty) loadConfig optPath
 
-  case C.runParser (parser optPath env dbSettings roleSettings roleIsolationLvl) =<< mapLeft show conf of
+  case C.runParser (parser optPath env dbSettings roleSettings roleIsolationLvl observer) =<< mapLeft show conf of
     Left err ->
       return . Left $ "Error in config " <> err
     Right parsedConfig ->
@@ -231,8 +234,8 @@ readAppConfig dbSettings optPath prevDbUri roleSettings roleIsolationLvl = do
       decodeJWKS <$>
         (decodeSecret =<< readSecretFile =<< readDbUriFile prevDbUri parsedConfig)
 
-parser :: Maybe FilePath -> Environment -> [(Text, Text)] -> RoleSettings -> RoleIsolationLvl -> C.Parser C.Config AppConfig
-parser optPath env dbSettings roleSettings roleIsolationLvl =
+parser :: Maybe FilePath -> Environment -> [(Text, Text)] -> RoleSettings -> RoleIsolationLvl -> ObservationHandler -> C.Parser C.Config AppConfig
+parser optPath env dbSettings roleSettings roleIsolationLvl observer =
   AppConfig
     <$> parseAppSettings "app.settings"
     <*> (fromMaybe False <$> optBool "db-aggregates-enabled")
@@ -285,6 +288,7 @@ parser optPath env dbSettings roleSettings roleIsolationLvl =
     <*> pure roleSettings
     <*> pure roleIsolationLvl
     <*> optInt "internal-schema-cache-sleep"
+    <*> pure observer
   where
     parseAppSettings :: C.Key -> C.Parser C.Config [(Text, Text)]
     parseAppSettings key = addFromEnv . fmap (fmap coerceText) <$> C.subassocs key C.value

--- a/src/PostgREST/Logger.hs
+++ b/src/PostgREST/Logger.hs
@@ -4,7 +4,7 @@ Description : Wai Middleware to log requests to stdout.
 -}
 module PostgREST.Logger
   ( middleware
-  , logObservation
+  , observationLogger
   , init
   ) where
 
@@ -50,8 +50,8 @@ middleware logLevel = case logLevel of
             & Wai.setApacheUserGetter Auth.getRole
       }
 
-logObservation :: LoggerState -> Observation -> IO ()
-logObservation loggerState obs = logWithZTime loggerState $ observationMessage obs
+observationLogger :: LoggerState -> ObservationHandler
+observationLogger loggerState obs = logWithZTime loggerState $ observationMessage obs
 
 logWithZTime :: LoggerState -> Text -> IO ()
 logWithZTime loggerState txt = do

--- a/src/PostgREST/Query.hs
+++ b/src/PostgREST/Query.hs
@@ -43,7 +43,6 @@ import PostgREST.Config                  (AppConfig (..),
 import PostgREST.Config.PgVersion        (PgVersion (..))
 import PostgREST.Error                   (Error)
 import PostgREST.MediaType               (MediaType (..))
-import PostgREST.Observation             (Observation (..))
 import PostgREST.Plan                    (ActionPlan (..),
                                           CallReadPlan (..),
                                           CrudPlan (..),
@@ -75,12 +74,12 @@ data QueryResult
   | NoDbResult    InfoPlan
 
 -- TODO This function needs to be free from IO, only App.hs should do IO
-runQuery :: AppState.AppState -> AppConfig -> AuthResult -> ApiRequest -> ActionPlan -> SchemaCache -> PgVersion -> Bool -> (Observation -> IO ()) -> ExceptT Error IO QueryResult
-runQuery _ _ _ _ (NoDb x) _ _ _ _ = pure $ NoDbResult x
-runQuery appState config AuthResult{..} apiReq (Db plan) sCache pgVer authenticated observer = do
+runQuery :: AppState.AppState -> AppConfig -> AuthResult -> ApiRequest -> ActionPlan -> SchemaCache -> PgVersion -> Bool -> ExceptT Error IO QueryResult
+runQuery _ _ _ _ (NoDb x) _ _ _ = pure $ NoDbResult x
+runQuery appState config AuthResult{..} apiReq (Db plan) sCache pgVer authenticated = do
   dbResp <- lift $ do
     let transaction = if prepared then SQL.transaction else SQL.unpreparedTransaction
-    AppState.usePool appState config (transaction isoLvl txMode $ runExceptT dbHandler) observer
+    AppState.usePool appState config (transaction isoLvl txMode $ runExceptT dbHandler)
 
   resp <-
     liftEither . mapLeft Error.PgErr $

--- a/test/spec/Main.hs
+++ b/test/spec/Main.hs
@@ -77,21 +77,20 @@ main = do
   sockets <- AppState.initSockets testCfg
 
   let
-    noObs = const $ pure ()
     -- For tests that run with the same refSchemaCache
     app config = do
-      appState <- AppState.initWithPool sockets pool config noObs
+      appState <- AppState.initWithPool sockets pool config
       AppState.putPgVersion appState actualPgVersion
       AppState.putSchemaCache appState (Just baseSchemaCache)
-      return ((), postgrest (configLogLevel config) appState (pure ()) noObs)
+      return ((), postgrest (configLogLevel config) appState (pure ()))
 
     -- For tests that run with a different SchemaCache(depends on configSchemas)
     appDbs config = do
       customSchemaCache <- loadSCache pool config
-      appState <- AppState.initWithPool sockets pool config noObs
+      appState <- AppState.initWithPool sockets pool config
       AppState.putPgVersion appState actualPgVersion
       AppState.putSchemaCache appState (Just customSchemaCache)
-      return ((), postgrest (configLogLevel config) appState (pure ()) noObs)
+      return ((), postgrest (configLogLevel config) appState (pure ()))
 
   let withApp              = app testCfg
       maxRowsApp           = app testMaxRowsCfg

--- a/test/spec/SpecHelper.hs
+++ b/test/spec/SpecHelper.hs
@@ -141,6 +141,7 @@ baseCfg = let secret = Just $ encodeUtf8 "reallyreallyreallyreallyverysafe" in
   , configRoleIsoLvl                = mempty
   , configInternalSCSleep           = Nothing
   , configServerTimingEnabled       = True
+  , configObserver                  = const $ pure ()
   }
 
 testCfg :: AppConfig

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -3759,3 +3759,8 @@ create aggregate test.outfunc_agg (anyelement) (
 , stype = "pg/outfunc"
 , sfunc = outfunc_trans
 );
+
+-- used for manual testing
+create or replace function test.sleep(seconds double precision default 5) returns void as $$
+  select pg_sleep(seconds);
+$$ language sql;


### PR DESCRIPTION
With this:

- Is no longer necessary to pass observer as an argument to every function that needs observations.
- We can invoke the observer on every function that uses AppConfig. However it'd be better to just call the observer in the upper modules (like on App.hs).