### PR TITLE
refactor: Replace interpolatedstring-perl6 with neat-interpolation

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -115,11 +115,11 @@ library
                     , heredoc                   >= 0.2 && < 0.3
                     , http-types                >= 0.12.2 && < 0.13
                     , insert-ordered-containers >= 0.2.2 && < 0.3
-                    , interpolatedstring-perl6  >= 1 && < 1.1
                     , jose                      >= 0.8.5.1 && < 0.12
                     , lens                      >= 4.14 && < 5.3
                     , lens-aeson                >= 1.0.1 && < 1.3
                     , mtl                       >= 2.2.2 && < 2.4
+                    , neat-interpolation        >= 0.5 && < 0.6
                     , network                   >= 2.6 && < 3.2
                     , network-uri               >= 2.6.1 && < 2.8
                     , optparse-applicative      >= 0.13 && < 0.19

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -53,8 +53,8 @@ import qualified Hasql.Encoders                  as HE
 
 import Control.Arrow ((***))
 
-import Data.Foldable                 (foldr1)
-import Text.InterpolatedString.Perl6 (qc)
+import Data.Foldable     (foldr1)
+import NeatInterpolation (trimming)
 
 import PostgREST.ApiRequest.Types        (AggregateFunction (..),
                                           Alias, Cast,
@@ -229,11 +229,11 @@ customFuncF _ funcQi RelAnyElement            = fromQi funcQi <> "(_postgrest_t)
 customFuncF _ funcQi (RelId target)           = fromQi funcQi <> "(_postgrest_t::" <> fromQi target <> ")"
 
 locationF :: [Text] -> SQL.Snippet
-locationF pKeys = [qc|(
-  WITH data AS (SELECT row_to_json(_) AS row FROM {sourceCTEName} AS _ LIMIT 1)
+locationF pKeys = SQL.sql $ encodeUtf8 [trimming|(
+  WITH data AS (SELECT row_to_json(_) AS row FROM ${sourceCTEName} AS _ LIMIT 1)
   SELECT array_agg(json_data.key || '=' || coalesce('eq.' || json_data.value, 'is.null'))
   FROM data CROSS JOIN json_each_text(data.row) AS json_data
-  WHERE json_data.key IN ('{fmtPKeys}')
+  WHERE json_data.key IN ('${fmtPKeys}')
 )|]
   where
     fmtPKeys = T.intercalate "','" pKeys


### PR DESCRIPTION
The former depends on th-orphans which does not cross-compile well, because of template haskell usage.

neat-interpolation is also much better maintained.

This also potentially helps with packaging for Debian/Ubuntu in #2273.