### PR TITLE
chore(deps): update docutils and sphinx-rtd-theme

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
-docutils==0.20.1
+docutils>=0.21
 sphinx-copybutton
 sphinx-intl
-sphinx-rtd-theme>=0.5.1
+sphinx-rtd-theme>=3.0.0rc1
 sphinx-rtd-dark-mode>=1.3.0
 sphinx-tabs>=3.2.0
 sphinx>=5.0.2


### PR DESCRIPTION
With https://github.com/readthedocs/sphinx_rtd_theme/issues/1557 resolved, let's see whether we can unpin `docutils` again.