### PR TITLE
docs: deprecate EOL pg versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Deprecated
 
+ - Support for PostgreSQL versions 9.6, 10 and 11 is deprecated. From this on version onwards, PostgREST will only support non-end-of-life PostgreSQL versions. See https://www.postgresql.org/support/versioning/.
  - `Prefer: params=single-object` is deprecated. Use [a function with a single unnamed JSON parameter](https://postgrest.org/en/latest/references/api/functions.html#function-single-json) instead. - @steve-chavez
 
 ### Documentation

--- a/docs/explanations/install.rst
+++ b/docs/explanations/install.rst
@@ -21,6 +21,12 @@ Supported PostgreSQL versions
 
 PostgREST works with all PostgreSQL versions starting from 9.6.
 
+.. note::
+
+   Support for PostgreSQL versions 9.6, 10 and 11 is deprecated. From this on version onwards, PostgREST will only support non-end-of-life PostgreSQL versions.
+
+   See https://www.postgresql.org/support/versioning/.
+
 Running PostgREST
 =================
 


### PR DESCRIPTION
As agreed on https://github.com/PostgREST/postgrest/issues/3501#issuecomment-2134016429