### PR TITLE
test: Fix internal_schema_cache_sleep after 747c78f6

### DIFF
--- a/test/io/config.py
+++ b/test/io/config.py
@@ -71,7 +71,7 @@ def slow_schema_cache_env(defaultenv):
     "Slow schema cache load environment PostgREST."
     return {
         **defaultenv,
-        "PGRST_INTERNAL_SCHEMA_CACHE_SLEEP": "1",  # this does a pg_sleep internally, it will cause the schema cache query to be slow
+        "PGRST_INTERNAL_SCHEMA_CACHE_SLEEP": "1000",  # this does a pg_sleep internally, it will cause the schema cache query to be slow
         # the slow schema cache query will keep using one pool connection until it finishes
         # to prevent requests waiting for PGRST_DB_POOL_ACQUISITION_TIMEOUT we'll increase the pool size (must be >= 2)
         "PGRST_DB_POOL": "2",

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -714,7 +714,7 @@ def test_admin_ready_includes_schema_cache_state(defaultenv, metapostgrest):
     }
 
     with run(env=env) as postgrest:
-        # The schema cache query takes at least 500ms, due do PGRST_INTERNAL_SCHEMA_CACHE_SLEEP above.
+        # The schema cache query takes at least 500ms, due to PGRST_INTERNAL_SCHEMA_CACHE_SLEEP above.
         # Make it impossible to load the schema cache, by setting statement timeout to 400ms.
         set_statement_timeout(metapostgrest, role, 400)
 
@@ -1024,7 +1024,9 @@ def test_isolation_level(defaultenv):
 def test_schema_cache_concurrent_notifications(slow_schema_cache_env):
     "schema cache should be up-to-date whenever a notification is sent while another reload is in progress, see https://github.com/PostgREST/postgrest/issues/2791"
 
-    internal_sleep = int(slow_schema_cache_env["PGRST_INTERNAL_SCHEMA_CACHE_SLEEP"])
+    internal_sleep = (
+        int(slow_schema_cache_env["PGRST_INTERNAL_SCHEMA_CACHE_SLEEP"]) / 1000
+    )
 
     with run(env=slow_schema_cache_env, wait_for_readiness=False) as postgrest:
         time.sleep(2 * internal_sleep + 0.1)  # wait for readiness manually


### PR DESCRIPTION
The $subject commit broke internal_schema_cache_sleep for other tests. This reverts the order change, but keeps the scaling by x1000 to ms and thus changes other users of this setting to the new scale.

@steve-chavez this should address your valid concerns in https://github.com/PostgREST/postgrest/pull/3497#discussion_r1595676859