### PR TITLE
add: override PGRST_CMD for postgrest-loadtest from env

### DIFF
--- a/nix/tools/withTools.nix
+++ b/nix/tools/withTools.nix
@@ -348,20 +348,22 @@ let
       ''
         export PGRST_SERVER_UNIX_SOCKET="$tmpdir"/postgrest.socket
 
-        rm -f result
-        if [ -z "''${PGRST_BUILD_CABAL:-}" ]; then
-          echo -n "Building postgrest (nix)... "
-          # Using lib.getBin to also make this work with older checkouts, where .bin was not a thing, yet.
-          nix-build -E 'with import ./. {}; pkgs.lib.getBin postgrestPackage' > "$tmpdir"/build.log 2>&1 || {
-            echo "failed, output:"
-            cat "$tmpdir"/build.log
-            exit 1
-          }
-          PGRST_CMD=$(echo ./result*/bin/postgrest)
-        else
-          echo -n "Building postgrest (cabal)... "
-          postgrest-build
-          PGRST_CMD=postgrest-run
+        if [ -z "''${PGRST_CMD:-}" ]; then
+          rm -f result
+          if [ -z "''${PGRST_BUILD_CABAL:-}" ]; then
+            echo -n "Building postgrest (nix)... "
+            # Using lib.getBin to also make this work with older checkouts, where .bin was not a thing, yet.
+            nix-build -E 'with import ./. {}; pkgs.lib.getBin postgrestPackage' > "$tmpdir"/build.log 2>&1 || {
+              echo "failed, output:"
+              cat "$tmpdir"/build.log
+              exit 1
+            }
+            PGRST_CMD=$(echo ./result*/bin/postgrest)
+          else
+            echo -n "Building postgrest (cabal)... "
+            postgrest-build
+            PGRST_CMD=postgrest-run
+          fi
         fi
         echo "done."
 


### PR DESCRIPTION
Enables `PGRST_CMD=postgrest-profiled-run postgrest-loadtest` running loadtest against profiled executable, which wasn't available before

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `fix`, bug fixes
  + `feat`, new features added
  + `perf`, performance improvements
  + `docs`, updating the documentation
  + `nix`, related to the Nix development environment
  + `ci`, related to the Continuous Integration modules
  + `test`, related to the testing modules
  + `refactor`, refactoring code
  + `deprecate`, deprecating a feature
  + `changelog`, updating the CHANGELOG
  + `chore`, maintenance (build process, updating sponsors, etc.)
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
