### PR TITLE
docs: add note in JWT Role Extraction section

### DIFF
--- a/docs/references/auth.rst
+++ b/docs/references/auth.rst
@@ -224,6 +224,9 @@ Usage examples:
     jwt-role-claim-key = ".postgrest.roles[?(@ ==^ \"hor\")]"
     jwt-role-claim-key = ".postgrest.roles[?(@ *== \"utho\")]"
 
+.. note::
+
+  The string comparison operators are implemented as a custom extension to the JSPath and does not strictly follow the `RFC 9535 <https://www.rfc-editor.org/rfc/rfc9535.html>`_.
 
 JWT Security
 ~~~~~~~~~~~~


### PR DESCRIPTION
Add a note describing that the used JSPath DSL does not strictly follow the JSONPath as described in RFC 9535.

Closes #4092.
