### PR TITLE
ci: Improve performance for nix jobs in CI

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -12,6 +12,10 @@ runs:
   using: composite
   steps:
     - uses: nixbuild/nix-quick-install-action@60e9c39264d4714139af3cdf15f691b19eec3530 # v28
+      with:
+        nix_conf: |-
+          always-allow-substitutes = true
+          max-jobs = auto
     - uses: cachix/cachix-action@18cf96c7c98e048e10a83abd92116114cd8504be # v14
       with:
         name: postgrest


### PR DESCRIPTION
Defaulting to max-jobs = auto should improve build times by using more cores.

Setting always-allow-substitutes to true should cause all nix derivations to be cached on cachix, which should improve performance of the MacOS job dramatically, when no rebuilds need to happen. This improvement will only be seen when the first run with this setting has happened on main and the cache has been filled.