### PR TITLE
nix: add process monitoring for loadtests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,7 +113,7 @@ jobs:
   loadtest:
     strategy:
       matrix:
-        kind: ['mixed', 'jwt-hs-50k', 'jwt-rsa-1k']
+        kind: ['mixed', 'jwt-hs', 'jwt-rsa']
     name: Loadtest
     runs-on: ubuntu-24.04
     steps:

--- a/nix/tools/generate_targets.py
+++ b/nix/tools/generate_targets.py
@@ -1,4 +1,14 @@
 # generates a file to be used by the vegeta load testing tool
+# it generates TOTAL_TARGETS amount of requests that will be run
+
+# This is a worst case scenario for the JWT cache:
+# - all requests will have a unique JWT so no cache hits
+# - all jwts have an expiration that will be long enough to be
+#   valid at time of request but short enough that already
+#   validated jwts will expire later during the loadtest run
+# - the above guarantees JWT cache purging will happen
+#
+# We want this to track resource consumption in the worst case
 import time
 import hmac
 import hashlib
@@ -10,7 +20,7 @@ import random
 
 SECRET = b"reallyreallyreallyreallyverysafe"
 URL = "http://postgrest"
-TOTAL_TARGETS = 50000  # tuned by hand to reduce result variance
+TOTAL_TARGETS = 200000  # tuned by hand to reduce result variance
 
 
 def base64url_encode(data: bytes) -> str:

--- a/nix/tools/loadtest.nix
+++ b/nix/tools/loadtest.nix
@@ -43,7 +43,7 @@ let
           "ARG_OPTIONAL_SINGLE([testdir], [t], [Directory to load tests and fixtures from], [./test/load])"
           "ARG_OPTIONAL_SINGLE([kind], [k], [Kind of loadtest], [mixed])"
           "ARG_OPTIONAL_SINGLE([jwtcache], [], [JWT Cache on/off], [on])"
-          "ARG_TYPE_GROUP_SET([KIND], [KIND], [kind], [mixed,jwt-hs-50k,jwt-rsa-1k])"
+          "ARG_TYPE_GROUP_SET([KIND], [KIND], [kind], [mixed,jwt-hs,jwt-rsa])"
           "ARG_TYPE_GROUP_SET([JWTCACHE], [JWTCACHE], [jwtcache], [on,off])"
           "ARG_LEFTOVERS([additional vegeta arguments])"
         ];
@@ -66,7 +66,7 @@ let
         abs_output="$(realpath "$_arg_output")"
 
         case "$_arg_kind" in
-          jwt-hs-50k)
+          jwt-hs)
 
             ${genTargets ./generate_targets.py} "$_arg_testdir"/gen_targets.http
 
@@ -81,7 +81,7 @@ let
             ${runner} -lazy -targets gen_targets.http -output \"$abs_output\" \"''${_arg_leftovers[@]}\""
             ;;
 
-          jwt-rsa-1k)
+          jwt-rsa)
 
             ${genTargets ./generate_targets_rsa.py} "$_arg_testdir"/gen_targets.http "$_arg_testdir"/gen_jwk.http
 

--- a/nix/tools/loadtest.nix
+++ b/nix/tools/loadtest.nix
@@ -77,8 +77,8 @@ let
             # shellcheck disable=SC2145
             ${withTools.withPg} -f "$_arg_testdir"/fixtures.sql \
             ${withTools.withPgrst} \
-            sh -c "cd \"$_arg_testdir\" && ${runner} -lazy -targets gen_targets.http -output \"$abs_output\" \"''${_arg_leftovers[@]}\""
-            ${vegeta}/bin/vegeta report -type=text "$_arg_output"
+            sh -c "cd \"$_arg_testdir\" && \
+            ${runner} -lazy -targets gen_targets.http -output \"$abs_output\" \"''${_arg_leftovers[@]}\""
             ;;
 
           jwt-rsa-1k)
@@ -94,8 +94,8 @@ let
             # shellcheck disable=SC2145
             ${withTools.withPg} -f "$_arg_testdir"/fixtures.sql \
             ${withTools.withPgrst} \
-            sh -c "cd \"$_arg_testdir\" && ${runner} -lazy -targets gen_targets.http -output \"$abs_output\" \"''${_arg_leftovers[@]}\""
-            ${vegeta}/bin/vegeta report -type=text "$_arg_output"
+            sh -c "cd \"$_arg_testdir\" && \
+            ${runner} -lazy -targets gen_targets.http -output \"$abs_output\" \"''${_arg_leftovers[@]}\""
             ;;
 
           *)
@@ -105,11 +105,12 @@ let
             ${withTools.withSlowPg} \
             ${withTools.withPgrst} \
             ${withTools.withSlowPgrst} \
-            sh -c "cd \"$_arg_testdir\" && ${runner} -targets targets.http -output \"$abs_output\" \"''${_arg_leftovers[@]}\""
-            ${vegeta}/bin/vegeta report -type=text "$_arg_output"
+            sh -c "cd \"$_arg_testdir\" && \
+            ${runner} -targets targets.http -output \"$abs_output\" \"''${_arg_leftovers[@]}\""
             ;;
