### PR TITLE
refactor: [WIP] remove auth and logging middleware

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -67,6 +67,7 @@ library
                       PostgREST.Error
                       PostgREST.Listener
                       PostgREST.Logger
+                      PostgREST.Logger.Apache
                       PostgREST.MediaType
                       PostgREST.Metrics
                       PostgREST.Network
@@ -109,6 +110,7 @@ library
                     , directory                 >= 1.2.6 && < 1.4
                     , either                    >= 4.4.1 && < 5.1
                     , extra                     >= 1.7.0 && < 2.0
+                    , fast-logger               >= 3.2.0 && < 3.3
                     , fuzzyset                  >= 0.2.4 && < 0.3
                     , hasql                     >= 1.6.1.1 && < 1.7
                     , hasql-dynamic-statements  >= 0.3.1 && < 0.4
@@ -142,7 +144,6 @@ library
                     , timeit                    >= 2.0 && < 2.1
                     , unordered-containers      >= 0.2.8 && < 0.3
                     , unix-compat               >= 0.5.4 && < 0.8
-                    , vault                     >= 0.3.1.5 && < 0.4
                     , vector                    >= 0.11 && < 0.14
                     , wai                       >= 3.2.1 && < 3.3
                     , wai-cors                  >= 0.2.5 && < 0.3

--- a/src/PostgREST/Logger.hs
+++ b/src/PostgREST/Logger.hs
@@ -4,29 +4,24 @@ Description : Logging based on the Observation.hs module. Access logs get sent t
 -}
 -- TODO log with buffering enabled to not lose throughput on logging levels higher than LogError
 module PostgREST.Logger
-  ( middleware
-  , observationLogger
+  (observationLogger
   , init
   , LoggerState
   ) where
 
-import           Control.AutoUpdate    (defaultUpdateSettings,
-                                        mkAutoUpdate, updateAction)
-import           Control.Debounce
 import qualified Data.ByteString.Char8 as BS
 
-import Data.Time (ZonedTime, defaultTimeLocale, formatTime,
-                  getZonedTime)
-
-import qualified Network.Wai                          as Wai
-import qualified Network.Wai.Middleware.RequestLogger as Wai
-
-import Network.HTTP.Types.Status (Status, status400, status500)
-import System.IO.Unsafe          (unsafePerformIO)
-
-import PostgREST.Config      (LogLevel (..))
+import PostgREST.Config        (LogLevel (..))
+import PostgREST.Logger.Apache (apacheFormat)
 import PostgREST.Observation
 
+import Control.AutoUpdate        (defaultUpdateSettings, mkAutoUpdate,
+                                  updateAction)
+import Data.Time                 (ZonedTime, defaultTimeLocale,
+                                  formatTime, getZonedTime)
+import Network.HTTP.Types.Status (Status, status400, status500)
+
+import Control.Debounce
 import Protolude
 
 data LoggerState = LoggerState
@@ -54,20 +49,6 @@ logWithDebounce loggerState action = do
            }
       putMVar (stateLogDebouncePoolTimeout loggerState) newDebouncer
       newDebouncer
-
--- TODO stop using this middleware to reuse the same "observer" pattern for all our logs
-middleware :: LogLevel -> (Wai.Request -> Maybe BS.ByteString) -> Wai.Middleware
-middleware logLevel getAuthRole =
-    unsafePerformIO $
-      Wai.mkRequestLogger Wai.defaultRequestLoggerSettings
-      { Wai.outputFormat =
-         Wai.ApacheWithSettings $
-           Wai.defaultApacheSettings &
-           Wai.setApacheRequestFilter (\_ res -> shouldLogResponse logLevel $ Wai.responseStatus res) &
-           Wai.setApacheUserGetter getAuthRole
-      , Wai.autoFlush = True
-      , Wai.destination = Wai.Handle stdout
-      }
 
 shouldLogResponse :: LogLevel -> Status -> Bool
 shouldLogResponse logLevel = case logLevel of
