### PR TITLE
Update nixpkgs for v12 branch

### DIFF
--- a/nix/nixpkgs-version.nix
+++ b/nix/nixpkgs-version.nix
@@ -2,7 +2,7 @@
 {
   owner = "NixOS";
   repo = "nixpkgs";
-  date = "2024-04-20";
-  rev = "92d295f588631b0db2da509f381b4fb1e74173c5";
-  tarballHash = "162w28y4i5c8g5qhjvs827qxphf2a8n4c8fwhcywzl1j1a35h2im";
+  date = "2024-05-29";
+  rev = "a15e8d1b3d9e6496c4a3214e2104f6d28dfa7df7";
+  tarballHash = "sha256:0r4a4165f4n1zlpnyjrdrwrg86n1b6g3axsdh3j5iizpmjrlxmd7";
 }

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -57,7 +57,14 @@ let
           }
           { });
 
-      hasql-pool = lib.dontCheck prev.hasql-pool_1_0_1;
+      hasql-pool = lib.dontCheck (prev.callHackageDirect
+        {
+          pkg = "hasql-pool";
+          ver = "1.0.1";
+          sha256 = "sha256-Hf1f7lX0LWkjrb25SDBovCYPRdmUP1H6pAxzi7kT4Gg=";
+        }
+        { }
+      );
 
       postgresql-libpq = lib.dontCheck
         (prev.postgresql-libpq.override {


### PR DESCRIPTION
This updates nixpkgs for the `v12` branch just enough to have actionlint v1.7.1 available, which adds support for the latest ubuntu runner. This will allow #3741 to pass.