### PR TITLE
refactor: remove auth middleware

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -142,7 +142,6 @@ library
                     , timeit                    >= 2.0 && < 2.1
                     , unordered-containers      >= 0.2.8 && < 0.3
                     , unix-compat               >= 0.5.4 && < 0.8
-                    , vault                     >= 0.3.1.5 && < 0.4
                     , vector                    >= 0.11 && < 0.14
                     , wai                       >= 3.2.1 && < 3.3
                     , wai-cors                  >= 0.2.5 && < 0.3

--- a/src/PostgREST/Logger.hs
+++ b/src/PostgREST/Logger.hs
@@ -10,10 +10,9 @@ module PostgREST.Logger
   , LoggerState
   ) where
 
-import           Control.AutoUpdate    (defaultUpdateSettings,
-                                        mkAutoUpdate, updateAction)
-import           Control.Debounce
-import qualified Data.ByteString.Char8 as BS
+import Control.AutoUpdate (defaultUpdateSettings, mkAutoUpdate,
+                           updateAction)
+import Control.Debounce
 
 import Data.Time (ZonedTime, defaultTimeLocale, formatTime,
                   getZonedTime)
@@ -56,15 +55,14 @@ logWithDebounce loggerState action = do
       newDebouncer
 
 -- TODO stop using this middleware to reuse the same "observer" pattern for all our logs
-middleware :: LogLevel -> (Wai.Request -> Maybe BS.ByteString) -> Wai.Middleware
-middleware logLevel getAuthRole =
+middleware :: LogLevel -> Wai.Middleware
+middleware logLevel =
     unsafePerformIO $
       Wai.mkRequestLogger Wai.defaultRequestLoggerSettings
       { Wai.outputFormat =
          Wai.ApacheWithSettings $
            Wai.defaultApacheSettings &
-           Wai.setApacheRequestFilter (\_ res -> shouldLogResponse logLevel $ Wai.responseStatus res) &
-           Wai.setApacheUserGetter getAuthRole
+           Wai.setApacheRequestFilter (\_ res -> shouldLogResponse logLevel $ Wai.responseStatus res)
       , Wai.autoFlush = True
       , Wai.destination = Wai.Handle stdout
       }

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -959,6 +959,8 @@ def test_log_level(level, defaultenv):
         assert response.status_code == 200
 
         output = sorted(postgrest.read_stdout(nlines=7))
+        for line in output:
+            print(line)
 
         if level == "crit":
             assert len(output) == 0
@@ -974,35 +976,35 @@ def test_log_level(level, defaultenv):
                 output[0],
             )
             assert re.match(
-                r'- - postgrest_test_anonymous \[.+\] "GET /unknown HTTP/1.1" 404 \d+ "" "python-requests/.+"',
+                r'- - - \[.+\] "GET /unknown HTTP/1.1" 404 \d+ "" "python-requests/.+"',
                 output[1],
             )
             assert len(output) == 2
         elif level == "info":
             assert re.match(
-                r'- - - \[.+\] "GET / HTTP/1.1" 500 \d+ "" "python-requests/.+"',
+                r'- - - \[.+\] "GET / HTTP/1.1" 200 \d+ "" "python-requests/.+"',
                 output[0],
             )
             assert re.match(
-                r'- - postgrest_test_anonymous \[.+\] "GET / HTTP/1.1" 200 \d+ "" "python-requests/.+"',
+                r'- - - \[.+\] "GET / HTTP/1.1" 500 \d+ "" "python-requests/.+"',
                 output[1],
             )
             assert re.match(
-                r'- - postgrest_test_anonymous \[.+\] "GET /unknown HTTP/1.1" 404 \d+ "" "python-requests/.+"',
+                r'- - - \[.+\] "GET /unknown HTTP/1.1" 404 \d+ "" "python-requests/.+"',
                 output[2],
             )
             assert len(output) == 3
         elif level == "debug":
             assert re.match(
-                r'- - - \[.+\] "GET / HTTP/1.1" 500 \d+ "" "python-requests/.+"',
+                r'- - - \[.+\] "GET / HTTP/1.1" 200 \d+ "" "python-requests/.+"',
                 output[0],
             )
             assert re.match(
-                r'- - postgrest_test_anonymous \[.+\] "GET / HTTP/1.1" 200 \d+ "" "python-requests/.+"',
+                r'- - - \[.+\] "GET / HTTP/1.1" 500 \d+ "" "python-requests/.+"',
                 output[1],
             )
             assert re.match(
-                r'- - postgrest_test_anonymous \[.+\] "GET /unknown HTTP/1.1" 404 \d+ "" "python-requests/.+"',
+                r'- - - \[.+\] "GET /unknown HTTP/1.1" 404 \d+ "" "python-requests/.+"',
                 output[2],
             )
 


### PR DESCRIPTION
Refactor for #3507.

This commit removes `Auth.middleware` as it hides side effects and obscures logic. The auth operations are now done in its own stage in the request-response cycle.