@@ -100,6 +81,11 @@ observationLogger loggerState logLevel obs = case obs of
   o@PoolRequestFullfilled ->
     when (logLevel >= LogDebug) $ do
       logWithZTime loggerState $ observationMessage o
+  ResponseObs maybeRole req status contentLen ->
+    when (shouldLogResponse logLevel status) $ do
+      zTime <- stateGetZTime loggerState
+      let handl = stdout -- doing this indirection since the linter wants to change "hPutStr stdout" to "putStr", but we want "stdout" to appear explicitly
+      hPutStr handl $ apacheFormat maybeRole (BS.pack $ formatTime defaultTimeLocale "%d/%b/%Y:%T %z" zTime) req status contentLen -- TODO: time formatting logic belongs in Logger/Apache.hs module
   o ->
     logWithZTime loggerState $ observationMessage o
 

--- a/src/PostgREST/Logger/Apache.hs
+++ b/src/PostgREST/Logger/Apache.hs
@@ -1,0 +1,48 @@
+module PostgREST.Logger.Apache
+  ( apacheFormat
+  ) where
+
+import qualified Data.ByteString.Char8 as BS
+import           Network.Wai.Logger
+import           System.Log.FastLogger
+
+import Network.HTTP.Types.Status (Status, statusCode)
+import Network.Wai
+
+import Protolude
+
+apacheFormat :: ToLogStr user => Maybe user -> FormattedTime -> Request -> Status -> Maybe Integer -> ByteString
+apacheFormat maybeUser tmstr req status msize =
+  fromLogStr $ apacheLogStr maybeUser tmstr req status msize
+
+-- This code is vendored from
+-- https://github.com/kazu-yamamoto/logger/blob/57bc4d3b26ca094fd0c3a8a8bb4421bcdcdd7061/wai-logger/Network/Wai/Logger/Apache.hs#L44-L45
+apacheLogStr :: ToLogStr user => Maybe user -> FormattedTime -> Request -> Status -> Maybe Integer -> LogStr
+apacheLogStr maybeUser tmstr req status msize =
+      toLogStr (getSourceFromSocket req)
+  <> " - "
+  <> maybe "-" toLogStr maybeUser
+  <> " ["
+  <> toLogStr tmstr
+  <> "] \""
+  <> toLogStr (requestMethod req)
+  <> " "
+  <> toLogStr path
+  <> " "
+  <> toLogStr (show (httpVersion req)::Text)
+  <> "\" "
+  <> toLogStr (show (statusCode status)::Text)
+  <> " "
+  <> toLogStr (maybe "-" show msize::Text)
+  <> " \""
+  <> toLogStr (fromMaybe "" mr)
+  <> "\" \""
+  <> toLogStr (fromMaybe "" mua)
+  <> "\"\n"
+  where
+    path = rawPathInfo req <> rawQueryString req
+    mr  = requestHeaderReferer req
+    mua = requestHeaderUserAgent req
+
+getSourceFromSocket :: Request -> ByteString
+getSourceFromSocket = BS.pack . showSockAddr . remoteHost

--- a/src/PostgREST/Observation.hs
+++ b/src/PostgREST/Observation.hs
@@ -21,6 +21,7 @@ import qualified Hasql.Pool                 as SQL
 import qualified Hasql.Pool.Observation     as SQL
 import           Network.HTTP.Types.Status  (Status)
 import qualified Network.Socket             as NS
+import qualified Network.Wai                as Wai
 import           Numeric                    (showFFloat)
 import           PostgREST.Config.PgVersion
 import qualified PostgREST.Error            as Error
@@ -57,6 +58,7 @@ data Observation
   | PoolInit Int
   | PoolAcqTimeoutObs SQL.UsageError
   | HasqlPoolObs SQL.Observation
+  | ResponseObs (Maybe ByteString) Wai.Request Status (Maybe Integer)
   | PoolRequest
   | PoolRequestFullfilled
 
@@ -142,6 +144,8 @@ observationMessage = \case
           SQL.ReleaseConnectionTerminationReason        -> "release"
           SQL.NetworkErrorConnectionTerminationReason _ -> "network error" -- usage error is already logged, no need to repeat the same message.
     )
