### PR TITLE
fix: Fix parsing of the `for` parameter of plan media type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - #3697, #3602, Handle queries on non-existing table gracefully - @taimoorzaeem
  - #3600, #3926, Improve JWT errors - @taimoorzaeem
  - #3013, Fix `order=` with POST, PATCH, PUT and DELETE requests - @taimoorzaeem
+ - #3498, Fix incorrect parsing of the `for` parameter of the `application/vnd.pgrst.plan` media type - @taimoorzaeem
 
 ### Changed
 


### PR DESCRIPTION
The media type parser had some bugs. It didn't allow space separated parameters and the handling of quoted text was clunky. This commit improves the media type parser to fix these bugs.

Closes #3498 without too many changes. More refactoring is needed but that's a task for the future.