### PR TITLE
fix: rounding error in exp claim validation causing tests flakiness

### DIFF
--- a/src/PostgREST/Auth/Jwt.hs
+++ b/src/PostgREST/Auth/Jwt.hs
@@ -75,9 +75,10 @@ checkForErrors time cfgAud = mconcat
       now = toSec time
 
       inTheFuture = checkTime ((now + allowedSkewSeconds) <)
-      inThePast = checkTime ((now - allowedSkewSeconds) >)
+      -- add 1 to account for floor in toSec (see above)
+      inThePast = checkTime ((now - allowedSkewSeconds + 1) >)
 
-      checkTime cond = checkValue (cond. sciToInt)
+      checkTime cond = checkValue (cond . sciToInt)
 
       checkAud = \case
         (VAString aud)                     -> liftMaybe cfgAud >>= checkValue (aud /=) JWTNotInAudience


### PR DESCRIPTION
Should fix issues described in: https://github.com/PostgREST/postgrest/issues/3424#issuecomment-3077777310

Changes in JWT module on which https://github.com/PostgREST/postgrest/pull/4208 is based do not look like necessary to fix it.