### PR TITLE
test: add loadtest for async purge of JWT cache

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -111,6 +111,9 @@ jobs:
 
 
   loadtest:
+    strategy:
+      matrix:
+        kind: ['mixed', 'jwt']
     name: Loadtest
     runs-on: ubuntu-24.04
     steps:
@@ -128,7 +131,7 @@ jobs:
           prefix: v
       - name: Run loadtest
         run: |
-          postgrest-loadtest-against main ${{ steps.get-latest-tag.outputs.tag }}
+          postgrest-loadtest-against -k ${{ matrix.kind }} main ${{ steps.get-latest-tag.outputs.tag }}
           postgrest-loadtest-report >> "$GITHUB_STEP_SUMMARY"
 
   flake:

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ coverage
 loadtest
 .history
 .docs-build
+gen_targets.http

--- a/nix/tools/generate_targets.py
+++ b/nix/tools/generate_targets.py
@@ -1,0 +1,94 @@
+# generates a file to be used by the vegeta load testing tool
+import time
+import hmac
+import hashlib
+import base64
+import json
+import argparse
+import sys
+import random
+
+SECRET = b"reallyreallyreallyreallyverysafe"
+URL = "http://postgrest"
+JWT_DURATION = 120
+TOTAL_TARGETS = 50000  # tuned by hand to reduce result variance
+
+
+def base64url_encode(data: bytes) -> str:
+    """URL-safe Base64 encode without padding."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def generate_jwt(exp_inc: int) -> str:
+    """Generate an HS256 JWT"""
+    # Header & payload
+    header = {"alg": "HS256", "typ": "JWT"}
+    now = int(time.time())
+    payload = {
+        "sub": f"user_{random.getrandbits(32)}",
+        "iat": now,
+        "exp": now + exp_inc,
+        "role": "postgrest_test_author",
+    }
+
+    # Encode to JSON and then to Base64URL
+    header_b = json.dumps(header, separators=(",", ":")).encode()
+    payload_b = json.dumps(payload, separators=(",", ":")).encode()
+    header_b64 = base64url_encode(header_b)
+    payload_b64 = base64url_encode(payload_b)
+
+    # Sign (HMAC‑SHA256) the "<header>.<payload>" string
+    signing_input = f"{header_b64}.{payload_b64}".encode()
+    signature = hmac.new(SECRET, signing_input, hashlib.sha256).digest()
+    signature_b64 = base64url_encode(signature)
+
+    return f"{header_b64}.{payload_b64}.{signature_b64}"
+
+
+# We want to ensure 401 Unauthorized responses don't happen during
+# JWT validation, this can happen when the jwt `exp` is too short.
+# At the same time, we want to ensure the `exp` is not too big,
+# so expires will occur and postgREST will have to clean cached expired JWTs.
+def estimate_adequate_jwt_exp_increase(iteration: int) -> int:
+    # estimated time takes to build and run postgrest itself
+    build_run_postgrest_time = 2
+    # estimated time it takes to generate the targets file
+    file_generation_time = TOTAL_TARGETS // (10**-5)
+    # estimated exp time so some JWTs will expire
+    dynamic_exp_inc = iteration // 1000
+
+    return build_run_postgrest_time + file_generation_time + dynamic_exp_inc
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate Vegeta targets with unique JWTs"
+    )
+    parser.add_argument(
+        "output",
+        help="Path to write the generated targets file",
+    )
+    args = parser.parse_args()
+
+    lines = []
+    start_time = time.time()
+
+    for i in range(TOTAL_TARGETS):
+        token = generate_jwt(estimate_adequate_jwt_exp_increase(i))
+        lines.append(f"OPTIONS {URL}/authors_only")
+        lines.append(f"Authorization: Bearer {token}")
+        lines.append("")  # blank line to separate requests
+
+    try:
+        with open(args.output, "w") as f:
+            f.write("\n".join(lines))
+    except IOError as e:
+        print(f"Error writing to {args.output}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    elapsed = time.time() - start_time
+    print(f"Created {TOTAL_TARGETS} targets in {args.output} ({elapsed:.2f}s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/nix/tools/loadtest.nix
+++ b/nix/tools/loadtest.nix
@@ -41,6 +41,8 @@ let
         args = [
           "ARG_OPTIONAL_SINGLE([output], [o], [Filename to dump json output to], [./loadtest/result.bin])"
           "ARG_OPTIONAL_SINGLE([testdir], [t], [Directory to load tests and fixtures from], [./test/load])"
+          "ARG_OPTIONAL_SINGLE([kind], [k], [Kind of loadtest (mixed: repeat mixed requests, jwt: run once over many requests with unique jwts)], [mixed])"
+          "ARG_TYPE_GROUP_SET([KIND], [KIND], [kind], [mixed,jwt])"
           "ARG_LEFTOVERS([additional vegeta arguments])"
         ];
         workingDir = "/";
@@ -61,13 +63,30 @@ let
         mkdir -p "$(dirname "$_arg_output")"
         abs_output="$(realpath "$_arg_output")"
 
-        # shellcheck disable=SC2145
-        ${withTools.withPg} -f "$_arg_testdir"/fixtures.sql \
-        ${withTools.withSlowPg} \
-        ${withTools.withPgrst} \
-        ${withTools.withSlowPgrst} \
-        sh -c "cd \"$_arg_testdir\" && ${runner} -targets targets.http -output \"$abs_output\" \"''${_arg_leftovers[@]}\""
-        ${vegeta}/bin/vegeta report -type=text "$_arg_output"
+        case "$_arg_kind" in
+          jwt)
+
+            ${genTargets} "$_arg_testdir"/gen_targets.http
+
+            # shellcheck disable=SC2145
+            ${withTools.withPg} -f "$_arg_testdir"/fixtures.sql \
+            ${withTools.withPgrst} \
+            sh -c "cd \"$_arg_testdir\" && ${runner} -lazy -targets gen_targets.http -output \"$abs_output\" \"''${_arg_leftovers[@]}\""
+            ${vegeta}/bin/vegeta report -type=text "$_arg_output"
+            ;;
+
+          *)
+
+            # shellcheck disable=SC2145
+            ${withTools.withPg} -f "$_arg_testdir"/fixtures.sql \
+            ${withTools.withSlowPg} \
+            ${withTools.withPgrst} \
+            ${withTools.withSlowPgrst} \
+            sh -c "cd \"$_arg_testdir\" && ${runner} -targets targets.http -output \"$abs_output\" \"''${_arg_leftovers[@]}\""
+            ${vegeta}/bin/vegeta report -type=text "$_arg_output"
+            ;;
+
+        esac
       '';
 
   loadtestAgainst =
@@ -85,6 +104,7 @@ let
           '';
         args = [
           "ARG_POSITIONAL_INF([target], [Commit-ish reference to compare with], 1)"
+          "ARG_OPTIONAL_SINGLE([kind], [k], [Kind of loadtest], [mixed])"
         ];
         positionalCompletion =
           ''
@@ -108,7 +128,7 @@ let
         # Save the results in the current working tree, too,
         # otherwise they'd be lost in the temporary working tree
         # created by withTools.withGit.
-        ${withTools.withGit} "$tgt" ${loadtest} --output "$PWD/loadtest/$tgt.bin" --testdir "$PWD/test/load"
+        ${withTools.withGit} "$tgt" ${loadtest} -k "$_arg_kind" --output "$PWD/loadtest/$tgt.bin" --testdir "$PWD/test/load"
 
         cat << EOF
 
@@ -124,7 +144,7 @@ let
 
         EOF
 
-        ${loadtest} --output "$PWD/loadtest/head.bin" --testdir "$PWD/test/load"
+        ${loadtest} -k "$_arg_kind" --output "$PWD/loadtest/head.bin" --testdir "$PWD/test/load"
 
         cat << EOF
 
@@ -180,6 +200,7 @@ let
           | ${toMarkdown}
       '';
 
+  genTargets = writers.writePython3 "postgrest-gen-loadtest-targets" { } (builtins.readFile ./generate_targets.py);
 in
 buildToolbox {
   name = "postgrest-loadtest";

--- a/test/load/fixtures.sql
+++ b/test/load/fixtures.sql
@@ -1,5 +1,7 @@
 CREATE ROLE postgrest_test_anonymous;
+CREATE ROLE postgrest_test_author;
 GRANT postgrest_test_anonymous TO :PGUSER;
+GRANT postgrest_test_author TO :PGUSER;
 CREATE SCHEMA test;
 
 -- PUT+PATCH target needs one record and column to modify
@@ -31,10 +33,19 @@ CREATE TABLE test.roles (
   character TEXT
 );
 
+
+CREATE TABLE test.authors_only ();
+
 CREATE FUNCTION test.call_me (name TEXT) RETURNS TEXT
 STABLE LANGUAGE SQL AS $$
   SELECT 'Hello ' || name || ', how are you?';
 $$;
 
-GRANT USAGE ON SCHEMA test TO postgrest_test_anonymous;
+GRANT USAGE ON SCHEMA test TO postgrest_test_anonymous, postgrest_test_author;
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA test TO postgrest_test_anonymous;
+
+REVOKE ALL PRIVILEGES ON TABLE
+      authors_only
+FROM postgrest_test_anonymous;
+
+GRANT ALL ON TABLE authors_only TO postgrest_test_author;


### PR DESCRIPTION
Closes #4001.

This proves the fix on https://github.com/PostgREST/postgrest/pull/3889, while running on v12.2.9 the loadtest doesn't even finish all the generated targets (50000) and has poor throughput, while HEAD will finish and show better throughput.

This has to be proved locally now since we already merged #3889 and released it, but it's very clear:

```
[nix-shell:~/Projects/postgrest]$ postgrest-loadtest-against -k jwt v12.2.9

Running loadtest on "v12.2.9"...

Preparing worktree (detached HEAD b454f29b)
Created 50000 targets in /home/stevechavez/Projects/postgrest/test/load/gen_targets.http (0.80s)
postgrest-with-postgresql-17: You can connect with: psql 'postgres:///postgres?host=/run/user/1000/postgrest/postgrest-with-postgresql-17-l0c/socket' -U postgres
postgrest-with-postgresql-17: You can tail the logs with: tail -f /run/user/1000/postgrest/postgrest-with-postgresql-17-l0c/db.log
Building postgrest (nix)... done.
Starting postgrest... done.
Requests      [total, rate, throughput]         12078, 201.27, 201.25
Duration      [total, attack, wait]             1m0s, 1m0s, 7.429ms
Latencies     [min, mean, 50, 90, 95, 99, max]  305.751µs, 4.966ms, 5.028ms, 8.792ms, 9.929ms, 11.863ms, 36.904ms
Bytes In      [total, mean]                     0, 0.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:12078  
Error Set:

Done running on "v12.2.9".


Running loadtest on HEAD...

Created 50000 targets in /home/stevechavez/Projects/postgrest/test/load/gen_targets.http (0.90s)
postgrest-with-postgresql-17: You can connect with: psql 'postgres:///postgres?host=/run/user/1000/postgrest/postgrest-with-postgresql-17-MkP/socket' -U postgres
postgrest-with-postgresql-17: You can tail the logs with: tail -f /run/user/1000/postgrest/postgrest-with-postgresql-17-MkP/db.log
Building postgrest (nix)... done.
Starting postgrest... done.
Requests      [total, rate, throughput]         50001, 3427.18, 3427.11
Duration      [total, attack, wait]             14.59s, 14.59s, 1.115µs
Latencies     [min, mean, 50, 90, 95, 99, max]  1.115µs, 290.499µs, 271.864µs, 364.489µs, 413.655µs, 653.284µs, 52.807ms
Bytes In      [total, mean]                     0, 0.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      0:1  200:50000  
Error Set:
no targets to attack

Done running on HEAD.
```