### PR TITLE
refactor: move `ApiRequestError` to Error module

### DIFF
--- a/src/PostgREST/ApiRequest.hs
+++ b/src/PostgREST/ApiRequest.hs
@@ -44,10 +44,10 @@ import Network.Wai.Parse         (parseHttpAccept)
 import Web.Cookie                (parseCookies)
 
 import PostgREST.ApiRequest.QueryParams  (QueryParams (..))
-import PostgREST.ApiRequest.Types        (ApiRequestError (..),
-                                          RangeError (..))
 import PostgREST.Config                  (AppConfig (..),
                                           OpenAPIMode (..))
+import PostgREST.Error                   (ApiRequestError (..),
+                                          RangeError (..))
 import PostgREST.MediaType               (MediaType (..))
 import PostgREST.RangeQuery              (NonnegRange, allRange,
                                           convertToLimitZeroRange,

--- a/src/PostgREST/ApiRequest/QueryParams.hs
+++ b/src/PostgREST/ApiRequest/QueryParams.hs
@@ -54,9 +54,11 @@ import PostgREST.ApiRequest.Types (AggregateFunction (..),
                                    OpQuantifier (..), Operation (..),
                                    OrderDirection (..),
                                    OrderNulls (..), OrderTerm (..),
-                                   QPError (..), QuantOperator (..),
+                                   QuantOperator (..),
                                    SelectItem (..),
                                    SimpleOperator (..), SingleVal)
+
+import PostgREST.Error (QPError (..))
 
 import Protolude hiding (Sum, try)
 

--- a/src/PostgREST/ApiRequest/Types.hs
+++ b/src/PostgREST/ApiRequest/Types.hs
@@ -5,7 +5,6 @@ module PostgREST.ApiRequest.Types
   , Cast
   , Depth
   , EmbedParam(..)
-  , ApiRequestError(..)
   , EmbedPath
   , Field
   , Filter(..)
@@ -25,9 +24,6 @@ module PostgREST.ApiRequest.Types
   , OrderDirection(..)
   , OrderNulls(..)
   , OrderTerm(..)
-  , QPError(..)
-  , RaiseError(..)
-  , RangeError(..)
   , SingleVal
   , IsVal(..)
   , SimpleOperator(..)
@@ -36,12 +32,7 @@ module PostgREST.ApiRequest.Types
   , SelectItem(..)
   ) where
 
-import PostgREST.MediaType                (MediaType (..))
-import PostgREST.SchemaCache.Identifiers  (FieldName,
-                                           QualifiedIdentifier)
-import PostgREST.SchemaCache.Relationship (Relationship,
-                                           RelationshipsMap)
-import PostgREST.SchemaCache.Routine      (Routine (..))
+import PostgREST.SchemaCache.Identifiers (FieldName)
 
 import Protolude
 
@@ -68,49 +59,6 @@ data SelectItem
     , selJoinType :: Maybe JoinType
     }
   deriving (Eq, Show)
-
-data ApiRequestError
-  = AggregatesNotAllowed
-  | AmbiguousRelBetween Text Text [Relationship]
-  | AmbiguousRpc [Routine]
-  | MediaTypeError [ByteString]
-  | InvalidBody ByteString
-  | InvalidFilters
-  | InvalidPreferences [ByteString]
-  | InvalidRange RangeError
-  | InvalidRpcMethod ByteString
-  | NotFound
-  | NoRelBetween Text Text (Maybe Text) Text RelationshipsMap
-  | NoRpc Text Text [Text] MediaType Bool [QualifiedIdentifier] [Routine]
-  | NotEmbedded Text
-  | PutLimitNotAllowedError
-  | QueryParamError QPError
-  | RelatedOrderNotToOne Text Text
-  | SpreadNotToOne Text Text
-  | UnacceptableFilter Text
-  | UnacceptableSchema [Text]
-  | UnsupportedMethod ByteString
-  | ColumnNotFound Text Text
-  | GucHeadersError
-  | GucStatusError
-  | PutMatchingPkError
-  | SingularityError Integer
-  | PGRSTParseError RaiseError
-  | MaxAffectedViolationError Integer
-  deriving Show
-
-data QPError = QPError Text Text
-  deriving Show
-data RaiseError
-  = MsgParseError ByteString
-  | DetParseError ByteString
-  | NoDetail
-  deriving Show
-data RangeError
-  = NegativeLimit
-  | LowerGTUpper
-  | OutOfBounds Text Text
-  deriving Show
 
 type NodeName = Text
 type Depth = Integer

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -42,7 +42,8 @@ import PostgREST.ApiRequest                  (Action (..),
                                               Mutation (..),
                                               Payload (..))
 import PostgREST.Config                      (AppConfig (..))
