### PR TITLE
refactor: cleanup error status and headers

### DIFF
--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -260,7 +260,7 @@ usePool AppState{stateObserver=observer, stateMainThreadId=mainThreadId, ..} ses
           observer $ ExitDBFatalError ServerError08P01 err
           killThread mainThreadId
         SQL.ServerError{} ->
-          when (Error.status (Error.PgError False err) >= HTTP.status500) $
+          when (Error.status False (Error.PgError err) >= HTTP.status500) $
             observer $ QueryErrorCodeHighObs err
     err@(SQL.SessionUsageError (SQL.QueryError _ _ (SQL.ClientError _))) ->
       -- An error on the client-side, usually indicates problems wth connection

--- a/src/PostgREST/Observation.hs
+++ b/src/PostgREST/Observation.hs
@@ -150,7 +150,7 @@ observationMessage = \case
     showMillis :: Double -> Text
     showMillis x = toS $ showFFloat (Just 1) (x * 1000) ""
 
-    jsonMessage err = T.decodeUtf8 . LBS.toStrict . Error.errorPayload $ Error.PgError False err
+    jsonMessage err = T.decodeUtf8 . LBS.toStrict . Error.errorPayload $ Error.PgError err
 
     showListenerError :: Either SomeException () -> Text
     showListenerError (Right _) = "Failed getting notifications" -- should not happen as the listener will never finish (hasql-notifications uses `forever` internally) with a Right result


### PR DESCRIPTION
The error status and headers depend on the authentication parameter. This was not explicitly showed and was hidden in the `PgError` type.

Later, it would be easier to implement new error related features with this change.

For #2967, we need to make `code :: a -> ErrorCode` part of the `PgrstError` typeclass to ensure that every error has a code. This refactor will help implement that cleanly.
