### PR TITLE
ci: fix loadtest job on stable branches

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -125,13 +125,16 @@ jobs:
         with:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
           tools: loadtest.loadtestAgainst.bin loadtest.report.bin
-      - uses: WyriHaximus/github-action-get-previous-tag@04e8485ecb6487243907e330d522ff60f02283ce # v1.4.0
-        id: get-latest-tag
-        with:
-          prefix: v
       - name: Run loadtest
+        env:
+          TARGET_BRANCH: ${{ github.base_ref || github.ref_name }}
         run: |
-          postgrest-loadtest-against -k ${{ matrix.kind }} main ${{ steps.get-latest-tag.outputs.tag }}
+          if [ "$TARGET_BRANCH" = "main" ]; then
+            latest_tag=$(git tag --sort=-creatordate --list "v*" | head -n1)
+          else
+            latest_tag=$(git tag --merged HEAD --sort=-creatordate "v*" | head -n1)
+          fi
+          postgrest-loadtest-against -k ${{ matrix.kind }} "$TARGET_BRANCH" "$latest_tag"
           postgrest-loadtest-report -g ${{ matrix.kind }} >> "$GITHUB_STEP_SUMMARY"
 
   flake:


### PR DESCRIPTION
Previously, the loadtest would always compare against main and the latest tag. This meant a loadtest running on the v13 release branch, would compare to a *future* version of both. This is not useful, and also not supported by `postgrest-loadtest-against`, which recently introduced a change on `main`, that now breaks the tests on the back branches.

With this change, the loadtest will always run against the current target branch of a PR, so against the v13 branch for a PR against v13, for example. Also, it will compare against the latest released tag *for that branch*.

Thus, when running this for v12, it will test against the v12 branch and the v12.2.12 tag.