### PR TITLE
test: Raise limit for memory tests

### DIFF
--- a/test/memory/memory-tests.sh
+++ b/test/memory/memory-tests.sh
@@ -103,8 +103,8 @@ postJsonArrayTest(){
 echo "Running memory usage tests.."
 
 jsonKeyTest "1M" "POST" "/rpc/leak?columns=blob" "27M"
-jsonKeyTest "1M" "POST" "/leak?columns=blob" "20M"
-jsonKeyTest "1M" "PATCH" "/leak?id=eq.1&columns=blob" "20M"
+jsonKeyTest "1M" "POST" "/leak?columns=blob" "21M"
+jsonKeyTest "1M" "PATCH" "/leak?id=eq.1&columns=blob" "21M"
 
 jsonKeyTest "10M" "POST" "/rpc/leak?columns=blob" "32M"
 jsonKeyTest "10M" "POST" "/leak?columns=blob" "32M"


### PR DESCRIPTION
Currently, two of the memory tests are failing with slightly more than 20M used:
- https://github.com/PostgREST/postgrest/actions/runs/9853459783/job/27225439722

I repeated this a few times - no chance. It always fails the same. It also fails when I run this test locally. And it also fails when I checkout older commits, before the merges I made yesterday and run the tests there.

The memory tests for all commits on main have passed before the PRs were merged. The pipelines on main didn't run through for b598b594dfc74569084df3047ce2d563a5b54fda and ee4bfbf2533211f90715fc512dad5f78ef6ccd9d - in fact they are still in an odd pending queued state for many hours. The last time that the memory test was run in CI was for 0dc1345eb4422ed9fb821fccc4d948f25a9869db in https://github.com/PostgREST/postgrest/actions/runs/9842378222. All good.

Literally the only change since the last time the memory tests ran successfully is... time. 1-2 days have passed and now the memory tests fail consistently.

That's quite odd, but I can't figure out why. So just bumping the memory limits for those tests for now.