### PR TITLE
fix: fix OpenAPI broken docs link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   + The exposed schemas are now listed in the `hint` instead of the `message` field.
 - Improve error details of `PGRST301` error by @taimoorzaeem in #4051
 
+### Fixed
+
+- Fix OpenAPI broken docs link by @taimoorzaeem in #4080
+
 ## [13.0.4] - 2025-06-17
 
 ### Fixed

--- a/src/PostgREST/Version.hs
+++ b/src/PostgREST/Version.hs
@@ -26,7 +26,7 @@ prettyVersion =
 docsVersion :: Text
 docsVersion
   | isPreRelease = "latest"
-  | otherwise    =  "v" <> (T.intercalate "." . map show . take 1 $ version)
+  | otherwise    =  "v" <> T.intercalate "." (take 1 version)
 
 
 -- | Versions with two components (e.g., '1.1') are treated as pre-releases.


### PR DESCRIPTION
Prevents future broken links. Related to #4080.