### PR TITLE
docs: add "config" and "schema_cache" endpoints to the admin server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Deprecated
 
- - `Prefer: params=single-object` is deprecated. Use [a function with a single unnamed JSON parameter](https://postgrest.org/en/latest/references/api/stored_procedures.html#s-proc-single-json) instead. - @steve-chavez
+ - `Prefer: params=single-object` is deprecated. Use [a function with a single unnamed JSON parameter](https://postgrest.org/en/latest/references/api/functions.html#function-single-json) instead. - @steve-chavez
 
 ### Documentation
 

--- a/docs/references/admin_server.rst
+++ b/docs/references/admin_server.rst
@@ -54,3 +54,40 @@ Metrics
 =======
 
 Provides :ref:`metrics`.
+
+Runtime Configuration
+=====================
+
+Provides a ``config`` endpoint that returns the runtime :ref:`configuration`.
+
+.. code-block:: bash
+
+  curl "http://localhost:3001/config"
+
+.. code-block::
+
+  db-aggregates-enabled = false
+  db-anon-role = "web_anon"
+  db-channel = "pgrst"
+  db-channel-enabled = false
+  ...
+
+Runtime Schema Cache
+====================
+
+Provides the ``schema_cache`` endpoint that prints the runtime :ref:`schema_cache`.
+
+.. code-block:: bash
+
+  curl "http://localhost:3001/schema_cache"
+
+.. code-block:: json
+
+  {
+    "dbMediaHandlers": ["..."],
+    "dbRelationships": ["..."],
+    "dbRepresentations": ["..."],
+    "dbRoutines": ["..."],
+    "dbTables": ["..."],
+    "dbTimezones": ["..."]
+  }


### PR DESCRIPTION
Closes #3501

Adds missing documentation.