### PR TITLE
feat: connection pool metrics in admin server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2676, Performance improvement on bulk json inserts, around 10% increase on requests per second by removing `json_typeof` from write queries - @steve-chavez
  - #3214, Log connection pool events on log-level=info - @steve-chavez
  - #3435, Add log-level=debug, for development purposes - @steve-chavez
+ - #1526, Add `/metrics` endpoint on admin server - @steve-chavez
+   - Exposes connection pool metrics
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3214, Log connection pool events on log-level=info - @steve-chavez
  - #3435, Add log-level=debug, for development purposes - @steve-chavez
  - #1526, Add `/metrics` endpoint on admin server - @steve-chavez
-   - Exposes connection pool metrics
+   - Exposes connection pool metrics, schema cache metrics
 
 ### Fixed
 

--- a/docs/references/admin_server.rst
+++ b/docs/references/admin_server.rst
@@ -39,3 +39,16 @@ Ready
 -----
 
 In addition, the ``ready`` endpoint checks the state of the :ref:`connection_pool` and the :ref:`schema_cache`. A request will return ``200 OK`` if both are good or ``503`` if not.
+
+.. code-block:: bash
+
+  curl -I "http://localhost:3001/ready"
+
+.. code-block:: http
+
+  HTTP/1.1 200 OK
+
+Metrics
+=======
+
+Provides :ref:`metrics`.

--- a/docs/references/observability.rst
+++ b/docs/references/observability.rst
@@ -3,10 +3,15 @@
 Observability
 #############
 
+.. contents::
+   :depth: 1
+   :local:
+   :backlinks: none
+
 .. _pgrst_logging:
 
-Logging
--------
+Logs
+====
 
 PostgREST logs basic request information to ``stdout``, including the authenticated user if available, the requesting IP address and user agent, the URL requested, and HTTP response status.
 
@@ -40,7 +45,7 @@ For diagnostic information about the server itself, PostgREST logs to ``stderr``
 Currently PostgREST doesn't log the SQL commands executed against the underlying database.
 
 Database Logs
-~~~~~~~~~~~~~
+-------------
 
 To find the SQL operations, you can watch the database logs. By default PostgreSQL does not keep these logs, so you'll need to make the configuration changes below.
 
@@ -80,6 +85,92 @@ Restart the database and watch the log file in real-time to understand how HTTP 
 
     docker run -v "$(pwd)/init.sh":"/docker-entrypoint-initdb.d/init.sh" -d postgres
     docker logs -f <container-id>
+
+.. _metrics:
+
+Metrics
+=======
+
+The ``metrics`` endpoint on the :ref:`admin_server` endpoint provides metrics in `Prometheus text format <https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format>`_.
+
+.. code-block:: bash
+
+  curl "http://localhost:3001/metrics"
+
+  # HELP pgrst_schema_cache_query_time_seconds The query time in seconds of the last schema cache load
+  # TYPE pgrst_schema_cache_query_time_seconds gauge
+  pgrst_schema_cache_query_time_seconds 1.5937927e-2
+  # HELP pgrst_schema_cache_loads_total The total number of times the schema cache was loaded
+  # TYPE pgrst_schema_cache_loads_total counter
+  pgrst_schema_cache_loads_total 1.0
+  ...
+
+Schema Cache Metrics
+--------------------
+
+Metrics related to the :ref:`schema_cache`.
+
+pgrst_schema_cache_query_time_seconds
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+======== =======
+**Type** Gauge
+======== =======
+
+The query time in seconds of the last schema cache load.
+
+pgrst_schema_cache_loads_total
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+======== =======
+**Type** Counter
+======== =======
+
+The total number of times the schema cache was loaded.
+
+Connection Pool Metrics
+-----------------------
+
+Metrics related to the :ref:`connection_pool`.
+
+pgrst_db_pool_timeouts_total
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+======== =======
+**Type** Counter
+======== =======
+
+The total number of pool connection timeouts.
+
+pgrst_db_pool_available
+~~~~~~~~~~~~~~~~~~~~~~~
+
+======== =======
+**Type** Gauge
+======== =======
+
+Available connections in the pool.
+
+pgrst_db_pool_waiting
+~~~~~~~~~~~~~~~~~~~~~
+
+======== =======
+**Type** Gauge
+======== =======
+
+Requests waiting to acquire a pool connection
+
+pgrst_db_pool_max
+~~~~~~~~~~~~~~~~~
+
+======== =======
+**Type** Gauge
+======== =======
+
+Max pool connections.
+
+Traces
+======
 
 Server Version
 --------------

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -36,12 +36,14 @@ let
       # - When adding a new library version here, postgrest.cabal and stack.yaml must also be updated
       #
       # Notes:
-      # - This should NOT be the first place to start managing dependencies. Check postgrest.cabal.
-      # - When adding a new package version here, you have to update stack:
-      #   + For stack.yml add:
+      # - When adding a new package version here, update cabal.
+      #   + Update postgrest.cabal with the package version
+      #   + Update cabal.project.freeze. Just set it to the current timestamp then run `cabal build`. It will tell you the correct timestamp for the index state.
+      # - When adding a new package version here, you have to update stack.
+      #   + To update stack.yaml add:
       #   extra-deps:
       #     - <package>-<ver>
