### PR TITLE
fix: bind admin server to the same host

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -116,6 +116,7 @@ library
                     , http-types                >= 0.12.2 && < 0.13
                     , insert-ordered-containers >= 0.2.2 && < 0.3
                     , interpolatedstring-perl6  >= 1 && < 1.1
+                    , iproute                   >= 1.7.0 && < 1.8
                     , jose                      >= 0.8.5.1 && < 0.12
                     , lens                      >= 4.14 && < 5.3
                     , lens-aeson                >= 1.0.1 && < 1.3

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -210,7 +210,7 @@ initSockets AppConfig{..} = do
   adminSock <- case cfg'adminport of
     Just adminPort -> do
       hp <- resolvedAddress sock -- reuse the same host as the main socket
-      adminSock <- bindPortTCP adminPort $ fromMaybe (fromString $ T.unpack cfg'host) $ hp
+      adminSock <- bindPortTCP adminPort $ fromMaybe (fromString $ T.unpack cfg'host) hp
       pure $ Just adminSock
     Nothing -> pure Nothing
 

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -74,7 +74,7 @@ import PostgREST.SchemaCache             (SchemaCache (..),
 import PostgREST.SchemaCache.Identifiers (dumpQi)
 import PostgREST.Unix                    (createAndBindDomainSocket)
 
-import Data.IP (fromHostAddress, fromHostAddress6)
+import Data.IP                (fromHostAddress, fromHostAddress6)
 import Data.Streaming.Network (HostPreference, bindPortTCP,
                                bindRandomPortTCP)
 import Data.String            (IsString (..))

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -74,6 +74,7 @@ import PostgREST.SchemaCache             (SchemaCache (..),
 import PostgREST.SchemaCache.Identifiers (dumpQi)
 import PostgREST.Unix                    (createAndBindDomainSocket)
 
+import Data.IP (fromHostAddress, fromHostAddress6)
 import Data.Streaming.Network (HostPreference, bindPortTCP,
                                bindRandomPortTCP)
 import Data.String            (IsString (..))
@@ -209,7 +210,7 @@ initSockets AppConfig{..} = do
   adminSock <- case cfg'adminport of
     Just adminPort -> do
       hp <- resolvedAddress sock -- reuse the same host as the main socket
-      adminSock <- bindPortTCP adminPort $ fromMaybe (fromString $ T.unpack cfg'host) hp
+      adminSock <- bindPortTCP adminPort $ fromMaybe (fromString $ T.unpack cfg'host) $ hp
       pure $ Just adminSock
     Nothing -> pure Nothing
 
@@ -219,7 +220,8 @@ initSockets AppConfig{..} = do
     resolvedAddress sock = do
       sn <- NS.getSocketName sock
       case sn of
-        NS.SockAddrInet _ hostAddr ->  pure $ Just $ fromString $ T.unpack $ show hostAddr
+        NS.SockAddrInet _ hostAddr ->  pure $ Just $ fromString $ show $ fromHostAddress hostAddr
+        NS.SockAddrInet6 _ _ hostAddr6 _ -> pure $ Just $ fromString $ show $ fromHostAddress6 hostAddr6
         _ -> pure Nothing
 
 


### PR DESCRIPTION
Reuse main socket address to bind admin socket there too by resolving the address main socket is bound at and binding admin socket to it explicitly.

Introduces extra dependency to `iproute` for `HostAddress -> IP -> String` conversions, following the reference in https://www.stackage.org/haddock/lts-22.21/network-3.1.4.0/src/Network.Socket.Info.html#line-415

Fixes #3508 

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `fix`, bug fixes
  + `feat`, new features added
  + `perf`, performance improvements
  + `nix`, related to the Nix development environment
  + `ci`, related to the Continuous Integration modules
  + `test`, related to the testing modules
  + `refactor`, refactoring code
  + `deprecate`, deprecating a feature
  + `chore`, maintenance (changelog, build process, etc.)
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
