### PR TITLE
feat: add metric label for scache load

### DIFF
--- a/docs/references/observability.rst
+++ b/docs/references/observability.rst
@@ -109,9 +109,10 @@ The query time in seconds of the last schema cache load.
 pgrst_schema_cache_loads_total
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-======== =======
-**Type** Counter
-======== =======
+========== ==========================
+**Type**   Counter
+**Labels** ``status``: SUCCESS | FAIL
+========== ==========================
 
 The total number of times the schema cache was loaded.
 

--- a/src/PostgREST/Metrics.hs
+++ b/src/PostgREST/Metrics.hs
@@ -8,47 +8,49 @@ module PostgREST.Metrics
 import qualified Data.ByteString.Lazy   as LBS
 import qualified Hasql.Pool.Observation as SQL
 
-import qualified Prometheus as Prom
+import Prometheus
 
 import PostgREST.Observation
 
 import Protolude
 
 data MetricsState =
-  MetricsState Prom.Counter Prom.Gauge Prom.Gauge Prom.Gauge Prom.Counter Prom.Gauge
+  MetricsState Counter Gauge Gauge Gauge (Vector Label1 Counter) Gauge
 
 init :: Int -> IO MetricsState
 init configDbPoolSize = do
-  poolTimeouts <- Prom.register $ Prom.counter (Prom.Info "pgrst_db_pool_timeouts_total" "The total number of pool connection timeouts")
-  poolAvailable <- Prom.register $ Prom.gauge (Prom.Info "pgrst_db_pool_available" "Available connections in the pool")
-  poolWaiting <- Prom.register $ Prom.gauge (Prom.Info "pgrst_db_pool_waiting" "Requests waiting to acquire a pool connection")
-  poolMaxSize <- Prom.register $ Prom.gauge (Prom.Info "pgrst_db_pool_max" "Max pool connections")
-  schemaCacheLoads <- Prom.register $ Prom.counter (Prom.Info "pgrst_schema_cache_loads_total" "The total number of times the schema cache was loaded")
-  schemaCacheQueryTime <- Prom.register $ Prom.gauge (Prom.Info "pgrst_schema_cache_query_time_seconds" "The query time in seconds of the last schema cache load")
-  Prom.setGauge poolMaxSize (fromIntegral configDbPoolSize)
+  poolTimeouts <- register $ counter (Info "pgrst_db_pool_timeouts_total" "The total number of pool connection timeouts")
+  poolAvailable <- register $ gauge (Info "pgrst_db_pool_available" "Available connections in the pool")
+  poolWaiting <- register $ gauge (Info "pgrst_db_pool_waiting" "Requests waiting to acquire a pool connection")
+  poolMaxSize <- register $ gauge (Info "pgrst_db_pool_max" "Max pool connections")
+  schemaCacheLoads <- register $ vector "status" $ counter (Info "pgrst_schema_cache_loads_total" "The total number of times the schema cache was loaded")
+  schemaCacheQueryTime <- register $ gauge (Info "pgrst_schema_cache_query_time_seconds" "The query time in seconds of the last schema cache load")
+  setGauge poolMaxSize (fromIntegral configDbPoolSize)
   pure $ MetricsState poolTimeouts poolAvailable poolWaiting poolMaxSize schemaCacheLoads schemaCacheQueryTime
 
 observationMetrics :: MetricsState -> ObservationHandler
 observationMetrics (MetricsState poolTimeouts poolAvailable poolWaiting _ schemaCacheLoads schemaCacheQueryTime) obs = case obs of
   (PoolAcqTimeoutObs _) -> do
-    Prom.incCounter poolTimeouts
+    incCounter poolTimeouts
   (HasqlPoolObs (SQL.ConnectionObservation _ status)) -> case status of
      SQL.ReadyForUseConnectionStatus  -> do
-      Prom.incGauge poolAvailable
+      incGauge poolAvailable
      SQL.InUseConnectionStatus        -> do
-      Prom.decGauge poolAvailable
+      decGauge poolAvailable
      SQL.TerminatedConnectionStatus  _ -> do
-      Prom.decGauge poolAvailable
+      decGauge poolAvailable
      SQL.ConnectingConnectionStatus -> pure ()
   PoolRequest ->
-    Prom.incGauge poolWaiting
+    incGauge poolWaiting
   PoolRequestFullfilled ->
-    Prom.decGauge poolWaiting
+    decGauge poolWaiting
   SchemaCacheLoadedObs resTime -> do
-    Prom.incCounter schemaCacheLoads
-    Prom.setGauge schemaCacheQueryTime resTime
+    withLabel schemaCacheLoads "SUCCESS" incCounter
+    setGauge schemaCacheQueryTime resTime
+  SchemaCacheNormalErrorObs _ -> do
+    withLabel schemaCacheLoads "FAIL" incCounter
   _ ->
     pure ()
 
 metricsToText :: IO LBS.ByteString
-metricsToText = Prom.exportMetricsAsText
+metricsToText = exportMetricsAsText


### PR DESCRIPTION
localhost:3001/metrics now includes:

```
pgrst_schema_cache_loads_total{status="FAIL"} 352.0 
pgrst_schema_cache_loads_total{status="SUCCESS"} 3.0
```

This allows testing the failure case on https://github.com/PostgREST/postgrest/issues/3424#issuecomment-2104904910