### PR TITLE
perf: Backport of #3889 to v12

### DIFF
--- a/src/PostgREST/Auth.hs
+++ b/src/PostgREST/Auth.hs
@@ -10,6 +10,7 @@ Authentication should always be implemented in an external service.
 In the test suite there is an example of simple login function that can be used for a
 very simple authentication system inside the PostgreSQL database.
 -}
+{-# LANGUAGE LambdaCase      #-}
 {-# LANGUAGE RecordWildCards #-}
 module PostgREST.Auth
   ( AuthResult (..)
@@ -44,8 +45,9 @@ import System.Clock            (TimeSpec (..))
 import System.IO.Unsafe        (unsafePerformIO)
 import System.TimeIt           (timeItT)
 
-import PostgREST.AppState (AppState, AuthResult (..), getConfig,
-                           getJwtCache, getTime)
+import PostgREST.AppState (AppState, AuthResult (..),
+                           JwtCacheState (..), getConfig,
+                           getJwtCacheState, getTime)
 import PostgREST.Config   (AppConfig (..), JSPath, JSPathExp (..))
 import PostgREST.Error    (Error (..))
 
@@ -131,7 +133,7 @@ middleware appState app req respond = do
 -- | Used to retrieve and insert JWT to JWT Cache
 getJWTFromCache :: AppState -> ByteString -> Int -> IO (Either Error AuthResult) -> UTCTime -> IO (Either Error AuthResult)
 getJWTFromCache appState token maxLifetime parseJwt utc = do
-  checkCache <- C.lookup (getJwtCache appState) token
+  checkCache <- C.lookup jwtCache token
   authResult <- maybe parseJwt (pure . Right) checkCache
 
   case (authResult,checkCache) of
@@ -151,17 +153,23 @@ getJWTFromCache appState token maxLifetime parseJwt utc = do
 
       let timeSpec = getTimeSpec res maxLifetime utc
 
-      -- purge expired cache entries
-      C.purgeExpired jwtCache
-
-      -- insert new cache entry
+      -- insert new cache entry first
       C.insert' jwtCache timeSpec token res
+
+      -- trigger asynchronous purging of expired cache entries
+      -- but only if not already running anotherpurging
+      tryPutMVar lock () >>= \case
+        -- start purge make sure lock is released
+        True -> void $ forkFinally (C.purgeExpired jwtCache) (const $ takeMVar lock)
+        -- purge already running - do nothing
+        _ -> pure ()
 
     _                    -> pure ()
 
   return authResult
     where
-      jwtCache = getJwtCache appState
+      lock = (purgeLock . getJwtCacheState) appState
+      jwtCache = (cache . getJwtCacheState) appState
 
 -- Used to extract JWT exp claim and add to JWT Cache
 getTimeSpec :: AuthResult -> Int -> UTCTime -> Maybe TimeSpec


### PR DESCRIPTION
See https://github.com/PostgREST/postgrest/pull/3889

@steve-chavez @taimoorzaeem
I've prepared a backport of asynchronous JWT cache purge to 12.
Looks like there is consistent (small but noticable) performance gain.

Done this as it is not clear when next major is going to be released (and if any JWT caching improvements are going to be included).