### PR TITLE
ci: Add MacOS x86-64 binaries to release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -96,13 +96,22 @@ jobs:
             artifact: postgrest-ubuntu-aarch64
             deps: sudo apt-get update && sudo apt-get install libpq-dev
 
-          - name: MacOS
+          - name: MacOS aarch64
             runs-on: macos-14
             cache: |
               ~/.stack/pantry
               ~/.stack/snapshots
               ~/.stack/stack.sqlite3
             artifact: postgrest-macos-aarch64
+            deps: brew link --force libpq
+
+          - name: MacOS x86-64
+            runs-on: macos-13
+            cache: |
+              ~/.stack/pantry
+              ~/.stack/snapshots
+              ~/.stack/stack.sqlite3
+            artifact: postgrest-macos-x86-64
             deps: brew link --force libpq
 
           - name: Windows

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,6 +81,9 @@ jobs:
           tar cJvf "release-bundle/postgrest-${GITHUB_REF_NAME}-macos-aarch64.tar.xz" \
             -C artifacts/postgrest-macos-aarch64 postgrest
 
+          tar cJvf "release-bundle/postgrest-${GITHUB_REF_NAME}-macos-x86-64.tar.xz" \
+            -C artifacts/postgrest-macos-x86-64 postgrest
+
           tar cJvf "release-bundle/postgrest-${GITHUB_REF_NAME}-freebsd-x86-64.tar.xz" \
             -C artifacts/postgrest-freebsd-x86-64 postgrest
 


### PR DESCRIPTION
The supported architectures for each GitHub Actions runner image can be seen here:
https://github.com/actions/runner-images?tab=readme-ov-file#available-images

Resolves #3937