### PR TITLE
config forbid same server-port and admin-server-port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2052, Dropped support for PostgreSQL 9.6 - @wolfgangwalther
  - #2052, Dropped support for PostgreSQL 10 - @wolfgangwalther
  - #2052, Dropped support for PostgreSQL 11 - @wolfgangwalther
- - #3508, #3559, Server port and admin server port can end up with the same value - @develop7
-    + The app fails to start when the server port and admin server port are the same
+ - #3508, PostgREST now fails to start when `server-port` and `admin-server-port` config options are the same - @develop7
 
 ## [12.2.0] - 2024-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3414, Force listener to connect to read-write instances using `target_session_attrs` - @steve-chavez
  - #3255, Fix incorrect `413 Request Entity Too Large` on pg errors `54*` - @taimoorzaeem
  - #3549, Remove verbosity from error logs starting with "An error occurred..." and replacing it with "Failed to..." - @laurenceisla
- - #3508, Server port and admin server port can end up with the same value - @develop7
+ - #3508, #3559, Server port and admin server port can end up with the same value - @develop7
     + The app is fails to start when the server port and admin server port are the same
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3414, Force listener to connect to read-write instances using `target_session_attrs` - @steve-chavez
  - #3255, Fix incorrect `413 Request Entity Too Large` on pg errors `54*` - @taimoorzaeem
  - #3549, Remove verbosity from error logs starting with "An error occurred..." and replacing it with "Failed to..." - @laurenceisla
+ - #3508, Server port and admin server port can end up with the same value - @develop7
+    + The app is fails to start when the server port and admin server port are the same
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #2052, Dropped support for PostgreSQL 9.6 - @wolfgangwalther
  - #2052, Dropped support for PostgreSQL 10 - @wolfgangwalther
  - #2052, Dropped support for PostgreSQL 11 - @wolfgangwalther
+ - #3508, #3559, Server port and admin server port can end up with the same value - @develop7
+    + The app fails to start when the server port and admin server port are the same
 
 ## [12.2.0] - 2024-06-11
 
@@ -53,8 +55,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3414, Force listener to connect to read-write instances using `target_session_attrs` - @steve-chavez
  - #3255, Fix incorrect `413 Request Entity Too Large` on pg errors `54*` - @taimoorzaeem
  - #3549, Remove verbosity from error logs starting with "An error occurred..." and replacing it with "Failed to..." - @laurenceisla
- - #3508, #3559, Server port and admin server port can end up with the same value - @develop7
-    + The app is fails to start when the server port and admin server port are the same
 
 ### Deprecated
 

--- a/docs/references/configuration.rst
+++ b/docs/references/configuration.rst
@@ -174,7 +174,7 @@ admin-server-port
   **In-Database** `n/a`
   =============== =======================
 
-  Specifies the port for the :ref:`admin_server`.
+  Specifies the port for the :ref:`admin_server`. Cannot be equal to :ref:`server-port`.
 
 .. _app.settings.*:
 

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -297,7 +297,7 @@ parser optPath env dbSettings roleSettings roleIsolationLvl =
         addFromEnv f = M.toList $ M.union fromEnv $ M.fromList f
         fromEnv = M.mapKeys fromJust $ M.filterWithKey (\k _ -> isJust k) $ M.mapKeys normalize env
         normalize k = ("app.settings." <>) <$> T.stripPrefix "PGRST_APP_SETTINGS_" (toS k)
-    
+
     parseServerPort :: C.Key -> C.Parser C.Config Int
     parseServerPort k = fromMaybe 3000 <$> optInt k
 

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -220,11 +220,11 @@ readAppConfig dbSettings optPath prevDbUri roleSettings roleIsolationLvl = do
 
   case C.runParser (parser optPath env dbSettings roleSettings roleIsolationLvl) =<< mapLeft show conf of
     Left err ->
-      return . Left $ "Error in config " <> err
+      return . Left $ "Error in config: " <> err
     Right parsedConfig ->
       case processForbiddenValues parsedConfig of
         Left err' ->
-          return . Left $ "Error in config " <> err'
+          return . Left $ "Error in config: " <> err'
         Right config ->
           Right <$> decodeLoadFiles config
   where

--- a/test/io/test_cli.py
+++ b/test/io/test_cli.py
@@ -122,6 +122,7 @@ def test_cli(args, env, use_defaultenv, expect, defaultenv):
         if expect:
             assert expect in dump
 
+
 def test_server_port_and_admin_port_same_value(defaultenv):
     "PostgREST should exit with an error message in output if server-port and admin-server-port are the same."
     env = {**defaultenv, "PGRST_SERVER_PORT": "3000", "PGRST_ADMIN_SERVER_PORT": "3000"}

--- a/test/io/test_cli.py
+++ b/test/io/test_cli.py
@@ -122,6 +122,14 @@ def test_cli(args, env, use_defaultenv, expect, defaultenv):
         if expect:
             assert expect in dump
 
+def test_server_port_and_admin_port_same_value(defaultenv):
+    "PostgREST should exit with an error message in output if server-port and admin-server-port are the same."
+    env = {**defaultenv, "PGRST_SERVER_PORT": "3000", "PGRST_ADMIN_SERVER_PORT": "3000"}
+
+    with pytest.raises(PostgrestError):
+        dump = cli(["--dump-config"], env=env).split("\n")
+        assert "admin-server-port cannot be the same as server-port" in dump
+
 
 @pytest.mark.parametrize(
     "expectedconfig",


### PR DESCRIPTION
Forbids `server-port` and `admin-server-port` from being equal altogether, despite they might not conflict at all in case admin and app are bound to different addresses. Implemented as per the discussion at
https://github.com/PostgREST/postgrest/issues/3508#issuecomment-2125123633

Fixes #3508
<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `fix`, bug fixes
  + `feat`, new features added
  + `perf`, performance improvements
  + `docs`, updating the documentation
  + `nix`, related to the Nix development environment
  + `ci`, related to the Continuous Integration modules
  + `test`, related to the testing modules
  + `refactor`, refactoring code
  + `deprecate`, deprecating a feature
  + `changelog`, updating the CHANGELOG
  + `chore`, maintenance (build process, updating sponsors, etc.)
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
