### PR TITLE
feat: apply `to_tsvector` to the filtered columns when a `fts` operator is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3727, Log maximum pool size - @steve-chavez
  - #1536, Add string comparison feature for jwt-role-claim-key - @taimoorzaeem
  - #3747, Allow `not_null` value for the `is` operator - @taimoorzaeem
+ - #2255, Apply `to_tsvector()` explicitly to the full-text search filtered column (excluding `tsvector` types) - @laurenceisla
 
 ### Fixed
 

--- a/docs/references/api/tables_views.rst
+++ b/docs/references/api/tables_views.rst
@@ -193,7 +193,21 @@ The :code:`fts` filter mentioned above has a number of options to support flexib
 
   curl "http://localhost:3000/tsearch?my_tsv=not.wfts(french).amusant"
 
-Using `websearch_to_tsquery` requires PostgreSQL of version at least 11.0 and will raise an error in earlier versions of the database.
+.. _fts_to_tsvector:
+
+Automatic ``tsvector`` conversion
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If the filtered column is not of type ``tsvector``, then it will be automatically converted using `to_tsvector() <https://www.postgresql.org/docs/current/functions-textsearch.html#TEXTSEARCH-FUNCTIONS-TABLE>`_.
+This allows using ``fts`` on ``text`` and ``json`` types out of the box, for example.
+
+.. code-block:: bash
+
+  curl "http://localhost:3000/tsearch?my_text_column=fts(french).amusant"
+
+.. code-block:: bash
+
+  curl "http://localhost:3000/tsearch?my_json_column=not.phfts(english).The%20Fat%20Cats"
 
 .. _v_filter:
 

--- a/src/PostgREST/ApiRequest/Types.hs
+++ b/src/PostgREST/ApiRequest/Types.hs
@@ -14,6 +14,7 @@ module PostgREST.ApiRequest.Types
   , JsonOperand(..)
   , JsonOperation(..)
   , JsonPath
+  , Language
   , ListVal
   , LogicOperator(..)
   , LogicTree(..)

--- a/src/PostgREST/Query/QueryBuilder.hs
+++ b/src/PostgREST/Query/QueryBuilder.hs
@@ -206,7 +206,7 @@ callPlanToQuery (FunctionCall qi params arguments returnsScalar returnsSetOfScal
       KeyParams []    -> "FROM " <> callIt mempty
       KeyParams prms  -> case arguments of
         DirectArgs args -> "FROM " <> callIt (fmtArgs prms args)
-        JsonArgs json   -> fromJsonBodyF json ((\p -> CoercibleField (ppName p) mempty False (ppTypeMaxLength p) Nothing Nothing False) <$> prms) False True False <> ", " <>
+        JsonArgs json   -> fromJsonBodyF json ((\p -> CoercibleField (ppName p) mempty False Nothing (ppTypeMaxLength p) Nothing Nothing False) <$> prms) False True False <> ", " <>
                          "LATERAL " <> callIt (fmtParams prms)
 
     callIt :: SQL.Snippet -> SQL.Snippet

--- a/test/spec/Feature/Query/AndOrParamsSpec.hs
+++ b/test/spec/Feature/Query/AndOrParamsSpec.hs
@@ -81,7 +81,7 @@ spec =
         it "can handle is" $
           get "/entities?and=(name.is.null,arr.is.null)&select=id" `shouldRespondWith`
             [json|[{ "id": 4 }]|] { matchHeaders = [matchContentTypeJson] }
-        it "can handle fts" $ do
+        it "can handle fts on tsvector columns" $ do
           get "/entities?or=(text_search_vector.fts.bar,text_search_vector.fts.baz)&select=id" `shouldRespondWith`
             [json|[{ "id": 1 }, { "id": 2 }]|] { matchHeaders = [matchContentTypeJson] }
           get "/tsearch?or=(text_search_vector.plfts(german).Art%20Spass, text_search_vector.plfts(french).amusant%20impossible, text_search_vector.fts(english).impossible)" `shouldRespondWith`
@@ -90,6 +90,17 @@ spec =
               {"text_search_vector": "'amus':5 'fair':7 'impossibl':9 'peu':4" },
               {"text_search_vector": "'art':4 'spass':5 'unmog':7"}
             ]|] { matchHeaders = [matchContentTypeJson] }
+        it "can handle fts on text and json columns" $ do
+          get "/grandchild_entities?or=(jsonb_col.fts.bar,jsonb_col.fts.foo)&select=jsonb_col" `shouldRespondWith`
+            [json|[
+              { "jsonb_col": {"a": {"b":"foo"}} },
+              { "jsonb_col": {"b":"bar"} }]
+            |] { matchHeaders = [matchContentTypeJson] }
+          get "/tsearch_to_tsvector?and=(text_search.not.plfts(german).Art%20Spass, text_search.not.plfts(french).amusant%20impossible, text_search.not.fts(english).impossible)&select=text_search" `shouldRespondWith`
+            [json|[
+              { "text_search": "But also fun to do what is possible" },
+              { "text_search": "Fat cats ate rats" }]
+            |] { matchHeaders = [matchContentTypeJson] }
         it "can handle isdistinct" $
           get "/entities?and=(id.gte.2,arr.isdistinct.{1,2})&select=id" `shouldRespondWith`
             [json|[{ "id": 3 }, { "id": 4 }]|] { matchHeaders = [matchContentTypeJson] }

