### PR TITLE
docs: horizontal filtering on table-valued functions

### DIFF
--- a/docs/postgrest.dict
+++ b/docs/postgrest.dict
@@ -174,6 +174,7 @@ unikernel
 unix
 updatable
 unfulfillable
+unselected
 Untyped
 UPSERT
 Upsert

--- a/docs/references/api/functions.rst
+++ b/docs/references/api/functions.rst
@@ -294,6 +294,23 @@ Let's get its :ref:`explain_plan` when calling it with filters applied:
 
 Notice there's no "Function Scan" node in the plan, which tells us it has been inlined.
 
+Horizontal Filtering
+~~~~~~~~~~~~~~~~~~~~
+
+Table-valued functions support horizontal filtering on selected and unselected columns.
+
+For example, the following RPC with filter on unselected column returns:
+
+.. code-block:: bash
+
+  curl "http://localhost:3000/rpc/getallprojects?select=id,client_id&name=like.OSX"
+
+.. code-block:: json
+
+  [
+    { "id": 4, "client_id": 2 }
+  ]
+
 .. _scalar_functions:
 
 Scalar functions


### PR DESCRIPTION
I forgot to add the docs for #4033 as mentioned in [#4033 (comment)](https://github.com/PostgREST/postgrest/pull/4033#issuecomment-2825420176). This adds a horizontal filtering sub-section with example in table-valued functions section.