+  ResponseObs {} ->
+    mempty -- We log this observation early in Logger.hs in apache format
   PoolRequest ->
     "Trying to borrow a connection from pool"
   PoolRequestFullfilled ->

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -948,7 +948,7 @@ def test_log_level(level, defaultenv):
         response = postgrest.session.get("/")
         assert response.status_code == 200
 
-        output = sorted(postgrest.read_stdout(nlines=7))
+        output = postgrest.read_stdout(nlines=7)
 
         if level == "crit":
             assert len(output) == 0
@@ -964,7 +964,7 @@ def test_log_level(level, defaultenv):
                 output[0],
             )
             assert re.match(
-                r'- - postgrest_test_anonymous \[.+\] "GET /unknown HTTP/1.1" 404 \d+ "" "python-requests/.+"',
+                r'- - - \[.+\] "GET /unknown HTTP/1.1" 404 \d+ "" "python-requests/.+"',
                 output[1],
             )
             assert len(output) == 2
@@ -974,11 +974,11 @@ def test_log_level(level, defaultenv):
                 output[0],
             )
             assert re.match(
-                r'- - postgrest_test_anonymous \[.+\] "GET / HTTP/1.1" 200 \d+ "" "python-requests/.+"',
+                r'- - - \[.+\] "GET /unknown HTTP/1.1" 404 \d+ "" "python-requests/.+"',
                 output[1],
             )
             assert re.match(
-                r'- - postgrest_test_anonymous \[.+\] "GET /unknown HTTP/1.1" 404 \d+ "" "python-requests/.+"',
+                r'- - postgrest_test_anonymous \[.+\] "GET / HTTP/1.1" 200 \d+ "" "python-requests/.+"',
                 output[2],
             )
             assert len(output) == 3
@@ -988,12 +988,12 @@ def test_log_level(level, defaultenv):
                 output[0],
             )
             assert re.match(
-                r'- - postgrest_test_anonymous \[.+\] "GET / HTTP/1.1" 200 \d+ "" "python-requests/.+"',
+                r'- - - \[.+\] "GET /unknown HTTP/1.1" 404 \d+ "" "python-requests/.+"',
                 output[1],
             )
             assert re.match(
-                r'- - postgrest_test_anonymous \[.+\] "GET /unknown HTTP/1.1" 404 \d+ "" "python-requests/.+"',
-                output[2],
+                r'- - postgrest_test_anonymous \[.+\] "GET / HTTP/1.1" 200 \d+ "" "python-requests/.+"',
+                output[6],
             )
 
             assert len(output) == 7

--- a/test/spec/Main.hs
+++ b/test/spec/Main.hs
@@ -94,7 +94,7 @@ main = do
       appState <- AppState.initWithPool sockets pool config jwtCacheState loggerState metricsState (const $ pure ())
       AppState.putPgVersion appState actualPgVersion
       AppState.putSchemaCache appState (Just sCache)
-      return ((), postgrest (configLogLevel config) appState (pure ()))
+      return ((), postgrest appState (pure ()))
 
     -- For tests that run with the same schema cache
     app = initApp baseSchemaCache


### PR DESCRIPTION
Combines #4059 and #4062.

- Removes `vault` library (no longer needed).
- [x] Refactor
- [ ] Code cleanup

The log format remains the same except on error cases we wouldn't be able to get the user/role.
```
Old: 127.0.0.1 - postgrest_test_anonymous [05/May/2025:01:39:57 -0500] "GET /projects HTTP/1.1" 200 212 "" "curl/7.81.0"
New: 127.0.0.1 - postgrest_test_anonymous [05/May/2025:01:39:57 -0500] "GET /projects HTTP/1.1" 200 212 "" "curl/7.81.0"

Old: 127.0.0.1 - postgrest_test_anonymous [05/May/2025:01:39:57 -0500] "GET /unknown HTTP/1.1" 404 212 "" "curl/7.81.0"
New: 127.0.0.1 - - [05/May/2025:01:39:57 -0500] "GET /unknown HTTP/1.1" 404 212 "" "curl/7.81.0"
```