-
         esac
+
+        ${vegeta}/bin/vegeta report -type=text "$_arg_output"
       '';
 
   loadtestAgainst =

--- a/nix/tools/merge_monitor_result.py
+++ b/nix/tools/merge_monitor_result.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import pandas as pd
+
+KEY = "Elapsed seconds"
+
+merged = None
+
+paths = [p.strip() for p in sys.stdin.read().split() if p.strip()]
+
+for csv_path in paths:
+    # pfix is prefix (variable shortened to pass linter)
+    pfix = os.path.splitext(os.path.basename(csv_path))[0]
+
+    df = pd.read_csv(csv_path)
+
+    if KEY not in df.columns:
+        sys.exit(f"{csv_path} is missing the {KEY} column")
+
+    # add prefix to every metric column
+    df = df.rename(columns={c: f"{pfix} {c}" for c in df.columns if c != KEY})
+
+    # outer join so missing rows appear
+    merged = df if merged is None else merged.merge(df, on=KEY, how="outer")
+
+# replace nan with empty string
+merged = merged.fillna("")
+merged.to_markdown(sys.stdout, index=False, tablefmt="github")

--- a/nix/tools/monitor_pid.py
+++ b/nix/tools/monitor_pid.py
@@ -1,0 +1,58 @@
+# Monitor a process pid with psutil and emits a CSV.
+import sys
+import time
+import psutil
+import pandas as pd
+
+KEY = "Elapsed seconds"
+SAMPLE_INTERVAL_SECS = 1
+
+if len(sys.argv) != 2 or not sys.argv[1].isdigit():
+    sys.exit(f"Usage: {sys.argv[0]} <PID>")
+
+pid = int(sys.argv[1])
+try:
+    proc = psutil.Process(pid)
+except psutil.NoSuchProcess:
+    sys.exit(f"Error: process {pid} not found.")
+
+print(f"Starting monitoring of {pid} pid", file=sys.stderr)
+
+records = []
+start = time.time()
+# ignore first result as per docs recommendation
+# https://psutil.readthedocs.io/en/latest/#psutil.cpu_percent
+proc.cpu_percent(None)
+
+while True:
+    try:
+        if not proc.is_running():
+            break
+        time.sleep(SAMPLE_INTERVAL_SECS)
+
+        elapsed_secs = int(time.time() - start)
+        cpu = proc.cpu_percent(None)
+        mem_pct = proc.memory_percent()
+        meminfo = proc.memory_info()
+        bytes_in_MB = 1024**2
+        rss_mb = meminfo.rss / bytes_in_MB
+
+        records.append(
+            [
+                str(elapsed_secs),
+                f"{cpu:.3f}",
+                f"{mem_pct:.3f}",
+                f"{rss_mb:.3f}",
+            ]
+        )
+
+    except psutil.NoSuchProcess:
+        break
+
+end = time.time()
+total_time = end - start
+print(f"Finished {pid} pid monitoring in {total_time:.3f}", file=sys.stderr)
+
+cols = [KEY, "CPU (%)", "MEM (%)", "Real (MB)"]
+df = pd.DataFrame(records, columns=cols, dtype=str)
+df.to_csv(sys.stdout, index=False)


### PR DESCRIPTION
Closes https://github.com/PostgREST/postgrest/issues/4107.

Adds a table for each loadtest that looks like this:

|   Elapsed seconds |   main CPU (%) |   main MEM (%) |   main Real (MB) |   head CPU (%) |   head MEM (%) |   head Real (MB) |
|-------------------|----------------|----------------|------------------|----------------|----------------|------------------|
|                 1 |              8 |          0.272 |           43.109 |              6 |          0.282 |           44.723 |
|                 2 |             19 |          0.462 |           73.332 |             21 |          0.453 |           71.895 |
|                 3 |             19 |          0.503 |           79.777 |             21 |          0.515 |           81.691 |
|                 4 |             21 |          0.546 |           86.738 |             22 |          0.569 |           90.289 |
|                 5 |             20 |          0.57  |           90.441 |             18 |          0.577 |           91.578 |
|                 6 |             19 |          0.581 |           92.203 |             19 |          0.587 |           93.125 |
|                 7 |             20 |          0.599 |           95.039 |             16 |          0.587 |           93.125 |
|                 8 |             21 |          0.602 |           95.555 |             20 |          0.6   |           95.188 |
|                 9 |             19 |          0.617 |           97.871 |             15 |          0.606 |           96.219 |

See example results on https://github.com/PostgREST/postgrest/actions/runs/15698512214?pr=4142

Adds two python scripts:

- monitor_pid.py: monitors the postgrest process each second until it exits, then outputs a csv with the results. The nix wrappers use the `loadtest` dir for the output.
- merge_monitor_result.py: receives a list of csvs and merges them into a single markdown table. The nix wrappers use the `loadtest/*.csv` files for the input.

The nix `postgrest-with-pgrst` and `postgrest-loadtest-report` commands use these scripts to add monitoring for `postgrest-loadtest` and `postgrest-loadtest-against`.