-      #   + For stack.yml.lock, CI should report an error with the correct lock, copy/paste that one into the file
+      #   + For stack.yaml.lock, CI should report an error with the correct lock, copy/paste that one into the file
       # - To modify and try packages locally, see "Working with locally modified Haskell packages" in the Nix README.
 
       # Before upgrading fuzzyset to 0.3, check: https://github.com/PostgREST/postgrest/issues/3329

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -64,6 +64,7 @@ library
                       PostgREST.Error
                       PostgREST.Logger
                       PostgREST.MediaType
+                      PostgREST.Metrics
                       PostgREST.Observation
                       PostgREST.Query
                       PostgREST.Query.QueryBuilder
@@ -124,6 +125,7 @@ library
                     , optparse-applicative      >= 0.13 && < 0.19
                     , parsec                    >= 3.1.11 && < 3.2
                     , postgresql-libpq          >= 0.10
+                    , prometheus-client         >= 1.1.1 && < 1.2.0
                     , protolude                 >= 0.3.1 && < 0.4
                     , regex-tdfa                >= 1.2.2 && < 1.4
                     , retry                     >= 0.7.4 && < 0.10

--- a/src/PostgREST/Admin.hs
+++ b/src/PostgREST/Admin.hs
@@ -19,10 +19,12 @@ import Network.Socket.ByteString
 
 import PostgREST.AppState    (AppState)
 import PostgREST.Config      (AppConfig (..))
+import PostgREST.Metrics     (metricsToText)
 import PostgREST.Observation (Observation (..))
 
 import qualified PostgREST.AppState as AppState
 import qualified PostgREST.Config   as Config
+
 
 import Protolude
 
@@ -56,6 +58,9 @@ admin appState appConfig req respond  = do
     ["schema_cache"] -> do
       sCache <- AppState.getSchemaCache appState
       respond $ Wai.responseLBS HTTP.status200 [] (maybe mempty JSON.encode sCache)
+    ["metrics"] -> do
+      mets <- metricsToText
+      respond $ Wai.responseLBS HTTP.status200 [] mets
     _ ->
       respond $ Wai.responseLBS HTTP.status404 [] mempty
 

--- a/src/PostgREST/Logger.hs
+++ b/src/PostgREST/Logger.hs
@@ -88,6 +88,10 @@ observationLogger loggerState logLevel obs = case obs of
   o@(SchemaCacheLoadedObs _) -> do
     when (logLevel >= LogDebug) $ do
       logWithZTime loggerState $ observationMessage o
+  PoolRequest ->
+    pure ()
+  PoolRequestFullfilled ->
+    pure ()
   o ->
     logWithZTime loggerState $ observationMessage o
 

--- a/src/PostgREST/Metrics.hs
+++ b/src/PostgREST/Metrics.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+module PostgREST.Metrics
+  ( init
+  , MetricsState (..)
+  , observationMetrics
+  , metricsToText
+  ) where
+
+import qualified Data.ByteString.Lazy   as LBS
+import qualified Hasql.Pool.Observation as SQL
+
+import qualified Prometheus as Prom
+
+import PostgREST.Observation
+
+import Protolude
+
+data MetricsState = MetricsState
+  { poolTimeouts         :: Prom.Counter
+  , poolAvailable        :: Prom.Gauge
+  , poolWaiting          :: Prom.Gauge
+  , poolMaxSize          :: Prom.Gauge
+  }
+
+init :: Int -> IO MetricsState
+init poolMaxSize = do
+  timeouts <- Prom.register $ Prom.counter (Prom.Info "pgrst_db_pool_timeouts_total" "The total number of pool connection timeouts")
+  available <- Prom.register $ Prom.gauge (Prom.Info "pgrst_db_pool_available" "Available connections in the pool")
+  waiting <- Prom.register $ Prom.gauge (Prom.Info "pgrst_db_pool_waiting" "Requests waiting to acquire a pool connection")
+  maxSize <- Prom.register $ Prom.gauge (Prom.Info "pgrst_db_pool_max" "Max pool connections")
+  Prom.setGauge maxSize (fromIntegral poolMaxSize)
+  pure $ MetricsState timeouts available waiting maxSize
+
+observationMetrics :: MetricsState -> ObservationHandler
+observationMetrics MetricsState{poolTimeouts, poolAvailable, poolWaiting} obs = case obs of
+  (PoolAcqTimeoutObs _) -> do
+    Prom.incCounter poolTimeouts
+  (HasqlPoolObs (SQL.ConnectionObservation _ status)) -> case status of
+     SQL.ReadyForUseConnectionStatus  -> do
+      Prom.incGauge poolAvailable
+     SQL.InUseConnectionStatus        -> do
+      Prom.decGauge poolAvailable
+     SQL.TerminatedConnectionStatus  _ -> do
+      Prom.decGauge poolAvailable
+     SQL.ConnectingConnectionStatus -> pure ()
+  PoolRequest ->
+    Prom.incGauge poolWaiting
+  PoolRequestFullfilled ->
+    Prom.decGauge poolWaiting
+  _ ->
+    pure ()
+
+metricsToText :: IO LBS.ByteString
+metricsToText = Prom.exportMetricsAsText

