### PR TITLE
Update slocat.nix to fix running tests

### DIFF
--- a/nix/overlays/slocat.nix
+++ b/nix/overlays/slocat.nix
@@ -8,6 +8,6 @@ _: prev:
       rev = "52e7512c6029fd00483e41ccce260a3b4b9b3b64";
       sha256 = "sha256-qn6luuh5wqREu3s8RfuMCP5PKdS2WdwPrujRYTpfzQ8=";
     };
-    vendorHash = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+    vendorHash = null;
   };
 }


### PR DESCRIPTION
This fixes the error when running `nix-shell --run postgrest-test-spec`: % nix-shell --run postgrest-test-spec
these 25 derivations will be built:
  /nix/store/bl6qvm461hny6fcdjsbpr6fhrn23df1s-toml-reader-0.2.1.0.drv
  /nix/store/n7lgd9y71jymdl7wjb463r2916df45z3-weeder-2.8.0.drv
  /nix/store/kq6ryrfcqfvsh1lc9lnax746as4vp91r-postgrest-coverage.drv
  /nix/store/1g9n1svkzd9mhf3rk2hz2h8i1n5f2nkl-postgrest-tests.drv
  /nix/store/1npwx4p22lqnai4g4d92rj90hdh9879p-texlive-combined-2023-tlpkg.drv
  /nix/store/a93islhcniry93rgianx0339mlmb2il0-texlive-combined-2023-texmfroot.drv
  /nix/store/lhc8x88fw8s7gpyb834g1kpaj5ig8hcn-fonts.conf.drv
  /nix/store/54gawc0ip47n8ln8rnm7jhx61d6zrxyn-texlive-combined-2023.drv
  /nix/store/kxnnr344n7gsxzc6kycj19hs19rvddjj-slocat-go-modules.drv
  /nix/store/x9w480k36a11i99m6zp12d5cjijsn3lm-slocat.drv
  /nix/store/l3waqhz32pr0vsjk7wyd4pc1wi92ql63-postgrest-with-slow-pg.drv
  /nix/store/idcsp6slq5ghmw663gc0gdxnf3x6j7v3-postgrest-with-slow-pg.drv
  /nix/store/nvqdgipknbiz8j5jiz4xbzcaqf943mlm-postgrest-with-slow-postgrest.drv
  /nix/store/khhmnb3ph8zhf1gka9k7zkn4kfz98967-postgrest-with-slow-postgrest.drv
  /nix/store/5wq62jxyxj8hk00s7ipn7aggyynxarc9-postgrest-loadtest.drv
  /nix/store/dm7c8h9jljmjxrc1mgb864f7y03ymhzg-postgrest-check.drv
  /nix/store/wwz8f5sr0f9l85m8by9avv9z9dcjcndg-postgrest-check.drv
  /nix/store/qcqkamgk0bklh1k9higl5h1qj4ps69bk-postgrest-git-hooks.drv
  /nix/store/8gjqzv77z0bfbn6ibqfbpsa0gm9452m7-postgrest-dev.drv
  /nix/store/bmymakijjn6c62caf45ws6clr9q013c3-postgrest-loadtest.drv
  /nix/store/j20di2cyh5wbmjfdgfnskq2lfqrr87qj-postgrest-with.drv
  /nix/store/qaab56p6sv37k5v91x22a9whkq7kb5da-postgrest-docs-render.drv
  /nix/store/p5pdw3lmg0krvqgxw3f01vwpd7xh0v1s-postgrest-docs.drv
  /nix/store/vd7njk3z8pyanlbkk2q3nki1nyswsxbx-postgrest-loadtest-against.drv
  /nix/store/xg959q8zm6qppk0x3lbryvawd49dwsms-postgrest-loadtest.drv
