### PR TITLE
feat: add delta value between loadtest report columns

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -131,7 +131,7 @@ jobs:
           prefix: v
       - name: Run loadtest
         run: |
-          postgrest-loadtest-against -k ${{ matrix.kind }} main ${{ steps.get-latest-tag.outputs.tag }}
+          postgrest-loadtest-against -k ${{ matrix.kind }} main HEAD ${{ steps.get-latest-tag.outputs.tag }}
           postgrest-loadtest-report >> "$GITHUB_STEP_SUMMARY"
 
   flake:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -130,6 +130,7 @@ jobs:
         with:
           prefix: v
       - name: Run loadtest
+
         run: |
           postgrest-loadtest-against -k ${{ matrix.kind }} main HEAD ${{ steps.get-latest-tag.outputs.tag }}
           postgrest-loadtest-report >> "$GITHUB_STEP_SUMMARY"

--- a/nix/tools/loadtest.nix
+++ b/nix/tools/loadtest.nix
@@ -139,18 +139,6 @@ let
         done
 
         cat << EOF
-
-        Running loadtest on HEAD...
-
-        EOF
-
-        ${loadtest} -k "$_arg_kind" --output "$PWD/loadtest/head.bin" --testdir "$PWD/test/load"
-
-        cat << EOF
-
-        Done running on HEAD.
-
-        EOF
       '';
 
   reporter =

--- a/nix/tools/loadtest.nix
+++ b/nix/tools/loadtest.nix
@@ -137,8 +137,6 @@ let
         EOF
 
         done
-
-        cat << EOF
       '';
 
   reporter =
@@ -166,11 +164,19 @@ let
         import sys
         import pandas as pd
 
-        pd.read_json(sys.stdin) \
+        df = pd.read_json(sys.stdin) \
           .set_index('param') \
           .drop(['branch', 'earliest', 'end', 'latest']) \
-          .convert_dtypes() \
-          .to_markdown(sys.stdout, floatfmt='.0f')
+          .convert_dtypes()
+        cols = df.columns
+        for i in range(len(cols) - 1):
+            col1, col2 = cols[i], cols[i + 1]
+            delta_name = f"{col2} - {col1}"
+            df[delta_name] = df[col2] - df[col1]
+            # Insert new column after new position of col2 from previous
+            # iteration and between current col1 and col2
+            df.insert(i*2 + 1, delta_name, df.pop(delta_name))
+        df.to_markdown(sys.stdout, floatfmt='.0f')
       '';
 
 


### PR DESCRIPTION
When generating loadtest reports, introduces additional column between every pair of loadtest target results.


<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `fix`, bug fixes
  + `feat`, new features added
  + `perf`, performance improvements
  + `docs`, updating the documentation
  + `nix`, related to the Nix development environment
  + `ci`, related to the Continuous Integration modules
  + `test`, related to the testing modules
  + `refactor`, refactoring code
  + `deprecate`, deprecating a feature
  + `changelog`, updating the CHANGELOG
  + `chore`, maintenance (build process, updating sponsors, etc.)
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
