### PR TITLE
ci: revert to macos-12

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,7 @@ jobs:
 
   macos:
     name: Nix - MacOS
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Setup Nix Environment
@@ -95,7 +95,7 @@ jobs:
             # no artifact for Linux, because we use the static build
 
           - name: MacOS
-            runs-on: macos-latest
+            runs-on: macos-12
             cache: |
               ~/.stack
               .stack-work


### PR DESCRIPTION
GitHub Actions updated the latest macos image to macos-14 [1], which made both of our macos build jobs fail.

This reverts to macos-12, which should fix CI for the moment. We can then look into migrating to macos-14 explicitly.

[1]: https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/