building '/nix/store/1npwx4p22lqnai4g4d92rj90hdh9879p-texlive-combined-2023-tlpkg.drv'... created 12 symlinks in user environment
building '/nix/store/kxnnr344n7gsxzc6kycj19hs19rvddjj-slocat-go-modules.drv'... Running phase: unpackPhase
unpacking source archive /nix/store/59wlpdb2qnykzprwfmnlxg909ag58jvn-source source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase Running phase: configurePhase
Running phase: buildPhase
go: no dependencies to vendor
Running phase: installPhase
vendor folder is empty, please set 'vendorHash = null;' in your expression error: builder for '/nix/store/kxnnr344n7gsxzc6kycj19hs19rvddjj-slocat-go-modules.drv' failed with exit code 10;
       last 10 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/59wlpdb2qnykzprwfmnlxg909ag58jvn-source
       > source root is source
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > Running phase: buildPhase
       > go: no dependencies to vendor
       > Running phase: installPhase
       > vendor folder is empty, please set 'vendorHash = null;' in your expression
       For full logs, run 'nix-store -l /nix/store/kxnnr344n7gsxzc6kycj19hs19rvddjj-slocat-go-modules.drv'.
error: 1 dependencies of derivation '/nix/store/x9w480k36a11i99m6zp12d5cjijsn3lm-slocat.drv' failed to build error: 1 dependencies of derivation '/nix/store/l3waqhz32pr0vsjk7wyd4pc1wi92ql63-postgrest-with-slow-pg.drv' failed to build error: 1 dependencies of derivation '/nix/store/nvqdgipknbiz8j5jiz4xbzcaqf943mlm-postgrest-with-slow-postgrest.drv' failed to build building '/nix/store/a93islhcniry93rgianx0339mlmb2il0-texlive-combined-2023-texmfroot.drv'... error: 1 dependencies of derivation '/nix/store/idcsp6slq5ghmw663gc0gdxnf3x6j7v3-postgrest-with-slow-pg.drv' failed to build error: 1 dependencies of derivation '/nix/store/j20di2cyh5wbmjfdgfnskq2lfqrr87qj-postgrest-with.drv' failed to build error: build of '/nix/store/1g9n1svkzd9mhf3rk2hz2h8i1n5f2nkl-postgrest-tests.drv', '/nix/store/8gjqzv77z0bfbn6ibqfbpsa0gm9452m7-postgrest-dev.drv', '/nix/store/j20di2cyh5wbmjfdgfnskq2lfqrr87qj-postgrest-with.drv', '/nix/store/p5pdw3lmg0krvqgxw3f01vwpd7xh0v1s-postgrest-docs.drv', '/nix/store/xg959q8zm6qppk0x3lbryvawd49dwsms-postgrest-loadtest.drv' failed joel@Joels-MBP postgrest % find . -name 'slocat-go-modules.drv' joel@Joels-MBP postgrest % nix-store -l /nix/store/kxnnr344n7gsxzc6kycj19hs19rvddjj-slocat-go-modules.drv @nix { "action": "setPhase", "phase": "unpackPhase" } Running phase: unpackPhase
unpacking source archive /nix/store/59wlpdb2qnykzprwfmnlxg909ag58jvn-source _: prev:
source root is source
@nix { "action": "setPhase", "phase": "patchPhase" } Running phase: patchPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" } Running phase: updateAutotoolsGnuConfigScriptsPhase @nix { "action": "setPhase", "phase": "configurePhase" } Running phase: configurePhase
@nix { "action": "setPhase", "phase": "buildPhase" } Running phase: buildPhase
go: no dependencies to vendor
@nix { "action": "setPhase", "phase": "installPhase" } Running phase: installPhase
vendor folder is empty, please set 'vendorHash = null;' in your expression

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `fix`, bug fixes
  + `feat`, new features added
  + `perf`, performance improvements
  + `docs`, updating the documentation
  + `nix`, related to the Nix development environment
  + `ci`, related to the Continuous Integration modules
  + `test`, related to the testing modules
  + `refactor`, refactoring code
  + `deprecate`, deprecating a feature
  + `changelog`, updating the CHANGELOG
  + `chore`, maintenance (build process, updating sponsors, etc.)
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
