### PR TITLE
test: Use RSA 4096 algorithm for JWT load test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,7 +113,7 @@ jobs:
   loadtest:
     strategy:
       matrix:
-        kind: ['mixed', 'jwt-hs-50k', 'jwt-rsa-10k']
+        kind: ['mixed', 'jwt-hs-50k', 'jwt-rsa-1k']
     name: Loadtest
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,7 +113,7 @@ jobs:
   loadtest:
     strategy:
       matrix:
-        kind: ['mixed', 'jwt-hs-50k']
+        kind: ['mixed', 'jwt-hs-50k', 'jwt-rsa-10k']
     name: Loadtest
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,7 +113,7 @@ jobs:
   loadtest:
     strategy:
       matrix:
-        kind: ['mixed', 'jwt']
+        kind: ['mixed', 'jwt-hs-50k']
     name: Loadtest
     runs-on: ubuntu-24.04
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ loadtest
 .history
 .docs-build
 gen_targets.http
+gen_jwk.http

--- a/nix/tools/generate_targets_rsa.py
+++ b/nix/tools/generate_targets_rsa.py
@@ -1,5 +1,6 @@
 # generates a file to be used by the vegeta load testing tool
-# It runs TOTAL_TARGETS amount of requests with TOTAL_JWTS amount of JWTs randomly spread among them 
+# It runs TOTAL_TARGETS amount of requests with
+# TOTAL_JWTS amount of JWTs randomly spread among them
 import time
 import argparse
 import sys

--- a/nix/tools/generate_targets_rsa.py
+++ b/nix/tools/generate_targets_rsa.py
@@ -1,0 +1,67 @@
+# generates a file to be used by the vegeta load testing tool
+import time
+import argparse
+import sys
+import random
+import jwt
+import jwcrypto.jwk as jwk
+
+SECRET = b"reallyreallyreallyreallyverysafe"
+URL = "http://postgrest"
+JWT_DURATION = 120
+TOTAL_TARGETS = 50000  # tuned by hand to reduce result variance
+
+key = jwk.JWK.generate(kty="RSA", size=4096)
+
+private_key = jwt.algorithms.RSAAlgorithm.from_jwk(key.export_private())
+public_key = key.export_public()
+
+
+def generate_jwt() -> str:
+    """Generate an RS256 JWT"""
+    now = int(time.time())
+    payload = {
+        "sub": f"user_{random.getrandbits(32)}",
+        "iat": now,
+        "role": "postgrest_test_author",
+    }
+
+    return jwt.encode(payload, private_key, "RS256")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate Vegeta targets with unique JWTs"
+    )
+    parser.add_argument(
+        "output",
+        help="Path to write the generated targets file",
+    )
+    parser.add_argument("jwk", help="Path to write the generated JWK")
+    args = parser.parse_args()
+
+    tokens = [generate_jwt() for _ in range(1000)]
+    lines = []
+    start_time = time.time()
+
+    for i in range(TOTAL_TARGETS):
+        token = random.choice(tokens)
+        lines.append(f"OPTIONS {URL}/authors_only")
+        lines.append(f"Authorization: Bearer {token}")
+        lines.append("")  # blank line to separate requests
+
+    try:
+        with open(args.jwk, "w") as jwk, open(args.output, "w") as f:
+            jwk.write(public_key)
+            f.write("\n".join(lines))
+    except IOError as e:
+        print(f"Error writing to {args.output}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    elapsed = time.time() - start_time
+    print(f"Created {TOTAL_TARGETS} targets with unique JWTs", end=" ")
+    print(f"in {args.output} ({elapsed:.2f}s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/nix/tools/generate_targets_rsa.py
+++ b/nix/tools/generate_targets_rsa.py
@@ -1,4 +1,5 @@
 # generates a file to be used by the vegeta load testing tool
+# It runs TOTAL_TARGETS amount of requests with TOTAL_JWTS amount of JWTs randomly spread among them 
 import time
 import argparse
 import sys

--- a/nix/tools/generate_targets_rsa.py
+++ b/nix/tools/generate_targets_rsa.py
@@ -6,9 +6,8 @@ import random
 import jwt
 import jwcrypto.jwk as jwk
 
-SECRET = b"reallyreallyreallyreallyverysafe"
 URL = "http://postgrest"
-JWT_DURATION = 120
+TOTAL_JWTS = 1000
 TOTAL_TARGETS = 50000  # tuned by hand to reduce result variance
 
 key = jwk.JWK.generate(kty="RSA", size=4096)
@@ -40,7 +39,7 @@ def main():
     parser.add_argument("jwk", help="Path to write the generated JWK")
     args = parser.parse_args()
 
-    tokens = [generate_jwt() for _ in range(1000)]
+    tokens = [generate_jwt() for _ in range(TOTAL_JWTS)]
     lines = []
     start_time = time.time()
 

--- a/nix/tools/loadtest.nix
+++ b/nix/tools/loadtest.nix
@@ -43,7 +43,7 @@ let
           "ARG_OPTIONAL_SINGLE([testdir], [t], [Directory to load tests and fixtures from], [./test/load])"
           "ARG_OPTIONAL_SINGLE([kind], [k], [Kind of loadtest], [mixed])"
           "ARG_OPTIONAL_SINGLE([jwtcache], [], [JWT Cache on/off], [on])"
-          "ARG_TYPE_GROUP_SET([KIND], [KIND], [kind], [mixed,jwt-hs-50k,jwt-rsa-10k])"
+          "ARG_TYPE_GROUP_SET([KIND], [KIND], [kind], [mixed,jwt-hs-50k,jwt-rsa-1k])"
           "ARG_TYPE_GROUP_SET([JWTCACHE], [JWTCACHE], [jwtcache], [on,off])"
           "ARG_LEFTOVERS([additional vegeta arguments])"
         ];
@@ -81,7 +81,7 @@ let
             ${vegeta}/bin/vegeta report -type=text "$_arg_output"
             ;;
 
-          jwt-rsa-10k)
+          jwt-rsa-1k)
 
             ${genTargets ./generate_targets_rsa.py} "$_arg_testdir"/gen_targets.http "$_arg_testdir"/gen_jwk.http
 

