### PR TITLE
test: sanity tests for primary and replica

### DIFF
--- a/nix/tools/devTools.nix
+++ b/nix/tools/devTools.nix
@@ -77,6 +77,7 @@ let
         ${tests}/bin/postgrest-test-doctests
         ${tests}/bin/postgrest-test-io
         ${tests}/bin/postgrest-test-big-schema
+        ${tests}/bin/postgrest-test-replica
         ${style}/bin/postgrest-lint
         ${style}/bin/postgrest-style-check
       '';

--- a/test/io/config.py
+++ b/test/io/config.py
@@ -46,6 +46,27 @@ def defaultenv(baseenv):
 
 
 @pytest.fixture
+def replicaenv(defaultenv):
+    "Default environment for a PostgREST replica."
+    conf = {
+        "PGRST_DB_ANON_ROLE": "postgrest_test_anonymous",
+        "PGRST_DB_SCHEMAS": "replica",
+    }
+    return {
+        "primary": {
+            **defaultenv,
+            **conf,
+        },
+        "replica": {
+            **defaultenv,
+            **conf,
+            "PGHOST": os.environ["PGREPLICAHOST"],
+            "PGREPLICASLOT": os.environ["PGREPLICASLOT"],
+        },
+    }
+
+
+@pytest.fixture
 def slow_schema_cache_env(defaultenv):
     "Slow schema cache load environment PostgREST."
     return {

--- a/test/io/replica.sql
+++ b/test/io/replica.sql
@@ -1,0 +1,21 @@
+create schema replica;
+
+create or replace function replica.is_replica() returns bool as $$
+  select pg_is_in_recovery();
+$$ language sql;
+
+create or replace function replica.get_replica_slot() returns name as $$
+  select slot_name from pg_replication_slots limit 1;
+$$ language sql;
+
+create table replica.items as select x as id from generate_series(1, 10) x;
+
+DROP ROLE IF EXISTS postgrest_test_anonymous;
+CREATE ROLE postgrest_test_anonymous;
+
+GRANT postgrest_test_anonymous TO :PGUSER;
+
+GRANT USAGE ON SCHEMA replica TO postgrest_test_anonymous;
+
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA replica
+TO postgrest_test_anonymous;

--- a/test/io/test_replica.py
+++ b/test/io/test_replica.py
@@ -1,0 +1,28 @@
+"IO tests for PostgREST started on replicas"
+
+import pytest
+
+from config import *
+from util import *
+from postgrest import *
+
+
+def test_sanity_replica(replicaenv):
+    "Test that primary and replica are working as intended"
+
+    with run(env=replicaenv["primary"]) as postgrest:
+        response = postgrest.session.get("/rpc/is_replica")
+        assert response.text == "false"
+
+        response = postgrest.session.get("/rpc/get_replica_slot")
+        assert response.text == '"' + replicaenv["replica"]["PGREPLICASLOT"] + '"'
+
+        response = postgrest.session.get("/items?select=count")
+        assert response.text == '[{"count":10}]'
+
+    with run(env=replicaenv["replica"]) as postgrest:
+        response = postgrest.session.get("/rpc/is_replica")
+        assert response.text == "true"
+
+        response = postgrest.session.get("/items?select=count")
+        assert response.text == '[{"count":10}]'


### PR DESCRIPTION
* new --replica option to `postgrest-with-postgresql-*`
  + replica process is properly logged to usual temporary log files
* new command `postgrest-test-replica`
  + runs sanity tests on `test_replica.py`
* add `postgrest-test-replica` to `postgrest-check` and `postgrest-coverage`