### PR TITLE
v12:  fix: Fix parsing of the for parameter of plan media type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+
+ - #3498, Fix incorrect parsing of the `for` parameter of the `application/vnd.pgrst.plan` media type - @taimoorzaeem
+
 ## [12.2.8] - 2025-02-10
 
 ### Fixed

--- a/test/memory/memory-tests.sh
+++ b/test/memory/memory-tests.sh
@@ -103,8 +103,8 @@ postJsonArrayTest(){
 echo "Running memory usage tests.."
 
 jsonKeyTest "1M" "POST" "/rpc/leak?columns=blob" "27M"
-jsonKeyTest "1M" "POST" "/leak?columns=blob" "20M"
-jsonKeyTest "1M" "PATCH" "/leak?id=eq.1&columns=blob" "20M"
+jsonKeyTest "1M" "POST" "/leak?columns=blob" "21M"
+jsonKeyTest "1M" "PATCH" "/leak?id=eq.1&columns=blob" "21M"
 
 jsonKeyTest "10M" "POST" "/rpc/leak?columns=blob" "32M"
 jsonKeyTest "10M" "POST" "/leak?columns=blob" "32M"


### PR DESCRIPTION
#4005 applies cleanly on v12.

I have not looked into it at all, should we backport it?