### PR TITLE
docs: fix deprecation of analytics in RTD

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -313,6 +313,12 @@ ogp_use_first_image = True
 ogp_enable_meta_description = True
 ogp_description_length = 300
 
+# sphinxcontrib.googleanalytics configuration
+if os.environ.get("READTHEDOCS"):
+    extensions.append("sphinxcontrib.googleanalytics")
+    googleanalytics_enabled = True
+    googleanalytics_id = "G-5CGB3QTKF1"
+
 ## RTD sets html_baseurl, ensures we use the correct env for canonical URLs
 ## Useful to generate correct meta tags for Open Graph
 ## Refs: https://github.com/readthedocs/readthedocs.org/issues/10226, https://github.com/urllib3/urllib3/pull/3064

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,5 +5,6 @@ sphinx-rtd-theme>=0.5.1
 sphinx-rtd-dark-mode>=1.3.0
 sphinx-tabs>=3.2.0
 sphinx>=5.0.2
+sphinxcontrib-googleanalytics>=0.4
 sphinxext-opengraph==0.9.1
 urllib3==2.2.3


### PR DESCRIPTION
It seems to be working in the `latest` docs. This should make it work for the `stable` version.