### PR TITLE
refactor: Define MetricsState as record and use Applicative to initialize one

### DIFF
--- a/src/PostgREST/Metrics.hs
+++ b/src/PostgREST/Metrics.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RecordWildCards #-}
 {-|
 Module      : PostgREST.Logger
 Description : Metrics based on the Observation module. See Observation.hs.
@@ -19,22 +20,30 @@ import PostgREST.Observation
 import Protolude
 
 data MetricsState =
-  MetricsState Counter Gauge Gauge Gauge (Vector Label1 Counter) Gauge
+  MetricsState {
+    poolTimeouts         :: Counter,
+    poolAvailable        :: Gauge,
+    poolWaiting          :: Gauge,
+    poolMaxSize          :: Gauge,
+    schemaCacheLoads     :: Vector Label1 Counter,
+    schemaCacheQueryTime :: Gauge
+  }
 
 init :: Int -> IO MetricsState
 init configDbPoolSize = do
-  poolTimeouts <- register $ counter (Info "pgrst_db_pool_timeouts_total" "The total number of pool connection timeouts")
-  poolAvailable <- register $ gauge (Info "pgrst_db_pool_available" "Available connections in the pool")
-  poolWaiting <- register $ gauge (Info "pgrst_db_pool_waiting" "Requests waiting to acquire a pool connection")
-  poolMaxSize <- register $ gauge (Info "pgrst_db_pool_max" "Max pool connections")
-  schemaCacheLoads <- register $ vector "status" $ counter (Info "pgrst_schema_cache_loads_total" "The total number of times the schema cache was loaded")
-  schemaCacheQueryTime <- register $ gauge (Info "pgrst_schema_cache_query_time_seconds" "The query time in seconds of the last schema cache load")
-  setGauge poolMaxSize (fromIntegral configDbPoolSize)
-  pure $ MetricsState poolTimeouts poolAvailable poolWaiting poolMaxSize schemaCacheLoads schemaCacheQueryTime
+  metricState <- MetricsState <$>
+    register (counter (Info "pgrst_db_pool_timeouts_total" "The total number of pool connection timeouts")) <*>
+    register (gauge (Info "pgrst_db_pool_available" "Available connections in the pool")) <*>
+    register (gauge (Info "pgrst_db_pool_waiting" "Requests waiting to acquire a pool connection")) <*>
+    register (gauge (Info "pgrst_db_pool_max" "Max pool connections")) <*>
+    register (vector "status" $ counter (Info "pgrst_schema_cache_loads_total" "The total number of times the schema cache was loaded")) <*>
+    register (gauge (Info "pgrst_schema_cache_query_time_seconds" "The query time in seconds of the last schema cache load"))
+  setGauge (poolMaxSize metricState) (fromIntegral configDbPoolSize)
+  pure metricState
 
 -- Only some observations are used as metrics
 observationMetrics :: MetricsState -> ObservationHandler
-observationMetrics (MetricsState poolTimeouts poolAvailable poolWaiting _ schemaCacheLoads schemaCacheQueryTime) obs = case obs of
+observationMetrics MetricsState{..} obs = case obs of
   (PoolAcqTimeoutObs _) -> do
     incCounter poolTimeouts
   (HasqlPoolObs (SQL.ConnectionObservation _ status)) -> case status of


### PR DESCRIPTION
As requested in https://github.com/PostgREST/postgrest/pull/4084#discussion_r2115866081

This is a simple refactoring that changes MetricsState to be a proper record.
It also changes MetricsState initialization code to use Applicative syntax.