### PR TITLE
fix: handle queries on non-existing table gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + Fixed `"column <json_aggregate>.<alias> does not exist"` error when selecting `?select=...table(aias:count())`
  - #3727, Clarify "listening" logs - @steve-chavez
  - #3795, Clarify `Accept: vnd.pgrst.object` error message - @steve-chavez
+ - #3697, #3602, Handle queries on non-existing table gracefully - @taimoorzaeem
 
 ### Changed
 
@@ -40,6 +41,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + This preference was deprecated in favor of Functions with an array of JSON objects
  - #3013, Drop support for Limited updates/deletes
    + The feature was complicated and largely unused.
+ - #3697, #3602, Querying non-existent table now returns `PGRST205` error instead of empty json - @taimoorzaeem
 
 ## [12.2.8] - 2025-02-10
 

--- a/docs/references/errors.rst
+++ b/docs/references/errors.rst
@@ -286,6 +286,10 @@ Related to a :ref:`schema_cache`. Most of the time, these errors are solved by :
 |               |             | in the ``columns`` query parameter is not found.            |
 | PGRST204      |             |                                                             |
 +---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst205: | 404         | Caused when the :ref:`table specified <tables_views>` in    |
+|               |             | the URI is not found.                                       |
+| PGRST205      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
 
 .. _pgrst3**:
 

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -976,7 +976,7 @@ mutatePlan mutation qi ApiRequest{iPreferences=Preferences{..}, ..} SchemaCache{
     typedColumnsOrError = resolveOrError ctx tbl `traverse` S.toList iColumns
 
 resolveOrError :: ResolverContext -> Maybe Table -> FieldName -> Either ApiRequestError CoercibleField
-resolveOrError _ Nothing _ = Left NotFound
+resolveOrError _ Nothing _ = Left NotFound -- TODO: control never reaches here since #3869, should be fixed when fixing #3906
 resolveOrError ctx (Just table) field =
   case resolveTableFieldName table field Nothing of
     CoercibleField{cfIRType=""} -> Left $ ColumnNotFound (tableName table) field

--- a/src/PostgREST/SchemaCache/Identifiers.hs
+++ b/src/PostgREST/SchemaCache/Identifiers.hs
@@ -25,6 +25,7 @@ instance Hashable RelIdentifier
 
 -- | Represents a pg identifier with a prepended schema name "schema.table".
 -- When qiSchema is "", the schema is defined by the pg search_path.
+-- TODO: Refactor this, we also use QI for procedure names
 data QualifiedIdentifier = QualifiedIdentifier
   { qiSchema :: Schema
   , qiName   :: TableName

--- a/test/io/test_big_schema.py
+++ b/test/io/test_big_schema.py
@@ -7,8 +7,8 @@ from util import *
 from postgrest import *
 
 
-def test_requests_wait_for_schema_cache_reload(defaultenv):
-    "requests that use the schema cache (e.g. resource embedding) wait for the schema cache to reload"
+def test_requests_with_resource_embedding_wait_for_schema_cache_reload(defaultenv):
+    "requests that use the schema cache with resource embedding wait long for the schema cache to reload"
 
     env = {
         **defaultenv,
@@ -32,6 +32,33 @@ def test_requests_wait_for_schema_cache_reload(defaultenv):
             "plan"
         ]
         assert plan_dur > 10000.0
+
+
+def test_requests_without_resource_embedding_wait_for_schema_cache_reload(defaultenv):
+    "requests that use the schema cache without resource embedding wait less for the schema cache to reload"
+
+    env = {
+        **defaultenv,
+        "PGRST_DB_SCHEMAS": "apflora",
+        "PGRST_DB_POOL": "2",
+        "PGRST_DB_ANON_ROLE": "postgrest_test_anonymous",
+        "PGRST_SERVER_TIMING_ENABLED": "true",
+    }
+
+    with run(env=env, wait_max_seconds=30) as postgrest:
+        # reload the schema cache
+        response = postgrest.session.get("/rpc/notify_pgrst")
+        assert response.status_code == 204
+
+        postgrest.wait_until_scache_starts_loading()
+
+        response = postgrest.session.get("/tpopmassn")
+        assert response.status_code == 200
+
+        plan_dur = parse_server_timings_header(response.headers["Server-Timing"])[
+            "plan"
+        ]
+        assert plan_dur < 10000.0
 
 
 # TODO: This test fails now because of https://github.com/PostgREST/postgrest/pull/2122
@@ -65,6 +92,6 @@ def test_should_not_fail_with_stack_overflow(defaultenv):
 
     with run(env=env, wait_max_seconds=30) as postgrest:
         response = postgrest.session.get("/unknown-table?select=unknown-rel(*)")
-        assert response.status_code == 400
+        assert response.status_code == 404
         data = response.json()
-        assert data["code"] == "PGRST200"
+        assert data["code"] == "PGRST205"

--- a/test/spec/Feature/ConcurrentSpec.hs
+++ b/test/spec/Feature/ConcurrentSpec.hs
@@ -24,12 +24,8 @@ spec =
     it "should not raise 'transaction in progress' error" $
       raceTest 10 $
         get "/fakefake"
-          `shouldRespondWith` [json|
-              { "hint": null,
-                "details":null,
-                "code":"42P01",
-                "message":"relation \"test.fakefake\" does not exist"
-              } |]
+          `shouldRespondWith`
+          [json| {"code":"PGRST205","details":null,"hint":"Perhaps you meant the table 'test.factories'","message":"Could not find the table 'test.fakefake' in the schema cache"} |]
           { matchStatus  = 404
           , matchHeaders = []
           }

--- a/test/spec/Feature/Query/DeleteSpec.hs
+++ b/test/spec/Feature/Query/DeleteSpec.hs
@@ -109,7 +109,12 @@ spec =
 
     context "totally unknown route" $
       it "fails with 404" $
-        request methodDelete "/foozle?id=eq.101" [] "" `shouldRespondWith` 404
+        request methodDelete "/foozle?id=eq.101" [] ""
+          `shouldRespondWith`
+          [json| {"code":"PGRST205","details":null,"hint":"Perhaps you meant the table 'test.foo'","message":"Could not find the table 'test.foozle' in the schema cache"} |]
+          { matchStatus = 404
+          , matchHeaders = []
+          }
 
     context "table with limited privileges" $ do
       it "fails deleting the row when return=representation and selecting all the columns" $

--- a/test/spec/Feature/Query/InsertSpec.hs
+++ b/test/spec/Feature/Query/InsertSpec.hs
@@ -477,7 +477,7 @@ spec actualPgVersion = do
             {"id": 204, "body": "yyy"},
             {"id": 205, "body": "zzz"}]|]
           `shouldRespondWith`
