### PR TITLE
ci: DRY the cleanup job for ARM servers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,18 +90,6 @@ jobs:
           fingerprint: ${{ secrets.SSH_ARM_FINGERPRINT }}
           source: "${{ steps.Remote-Dir.outputs.remotepath }}/result.tar.xz"
           target: "result.tar.xz"
-      - name: Remove uploaded files from server
-        if: ${{ always() && !startsWith(github.ref, 'refs/tags/v') }}
-        uses: appleboy/ssh-action@master
-        env:
-          REMOTE_DIR: ${{ steps.Remote-Dir.outputs.remotepath }}
-        with:
-          host: ${{ secrets.SSH_ARM_HOST }}
-          username: ubuntu
-          key: ${{ secrets.SSH_ARM_PRIVATE_KEY }}
-          fingerprint: ${{ secrets.SSH_ARM_FINGERPRINT }}
-          envs: REMOTE_DIR
-          script: rm -rf $REMOTE_DIR
       - name: Extract downloaded binaries
         run: tar -xvf result.tar.xz && rm result.tar.xz
       - name: Save aarch64 executable as artifact
@@ -315,7 +303,7 @@ jobs:
     needs:
       - arm
       - docker-arm
-    if: ${{ always() && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ always() && vars.SSH_ARM_ENABLED }}
     runs-on: ubuntu-22.04
     env:
       REMOTE_DIR: ${{ needs.arm.outputs.remotepath }}


### PR DESCRIPTION
DRYed the job according to the [GitHub Actions docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds):

> If a job fails or is skipped, all jobs that need it are skipped unless the jobs use a conditional expression that causes the job to continue. [...] If you would like a job to run even if a job it is dependent on did not succeed, use the always() conditional expression in jobs.<job_id>.if.