### PR TITLE
fix: Fix ordering with mutation queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3795, Clarify `Accept: vnd.pgrst.object` error message - @steve-chavez
  - #3697, #3602, Handle queries on non-existing table gracefully - @taimoorzaeem
  - #3600, #3926, Improve JWT errors - @taimoorzaeem
+ - #3013, Fix `order=` with POST, PATCH, PUT and DELETE requests - @taimoorzaeem
 
 ### Changed
 

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -770,10 +770,7 @@ addFilters ctx ApiRequest{..} rReq =
       updateNode (\flt (Node q@ReadPlan{from=fromTable, where_=lf} f) -> Node q{ReadPlan.where_=addFilterToLogicForest (resolveFilter ctx{qi=fromTable} flt) lf}  f)
 
 addOrders :: ResolverContext -> ApiRequest -> ReadPlanTree -> Either ApiRequestError ReadPlanTree
-addOrders ctx ApiRequest{..} rReq =
-  case iAction of
-    ActDb (ActRelationMut _ _) -> Right rReq
-    _                          -> foldr addOrderToNode (Right rReq) qsOrder
+addOrders ctx ApiRequest{..} rReq = foldr addOrderToNode (Right rReq) qsOrder
   where
     QueryParams.QueryParams{..} = iQueryParams
 

--- a/test/spec/Feature/Query/DeleteSpec.hs
+++ b/test/spec/Feature/Query/DeleteSpec.hs
@@ -149,3 +149,15 @@ spec =
             { matchStatus = 204
             , matchHeaders = [matchHeaderAbsent hContentType]
             }
+
+    context "with ordering" $
+      it "works with request method DELETE and embedded resource" $ do
+        request methodDelete "/artists?id=lt.3&select=id,name,albums(title)&order=id.desc"
+          [("Prefer", "return=representation")]
+          ""
+          `shouldRespondWith`
+          [json| [ {"id":2,"name":"black country, new road","albums":[{"title": "ants from up above"}]}, {"id":1,"name":"duster","albums":[{"title": "stratosphere"},{"title": "contemporary movement"}]}]
+          |]
+          { matchStatus  = 200
+          , matchHeaders = [matchContentTypeJson, "Preference-Applied" <:> "return=representation"]
+          }

--- a/test/spec/fixtures/data.sql
+++ b/test/spec/fixtures/data.sql
@@ -921,3 +921,15 @@ INSERT INTO tsearch_to_tsvector(text_search) VALUES ('C''est un peu amusant de f
 INSERT INTO tsearch_to_tsvector(text_search) VALUES ('Es ist eine Art Spaß, das Unmögliche zu machen');
 
 UPDATE tsearch_to_tsvector SET jsonb_search = jsonb_build_object('text_search', text_search);
+
+
+TRUNCATE TABLE artists CASCADE;
+INSERT INTO artists
+VALUES (1, 'duster'), (2, 'black country, new road'), (3, 'bjork');
+
+TRUNCATE TABLE albums CASCADE;
+INSERT INTO albums 
+VALUES (1, 'stratosphere', 1),
+       (2, 'ants from up above',2), 
+       (3, 'vespertine',3),
+       (4, 'contemporary movement', 1);

--- a/test/spec/fixtures/privileges.sql
+++ b/test/spec/fixtures/privileges.sql
@@ -61,3 +61,6 @@ REVOKE EXECUTE ON FUNCTION privileged_hello(text) FROM PUBLIC; -- All functions 
 GRANT EXECUTE ON FUNCTION privileged_hello(text) TO postgrest_test_author;
 
 GRANT USAGE ON SCHEMA test TO postgrest_test_default_role;
+
+GRANT ALL ON TABLE artists TO postgrest_test_anonymous;
+GRANT ALL ON TABLE albums TO postgrest_test_anonymous;

--- a/test/spec/fixtures/schema.sql
+++ b/test/spec/fixtures/schema.sql
@@ -3762,3 +3762,20 @@ $$ language sql;
 create function test.text_search_vector(test.tsearch_to_tsvector) returns tsvector AS $$
   select to_tsvector('simple', $1.text_search)
 $$ language sql;
+
+-- to test ordering with mutations
+CREATE TABLE test.artists (
+  id int PRIMARY KEY,
+  name text
+);
+
+CREATE TABLE test.albums (
+  id int PRIMARY KEY,
+  title text,
+  artist_id int,
+
+  CONSTRAINT fk_artist
+    FOREIGN KEY (artist_id) REFERENCES artists (id)
+    ON UPDATE CASCADE
+    ON DELETE CASCADE
+);


### PR DESCRIPTION
Closes #3013. Do we need more tests? Not sure if ordering is used for `POST` requests.
