### PR TITLE
docs: Fixed rendering issue in api/tables_views

### DIFF
--- a/docs/references/api/tables_views.rst
+++ b/docs/references/api/tables_views.rst
@@ -82,7 +82,7 @@ cs            :code:`@>`                contains e.g. :code:`?tags=cs.{example, 
 cd            :code:`<@`                contained in e.g. :code:`?values=cd.{1,2,3}`
 ov            :code:`&&`                overlap (have points in common), e.g. :code:`?period=ov.[2017-01-01,2017-06-30]` –
                                         also supports array types, use curly braces instead of square brackets e.g.
-                                        :code: `?arr=ov.{1,3}`
+                                        :code:`?arr=ov.{1,3}`
 sl            :code:`<<`                strictly left of, e.g. :code:`?range=sl.(1,10)`
 sr            :code:`>>`                strictly right of
 nxr           :code:`&<`                does not extend to the right of, e.g. :code:`?range=nxr.(1,10)`


### PR DESCRIPTION
I saw the ov operator had a rendering issue in the documentation while [looking it up](https://postgrest.org/en/v12/references/api/tables_views.html). This is a fix to that.
