### PR TITLE
nix: Disable building profiled or dynamic libraries by default

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -72,17 +72,17 @@ The PostgREST utilities available in `nix-shell` all have names that begin with
 ```bash
 # Note: The utilities listed here might not be up to date.
 [nix-shell]$ postgrest-<tab>
-postgrest-build                   postgrest-parallel-curl
-postgrest-check                   postgrest-profiled-run
-postgrest-clean                   postgrest-push-cachix
-postgrest-coverage                postgrest-release
-postgrest-coverage-draft-overlay  postgrest-repl
-postgrest-docs-build              postgrest-run
-postgrest-docs-check              postgrest-style
-postgrest-docs-dictcheck          postgrest-style-check
-postgrest-docs-linkcheck          postgrest-test-big-schema
-postgrest-docs-render             postgrest-test-doctests
-postgrest-docs-serve              postgrest-test-io
+postgrest-build                   postgrest-profiled-run
+postgrest-check                   postgrest-push-cachix
+postgrest-clean                   postgrest-release
+postgrest-coverage                postgrest-repl
+postgrest-coverage-draft-overlay  postgrest-run
+postgrest-docs-build              postgrest-style
+postgrest-docs-check              postgrest-style-check
+postgrest-docs-dictcheck          postgrest-test-big-schema
+postgrest-docs-linkcheck          postgrest-test-doctests
+postgrest-docs-render             postgrest-test-io
+postgrest-docs-serve              postgrest-test-memory
 postgrest-docs-spellcheck         postgrest-test-replica
 postgrest-dump-minimal-imports    postgrest-test-spec
 postgrest-dump-schema             postgrest-test-spec-idempotence
@@ -98,27 +98,27 @@ postgrest-loadtest                postgrest-with-postgresql-16
 postgrest-loadtest-against        postgrest-with-postgresql-17
 postgrest-loadtest-report         postgrest-with-slow-pg
 postgrest-nixpkgs-upgrade         postgrest-with-slow-postgrest
+postgrest-parallel-curl
 ...
 
 [nix-shell]$
 
 ```
 
-Some additional modules like `memory` and `docker`
-have large dependencies that would need to be built before the shell becomes
+The `docker` module has large dependencies to be build before the shell becomes
 available, which could take an especially long time if the cachix binary cache
-is not used. You can activate those by passing a flag to `nix-shell` with
-`nix-shell --arg <module> true`. This will make the respective utilities available:
+is not used. You can activate it by passing a flag to `nix-shell` with
+`nix-shell --arg docker true`. This will make the respective utilities available:
 
 ```bash
-$ nix-shell --arg memory true
-[nix-shell]$ postgrest-test-m<tab>
-postgrest-test-memory
+$ nix-shell --arg docker true
+[nix-shell]$ postgrest-docker-<tab>
+postgrest-docker-load
 ...
 
 ```
 
-Note that `postgrest-test-memory` is now also available.
+Note that `postgrest-docker-load` is now also available.
 
 To run one-off commands, you can also use `nix-shell --run <command>`, which
 will launch the Nix shell, run that one command and exit. Note that the tab

--- a/shell.nix
+++ b/shell.nix
@@ -7,7 +7,6 @@
 # We highly recommend that use the PostgREST binary cache by installing cachix
 # (https://app.cachix.org/) and running `cachix use postgrest`.
 { docker ? false
-, memory ? false
 }:
 let
   postgrest =
@@ -23,14 +22,14 @@ let
       postgrest.devTools
       postgrest.docs
       postgrest.loadtest
+      postgrest.memory
       postgrest.nixpkgsTools
       postgrest.release
       postgrest.style
       postgrest.tests
       postgrest.withTools
     ]
-    ++ lib.optional docker postgrest.docker
-    ++ lib.optional memory postgrest.memory;
+    ++ lib.optional docker postgrest.docker;
 
 in
 lib.overrideDerivation postgrest.env (


### PR DESCRIPTION
We never need dynamic haskell libraries, because even the dynamic builds
only dynamically link non-haskell dependencies, but always link haskell
dependencies statically.

Profiled libraries are only required when running the memory test, so
explicitly enable them for the profiled package.

This also means, that we don't need to hide the memory test behind a
feature flag anymore. The reason always was assumed to be the big number
of rebuilds required for it. I assume ever since we moved off of
static-haskell-nix and back to nixpkgs-based builds, we have been
building profiled libraries for all our dependencies anway.

As discussed in https://github.com/PostgREST/postgrest/pull/3802#issuecomment-2737746937

Resolves #3881