### PR TITLE
perf: Pass arguments to RPCs called via GET directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
  - #3558, Add the `admin-server-host` config to set the host for the admin server - @develop7
  - #3607, Log to stderr when the JWT secret is less than 32 characters long - @laurenceisla
+ - #2858, Performance improvements when calling RPCs via GET using indexes in more cases - @wolfgangwalther
 
 ### Fixed
 

--- a/src/PostgREST/Plan/CallPlan.hs
+++ b/src/PostgREST/Plan/CallPlan.hs
@@ -2,7 +2,9 @@
 module PostgREST.Plan.CallPlan
   ( CallPlan(..)
   , CallParams(..)
-  , jsonRpcParams
+  , CallArgs(..)
+  , RpcParamValue(..)
+  , toRpcParams
   )
 where
 
@@ -19,7 +21,7 @@ import Protolude
 data CallPlan = FunctionCall
   { funCQi                :: QualifiedIdentifier
   , funCParams            :: CallParams
-  , funCArgs              :: Maybe LBS.ByteString
+  , funCArgs              :: CallArgs
   , funCScalar            :: Bool
   , funCSetOfScalar       :: Bool
   , funCRetCompositeAlias :: Bool
@@ -30,14 +32,26 @@ data CallParams
   = KeyParams [RoutineParam] -- ^ Call with key params: func(a := val1, b:= val2)
   | OnePosParam RoutineParam -- ^ Call with positional params(only one supported): func(val)
 
+data CallArgs
+  = DirectArgs (HM.HashMap Text RpcParamValue)
+  | JsonArgs (Maybe LBS.ByteString)
+
+-- | RPC query param value `/rpc/func?v=<value>`, used for VARIADIC functions on form-urlencoded POST and GETs
+-- | It can be fixed `?v=1` or repeated `?v=1&v=2&v=3.
+data RpcParamValue = Fixed Text | Variadic [Text]
+instance JSON.ToJSON RpcParamValue where
+  toJSON (Fixed    v) = JSON.toJSON v
+  -- Not possible to get here anymore. Variadic arguments are only supported for
+  -- true variadic arguments, but the toJSON instance is only used for the "single unnamed json argument" case.
+  toJSON (Variadic v) = JSON.toJSON v
+
 -- | Convert rpc params `/rpc/func?a=val1&b=val2` to json `{"a": "val1", "b": "val2"}
-jsonRpcParams :: Routine -> [(Text, Text)] -> LBS.ByteString
-jsonRpcParams proc prms =
-  if not $ pdHasVariadic proc then -- if proc has no variadic param, save steps and directly convert to json
-    JSON.encode $ HM.fromList $ second JSON.toJSON <$> prms
+toRpcParams :: Routine -> [(Text, Text)] -> HM.HashMap Text RpcParamValue
+toRpcParams proc prms =
+  if not $ pdHasVariadic proc then -- if proc has no variadic param, save steps and directly convert to map
+    HM.fromList $ second Fixed <$> prms
   else
-    let paramsMap = HM.fromListWith mergeParams $ toRpcParamValue proc <$> prms in
-    JSON.encode paramsMap
+    HM.fromListWith mergeParams $ toRpcParamValue proc <$> prms
   where
     mergeParams :: RpcParamValue -> RpcParamValue -> RpcParamValue
     mergeParams (Variadic a) (Variadic b) = Variadic $ b ++ a
@@ -48,10 +62,3 @@ toRpcParamValue proc (k, v) | prmIsVariadic k = (k, Variadic [v])
                             | otherwise       = (k, Fixed v)
   where
     prmIsVariadic prm = isJust $ find (\RoutineParam{ppName, ppVar} -> ppName == prm && ppVar) $ pdParams proc
-
--- | RPC query param value `/rpc/func?v=<value>`, used for VARIADIC functions on form-urlencoded POST and GETs
--- | It can be fixed `?v=1` or repeated `?v=1&v=2&v=3.
-data RpcParamValue = Fixed Text | Variadic [Text]
-instance JSON.ToJSON RpcParamValue where
-  toJSON (Fixed    v) = JSON.toJSON v
-  toJSON (Variadic v) = JSON.toJSON v

--- a/test/spec/Feature/Query/PlanSpec.hs
+++ b/test/spec/Feature/Query/PlanSpec.hs
@@ -348,7 +348,7 @@ spec actualPgVersion = do
       r <- request methodGet "/rpc/get_projects_below?id=3"
              [planHdr] ""
 
-      liftIO $ planCost r `shouldSatisfy` (< 45.4)
+      liftIO $ planCost r `shouldSatisfy` (< 35.4)
 
     it "should not exceed cost when calling setof composite proc with empty params" $ do
       r <- request methodGet "/rpc/getallprojects"
@@ -360,7 +360,7 @@ spec actualPgVersion = do
       r <- request methodGet "/rpc/add_them?a=3&b=4"
              [planHdr] ""
 
-      liftIO $ planCost r `shouldSatisfy` (< 0.11)
+      liftIO $ planCost r `shouldSatisfy` (< 0.08)
 
     context "function inlining" $ do
       it "should inline a zero argument function(the function won't appear in the plan tree)" $ do


### PR DESCRIPTION
Previously they were passed as a JSON payload. This results in a LATERAL join for the calling expression, which prevents LIMIT from being pushed into the inlined function call, making some requests really slow.

Resolves #2858

I'm actually quite surprised that all tests were still passing when I made the build pass. I have not tried to confirm that this makes the respective RPC calls faster, but I'm pretty certain it should do so. I observed the same thing as @steve-chavez did in https://github.com/PostgREST/postgrest/issues/2858#issuecomment-1629999941 in one of my projects.