### PR TITLE
nix: detect unused python code

### DIFF
--- a/nix/tools/generate_targets.py
+++ b/nix/tools/generate_targets.py
@@ -10,7 +10,6 @@ import random
 
 SECRET = b"reallyreallyreallyreallyverysafe"
 URL = "http://postgrest"
-JWT_DURATION = 120
 TOTAL_TARGETS = 50000  # tuned by hand to reduce result variance
 
 

--- a/nix/tools/style.nix
+++ b/nix/tools/style.nix
@@ -7,6 +7,7 @@
 , hlint
 , hsie
 , nixpkgs-fmt
+, python3Packages
 , silver-searcher
 , statix
 , stylish-haskell
@@ -62,6 +63,10 @@ let
 
         echo "Scanning nix files for unused code..."
         ${deadnix}/bin/deadnix -f
+
+        echo "Scanning python files for unused code..."
+        ${silver-searcher}/bin/ag -l --vimgrep -g '\.l?py$' . \
+          | xargs ${python3Packages.vulture}/bin/vulture --exclude docs/conf.py
 
         echo "Checking consistency of import aliases in Haskell code..."
         ${hsie} check-aliases main src

--- a/test/io/test_cli.py
+++ b/test/io/test_cli.py
@@ -3,7 +3,6 @@
 import contextlib
 import dataclasses
 from datetime import datetime
-from itertools import repeat
 from operator import attrgetter
 import os
 import pathlib


### PR DESCRIPTION
Now `postgrest-lint` shows:

```
Linting workflows...
Scanning nix files for unused code...
Scanning python files for unused code...
nix/tools/generate_targets.py:13: unused variable 'JWT_DURATION' (60% confidence)
test/io/test_cli.py:6: unused import 'repeat' (90% confidence)
```

Also corrected the above detected files