--- a/src/PostgREST/Observation.hs
+++ b/src/PostgREST/Observation.hs
@@ -52,6 +52,8 @@ data Observation
   | QueryErrorCodeHighObs SQL.UsageError
   | PoolAcqTimeoutObs SQL.UsageError
   | HasqlPoolObs SQL.Observation
+  | PoolRequest
+  | PoolRequestFullfilled
 
 type ObservationHandler = Observation -> IO ()
 
@@ -125,6 +127,7 @@ observationMessage = \case
           SQL.ReleaseConnectionTerminationReason        -> "release"
           SQL.NetworkErrorConnectionTerminationReason _ -> "network error" -- usage error is already logged, no need to repeat the same message.
     )
+  _ -> mempty
   where
     showMillis :: Double -> Text
     showMillis x = toS $ showFFloat (Just 1) (x * 1000) ""

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -1427,3 +1427,15 @@ def test_multiple_func_settings(defaultenv):
         response = postgrest.session.post("/rpc/multiple_func_settings_test")
 
         assert response.text == '[{"work_mem":"5000kB","statement_timeout":"10s"}]'
+
+
+def test_admin_metrics(defaultenv):
+    "Should get metrics from the admin endpoint"
+
+    with run(env=defaultenv, port=freeport()) as postgrest:
+        response = postgrest.admin.get("/metrics")
+        assert response.status_code == 200
+        assert "pgrst_db_pool_max" in response.text
+        assert "pgrst_db_pool_waiting" in response.text
+        assert "pgrst_db_pool_available" in response.text
+        assert "pgrst_db_pool_timeouts_total" in response.text

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -1435,6 +1435,8 @@ def test_admin_metrics(defaultenv):
     with run(env=defaultenv, port=freeport()) as postgrest:
         response = postgrest.admin.get("/metrics")
         assert response.status_code == 200
+        assert "pgrst_schema_cache_query_time_seconds" in response.text
+        assert "pgrst_schema_cache_loads_total" in response.text
         assert "pgrst_db_pool_max" in response.text
         assert "pgrst_db_pool_waiting" in response.text
         assert "pgrst_db_pool_available" in response.text

--- a/test/spec/Main.hs
+++ b/test/spec/Main.hs
@@ -280,4 +280,3 @@ main = do
   where
     loadSCache pool conf =
       either (panic.show) id <$> P.use pool (HT.transaction HT.ReadCommitted HT.Read $ querySchemaCache conf)
-


### PR DESCRIPTION
Closes https://github.com/PostgREST/postgrest/issues/1526

```
curl localhost:3001/metrics

# HELP pgrst_schema_cache_query_time_seconds The time it took to query the schema cache in seconds
# TYPE pgrst_schema_cache_query_time_seconds gauge
pgrst_schema_cache_query_time_seconds 1.3591601e-2
# HELP pgrst_schema_cache_loads_total The total number of times the schema cache was loaded
# TYPE pgrst_schema_cache_loads_total counter
pgrst_schema_cache_loads_total 1.0

# HELP pgrst_db_pool_max Max pool connections
# TYPE pgrst_db_pool_max gauge
pgrst_db_pool_max 20.0
# HELP pgrst_db_pool_waiting Requests waiting to acquire a pool connection
# TYPE pgrst_db_pool_waiting gauge
pgrst_db_pool_waiting 0.0
# HELP pgrst_db_pool_available Available connections in the pool
# TYPE pgrst_db_pool_available gauge
pgrst_db_pool_available 1.0
# HELP pgrst_db_pool_timeouts_total The total number of pool connection timeouts
# TYPE pgrst_db_pool_timeouts_total counter
pgrst_db_pool_timeouts_total 0.0
```
Added a couple of schema cache load metrics plus 4 pool metrics.

## References

- Hikari Pool metrics ([ref1](https://github.com/brettwooldridge/HikariCP/blob/dev/src/main/java/com/zaxxer/hikari/metrics/prometheus/HikariCPCollector.java#L40-L54), [ref2](https://github.com/brettwooldridge/HikariCP/blob/dev/src/main/java/com/zaxxer/hikari/metrics/prometheus/PrometheusMetricsTracker.java#L33-L46)).
- [WebSphere Application Server pool metrics](https://www.ibm.com/docs/en/was/9.0.5?topic=app-prometheus-metrics#rprf_prometheus_data__table_mz1_xqb_m4b)
- [generic-pool-prometheus-exporter](https://github.com/hekike/generic-pool-prometheus-exporter?tab=readme-ov-file#api)