### PR TITLE
ci: Update cirrus' freebsd image to 14.1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-14-0
+  image_family: freebsd-14-1
 
 build_task:
   # Don't change this name without adjusting .github/workflows/build.yaml


### PR DESCRIPTION
This should hopefully fix CI which is [failing lately](https://cirrus-ci.com/task/4665005218463744) like this: 

```
ld-elf.so.1: /lib/libc.so.7: version FBSD_1.8 required by /usr/local/bin/stack not found
```