### PR TITLE
refactor: move AuthResult to Auth/Types.hs module

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -49,6 +49,7 @@ library
                       PostgREST.App
                       PostgREST.AppState
                       PostgREST.Auth
+                      PostgREST.Auth.Types
                       PostgREST.CLI
                       PostgREST.Config
                       PostgREST.Config.Database

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -42,7 +42,7 @@ import qualified PostgREST.Unix       as Unix (installSignalHandlers)
 
 import PostgREST.ApiRequest           (ApiRequest (..))
 import PostgREST.AppState             (AppState)
-import PostgREST.Auth                 (AuthResult (..))
+import PostgREST.Auth.Types           (AuthResult (..))
 import PostgREST.Config               (AppConfig (..), LogLevel (..))
 import PostgREST.Config.PgVersion     (PgVersion (..))
 import PostgREST.Error                (Error)

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -4,7 +4,6 @@
 
 module PostgREST.AppState
   ( AppState
-  , AuthResult(..)
   , destroy
   , getConfig
   , getSchemaCache
@@ -31,8 +30,6 @@ module PostgREST.AppState
   , isPending
   ) where
 
-import qualified Data.Aeson                 as JSON
-import qualified Data.Aeson.KeyMap          as KM
 import qualified Data.ByteString.Char8      as BS
 import qualified Data.Cache                 as C
 import           Data.Either.Combinators    (whenLeft)
@@ -60,6 +57,7 @@ import Data.IORef         (IORef, atomicWriteIORef, newIORef,
                            readIORef)
 import Data.Time.Clock    (UTCTime, getCurrentTime)
 
+import PostgREST.Auth.Types              (AuthResult)
 import PostgREST.Config                  (AppConfig (..),
                                           addFallbackAppName,
                                           readAppConfig)
@@ -77,11 +75,6 @@ import PostgREST.Unix                    (createAndBindDomainSocket)
 import Data.Streaming.Network (bindPortTCP, bindRandomPortTCP)
 import Data.String            (IsString (..))
 import Protolude
-
-data AuthResult = AuthResult
-  { authClaims :: KM.KeyMap JSON.Value
-  , authRole   :: BS.ByteString
-  }
 
 data AppState = AppState
   -- | Database connection pool

--- a/src/PostgREST/Auth.hs
+++ b/src/PostgREST/Auth.hs
@@ -12,8 +12,7 @@ very simple authentication system inside the PostgreSQL database.
 -}
 {-# LANGUAGE RecordWildCards #-}
 module PostgREST.Auth
-  ( AuthResult (..)
-  , getResult
+  ( getResult
   , getJwtDur
   , getRole
   , middleware
@@ -45,11 +44,12 @@ import System.Clock            (TimeSpec (..))
 import System.IO.Unsafe        (unsafePerformIO)
 import System.TimeIt           (timeItT)
 
-import PostgREST.AppState (AppState, AuthResult (..), getConfig,
-                           getJwtCache, getTime)
-import PostgREST.Config   (AppConfig (..), FilterExp (..), JSPath,
-                           JSPathExp (..))
-import PostgREST.Error    (Error (..))
+import PostgREST.AppState   (AppState, getConfig, getJwtCache,
+                             getTime)
+import PostgREST.Auth.Types (AuthResult (..))
+import PostgREST.Config     (AppConfig (..), FilterExp (..), JSPath,
+                             JSPathExp (..))
+import PostgREST.Error      (Error (..))
 
 import Protolude
 

--- a/src/PostgREST/Auth/Types.hs
+++ b/src/PostgREST/Auth/Types.hs
@@ -1,0 +1,13 @@
+module PostgREST.Auth.Types
+  ( AuthResult (..) )
+  where
+
+import qualified Data.Aeson        as JSON
+import qualified Data.Aeson.KeyMap as KM
+import qualified Data.ByteString   as BS
+
+-- | Parse result for JWT Claims
+data AuthResult = AuthResult
+  { authClaims :: KM.KeyMap JSON.Value
+  , authRole   :: BS.ByteString
+  }

--- a/src/PostgREST/Query.hs
+++ b/src/PostgREST/Query.hs
@@ -37,7 +37,7 @@ import PostgREST.ApiRequest.Preferences  (PreferCount (..),
                                           PreferTransaction (..),
                                           Preferences (..),
                                           shouldCount)
-import PostgREST.Auth                    (AuthResult (..))
+import PostgREST.Auth.Types              (AuthResult (..))
 import PostgREST.Config                  (AppConfig (..),
                                           OpenAPIMode (..))
 import PostgREST.Config.PgVersion        (PgVersion (..))


### PR DESCRIPTION
The `AuthResult` type does not belong to AppState module. This commit refactors this by moving it to a new module `Auth/Types.hs`.

The dependency graph now looks something like
```haskell
-- App.hs <-- Auth.hs <-- AppState.hs <-- Auth/Types.hs
```