### PR TITLE
docs: add PGRST123 to error table

### DIFF
--- a/docs/references/errors.rst
+++ b/docs/references/errors.rst
@@ -257,6 +257,10 @@ Related to the HTTP request elements.
 |               |             | ``Prefer: handling=strict``. See :ref:`prefer_handling`.    |
 | PGRST122      |             |                                                             |
 +---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst123: | 400         | Aggregate functions are disabled.                           |
+|               |             | See :ref:`db-aggregates-enabled`.                           |
+| PGRST123      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
 
 .. _pgrst2**:
 


### PR DESCRIPTION
#2925 added support for aggregate functions. This commit adds the PGRST123 error code description to the docs.