### PR TITLE
ci: fix release not executing when skipping CI for docs and tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,8 +155,6 @@ jobs:
       (needs.arm.result == 'skipped' || success())
     runs-on: ubuntu-22.04
     needs:
-      - docs
-      - test
       - build
       - arm
     steps:


### PR DESCRIPTION
Starting [with this CI](https://github.com/PostgREST/postgrest/actions/runs/9051649434), the release to `devel` is skipped, because it still `needs` the `test` and `docs` job to execute when it shouldn't.