### PR TITLE
ci: fix commitlint CI failure

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -46,7 +46,9 @@ jobs:
       - name: Run commitlint (check locally with `nix-shell --run postgrest-commitlint`)
         run: |
           # Fetch target branch explicitly
-          git fetch origin ${{ github.base_ref }}
+          # For PRs event  -> github.base_ref
+          # For push event -> github.ref_name
+          git fetch origin ${{ github.base_ref || github.ref_name }}
 
           # Run commitlint
-          postgrest-commitlint --from origin/${{ github.base_ref }} --to HEAD
+          postgrest-commitlint --from origin/${{ github.base_ref || github.ref_name }} --to HEAD

--- a/nix/tools/gitTools.nix
+++ b/nix/tools/gitTools.nix
@@ -23,7 +23,7 @@ let
             'test',     // Adding tests
           ]],
 
-          'subject-case':       [2, 'always', ['lower-case','sentence-case']],
+          'subject-case':       [2, 'never', ['pascal-case', 'start-case']],
           'subject-empty':      [2, 'never'],
           'subject-full-stop':  [2, 'never', '.'],
           'subject-max-length': [2, 'always', 80],


### PR DESCRIPTION
Fixes CI failure of `commitlint` as occurred in [#4128 (comment)](https://github.com/PostgREST/postgrest/pull/4128#issuecomment-2981862857).
