### PR TITLE
fix: jwt-aud config not failing when set to invalid URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix `max-affected` preference not failing with RPC when `handling=strict` by @taimoorzaeem in #4100
+- Fix `jwt-aud` config not failing when set to an invalid URI by @taimoorzaeem in #4132
 
 ## [13.0.2] - 2025-06-02
 

--- a/test/io/fixtures.yaml
+++ b/test/io/fixtures.yaml
@@ -41,12 +41,11 @@ cli:
     use_defaultenv: true
     env:
       PGRST_SERVER_UNIX_SOCKET_MODE: '778'
-# TODO: Bug needs to be fixed
-#  - name: invalid jwt-aud
-#    expect: error
-#    use_defaultenv: true
-#    env:
-#      PGRST_JWT_AUD: 'htp:/@@localhorst.invalid'
+  - name: invalid jwt-aud
+    expect: error
+    use_defaultenv: true
+    env:
+      PGRST_JWT_AUD: 'http://%%localhorst.invalid'
   - name: invalid log-level
     expect: error
     use_defaultenv: true

--- a/test/io/test_cli.py
+++ b/test/io/test_cli.py
@@ -277,3 +277,15 @@ def test_schema_cache_snapshot(baseenv, key, snapshot_yaml):
         Dumper=yaml.SafeDumper if key == "dbTimezones" else ExtraNewLinesDumper,
     )
     assert formatted == snapshot_yaml
+
+
+def test_jwt_aud_config_set_to_invalid_uri(defaultenv):
+    "PostgREST should exit with an error message in output if jwt-aud config is set to an invalid URI"
+    env = {
+        **defaultenv,
+        "PGRST_JWT_AUD": "foo://%%$$^^.com",
+    }
+
+    with pytest.raises(PostgrestError):
+        dump = cli(["--dump-config"], env=env).split("\n")
+        assert "jwt-aud should be a string or a valid URI" in dump


### PR DESCRIPTION
The `jwt-aud` config was not validated when containing ':' character according to RFC 3986. This fix validates it and fails at startup if it is invalid.

Closes #4132.
