### PR TITLE
fix: Make postgrest binary in arm64 docker image executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY postgrest /usr/bin/postgrest
+RUN chmod +x /usr/bin/postgrest
 
 EXPOSE 3000
 


### PR DESCRIPTION
This happened in 06aebfaa and caused the arm64 docker image to not start up properly.

Resolves #3867