### PR TITLE
drop: Admin server `/config` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + This preference was deprecated in favor of Functions with an array of JSON objects
  - #3013, Drop support for Limited updates/deletes
    + The feature was complicated and largely unused.
+ - #3956, Drop `/config` endpoint of admin server - @steve-chavez
+   + The endpoint was at risk of being left unprotected when exposing it.
+   + The accompanying `admin-server-config-enabled` config was also dropped.
  - #3697, #3602, Querying non-existent table now returns `PGRST205` error instead of empty json - @taimoorzaeem
  - #3600, #3926, Improve JWT errors - @taimoorzaeem
    + Return `PGRST301` error when `Bearer` in auth header is sent empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    + Return new `PGRST303` error when jwt claims decoding fails
  - #3906, Return `PGRST125` and `PGRST126` errors instead of empty json - @taimoorzaeem
 
+## [12.2.12] - 2025-05-01
+
+### Fixed
+
+- #3956, Fix exposing admin server `/config` by default - @steve-chavez
+  + The above endpoint is now disabled unless the `admin-server-config-enabled` config is set to `true`
+
 ## [12.2.11] - 2025-04-22
 
 ### Fixed

--- a/docs/references/admin_server.rst
+++ b/docs/references/admin_server.rst
@@ -55,23 +55,6 @@ Metrics
 
 Provides :ref:`metrics`.
 
-Runtime Configuration
-=====================
-
-Provides a ``config`` endpoint that returns the runtime :ref:`configuration`.
-
-.. code-block:: bash
-
-  curl "http://localhost:3001/config"
-
-.. code-block::
-
-  db-aggregates-enabled = false
-  db-anon-role = "web_anon"
-  db-channel = "pgrst"
-  db-channel-enabled = false
-  ...
-
 Runtime Schema Cache
 ====================
 

--- a/src/PostgREST/Admin.hs
+++ b/src/PostgREST/Admin.hs
@@ -11,8 +11,6 @@ import qualified Network.Wai.Handler.Warp  as Warp
 
 import Control.Monad.Extra (whenJust)
 
-import qualified Data.ByteString.Lazy as LBS
-
 import Network.Socket
 import Network.Socket.ByteString
 
@@ -23,8 +21,6 @@ import PostgREST.Network     (resolveHost)
 import PostgREST.Observation (Observation (..))
 
 import qualified PostgREST.AppState as AppState
-import qualified PostgREST.Config   as Config
-
 
 import Protolude
 
@@ -57,9 +53,6 @@ admin appState req respond  = do
                | otherwise              = HTTP.status500
       in
       respond $ Wai.responseLBS status [] mempty
-    ["config"] -> do
-      config <- AppState.getConfig appState
-      respond $ Wai.responseLBS HTTP.status200 [] (LBS.fromStrict $ encodeUtf8 $ Config.toText config)
     ["schema_cache"] -> do
       sCache <- AppState.getSchemaCache appState
       respond $ Wai.responseLBS HTTP.status200 [] (maybe mempty JSON.encode sCache)

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -776,16 +776,6 @@ def test_change_statement_timeout_held_connection(defaultenv, metapostgrest):
     reset_statement_timeout(metapostgrest, role)
 
 
-def test_admin_config(defaultenv):
-    "Should get a success response from the admin server containing current configuration"
-
-    with run(env=defaultenv) as postgrest:
-        response = postgrest.admin.get("/config")
-        print(response.text)
-        assert response.status_code == 200
-        assert "admin-server-port" in response.text
-
-
 def test_admin_schema_cache(defaultenv):
     "Should get a success response from the admin server containing current schema cache"
 


### PR DESCRIPTION
BREAKING CHANGE

The endpoint was at risk of being left unprotected when exposing it.

The accompanying `admin-server-config-enabled` config was also dropped.

Closes https://github.com/PostgREST/postgrest/issues/3956