### PR TITLE
nix: add commitlint to lint commit messages

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 100  # fetch history (last 100 commits) instead of default shallow clone history
+          fetch-depth: 100  # fetch history (last 100 commits) instead of default shallow clone history, this is deemed enough for a PR history
       - name: Setup Nix Environment
         uses: ./.github/actions/setup-nix
         with:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -30,3 +30,23 @@ jobs:
         run: postgrest-lint
       - name: Run style check (auto-format with `nix-shell --run postgrest-style`)
         run: postgrest-style-check
+
+  commit:
+    name: Commit
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 100  # fetch history (last 100 commits) instead of default shallow clone history
+      - name: Setup Nix Environment
+        uses: ./.github/actions/setup-nix
+        with:
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          tools: gitTools.commitCheck.bin
+      - name: Run commitlint (check locally with `nix-shell --run postgrest-commitlint`)
+        run: |
+          # Fetch target branch explicitly
+          git fetch origin ${{ github.base_ref }}
+
+          # Run commitlint
+          postgrest-commitlint --from origin/${{ github.base_ref }} --to HEAD

--- a/default.nix
+++ b/default.nix
@@ -119,6 +119,10 @@ rec {
   docs =
     pkgs.callPackage nix/tools/docs.nix { };
 
+  # Git tools.
+  gitTools =
+    pkgs.callPackage nix/tools/gitTools.nix { };
+
   # Load testing tools.
   loadtest =
     pkgs.callPackage nix/tools/loadtest.nix { inherit withTools; };

--- a/nix/tools/gitTools.nix
+++ b/nix/tools/gitTools.nix
@@ -1,0 +1,60 @@
+{ buildToolbox
+, checkedShellScript
+, commitlint
+, writeText
+}:
+let
+  # Rules format: [<severity>, <"always"/"never">, <value>]
+  commitlintConfig = writeText "commitlint.config.mjs" ''
+    export default {
+      rules: {
+        "type-enum": [2, "always", [
+            'add',      // Add a new feature
+            'amend',    // To amend an unrealease commit
+            'change',   // Breaking changes
+            'chore',    // Update sponsors, changelog, readme etc
+            'ci',       // CI configuration files and scripts
+            'docs',     // Documentation
+            'fix',      // Bug fix
+            'nix',      // Related to Nix
+            'perf',     // Performance improvements
+            'refactor', // Refactoring code
+            'remove',   // Remove a feature or fix
+            'test',     // Adding tests
+          ]],
+
+          'subject-case':       [2, 'always', ['lower-case','sentence-case']],
+          'subject-empty':      [2, 'never'],
+          'subject-full-stop':  [2, 'never', '.'],
+          'subject-max-length': [2, 'always', 80],
+          'subject-min-length': [2, 'always', 5],
+
+          'scope-case':         [2, 'always', 'lower-case'],
+
+          'body-leading-blank': [2, 'always'],
+      },
+    };
+  '';
+
+  commitCheck =
+    checkedShellScript
+      {
+        name = "postgrest-commitlint";
+        docs = "Script to validate commit messages";
+        workingDir = "/";
+        args = [
+          "ARG_OPTIONAL_SINGLE([from],, [commit ref start from], [main])"
+          "ARG_OPTIONAL_SINGLE([to],, [commit ref end at], [HEAD])"
+        ];
+      }
+      ''
+        # Run commitlint with the given configuration
+
+        ${commitlint}/bin/commitlint --config ${commitlintConfig} --from "$_arg_from" --to "$_arg_to"
+      '';
+in
+buildToolbox
+{
+  name = "postgrest-commitlint";
+  tools = { inherit commitCheck; };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -21,6 +21,7 @@ let
       postgrest.cabalTools
       postgrest.devTools
       postgrest.docs
+      postgrest.gitTools
       postgrest.loadtest
       postgrest.release
       postgrest.style


### PR DESCRIPTION
Adds a new script `postgrest-commitlint` to validate the commit messages.

Closes #4122.