-import PostgREST.Error                       (Error (..))
+import PostgREST.Error                       (ApiRequestError (..),
+                                              Error (..))
 import PostgREST.MediaType                   (MediaType (..))
 import PostgREST.Query.SqlFragment           (sourceCTEName)
 import PostgREST.RangeQuery                  (NonnegRange, allRange,

--- a/src/PostgREST/Query.hs
+++ b/src/PostgREST/Query.hs
@@ -20,7 +20,6 @@ import qualified Hasql.DynamicStatements.Statement as SQL
 import qualified Hasql.Transaction                 as SQL
 import qualified Hasql.Transaction.Sessions        as SQL
 
-import qualified PostgREST.ApiRequest.Types   as ApiRequestTypes
 import qualified PostgREST.AppState           as AppState
 import qualified PostgREST.Error              as Error
 import qualified PostgREST.Query.QueryBuilder as QueryBuilder
@@ -217,7 +216,7 @@ failPut RSPlan{} = pure ()
 failPut RSStandard{rsQueryTotal=queryTotal} =
   when (queryTotal /= 1) $ do
     lift SQL.condemn
-    throwError $ Error.ApiRequestError ApiRequestTypes.PutMatchingPkError
+    throwError $ Error.ApiRequestError Error.PutMatchingPkError
 
 resultSetWTotal :: AppConfig -> ApiRequest -> ResultSet -> SQL.Snippet -> DbHandler ResultSet
 resultSetWTotal _ _ rs@RSPlan{} _ = return rs
@@ -249,14 +248,14 @@ failNotSingular _ RSPlan{} = pure ()
 failNotSingular mediaType RSStandard{rsQueryTotal=queryTotal} =
   when (elem mediaType [MTVndSingularJSON True, MTVndSingularJSON False] && queryTotal /= 1) $ do
     lift SQL.condemn
-    throwError $ Error.ApiRequestError . ApiRequestTypes.SingularityError $ toInteger queryTotal
+    throwError $ Error.ApiRequestError . Error.SingularityError $ toInteger queryTotal
 
 failExceedsMaxAffectedPref :: (Maybe PreferMaxAffected, Maybe PreferHandling) -> ResultSet -> DbHandler ()
 failExceedsMaxAffectedPref (Nothing,_) _ = pure ()
 failExceedsMaxAffectedPref _ RSPlan{} = pure ()
 failExceedsMaxAffectedPref (Just (PreferMaxAffected n), handling) RSStandard{rsQueryTotal=queryTotal} = when ((queryTotal > n) && (handling == Just Strict)) $ do
   lift SQL.condemn
-  throwError $ Error.ApiRequestError . ApiRequestTypes.MaxAffectedViolationError $ toInteger queryTotal
+  throwError $ Error.ApiRequestError . Error.MaxAffectedViolationError $ toInteger queryTotal
 
 -- | Set a transaction to roll back if requested
 optionalRollback :: AppConfig -> ApiRequest -> DbHandler ()

--- a/src/PostgREST/Response.hs
+++ b/src/PostgREST/Response.hs
@@ -50,7 +50,6 @@ import PostgREST.SchemaCache.Routine     (FuncVolatility (..),
                                           Routine (..))
 import PostgREST.SchemaCache.Table       (Table (..))
 
-import qualified PostgREST.ApiRequest.Types    as ApiRequestTypes
 import qualified PostgREST.SchemaCache.Routine as Routine
 
 import Protolude      hiding (Handler, toS)
@@ -83,8 +82,8 @@ actionResponse (DbCrudResult WrappedReadPlan{wrMedia, wrHdrsOnly=headersOnly, cr
 
       (ovStatus, ovHeaders) <- overrideStatusHeaders rsGucStatus rsGucHeaders status headers
 
-      let bod | status == HTTP.status416 = Error.errorPayload $ Error.ApiRequestError $ ApiRequestTypes.InvalidRange $
-                                           ApiRequestTypes.OutOfBounds (show $ RangeQuery.rangeOffset iTopLevelRange) (maybe "0" show rsTableTotal)
+      let bod | status == HTTP.status416 = Error.errorPayload $ Error.ApiRequestError $ Error.InvalidRange $
+                                           Error.OutOfBounds (show $ RangeQuery.rangeOffset iTopLevelRange) (maybe "0" show rsTableTotal)
               | headersOnly              = mempty
               | otherwise                = LBS.fromStrict rsBody
 
@@ -203,8 +202,8 @@ actionResponse (DbCallResult CallReadPlan{crMedia, crInvMthd=invMethod, crProc=p
       (status, contentRange) =
         RangeQuery.rangeStatusHeader iTopLevelRange rsQueryTotal rsTableTotal
       rsOrErrBody = if status == HTTP.status416
-        then Error.errorPayload $ Error.ApiRequestError $ ApiRequestTypes.InvalidRange
-          $ ApiRequestTypes.OutOfBounds (show $ RangeQuery.rangeOffset iTopLevelRange) (maybe "0" show rsTableTotal)
+        then Error.errorPayload $ Error.ApiRequestError $ Error.InvalidRange
+          $ Error.OutOfBounds (show $ RangeQuery.rangeOffset iTopLevelRange) (maybe "0" show rsTableTotal)
         else LBS.fromStrict rsBody
       prefHeader = maybeToList . prefAppliedHeader $ Preferences Nothing Nothing preferCount preferTransaction Nothing preferHandling preferTimezone preferMaxAffected []
       headers = contentRange : prefHeader
@@ -232,7 +231,7 @@ actionResponse (MaybeDbResult InspectPlan{ipHdrsOnly=headersOnly} body) _ versio
 actionResponse (NoDbResult (RelInfoPlan identifier)) _ _ _ sCache _ _ =
   case HM.lookup identifier (dbTables sCache) of
     Just tbl -> respondInfo $ allowH tbl
-    Nothing  -> Left $ Error.ApiRequestError ApiRequestTypes.NotFound
+    Nothing  -> Left $ Error.ApiRequestError Error.NotFound
   where
     allowH table =
       let hasPK = not . null $ tablePKCols table in
@@ -263,11 +262,11 @@ overrideStatusHeaders rsGucStatus rsGucHeaders pgrstStatus pgrstHeaders = do
 
 decodeGucHeaders :: Maybe BS.ByteString -> Either Error.Error [GucHeader]
 decodeGucHeaders =
-  maybe (Right []) $ first (const . Error.ApiRequestError $ ApiRequestTypes.GucHeadersError) . JSON.eitherDecode . LBS.fromStrict
+  maybe (Right []) $ first (const . Error.ApiRequestError $ Error.GucHeadersError) . JSON.eitherDecode . LBS.fromStrict
 
 decodeGucStatus :: Maybe Text -> Either Error.Error (Maybe HTTP.Status)
 decodeGucStatus =
-  maybe (Right Nothing) $ first (const . Error.ApiRequestError $ ApiRequestTypes.GucStatusError) . fmap (Just . toEnum . fst) . decimal
+  maybe (Right Nothing) $ first (const . Error.ApiRequestError $ Error.GucStatusError) . fmap (Just . toEnum . fst) . decimal
 
 contentTypeHeaders :: MediaType -> ApiRequest -> [HTTP.Header]
 contentTypeHeaders mediaType ApiRequest{..} =


### PR DESCRIPTION
This is first steps to improving our error infrastructure.
### Reasons for this refactor

- All error types should originate from `Error` module
- Removes re-exporting types
- No need to depend on an extra module (namely `ApiRequest/Types`).
- Would help in representing errors internally to something similar to how we group them in [docs](https://docs.postgrest.org/en/v12/references/errors.html#postgrest-error-codes)
- Would eventually help in adding new error types for error related issues (eg. #3600)