### PR TITLE
fix: Remove OpenAPI format for rowFilter params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
  - #3091, Broken link in OpenAPI description `externalDocs` - @salim-b
  - #3659, Embed One-to-One relationship with different column order properly - @wolfgangwalther
+ - #3504, Eliminate `format` parameter on `rowFilter` parameters in OpenAPI - @dantheman2865
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
- - #3504, Eliminate `format` parameter on `rowFilter` parameters in OpenAPI - @dantheman2865
 
 ### Added
 
@@ -17,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
  - #3091, Broken link in OpenAPI description `externalDocs` - @salim-b
  - #3659, Embed One-to-One relationship with different column order properly - @wolfgangwalther
+ - #3504, Remove `format` from `rowFilter` parameters in OpenAPI - @dantheman2865
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+ - #3504, Eliminate `format` parameter on `rowFilter` parameters in OpenAPI - @dantheman2865
+
 ### Added
 
  - #3558, Add the `admin-server-host` config to set the host for the admin server - @develop7
@@ -15,7 +17,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
  - #3091, Broken link in OpenAPI description `externalDocs` - @salim-b
  - #3659, Embed One-to-One relationship with different column order properly - @wolfgangwalther
- - #3504, Eliminate `format` parameter on `rowFilter` parameters in OpenAPI - @dantheman2865
 
 ### Changed
 

--- a/src/PostgREST/Response/OpenAPI.hs
+++ b/src/PostgREST/Response/OpenAPI.hs
@@ -296,8 +296,7 @@ makeRowFilter tn c =
     & required ?~ False
     & schema .~ ParamOther ((mempty :: ParamOtherSchema)
       & in_ .~ ParamQuery
-      & type_ ?~ SwaggerString
-      & format ?~ colType c))
+      & type_ ?~ SwaggerString))
 
 makeRowFilters :: Text -> [Column] -> [(Text, Param)]
 makeRowFilters tn = fmap (makeRowFilter tn)


### PR DESCRIPTION
See #3504 for more details.

When using OpenAPI docs with some code generators, rowFilter parameters will be incorrectly typed. Because Row Filter parameters are always a string (e.g. `eq.1001`), the `format` field should not be included.

Note: I could not see any tests to update for this case. Please let me know if I should add a test (presumably to `test/spec/Feature/OpenApi/OpenApiSpec.hs`).