### PR TITLE
Remove Template Haskell from `postgrest --version`

### DIFF
--- a/src/PostgREST/Version.hs
+++ b/src/PostgREST/Version.hs
@@ -1,14 +1,10 @@
-{-# LANGUAGE CPP             #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE CPP #-}
 module PostgREST.Version
   ( docsVersion
   , prettyVersion
   ) where
 
-import qualified Data.ByteString as BS
-import qualified Data.Text       as T
-
-import Development.GitRev (gitHash)
+import qualified Data.Text as T
 
 import Protolude
 
@@ -17,16 +13,10 @@ version = T.splitOn "." VERSION_postgrest
 
 -- | User friendly version number such as '1.1.1'.
 -- Pre-release versions are tagged as such, e.g., '1.1 (pre-release)'.
--- If a git hash is available, it's added to the version, e.g., '1.1.1 (abcdef0)'.
 prettyVersion :: ByteString
 prettyVersion =
-  VERSION_postgrest <> preRelease <> gitRev
+  VERSION_postgrest <> preRelease
   where
-    gitRev =
-      if $(gitHash) == ("UNKNOWN" :: Text) then
-        mempty
-      else
-        " (" <> BS.take 7 $(gitHash) <> ")"
     preRelease = if isPreRelease then " (pre-release)" else mempty
 
 


### PR DESCRIPTION
The first commit fixes some things around the pre-release detection which we missed for our new release workflow. The first commit should be backpatched to v12.

The next commit removes the dependency on `Paths_` - reasons given in the commit message.

The last two commits are "either one or the other". I'd like to remove the dependency on template haskell in our own code, reading the git hash. I have a working replacement via CPP macros, but that's jumping some hoops. I haven't tried to make that work for the Windows build, because the shell syntax is different there. In any case, this doesn't change the fact that this will never work for any nix-based builds - because the commit hash is just not part of the files that the build is based on. This will also never happen if we want to avoid full rebuilds on every commit, because the hash changes.

Thus, the other option is to just remove that git hash thing from our version entirely.

Opinions?