--- a/nix/tools/loadtest.nix
+++ b/nix/tools/loadtest.nix
@@ -41,7 +41,7 @@ let
         args = [
           "ARG_OPTIONAL_SINGLE([output], [o], [Filename to dump json output to], [./loadtest/result.bin])"
           "ARG_OPTIONAL_SINGLE([testdir], [t], [Directory to load tests and fixtures from], [./test/load])"
-          "ARG_OPTIONAL_SINGLE([kind], [k], [Kind of loadtest (mixed: repeat mixed requests, jwt: run once over many requests with 1000 different jwts)], [mixed])"
+          "ARG_OPTIONAL_SINGLE([kind], [k], [Kind of loadtest], [mixed])"
           "ARG_OPTIONAL_SINGLE([jwtcache], [], [JWT Cache on/off], [on])"
           "ARG_TYPE_GROUP_SET([KIND], [KIND], [kind], [mixed,jwt-hs-50k,jwt-rsa-10k])"
           "ARG_TYPE_GROUP_SET([JWTCACHE], [JWTCACHE], [jwtcache], [on,off])"


### PR DESCRIPTION
As requested in https://github.com/PostgREST/postgrest/pull/4084#issuecomment-2920351221

Note that after this PR `gen_targets` no longer generates JWTs with short expiration to test current implementation cache cleanup.
That's because generating JWTs takes considerable more time right now and generating 50k JWTs takes more than 2 minutes on my beefy MacBook Pro.

Not sure if it makes sense to merge it without changing the JWT cache to the bounded one (either LRU or Sieve). 