### PR TITLE
fix: listener silent fail on replica

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3424, Admin `/live` and `/ready` now differentiates a failure as 500 status - @steve-chavez
     + 503 status is still given when postgREST is in a recovering state
  - #3478, Media Types are parsed case insensitively - @develop7
+ - #2781, Fix listener silently failing on read replica - @steve-chavez
 
 ### Deprecated
 

--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -1,1 +1,1 @@
-index-state: hackage.haskell.org 2024-04-15T20:28:44Z
+index-state: hackage.haskell.org 2024-05-17T23:41:49Z

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -38,7 +38,7 @@ let
       # Notes:
       # - When adding a new package version here, update cabal.
       #   + Update postgrest.cabal with the package version
-      #   + Update cabal.project.freeze. Just set it to the current timestamp then run `cabal build`. It will tell you the correct timestamp for the index state.
+      #   + Update the index-state in cabal.project.freeze. Run `cabal update` which should return the latest index state.
       # - When adding a new package version here, you have to update stack.
       #   + To update stack.yaml add:
       #   extra-deps:
@@ -67,8 +67,8 @@ let
       hasql-notifications = lib.dontCheck (prev.callHackageDirect
         {
           pkg = "hasql-notifications";
-          ver = "0.2.1.1";
-          sha256 = "sha256-oPhKA/pSQGJvgQyhsi7CVr9iDT7uWpKUz0iJfXsaxXo=";
+          ver = "0.2.2.0";
+          sha256 = "sha256-73OQ9/su2qvO7HavF3xuuNWLXSXyB9reBUQDaHys06I=";
         }
         { }
       );

--- a/nix/tools/withTools.nix
+++ b/nix/tools/withTools.nix
@@ -106,6 +106,7 @@ let
 
             export PGREPLICAHOST="$replica_host"
             export PGREPLICASLOT="$replica_slot"
+            export PGRST_DB_URI="postgres:///$PGDATABASE?host=$PGREPLICAHOST,$PGHOST"
           fi
 
           # shellcheck disable=SC2317

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -109,7 +109,7 @@ library
                     , gitrev                    >= 1.2 && < 1.4
                     , hasql                     >= 1.6.1.1 && < 1.7
                     , hasql-dynamic-statements  >= 0.3.1 && < 0.4
-                    , hasql-notifications       >= 0.2.1.1 && < 0.3
+                    , hasql-notifications       >= 0.2.2.0 && < 0.3
                     , hasql-pool                >= 1.0.1 && < 1.1
                     , hasql-transaction         >= 1.0.1 && < 1.1
                     , heredoc                   >= 0.2 && < 0.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,4 +11,5 @@ nix:
 
 extra-deps:
   - fuzzyset-0.2.4
+  - hasql-notifications-0.2.2.0
   - hasql-pool-1.0.1

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,6 +12,13 @@ packages:
   original:
     hackage: fuzzyset-0.2.4
 - completed:
+    hackage: hasql-notifications-0.2.2.0@sha256:a4e591ef3f06647b056567d3b66948c4a85371f05deb5434edb6ce190f7c845d,2021
+    pantry-tree:
+      sha256: bd7192a5e82ef6dbac711c3433408a0330c8db1cd3482be1ccd4fbd0a63bc2f6
+      size: 452
+  original:
+    hackage: hasql-notifications-0.2.2.0
+- completed:
     hackage: hasql-pool-1.0.1@sha256:3cfb4c7153a6c536ac7e126c17723e6d26ee03794954deed2d72bcc826d05a40,2302
     pantry-tree:
       sha256: d98e1269bdd60989b0eb0b84e1d5357eaa9f92821439d9f206663b7251ee95b2


### PR DESCRIPTION
Update hasql-notifications to include the fix on https://github.com/diogob/hasql-notifications/issues/24.

Which now reveals the following error:

```
$ postgrest-with-postgresql-16 --replica -f test/spec/fixtures/load.sql postgrest-run

17/May/2024:18:35:38 -0500: Successfully connected to PostgreSQL 16.2 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 13.2.0, 64-bit
17/May/2024:18:35:38 -0500: Failed listening for notifications on the "pgrst" channel. ERROR:  cannot execute LISTEN during recovery
17/May/2024:18:35:38 -0500: Retrying listening for notifications...
```

This is still not good because the LISTEN channel will be retried forever (with an unnecessary schema cache reload too) without a backoff.