### PR TITLE
ci: Fix cirrus FreeBSD builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-14-1
+  image_family: freebsd-14-2
 
 build_task:
   # Don't change this name without adjusting .github/workflows/build.yaml


### PR DESCRIPTION
Apparently Cirrus removed the 14-1 image. When I firsted looked into this some days ago, when the job started failing, the docs were not updated, yet - so it wasn't clear. Now the docs mention freebsd-14-2 explicitly...