### PR TITLE
test: isolate pg_terminate_backend to appname

### DIFF
--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -493,7 +493,7 @@ pgErrorStatus authed (SQL.SessionUsageError (SQL.QueryError _ _ (SQL.ResultError
         '5':'3':_ -> HTTP.status503 -- insufficient resources
         '5':'4':_ -> HTTP.status413 -- too complex
         '5':'5':_ -> HTTP.status500 -- obj not on prereq state
-        '5':'7':'P':'0':'1':_ -> HTTP.status503 -- terminating connection due to administrator command
+        "57P01"   -> HTTP.status503 -- terminating connection due to administrator command
         '5':'7':_ -> HTTP.status500 -- operator intervention
         '5':'8':_ -> HTTP.status500 -- system error
         'F':'0':_ -> HTTP.status500 -- conf file error

--- a/test/io/__snapshots__/test_cli/test_schema_cache_snapshot[dbRoutines].yaml
+++ b/test/io/__snapshots__/test_cli/test_schema_cache_snapshot[dbRoutines].yaml
@@ -137,7 +137,12 @@
       pdFuncSettings: []
       pdHasVariadic: false
       pdName: terminate_pgrst
-      pdParams: []
+      pdParams:
+      - ppName: appname
+        ppReq: true
+        ppType: text
+        ppTypeMaxLength: text
+        ppVar: false
       pdReturnType:
         contents:
           contents:

--- a/test/io/fixtures.sql
+++ b/test/io/fixtures.sql
@@ -187,8 +187,8 @@ where application_name ilike 'postgrest%'
 limit 1;
 $$;
 
-create function terminate_pgrst() returns setof record as $$
-select pg_terminate_backend(pid) from pg_stat_activity where application_name iLIKE '%postgrest%';
+create function terminate_pgrst(appname text) returns setof record as $$
+select pg_terminate_backend(pid) from pg_stat_activity where application_name iLIKE '%' || appname || '%';
 $$ language sql security definer;
 
 create or replace function one_sec_timeout() returns void as $$

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -1214,11 +1214,14 @@ def test_fail_with_automatic_recovery_disabled_and_terminated_using_query(defaul
     env = {
         **defaultenv,
         "PGRST_DB_POOL_AUTOMATIC_RECOVERY": "false",
+        "PGAPPNAME": "target",
     }
+
+    app_name = "'{}'".format(env["PGAPPNAME"])
 
     with run(env=env) as postgrest:
         os.system(
-            f'psql -d {defaultenv["PGDATABASE"]} -U {defaultenv["PGUSER"]} -h {defaultenv["PGHOST"]} --set ON_ERROR_STOP=1 -a -c "SELECT terminate_pgrst()"'
+            f'psql -d {env["PGDATABASE"]} -U {env["PGUSER"]} -h {env["PGHOST"]} --set ON_ERROR_STOP=1 -a -c "SELECT terminate_pgrst({app_name})"'
         )
 
         exitCode = wait_until_exit(postgrest)


### PR DESCRIPTION
The pg_terminate_backend done in the io test:

`test_fail_with_automatic_recovery_disabled_and_terminated_using_query`

Can affect other connections.

Related https://github.com/PostgREST/postgrest/pull/3536.