### PR TITLE
refactor: Pass params in SchemaCache without contrazip2

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -101,7 +101,6 @@ library
                     , clock                     >= 0.8.3 && < 0.9.0
                     , configurator-pg           >= 0.2 && < 0.3
                     , containers                >= 0.5.7 && < 0.7
-                    , contravariant-extras      >= 0.3.3 && < 0.4
                     , cookie                    >= 0.4.2 && < 0.5
                     , directory                 >= 1.2.6 && < 1.4
                     , either                    >= 4.4.1 && < 5.1


### PR DESCRIPTION
Contravariant.Extras uses Template Haskell, which is hard to cross-compile. Reducing usage of Template Haskell with the ultimate goal of solving all cross compilation challenges.

This will still leave us with a transitive dependency through hasql, but I opened https://github.com/nikita-volkov/hasql/issues/163 upstream.