### PR TITLE
feat: log pool maximum size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3607, Log to stderr when the JWT secret is less than 32 characters long - @laurenceisla
  - #2858, Performance improvements when calling RPCs via GET using indexes in more cases - @wolfgangwalther
  - #3560, Log resolved host in "Listening on ..." messages - @develop7
+ - #3727, Log maximum pool size - @steve-chavez
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3693, Fix spread embedding errors when using the `count()` aggregate without a field - @laurenceisla
    + Fixed `"column reference <col> is ambiguous"` error when selecting `?select=...table(col,count())`
    + Fixed `"column <json_aggregate>.<alias> does not exist"` error when selecting `?select=...table(aias:count())`
+ - #3727, Clarify "listening" logs - @steve-chavez
 
 ### Changed
 

--- a/docs/references/observability.rst
+++ b/docs/references/observability.rst
@@ -33,8 +33,8 @@ For diagnostic information about the server itself, PostgREST logs to ``stderr``
    06/May/2024:08:16:11 -0500: Starting PostgREST 12.1...
    06/May/2024:08:16:11 -0500: Attempting to connect to the database...
    06/May/2024:08:16:11 -0500: Successfully connected to PostgreSQL 14.10 (Ubuntu 14.10-0ubuntu0.22.04.1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit
-   06/May/2024:08:16:11 -0500: Listening on port 3000
-   06/May/2024:08:16:11 -0500: Listening for notifications on the "pgrst" channel
+   06/May/2024:08:16:11 -0500: API server listening on port 3000
+   06/May/2024:08:16:11 -0500: Listening for database notifications on the "pgrst" channel
    06/May/2024:08:16:11 -0500: Config reloaded
    06/May/2024:08:16:11 -0500: Schema cache queried in 3.8 milliseconds
    06/May/2024:08:16:11 -0500: Schema cache loaded 15 Relations, 8 Relationships, 8 Functions, 0 Domain Representations, 4 Media Type Handlers

--- a/docs/references/observability.rst
+++ b/docs/references/observability.rst
@@ -31,8 +31,8 @@ For diagnostic information about the server itself, PostgREST logs to ``stderr``
 .. code::
 
    06/May/2024:08:16:11 -0500: Starting PostgREST 12.1...
-   06/May/2024:08:16:11 -0500: Attempting to connect to the database...
    06/May/2024:08:16:11 -0500: Successfully connected to PostgreSQL 14.10 (Ubuntu 14.10-0ubuntu0.22.04.1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit
+   06/May/2024:08:16:11 -0500: Connection Pool initialized with a maximum size of 10 connections
    06/May/2024:08:16:11 -0500: API server listening on port 3000
    06/May/2024:08:16:11 -0500: Listening for database notifications on the "pgrst" channel
    06/May/2024:08:16:11 -0500: Config reloaded

--- a/docs/tutorials/tut0.rst
+++ b/docs/tutorials/tut0.rst
@@ -213,12 +213,8 @@ You should see something similar to:
 .. code-block:: text
 
   Starting PostgREST 12.0.2...
-  Attempting to connect to the database...
-  Connection successful
-  Listening on port 3000
-  Config reloaded
-  Listening for notifications on the pgrst channel
-  Schema cache loaded
+  Successfully connected to PostgreSQL 14.10 (Ubuntu 14.10-0ubuntu0.22.04.1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit
+  API server listening on port 3000
 
 It's now ready to serve web requests. There are many nice graphical API exploration tools you can use, but for this tutorial we'll use :code:`curl` because it's likely to be installed on your system already. Open a new terminal (leaving the one open that PostgREST is running inside). Try doing an HTTP request for the todos.
 

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -67,8 +67,6 @@ run appState = do
   let observer = AppState.getObserver appState
   conf@AppConfig{..} <- AppState.getConfig appState
 
-  observer $ AppStartObs prettyVersion
-
   AppState.schemaCacheLoader appState -- Loads the initial SchemaCache
   Unix.installSignalHandlers (AppState.getMainThreadId appState) (AppState.schemaCacheLoader appState) (AppState.readInDbConfig False appState)
 

--- a/src/PostgREST/Observation.hs
+++ b/src/PostgREST/Observation.hs
@@ -65,9 +65,9 @@ observationMessage = \case
   AppStartObs ver ->
     "Starting PostgREST " <> T.decodeUtf8 ver <> "..."
   AppServerPortObs host port ->
-    "Listening on " <> host <> ":" <> show port
+    "API server listening on " <> host <> ":" <> show port
   AppServerUnixObs sock ->
-    "Listening on unix socket " <> show sock
+    "API server listening on unix socket " <> show sock
   DBConnectedObs ver ->
     "Successfully connected to " <> ver
   ExitUnsupportedPgVersion pgVer minPgVer ->
@@ -95,15 +95,15 @@ observationMessage = \case
   QueryPgVersionError usageErr ->
     "Failed to query the PostgreSQL version. " <> jsonMessage usageErr
   DBListenStart channel -> do
-    "Listening for notifications on the " <> show channel <> " channel"
+    "Listening for database notifications on the " <> show channel <> " channel"
   DBListenFail channel listenErr ->
-    "Failed listening for notifications on the " <> show channel <> " channel. " <> (
+    "Failed listening for database notifications on the " <> show channel <> " channel. " <> (
       case listenErr of
         Left err  -> show err
         Right err -> showListenerError err
     )
   DBListenRetry delay ->
-    "Retrying listening for notifications in " <> (show delay::Text) <> " seconds..."
+    "Retrying listening for database notifications in " <> (show delay::Text) <> " seconds..."
   DBListenerGotSCacheMsg channel ->
     "Received a schema cache reload message on the " <> show channel <> " channel"
   DBListenerGotConfigMsg channel ->

--- a/src/PostgREST/Observation.hs
+++ b/src/PostgREST/Observation.hs
@@ -49,6 +49,7 @@ data Observation
   | QueryRoleSettingsErrorObs SQL.UsageError
   | QueryErrorCodeHighObs SQL.UsageError
   | QueryPgVersionError SQL.UsageError
+  | PoolInit Int
   | PoolAcqTimeoutObs SQL.UsageError
   | HasqlPoolObs SQL.Observation
   | PoolRequest
@@ -118,6 +119,8 @@ observationMessage = \case
     "Failed reloading config: " <> err
   ConfigSucceededObs ->
      "Config reloaded"
+  PoolInit poolSize ->
+     "Connection Pool initialized with a maximum size of " <> show poolSize <> " connections"
   PoolAcqTimeoutObs usageErr ->
     jsonMessage usageErr
   HasqlPoolObs (SQL.ConnectionObservation uuid status) ->

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -1268,7 +1268,7 @@ def test_log_postgrest_host_and_port(defaultenv):
     ) as postgrest:
         output = postgrest.read_stdout(nlines=10)
 
-        assert f"Listening on {host}:{port}" in output[2]  # output-sensitive
+        assert f"API server listening on {host}:{port}" in output[2]  # output-sensitive
 
 
 def test_succeed_w_role_having_superuser_settings(defaultenv):


### PR DESCRIPTION
It's important for observability to have an historic trace of the pool size. Currently we expose it on the metrics endpoint, but not all deployments use it.

This logs the pool size after the successful connection log to make it more visible:

```
<timestamp>: Connection Pool initialized with a maximum size of 4 connections
```