### PR TITLE
chore: remove Paths_postgrest module

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -92,7 +92,6 @@ library
                       PostgREST.Response.GucHeader
                       PostgREST.Response.Performance
                       PostgREST.Version
-  other-modules:      Paths_postgrest
   build-depends:      base                      >= 4.9 && < 4.20
                     , HTTP                      >= 4000.3.7 && < 4000.5
                     , Ranged-sets               >= 0.3 && < 0.5


### PR DESCRIPTION
The dependency on it was removed in #3608 already, but we forgot to remove it from postgrest.cabal, which caused it to still be built.

We didn't realize because all references of it were stripped away by dead code elimination anyway.

Will backport this to v13, too, to allow further experimentation in nixpkgs with the static build on MacOS.