### PR TITLE
fix: remove verbosity from some error logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     + If the LISTEN connection fails, it's retried with exponential backoff
  - #3414, Force listener to connect to read-write instances using `target_session_attrs` - @steve-chavez
  - #3255, Fix incorrect `413 Request Entity Too Large` on pg errors `54*` - @taimoorzaeem
+ - #3549, Remove verbosity from error logs starting with "An error occurred..." and replacing it with "Failed to..." - @laurenceisla
 
 ### Deprecated
 

--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -14,11 +14,11 @@ import qualified Data.ByteString.Lazy       as LBS
 import qualified Hasql.Transaction.Sessions as SQL
 import qualified Options.Applicative        as O
 
-import Data.Text.IO (hPutStrLn)
 import Text.Heredoc (str)
 
 import PostgREST.AppState    (AppState)
 import PostgREST.Config      (AppConfig (..))
+import PostgREST.Observation (Observation (..))
 import PostgREST.SchemaCache (querySchemaCache)
 import PostgREST.Version     (prettyVersion)
 
@@ -26,7 +26,7 @@ import qualified PostgREST.App      as App
 import qualified PostgREST.AppState as AppState
 import qualified PostgREST.Config   as Config
 
-import Protolude hiding (hPutStrLn)
+import Protolude
 
 
 main :: CLI -> IO ()
@@ -57,7 +57,8 @@ dumpSchema appState = do
       (transaction SQL.ReadCommitted SQL.Read $ querySchemaCache conf)
   case result of
     Left e -> do
-      hPutStrLn stderr $ "An error ocurred when loading the schema cache:\n" <> show e
+      let observer = AppState.getObserver appState
+      observer $ SchemaCacheErrorObs e
       exitFailure
     Right sCache -> return $ JSON.encode sCache
 

--- a/src/PostgREST/Observation.hs
+++ b/src/PostgREST/Observation.hs
@@ -86,7 +86,7 @@ observationMessage = \case
   ExitDBFatalError ServerError08P01 usageErr ->
     "Connection poolers in statement mode are not supported." <> jsonMessage usageErr
   SchemaCacheErrorObs usageErr ->
-    "An error ocurred when loading the schema cache. " <> jsonMessage usageErr
+    "Failed to load the schema cache. " <> jsonMessage usageErr
   SchemaCacheQueriedObs resultTime ->
     "Schema cache queried in " <> showMillis resultTime  <> " milliseconds"
   SchemaCacheSummaryObs summary ->
@@ -112,9 +112,9 @@ observationMessage = \case
   DBListenerGotConfigMsg channel ->
     "Received a config reload message on the " <> show channel <> " channel"
   ConfigReadErrorObs usageErr ->
-    "An error ocurred when trying to query database settings for the config parameters." <> jsonMessage usageErr
+    "Failed to query database settings for the config parameters." <> jsonMessage usageErr
   QueryRoleSettingsErrorObs usageErr ->
-    "An error ocurred when trying to query the role settings. " <> jsonMessage usageErr
+    "Failed to query the role settings. " <> jsonMessage usageErr
   QueryErrorCodeHighObs usageErr ->
     jsonMessage usageErr
   ConfigInvalidObs err ->


### PR DESCRIPTION
Error logs starting with "An error occured..." are replaced with "Failed to..."

