### PR TITLE
docs: ignore linkcheck for blog.frankel.ch

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -295,9 +295,13 @@ def setup(app):
 # taken from https://github.com/sphinx-doc/sphinx/blob/82dad44e5bd3776ecb6fd8ded656bc8151d0e63d/sphinx/util/requests.py#L42
 user_agent = "Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0"
 
-# TODO: stackoverflow and patreon only returns 403 right now. We might need to come back later to check whether that's
-# a permanent issue or not.
-linkcheck_ignore = [r"https://stackoverflow.com/", r"https://www.patreon.com/postgrest"]
+# TODO: these pages are returning 403 right now. Verify if they can be fixed by addressing the issue:
+# https://github.com/PostgREST/postgrest/issues/3544
+linkcheck_ignore = [
+    r"https://stackoverflow.com/",
+    r"https://www.patreon.com/postgrest",
+    r"https://blog.frankel.ch/poor-man-api",
+]
 
 # sphinx-tabs configuration
 sphinx_tabs_disable_tab_closing = True


### PR DESCRIPTION
Temporary solution to avoid the link check error mentioned here: https://github.com/PostgREST/postgrest/pull/3534#issuecomment-2121075773

It could be permanently fixed by addressing #3544