-          [json|{} |]
+          [json| {"code":"PGRST205","details":null,"hint":"Perhaps you meant the table 'test.articles'","message":"Could not find the table 'test.garlic' in the schema cache"} |]
           { matchStatus  = 404
           , matchHeaders = []
           }

--- a/test/spec/Feature/Query/MultipleSchemaSpec.hs
+++ b/test/spec/Feature/Query/MultipleSchemaSpec.hs
@@ -64,7 +64,13 @@ spec =
           }
 
       it "doesn't find another_table in schema v1" $
-        request methodGet "/another_table" [("Accept-Profile", "v1")] "" `shouldRespondWith` 404
+        request methodGet "/another_table"
+          [("Accept-Profile", "v1")] ""
+          `shouldRespondWith`
+          [json| {"code":"PGRST205","details":null,"hint":null,"message":"Could not find the table 'v1.another_table' in the schema cache"} |]
+          { matchStatus = 404
+          , matchHeaders = []
+          }
 
       it "fails trying to read table from unkown schema" $
         request methodGet "/parents" [("Accept-Profile", "unkown")] "" `shouldRespondWith`

--- a/test/spec/Feature/Query/UpdateSpec.hs
+++ b/test/spec/Feature/Query/UpdateSpec.hs
@@ -17,7 +17,12 @@ spec = do
       it "indicates no table found by returning 404" $
         request methodPatch "/fake" []
           [json| { "real": false } |]
-            `shouldRespondWith` 404
+          `shouldRespondWith`
+          [json| {"code":"PGRST205","details":null,"hint":"Perhaps you meant the table 'test.factories'","message":"Could not find the table 'test.fake' in the schema cache"} |]
+          { matchStatus = 404
+          , matchHeaders = []
+          }
+
 
     context "on an empty table" $
       it "succeeds with status code 204" $
@@ -343,7 +348,7 @@ spec = do
             {"id": 204, "body": "yyy"},
             {"id": 205, "body": "zzz"}]|]
           `shouldRespondWith`
-          [json|{} |]
+          [json| {"code":"PGRST205","details":null,"hint":"Perhaps you meant the table 'test.articles'","message":"Could not find the table 'test.garlic' in the schema cache"} |]
           { matchStatus  = 404
           , matchHeaders = []
           }


### PR DESCRIPTION
Add new `TableNotFound` error and add json error
message for this error. Closes #3697, closes #3602.

(Couldn't think of a better changelog/commit message. Feel free to suggest a new/better message).