### PR TITLE
Make IO tests more stable

### DIFF
--- a/src/PostgREST/SchemaCache.hs
+++ b/src/PostgREST/SchemaCache.hs
@@ -145,6 +145,9 @@ type SqlQuery = ByteString
 
 querySchemaCache :: AppConfig -> SQL.Transaction SchemaCache
 querySchemaCache AppConfig{..} = do
+  _       <-
+    let sleepCall = SQL.Statement "select pg_sleep($1 / 1000.0)" (param HE.int4) HD.noResult prepared in
+    whenJust configInternalSCSleep (`SQL.statement` sleepCall) -- only used for testing
   SQL.sql "set local schema ''" -- This voids the search path. The following queries need this for getting the fully qualified name(schema.name) of every db object
   pgVer   <- SQL.statement mempty $ pgVersionStatement prepared
   tabs    <- SQL.statement schemas $ allTables pgVer prepared
@@ -155,9 +158,6 @@ querySchemaCache AppConfig{..} = do
   reps    <- SQL.statement schemas $ dataRepresentations prepared
   mHdlers <- SQL.statement schemas $ mediaHandlers pgVer prepared
   tzones  <- SQL.statement mempty $ timezones prepared
-  _       <-
-    let sleepCall = SQL.Statement "select pg_sleep($1)" (param HE.int4) HD.noResult prepared in
-    whenJust configInternalSCSleep (`SQL.statement` sleepCall) -- only used for testing
 
   let tabsWViewsPks = addViewPrimaryKeys tabs keyDeps
       rels          = addInverseRels $ addM2MRels tabsWViewsPks $ addViewM2OAndO2ORels keyDeps m2oRels


### PR DESCRIPTION
This tries to address #3424 by preventing `test_admin_ready_includes_schema_cache_state` from creating 100s of connection retries per second and thus somehow making postgrest unresponsive. This does not fix the underlying problem, but should at least make the tests not cause random failures anymore.

One thing that is not clear to me is: Why are the IO tests only failing recently and not before? The test here has been in there for a long time already. It might be connected to the much extended logging, maybe the huge number of connection retries only becomes a problem due to the big number of logs generated that way.