### PR TITLE
Revert "ci: Remove brew install libpq for macos-14 stack build"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,6 +103,7 @@ jobs:
               ~/.stack/snapshots
               ~/.stack/stack.sqlite3
             artifact: postgrest-macos-aarch64
+            deps: brew link --force libpq
 
           - name: Windows
             runs-on: windows-2022


### PR DESCRIPTION
This partially reverts commit 53164453d8c9ac289af4f1a676d8fce2d52dedbc.

Only showed up after I cleared the current stack cache, apparently the existing cache hid the issue.

Let's see whether this partial revert is enough or whether we need the full line back.