### PR TITLE
nix: run hlint on multiple threads

### DIFF
--- a/nix/tools/style.nix
+++ b/nix/tools/style.nix
@@ -74,7 +74,7 @@ let
         echo "Linting Haskell files..."
         # --vimgrep fixes a bug in ag: https://github.com/ggreer/the_silver_searcher/issues/753
         ${silver-searcher}/bin/ag -l --vimgrep -g '\.l?hs$' . \
-          | xargs ${hlint}/bin/hlint -X QuasiQuotes -X NoPatternSynonyms
+          | xargs ${hlint}/bin/hlint -j -X QuasiQuotes -X NoPatternSynonyms
       '';
 
 in


### PR DESCRIPTION
I have noticed `postgrest-lint` to be quite slow, primarily because of `hlint`. It turns out that `hlint` can be run on multiple threads. This reduces `postgrest-lint` runtime depending on number of cores and threads.

I think `4` threads is good default. The github action runners also have 4 cores according to [github docs](https://docs.github.com/en/actions/how-tos/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories).