### PR TITLE
ci: bundle DLL dependencies for windows release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,7 +191,7 @@ jobs:
           tar cJvf "release-bundle/postgrest-v$VERSION-ubuntu-aarch64.tar.xz" \
             -C artifacts/postgrest-ubuntu-aarch64 postgrest
 
-          zip "release-bundle/postgrest-v$VERSION-windows-x64.zip" \
+          zip --junk-paths "release-bundle/postgrest-v$VERSION-windows-x64.zip" \
             artifacts/postgrest-windows-x64/postgrest.exe
 
       - name: Save release bundle

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -173,6 +173,12 @@ jobs:
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           path: artifacts
+      - name: Prepare PostgreSQL binaries for Windows
+        run: |
+          mkdir -p dependencies/postgresql
+          curl --proto '=https' --tlsv1.2 -Sf -L -o dependencies/postgresql/postgresql-16.2-1-windows-x64-binaries.zip \
+            "https://get.enterprisedb.com/postgresql/postgresql-16.2-1-windows-x64-binaries.zip"
+          unzip -d dependencies/postgresql dependencies/postgresql/postgresql-16.2-1-windows-x64-binaries.zip
       - name: Create release bundle with archives for all builds
         run: |
           find artifacts -type f -iname postgrest -exec chmod +x {} \;
@@ -192,7 +198,9 @@ jobs:
             -C artifacts/postgrest-ubuntu-aarch64 postgrest
 
           zip --junk-paths "release-bundle/postgrest-v$VERSION-windows-x64.zip" \
-            artifacts/postgrest-windows-x64/postgrest.exe
+            artifacts/postgrest-windows-x64/postgrest.exe \
+            dependencies/postgresql/pgsql/bin/{libcrypto-3-x64,libiconv-2,libintl-9,libssl-3-x64,libwinpthread-1}.dll \
+            dependencies/postgresql/pgsql/lib/libpq.dll
 
       - name: Save release bundle
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3


### PR DESCRIPTION
<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `fix`, bug fixes
  + `feat`, new features added
  + `perf`, performance improvements
  + `nix`, related to the Nix development environment
  + `ci`, related to the Continuous Integration modules
  + `test`, related to the testing modules
  + `refactor`, refactoring code
  + `deprecate`, deprecating a feature
  + `chore`, maintenance (changelog, build process, etc.)
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->

This PR downloads the latest (so far) EnterpriseDB's build for Windows, unpacks the archive and cherry-picks DLLs (the complete list of which is generously provided by @locktarr at https://github.com/PostgREST/postgrest/issues/3136#issuecomment-2075050340) required for `postgrest.exe` to start. These are *not* the DLLs (or, rather, `.lib`s) postgrest.exe was built against, but they should do the job.

Also this PR puts postgrest.exe to the top of the zip archive, losing an awkward `artifacts/postgrest-windows-x64` prefix.

Fixes #3136 
