### PR TITLE
refactor: move checkIsFatal logic to usePool

### DIFF
--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -65,7 +65,7 @@ run appState = do
   let observer = AppState.getObserver appState
   conf@AppConfig{..} <- AppState.getConfig appState
 
-  observer $ AppServerStartObs prettyVersion
+  observer $ AppStartObs prettyVersion
 
   AppState.connectionWorker appState -- Loads the initial SchemaCache
   Unix.installSignalHandlers (AppState.getMainThreadId appState) (AppState.connectionWorker appState) (AppState.reReadConfig False appState)

--- a/src/PostgREST/Metrics.hs
+++ b/src/PostgREST/Metrics.hs
@@ -47,7 +47,7 @@ observationMetrics (MetricsState poolTimeouts poolAvailable poolWaiting _ schema
   SchemaCacheLoadedObs resTime -> do
     withLabel schemaCacheLoads "SUCCESS" incCounter
     setGauge schemaCacheQueryTime resTime
-  SchemaCacheNormalErrorObs _ -> do
+  SchemaCacheErrorObs _ -> do
     withLabel schemaCacheLoads "FAIL" incCounter
   _ ->
     pure ()

--- a/src/PostgREST/Query.hs
+++ b/src/PostgREST/Query.hs
@@ -43,7 +43,6 @@ import PostgREST.Config                  (AppConfig (..),
 import PostgREST.Config.PgVersion        (PgVersion (..))
 import PostgREST.Error                   (Error)
 import PostgREST.MediaType               (MediaType (..))
-import PostgREST.Observation             (Observation (..))
 import PostgREST.Plan                    (ActionPlan (..),
                                           CallReadPlan (..),
                                           CrudPlan (..),
@@ -78,15 +77,9 @@ data QueryResult
 runQuery :: AppState.AppState -> AppConfig -> AuthResult -> ApiRequest -> ActionPlan -> SchemaCache -> PgVersion -> Bool -> ExceptT Error IO QueryResult
 runQuery _ _ _ _ (NoDb x) _ _ _ = pure $ NoDbResult x
 runQuery appState config AuthResult{..} apiReq (Db plan) sCache pgVer authenticated = do
-  let observer = AppState.getObserver appState
-
-  lift $ observer PoolRequest
-
   dbResp <- lift $ do
     let transaction = if prepared then SQL.transaction else SQL.unpreparedTransaction
     AppState.usePool appState (transaction isoLvl txMode $ runExceptT dbHandler)
-
-  lift $ observer PoolRequestFullfilled
 
   resp <-
     liftEither . mapLeft Error.PgErr $


### PR DESCRIPTION
Towards solving https://github.com/PostgREST/postgrest/issues/3523

The fatal logic is now inside `usePool`. It centralizes the logic which is better for Locality of Behavior.

Removes:

- The need to do checkIsFatal on other parts of the code
- SCFatalFail/ConnFatalFail states which are no longer needed.