### PR TITLE
fix: Add errors OpenAPIDisabled and InvalidResourcePath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3697, #3602, Handle queries on non-existing table gracefully - @taimoorzaeem
  - #3600, #3926, Improve JWT errors - @taimoorzaeem
  - #3013, Fix `order=` with POST, PATCH, PUT and DELETE requests - @taimoorzaeem
- - #3906, Add `PGRST125` and `PGRST126` errors instead of empty json - @taimoorzaeem
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3697, #3602, Handle queries on non-existing table gracefully - @taimoorzaeem
  - #3600, #3926, Improve JWT errors - @taimoorzaeem
  - #3013, Fix `order=` with POST, PATCH, PUT and DELETE requests - @taimoorzaeem
+ - #3906, Add `PGRST125` and `PGRST126` errors instead of empty json - @taimoorzaeem
 
 ### Changed
 
@@ -49,6 +50,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + Return `PGRST301` error when `Bearer` in auth header is sent empty
    + Diagnostic error messages instead of exposed internals
    + Return new `PGRST303` error when jwt claims decoding fails
+ - #3906, Return `PGRST125` and `PGRST126` errors instead of empty json - @taimoorzaeem
 
 ## [12.2.8] - 2025-02-10
 

--- a/docs/references/errors.rst
+++ b/docs/references/errors.rst
@@ -253,6 +253,14 @@ Related to the HTTP request elements.
 |               |             | See :ref:`db-aggregates-enabled`.                           |
 | PGRST123      |             |                                                             |
 +---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst125: | 404         | Invalid path is specified in request URL.                   |
+|               |             |                                                             |
+| PGRST125      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst126: | 404         | Open API config is disabled but API root path is            |
+|               |             | accessed. See :ref:`openapi-mode`.                          |
+| PGRST126      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
 
 .. _pgrst2**:
 

--- a/src/PostgREST/Response.hs
+++ b/src/PostgREST/Response.hs
@@ -228,10 +228,10 @@ actionResponse (MaybeDbResult InspectPlan{ipHdrsOnly=headersOnly} body) _ versio
     (MediaType.toContentType MTOpenAPI : maybeToList (profileHeader schema negotiatedByProfile))
     (maybe mempty (\(x, y, z) -> if headersOnly then mempty else OpenAPI.encode versions conf sCache x y z) body)
 
-actionResponse (NoDbResult (RelInfoPlan identifier)) _ _ _ sCache _ _ =
-  case HM.lookup identifier (dbTables sCache) of
+actionResponse (NoDbResult (RelInfoPlan qi@QualifiedIdentifier{..})) _ _ _ SchemaCache{dbTables} _ _ =
+  case HM.lookup qi dbTables of
     Just tbl -> respondInfo $ allowH tbl
-    Nothing  -> Left $ Error.ApiRequestError Error.NotFound
+    Nothing  -> Left $ Error.ApiRequestError $ Error.TableNotFound qiSchema qiName (HM.elems dbTables)
   where
     allowH table =
       let hasPK = not . null $ tablePKCols table in

--- a/test/spec/Feature/OpenApi/DisabledOpenApiSpec.hs
+++ b/test/spec/Feature/OpenApi/DisabledOpenApiSpec.hs
@@ -3,8 +3,9 @@ module Feature.OpenApi.DisabledOpenApiSpec where
 import Network.HTTP.Types
 import Network.Wai        (Application)
 
-import Test.Hspec     hiding (pendingWith)
+import Test.Hspec
 import Test.Hspec.Wai
+import Test.Hspec.Wai.JSON
 
 import Protolude
 
@@ -13,4 +14,7 @@ spec =
   describe "Disabled OpenApi" $ do
     it "responds with 404" $
       request methodGet "/"
-        [("Accept","application/openapi+json")] "" `shouldRespondWith` 404
+        [("Accept","application/openapi+json")] ""
+        `shouldRespondWith`
+        [json| {"code":"PGRST126","details":null,"hint":null,"message":"Root endpoint metadata is disabled"} |]
+        { matchStatus = 404 }

--- a/test/spec/Feature/Query/QuerySpec.hs
+++ b/test/spec/Feature/Query/QuerySpec.hs
@@ -1625,3 +1625,10 @@ spec = do
       get "/infinite_recursion?select=*" `shouldRespondWith`
         [json|{"code":"42P17","message":"infinite recursion detected in rules for relation \"infinite_recursion\"","details":null,"hint":null}|]
         { matchStatus = 500 }
+
+  context "invalid resource path" $ do
+    it "return http status 404" $
+      get "/first/second/third?select=*"
+      `shouldRespondWith`
+      [json| {"code":"PGRST125","details":null,"hint":null,"message":"Invalid path specified in request URL"} |]
+      { matchStatus = 404 }


### PR DESCRIPTION
Removes the empty `NotFound` error.

Closes #3906.