### PR TITLE
ci: Use newer macos VMs on v12 branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -96,12 +96,13 @@ jobs:
             # no artifact for Linux, because we use the static build
 
           - name: MacOS
-            runs-on: macos-12
+            runs-on: macos-14
             cache: |
               ~/.stack/pantry
               ~/.stack/snapshots
               ~/.stack/stack.sqlite3
             artifact: postgrest-macos-x64
+            deps: brew install libpq && brew link --force libpq
 
           - name: Windows
             runs-on: windows-2022


### PR DESCRIPTION
Macos jobs are currently cancelled on the backbranch. Let's see whether that works.