### PR TITLE
ci: drop directories from windows release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -222,7 +222,7 @@ jobs:
           tar cJvf "release-bundle/postgrest-${GITHUB_REF_NAME}-ubuntu-aarch64.tar.xz" \
             -C artifacts/postgrest-ubuntu-aarch64 postgrest
 
-          zip "release-bundle/postgrest-${GITHUB_REF_NAME}-windows-x64.zip" \
+          zip --junk-paths "release-bundle/postgrest-${GITHUB_REF_NAME}-windows-x64.zip" \
             artifacts/postgrest-windows-x64/postgrest.exe
 
       - name: Save release bundle


### PR DESCRIPTION
Puts windows release in line with others which have the executable on the top level

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `fix`, bug fixes
  + `feat`, new features added
  + `perf`, performance improvements
  + `docs`, updating the documentation
  + `nix`, related to the Nix development environment
  + `ci`, related to the Continuous Integration modules
  + `test`, related to the testing modules
  + `refactor`, refactoring code
  + `deprecate`, deprecating a feature
  + `changelog`, updating the CHANGELOG
  + `chore`, maintenance (build process, updating sponsors, etc.)
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