--- a/test/spec/Feature/Query/RpcSpec.hs
+++ b/test/spec/Feature/Query/RpcSpec.hs
@@ -949,7 +949,7 @@ spec =
           [json|[{ "id": 2 }, { "id": 4 }]|]
           { matchHeaders = [matchContentTypeJson] }
 
-      it "should work with filters that use the plain with language fts operator" $ do
+      it "should work with filters that use the fts operator on tsvector columns" $ do
         get "/rpc/get_tsearch?text_search_vector=fts(english).impossible" `shouldRespondWith`
           [json|[{"text_search_vector":"'fun':5 'imposs':9 'kind':3"}]|]
           { matchHeaders = [matchContentTypeJson] }
@@ -961,6 +961,31 @@ spec =
           { matchHeaders = [matchContentTypeJson] }
         get "/rpc/get_tsearch?text_search_vector=wfts.impossible" `shouldRespondWith`
           [json|[{"text_search_vector":"'fun':5 'imposs':9 'kind':3"}]|]
+          { matchHeaders = [matchContentTypeJson] }
+      it "should work with filters that use the fts operator on text and json columns" $ do
+        get "/rpc/get_tsearch_to_tsvector?select=text_search&text_search=fts(english).impossible" `shouldRespondWith`
+          [json|[
+            {"text_search":"It's kind of fun to do the impossible"},
+            {"text_search":"C'est un peu amusant de faire l'impossible"}]
+          |]
+          { matchHeaders = [matchContentTypeJson] }
+        get "/rpc/get_tsearch_to_tsvector?select=text_search&text_search=plfts.impossible" `shouldRespondWith`
+          [json|[
+            {"text_search":"It's kind of fun to do the impossible"},
+            {"text_search":"C'est un peu amusant de faire l'impossible"}]
+          |]
+          { matchHeaders = [matchContentTypeJson] }
+        get "/rpc/get_tsearch_to_tsvector?select=text_search&text_search=not.fts(english).fun%7Crat" `shouldRespondWith`
+          [json|[
+            {"text_search":"C'est un peu amusant de faire l'impossible"},
+            {"text_search":"Es ist eine Art Spaß, das Unmögliche zu machen"}]
+          |]
+          { matchHeaders = [matchContentTypeJson] }
+        get "/rpc/get_tsearch_to_tsvector?select=text_search&text_search=wfts.impossible" `shouldRespondWith`
+          [json|[
+            {"text_search":"It's kind of fun to do the impossible"},
+            {"text_search":"C'est un peu amusant de faire l'impossible"}]
+          |]
           { matchHeaders = [matchContentTypeJson] }
 
       it "should work with the phraseto_tsquery function" $

--- a/test/spec/fixtures/data.sql
+++ b/test/spec/fixtures/data.sql
@@ -930,3 +930,12 @@ INSERT INTO surr_serial_upsert(name, extra) VALUES ('value', 'existing value');
 
 TRUNCATE TABLE surr_gen_default_upsert CASCADE;
 INSERT INTO surr_gen_default_upsert(name, extra) VALUES ('value', 'existing value');
+
+TRUNCATE TABLE tsearch_to_tsvector CASCADE;
+INSERT INTO tsearch_to_tsvector(text_search) VALUES ('It''s kind of fun to do the impossible');
+INSERT INTO tsearch_to_tsvector(text_search) VALUES ('But also fun to do what is possible');
+INSERT INTO tsearch_to_tsvector(text_search) VALUES ('Fat cats ate rats');
+INSERT INTO tsearch_to_tsvector(text_search) VALUES ('C''est un peu amusant de faire l''impossible');
+INSERT INTO tsearch_to_tsvector(text_search) VALUES ('Es ist eine Art Spaß, das Unmögliche zu machen');
+
+UPDATE tsearch_to_tsvector SET jsonb_search = jsonb_build_object('text_search', text_search);

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -3799,3 +3799,16 @@ create table surr_gen_default_upsert (
   name text,
   extra text
 );
+
+create table tsearch_to_tsvector (
+  text_search text,
+  jsonb_search jsonb
+);
+
+create function test.get_tsearch_to_tsvector() returns setof test.tsearch_to_tsvector AS $$
+  select * from test.tsearch_to_tsvector;
+$$ language sql;
+
+create function test.text_search_vector(test.tsearch_to_tsvector) returns tsvector AS $$
+  select to_tsvector('simple', $1.text_search)
+$$ language sql;


### PR DESCRIPTION
Closes #2255 

When an `fts` operator is used, then it applies `to_tsvector` to the filtered column. For example:

```
/table?column=fts(simple).test
```

is equivalent to this in SQL:

```sql
SELECT *
FROM table
WHERE to_tsvector('simple', column) = to_tsquery('simple', 'test')
```

<s>
If the `totsv` modifier (short for `to_tsvector`) is used for `fts` operators then it applies `to_tsvector` to the filtered column. For example:

```
/table?column=totsv.fts(simple).test
```

Is equivalent to this in SQL:

```sql
SELECT *
FROM table
WHERE to_tsvector('simple', column) = to_tsquery('simple', 'test')
```
</s>