### PR TITLE
fix: always show schema cache load time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + Fixed `"column reference <col> is ambiguous"` error when selecting `?select=...table(col,count())`
    + Fixed `"column <json_aggregate>.<alias> does not exist"` error when selecting `?select=...table(aias:count())`
  - #3727, Clarify "listening" logs - @steve-chavez
+ - #3779, Always log the schema cache load time - @steve-chavez
 
 ### Changed
 

--- a/src/PostgREST/Logger.hs
+++ b/src/PostgREST/Logger.hs
@@ -87,9 +87,6 @@ observationLogger loggerState logLevel obs = case obs of
   o@(HasqlPoolObs _) -> do
     when (logLevel >= LogDebug) $ do
       logWithZTime loggerState $ observationMessage o
-  o@(SchemaCacheLoadedObs _) -> do
-    when (logLevel >= LogDebug) $ do
-      logWithZTime loggerState $ observationMessage o
   PoolRequest ->
     pure ()
   PoolRequestFullfilled ->

--- a/src/PostgREST/Logger.hs
+++ b/src/PostgREST/Logger.hs
@@ -75,6 +75,7 @@ middleware logLevel getAuthRole = case logLevel of
       , Wai.destination = Wai.Handle stdout
       }
 
+-- All observations are logged except some that depend on the log-level
 observationLogger :: LoggerState -> LogLevel -> ObservationHandler
 observationLogger loggerState logLevel obs = case obs of
   o@(PoolAcqTimeoutObs _) -> do

--- a/src/PostgREST/Metrics.hs
+++ b/src/PostgREST/Metrics.hs
@@ -1,3 +1,7 @@
+{-|
+Module      : PostgREST.Logger
+Description : Metrics based on the Observation module. See Observation.hs.
+-}
 module PostgREST.Metrics
   ( init
   , MetricsState (..)
@@ -28,6 +32,7 @@ init configDbPoolSize = do
   setGauge poolMaxSize (fromIntegral configDbPoolSize)
   pure $ MetricsState poolTimeouts poolAvailable poolWaiting poolMaxSize schemaCacheLoads schemaCacheQueryTime
 
+-- Only some observations are used as metrics
 observationMetrics :: MetricsState -> ObservationHandler
 observationMetrics (MetricsState poolTimeouts poolAvailable poolWaiting _ schemaCacheLoads schemaCacheQueryTime) obs = case obs of
   (PoolAcqTimeoutObs _) -> do

--- a/src/PostgREST/Observation.hs
+++ b/src/PostgREST/Observation.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE LambdaCase #-}
 {-|
 Module      : PostgREST.Observation
-Description : Observations that can be used for Logging and Metrics
+Description : This module holds an Observation type which is the core of Observability for PostgREST.
+              The Observation and ObservationHandler (the observer) are abstractions that allow centralizing logging and metrics concerns,
+              only observer calls with an Observation constructor are applied at different parts in the codebase.
+              The Logger and Metrics modules then decide which observations to expose. Not all observations need to be logged nor all correspond to a metric.
 -}
 module PostgREST.Observation
   ( Observation(..)


### PR DESCRIPTION
It used to be that this was only enabled with log-level=debug but doing it this way is misleading for the default log-level. For example:

```
$ PGRST_DB_SCHEMAS="apflora" postgrest-with-postgresql-16  -f test/io/big_schema.sql postgrest-run

...
13/Nov/2024:22:08:20 -0500: Config reloaded
13/Nov/2024:22:08:20 -0500: Schema cache queried in 36.3 milliseconds
13/Nov/2024:22:08:20 -0500: Schema cache loaded 326 Relations, 305 Relationships, 7 Functions, 0 Domain Representations, 4 Media Type Handlers, 1194 Timezones
```

The "Schema cache loaded" can take a while to appear, yet the 22:08:20 time is the same. If we reveal the load time this is clarified:

```
13/Nov/2024:22:08:37 -0500: Schema cache loaded in 16770.1 milliseconds
```