### PR TITLE
fix: listener retries with exponential backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3424, Admin `/live` and `/ready` now differentiates a failure as 500 status - @steve-chavez
     + 503 status is still given when postgREST is in a recovering state
  - #3478, Media Types are parsed case insensitively - @develop7
- - #2781, Fix listener silently failing on read replica - @steve-chavez
+ - #3533, #3536, Fix listener silently failing on read replica - @steve-chavez
+    + If the LISTEN connection fails, it's retried with exponential backoff
 
 ### Deprecated
 

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -70,7 +70,7 @@ run appState = do
   AppState.connectionWorker appState -- Loads the initial SchemaCache
   Unix.installSignalHandlers (AppState.getMainThreadId appState) (AppState.connectionWorker appState) (AppState.reReadConfig False appState)
   -- reload schema cache + config on NOTIFY
-  AppState.runListener conf appState
+  AppState.runListener appState
 
   Admin.runAdmin appState (serverSettings conf)
 

--- a/src/PostgREST/Observation.hs
+++ b/src/PostgREST/Observation.hs
@@ -42,7 +42,7 @@ data Observation
   | ConnectionPgVersionErrorObs SQL.UsageError
   | DBListenStart Text
   | DBListenFail Text (Either SQL.ConnectionError (Either SomeException ()))
-  | DBListenRetry
+  | DBListenRetry Int
   | DBListenerGotSCacheMsg ByteString
   | DBListenerGotConfigMsg ByteString
   | ConfigReadErrorObs SQL.UsageError
@@ -105,8 +105,8 @@ observationMessage = \case
         Left err  -> show err
         Right err -> showListenerError err
     )
-  DBListenRetry ->
-    "Retrying listening for notifications..."
+  DBListenRetry delay ->
+    "Retrying listening for notifications in " <> (show delay::Text) <> " seconds..."
   DBListenerGotSCacheMsg channel ->
     "Received a schema cache reload message on the " <> show channel <> " channel"
   DBListenerGotConfigMsg channel ->

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -733,8 +733,8 @@ def test_admin_ready_includes_schema_cache_state(defaultenv, metapostgrest):
 
         # force a reconnection so the new role setting is picked up
         postgrest.process.send_signal(signal.SIGUSR1)
-        # wait 600ms to finish schema cache reload attempt
-        time.sleep(0.6)
+
+        postgrest.wait_until_scache_starts_loading()
 
         response = postgrest.admin.get("/ready", timeout=1)
         assert response.status_code == 503

--- a/test/io/test_replica.py
+++ b/test/io/test_replica.py
@@ -20,7 +20,12 @@ def test_sanity_replica(replicaenv):
         response = postgrest.session.get("/items?select=count")
         assert response.text == '[{"count":10}]'
 
-    with run(env=replicaenv["replica"]) as postgrest:
+    working_replica_env = {
+        **replicaenv["replica"],
+        "PGRST_DB_CHANNEL_ENABLED": "false",  # LISTEN doesn't work on read replicas
+    }
+
+    with run(env=working_replica_env) as postgrest:
         response = postgrest.session.get("/rpc/is_replica")
         assert response.text == "true"
 


### PR DESCRIPTION
Closes https://github.com/PostgREST/postgrest/issues/3523.

Now it works like:

```
$ postgrest-with-postgresql-16 --replica -f test/spec/fixtures/load.sql postgrest-run

19/May/2024:20:24:28 -0500: Retrying listening for notifications in 1 seconds...
19/May/2024:20:24:28 -0500: Failed listening for notifications on the "pgrst" channel. ERROR:  cannot execute LISTEN during recovery
19/May/2024:20:24:30 -0500: Retrying listening for notifications in 2 seconds...
19/May/2024:20:24:30 -0500: Failed listening for notifications on the "pgrst" channel. ERROR:  cannot execute LISTEN during recovery
19/May/2024:20:24:34 -0500: Retrying listening for notifications in 4 seconds...
19/May/2024:20:24:34 -0500: Failed listening for notifications on the "pgrst" channel. ERROR:  cannot execute LISTEN during recovery
```

## Limitation

Once the listen channel is recovered, the retry status is not reset. So if the last backoff was 4 seconds, the next time recovery kicks in the backoff will be 8 seconds. If a recovery reaches 32 seconds, the backoff will stay there.

This is a problem with the interaction between `hasql-notifications` and `retry`. The `Hasql.Notifications.waitForNotifications` uses a forever loop that only finishes when it throws an exception, retry recovers on an exception and succeeds (here it restarts the retry status) when the function finishes .

I've left this as a TODO for now, it's still better than retrying without backoff.