### PR TITLE
fix: unbreaks postgrest-profiled-run

### DIFF
--- a/nix/tools/cabalTools.nix
+++ b/nix/tools/cabalTools.nix
@@ -95,9 +95,8 @@ let
         export PGRST_DB_POOL_ACQUISITION_TIMEOUT
         export PGRST_JWT_SECRET
 
-        ${cabal-install}/bin/cabal --builddir="dist-prof" v2-build --enable-profiling --disable-shared exe:postgrest
-        ${cabal-install}/bin/cabal --builddir="dist-prof" v2-run -- \
-          postgrest +RTS -p -h -RTS "''${_arg_leftovers[@]}"
+        exec ${cabal-install}/bin/cabal --builddir="dist-prof" v2-run --enable-profiling --disable-shared exe:postgrest -- \
+          +RTS -p -h -RTS "''${_arg_leftovers[@]}"
       '';
 
   repl =

--- a/nix/tools/withTools.nix
+++ b/nix/tools/withTools.nix
@@ -5,6 +5,7 @@
 , lib
 , postgresqlVersions
 , postgrest
+, procps
 , python3Packages
 , slocat
 , writeText
@@ -373,6 +374,14 @@ let
         pid=$!
         # shellcheck disable=SC2317
         cleanup() {
+          # Send INT to all postgrest processes.
+          # Workaround to trigger dumping postgrest.prof for postgrest-profiled-run
+          # Caveat: we cannot realistically limit this to the current process' tree,
+          # since pkill's --parent supports only direct children; therefore this
+          # would reap neighbor postgrest instances as well, because INT is asking
+          # the process to terminate too.
+          # TODO: consider cgroups to make this cleaner
+          ${procps}/bin/pkill --echo --signal=INT --exact postgrest
           kill "$pid" || true
         }
         trap cleanup EXIT


### PR DESCRIPTION
replaces `cabal` `v2-build`  `v2-run` (which should be `v2-exec`, because it didn't specify the target) with one-shot `v2-run`

before this change `postgrest-profiled-run` was not starting, because `cabal v2-build --enable-profiling` did build it with `-fprof`, but `cabal v2-run` _without `--enable-profiling`_ did rebuild it back to non-profiled executable, which, naturally, produced an error when being run with `+RTS -p -RTS`

UPD: Also even then the produced `postgrest.prof` file was empty, because the `postgrest` process was reaped, not interrupted. This PR makes `postgrest-with-pgrst` script send an additional `INT` signal to the `postgrest` process it started, enabling the latter to shut down properly; in case of profiled executable it also triggers writing `.prof` file explicitly
 
here's relevant console output <details>

```console
❯ bash -x postgrest-profiled-run
+ source /nix/store/yzm05qvjjhr3ii63mx2lmqwzkqsba2ra-postgrest-profiled-run-parser
+++ basename postgrest-profiled-run
++ BASH_ARGV0=postgrest-profiled-run
++ _positionals=()
++ _arg_leftovers=()
++ parse_commandline
++ _positionals_count=0
++ test 0 -gt 0
++ assign_positional_args 1
++ local _positional_name _shift_for=1
++ _positional_names=
++ _our_args=0
++ (( ii = 0 ))
++ (( ii < _our_args ))
++ shift 1
++ test -n ''
++ PGRST_DB_ANON_ROLE=postgrest_test_anonymous
++ test -n ''
++ PGRST_DB_POOL=1
++ test -n ''
++ PGRST_DB_POOL_ACQUISITION_TIMEOUT=1
++ test -n ''
++ PGRST_JWT_SECRET=reallyreallyreallyreallyverysafe
+ set -euo pipefail
++ /nix/store/mp7ba85zcqdj2sqwa29pql02s6nqpcxy-coreutils-9.7/bin/mktemp -d
+ hpctixdir=/tmp/nix-shell-43614-1878198251/tmp.3XtIE8mlED
+ export HPCTIXFILE=/tmp/nix-shell-43614-1878198251/tmp.3XtIE8mlED/postgrest.tix
+ HPCTIXFILE=/tmp/nix-shell-43614-1878198251/tmp.3XtIE8mlED/postgrest.tix
+ trap 'rm -rf $hpctixdir' EXIT
++ /nix/store/smaydcvrcaz906653vbnps70y9j7w658-git-2.49.0/bin/git rev-parse --show-toplevel
+ cd /home/adziahel/projects/postgrest/postgrest
+ test '!' -f postgrest.cabal
+ cd /home/adziahel/projects/postgrest/postgrest/
++ cat /nix/store/2ipw38gsd4qsy2fv8pmcrfgq9bxd5yv7-ghc-shell-for-postgrest-13.1
+ env=/nix/store/kl6qp0mgy43l8agzwy44mir22098svss-ghc-9.4.8-with-packages
+ export PATH=/nix/store/kl6qp0mgy43l8agzwy44mir22098svss-ghc-9.4.8-with-packages/bin:/nix/store/345523198bcsdzay55pfiimkiajq6lq8-bash-interactive-5.2p37/bin:/nix/store/kl6qp0mgy43l8agzwy44mir22098svss-ghc-9.4.8-with-packages/bin:/nix/store/0flj33q30lmzdjagwjqh964qmiyklww2-patchelf-0.15.0/bin:/nix/store/a0d7m3zn9p2dfa1h7ag9h2wzzr2w25sn-gcc-wrapper-14.2.1.20250322/bin:/nix/store/6i862vz60awrlsila8vw18rg4d4l66iy-gcc-14.2.1.20250322/bin:/nix/store/y2xdxp8r4g92q28am6mbxj44rivnyirl-glibc-2.40-66-bin/bin:/nix/store/mp7ba85zcqdj2sqwa29pql02s6nqpcxy-coreutils-9.7/bin:/nix/store/2gkh9v7wrzjq6ws312c6z6ajwnjvwcmb-binutils-wrapper-2.44/bin:/nix/store/mkvc0lnnpmi604rqsjdlv1pmhr638nbd-binutils-2.44/bin:/nix/store/4mys0gv17cn0lrdvlhks0zx27854nmkg-ncurses-6.5/bin:/nix/store/rw6qpkkm3bjvmk5yx2mbsyqcc6i0fmwb-cabal-install-3.14.2.0/bin:/nix/store/1x5r7lgky64fqd8mnni865www6gqvnxn-cabal2nix-2.20.0/bin:/nix/store/smaydcvrcaz906653vbnps70y9j7w658-git-2.49.0/bin:/nix/store/jawi15brxq4h3a9snmlr9szx0zcaf2yx-postgresql-17.5/bin:/nix/store/dlgs69jmnpqdb4xhiprh462v2s9x9hza-update-nix-fetchgit-0.2.11/bin:/nix/store/qwclc46fmwr5jb20zsk1dsrvxysw858a-hsie/bin:/nix/store/b08q1cywlfpq0v0zf88vq94zh9mj689s-postgrest-cabal/bin:/nix/store/8ppli1n3fy3ki3nwmyc7czwbm3lvxkpf-postgrest-dev/bin:/nix/store/m9j30xqq4dj99r4bv37mibivzjshs2ax-postgrest-docs/bin:/nix/store/0bmvmh2qcl8znmd6b4w6vahq09q7vj08-postgrest-commitlint/bin:/nix/store/j79bz86j0fmjh4p4s3yrgsnfgkl19yx0-postgrest-loadtest/bin:/nix/store/lg30g21zhfr3g81qj77pwhp3wap1mfvw-postgrest-nixpkgs/bin:/nix/store/mh7x1lainriviidn4ycyrixilraw9593-postgrest-release/bin:/nix/store/ych1mnagi4b8piv5xxxlfar8xj2abc5a-postgrest-style/bin:/nix/store/yhhdzyjfd9l924jd6j8xbg29kgznp6cr-postgrest-tests/bin:/nix/store/5h1jg20m9v8r8wnw8mkwhishjl4269rf-postgrest-with/bin:/nix/store/mp7ba85zcqdj2sqwa29pql02s6nqpcxy-coreutils-9.7/bin:/nix/store/7fjnb79r7p38piiyn5xwgcj5w7fpfi02-findutils-4.10.0/bin:/nix/store/1pi99mlqimxmqm1jvllbcaj8v16w2nbv-diffutils-3.12/bin:/nix/store/x23s7lcvhf18zz3rj543680jgrj71vil-gnused-4.9/bin:/nix/store/8b4vn1iyn6kqiisjvlmv67d1c0p3j6wj-gnugrep-3.11/bin:/nix/store/n8825s8qprf8p70m0hq6pz7rvlnsxdjm-gawk-5.3.2/bin:/nix/store/7nilh5hvnfbsx3vn020pkjkgx9rgsizb-gnutar-1.35/bin:/nix/store/gqpd9ax2s6jjf7mjyv1q7bwbsycyaxic-gzip-1.14/bin:/nix/store/28z6bx9sg0lsr7wra22pbjsk6fzfphy4-bzip2-1.0.8-bin/bin:/nix/store/8dl5ryfna3hjqhvnkw7srm6wnka6agxl-gnumake-4.4.1/bin:/nix/store/ih68ar79msmj0496pgld4r3vqfr7bbin-bash-5.2p37/bin:/nix/store/kc8h52p4dfgajrg3qlgx246hl0znr213-patch-2.7.6/bin:/nix/store/cmv326slnswzsjm2sqgbz16hzzqvkfjy-xz-5.8.1-bin/bin:/nix/store/v5skl3bspzhm2y13vcxcrw8w29g6phi0-file-5.45/bin:/home/adziahel/.npm/bin:/home/adziahel/.cargo/bin:/home/adziahel/.cabal/bin:/home/adziahel/.ghcup/bin:/home/adziahel/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/home/adziahel/.local/bin:/home/adziahel/bin:/usr/local/bin:/usr/bin:/bin:/home/adziahel/.local/share/JetBrains/Toolbox/scripts
+ PATH=/nix/store/kl6qp0mgy43l8agzwy44mir22098svss-ghc-9.4.8-with-packages/bin:/nix/store/345523198bcsdzay55pfiimkiajq6lq8-bash-interactive-5.2p37/bin:/nix/store/kl6qp0mgy43l8agzwy44mir22098svss-ghc-9.4.8-with-packages/bin:/nix/store/0flj33q30lmzdjagwjqh964qmiyklww2-patchelf-0.15.0/bin:/nix/store/a0d7m3zn9p2dfa1h7ag9h2wzzr2w25sn-gcc-wrapper-14.2.1.20250322/bin:/nix/store/6i862vz60awrlsila8vw18rg4d4l66iy-gcc-14.2.1.20250322/bin:/nix/store/y2xdxp8r4g92q28am6mbxj44rivnyirl-glibc-2.40-66-bin/bin:/nix/store/mp7ba85zcqdj2sqwa29pql02s6nqpcxy-coreutils-9.7/bin:/nix/store/2gkh9v7wrzjq6ws312c6z6ajwnjvwcmb-binutils-wrapper-2.44/bin:/nix/store/mkvc0lnnpmi604rqsjdlv1pmhr638nbd-binutils-2.44/bin:/nix/store/4mys0gv17cn0lrdvlhks0zx27854nmkg-ncurses-6.5/bin:/nix/store/rw6qpkkm3bjvmk5yx2mbsyqcc6i0fmwb-cabal-install-3.14.2.0/bin:/nix/store/1x5r7lgky64fqd8mnni865www6gqvnxn-cabal2nix-2.20.0/bin:/nix/store/smaydcvrcaz906653vbnps70y9j7w658-git-2.49.0/bin:/nix/store/jawi15brxq4h3a9snmlr9szx0zcaf2yx-postgresql-17.5/bin:/nix/store/dlgs69jmnpqdb4xhiprh462v2s9x9hza-update-nix-fetchgit-0.2.11/bin:/nix/store/qwclc46fmwr5jb20zsk1dsrvxysw858a-hsie/bin:/nix/store/b08q1cywlfpq0v0zf88vq94zh9mj689s-postgrest-cabal/bin:/nix/store/8ppli1n3fy3ki3nwmyc7czwbm3lvxkpf-postgrest-dev/bin:/nix/store/m9j30xqq4dj99r4bv37mibivzjshs2ax-postgrest-docs/bin:/nix/store/0bmvmh2qcl8znmd6b4w6vahq09q7vj08-postgrest-commitlint/bin:/nix/store/j79bz86j0fmjh4p4s3yrgsnfgkl19yx0-postgrest-loadtest/bin:/nix/store/lg30g21zhfr3g81qj77pwhp3wap1mfvw-postgrest-nixpkgs/bin:/nix/store/mh7x1lainriviidn4ycyrixilraw9593-postgrest-release/bin:/nix/store/ych1mnagi4b8piv5xxxlfar8xj2abc5a-postgrest-style/bin:/nix/store/yhhdzyjfd9l924jd6j8xbg29kgznp6cr-postgrest-tests/bin:/nix/store/5h1jg20m9v8r8wnw8mkwhishjl4269rf-postgrest-with/bin:/nix/store/mp7ba85zcqdj2sqwa29pql02s6nqpcxy-coreutils-9.7/bin:/nix/store/7fjnb79r7p38piiyn5xwgcj5w7fpfi02-findutils-4.10.0/bin:/nix/store/1pi99mlqimxmqm1jvllbcaj8v16w2nbv-diffutils-3.12/bin:/nix/store/x23s7lcvhf18zz3rj543680jgrj71vil-gnused-4.9/bin:/nix/store/8b4vn1iyn6kqiisjvlmv67d1c0p3j6wj-gnugrep-3.11/bin:/nix/store/n8825s8qprf8p70m0hq6pz7rvlnsxdjm-gawk-5.3.2/bin:/nix/store/7nilh5hvnfbsx3vn020pkjkgx9rgsizb-gnutar-1.35/bin:/nix/store/gqpd9ax2s6jjf7mjyv1q7bwbsycyaxic-gzip-1.14/bin:/nix/store/28z6bx9sg0lsr7wra22pbjsk6fzfphy4-bzip2-1.0.8-bin/bin:/nix/store/8dl5ryfna3hjqhvnkw7srm6wnka6agxl-gnumake-4.4.1/bin:/nix/store/ih68ar79msmj0496pgld4r3vqfr7bbin-bash-5.2p37/bin:/nix/store/kc8h52p4dfgajrg3qlgx246hl0znr213-patch-2.7.6/bin:/nix/store/cmv326slnswzsjm2sqgbz16hzzqvkfjy-xz-5.8.1-bin/bin:/nix/store/v5skl3bspzhm2y13vcxcrw8w29g6phi0-file-5.45/bin:/home/adziahel/.npm/bin:/home/adziahel/.cargo/bin:/home/adziahel/.cabal/bin:/home/adziahel/.ghcup/bin:/home/adziahel/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/home/adziahel/.local/bin:/home/adziahel/bin:/usr/local/bin:/usr/bin:/bin:/home/adziahel/.local/share/JetBrains/Toolbox/scripts
+ export PGRST_DB_ANON_ROLE
+ export PGRST_DB_POOL
+ export PGRST_DB_POOL_ACQUISITION_TIMEOUT
+ export PGRST_JWT_SECRET
+ /nix/store/rw6qpkkm3bjvmk5yx2mbsyqcc6i0fmwb-cabal-install-3.14.2.0/bin/cabal --builddir=dist-prof v2-build --enable-profiling --disable-shared exe:postgrest
Configuration is affected by the following files:
- cabal.project
- cabal.project.freeze
Build profile: -w ghc-9.4.8 -O1
In order, the following will be built (use -v for more details):
 - postgrest-13.1 (lib)  --enable-profiling (configuration changed)
 - postgrest-13.1 (exe:postgrest)  --enable-profiling (configuration changed)
Configuring library for postgrest-13.1...
Warning: [git-protocol] Cloning over git:// might lead to an arbitrary code
execution vulnerability. Furthermore, popular forges like GitHub do not
support it. Use https:// or ssh:// instead.
Preprocessing library for postgrest-13.1...
Building library for postgrest-13.1...
Configuring executable 'postgrest' for postgrest-13.1...
Warning: [git-protocol] Cloning over git:// might lead to an arbitrary code
execution vulnerability. Furthermore, popular forges like GitHub do not
support it. Use https:// or ssh:// instead.
Preprocessing executable 'postgrest' for postgrest-13.1...
Building executable 'postgrest' for postgrest-13.1...
[2 of 2] Linking dist-prof/build/x86_64-linux/ghc-9.4.8/postgrest-13.1/x/postgrest/build/postgrest/postgrest [Flags changed]
+ /nix/store/rw6qpkkm3bjvmk5yx2mbsyqcc6i0fmwb-cabal-install-3.14.2.0/bin/cabal --builddir=dist-prof v2-run exe:postgrest -- +RTS -p -hT -RTS
Configuration is affected by the following files:
- cabal.project
- cabal.project.freeze
Build profile: -w ghc-9.4.8 -O1
In order, the following will be built (use -v for more details):
 - postgrest-13.1 (lib) (configuration changed)
 - postgrest-13.1 (exe:postgrest) (configuration changed)
Configuring library for postgrest-13.1...
Warning: [git-protocol] Cloning over git:// might lead to an arbitrary code
execution vulnerability. Furthermore, popular forges like GitHub do not
support it. Use https:// or ssh:// instead.
Preprocessing library for postgrest-13.1...
Building library for postgrest-13.1...
Configuring executable 'postgrest' for postgrest-13.1...
Warning: [git-protocol] Cloning over git:// might lead to an arbitrary code
execution vulnerability. Furthermore, popular forges like GitHub do not
support it. Use https:// or ssh:// instead.
Preprocessing executable 'postgrest' for postgrest-13.1...
Building executable 'postgrest' for postgrest-13.1...
[2 of 2] Linking dist-prof/build/x86_64-linux/ghc-9.4.8/postgrest-13.1/x/postgrest/build/postgrest/postgrest [Flags changed]
postgrest: the flag -p requires the program to be built with -prof
postgrest:
postgrest: Usage: <prog> <args> [+RTS <rtsopts> | -RTS <args>] ... --RTS <args>
postgrest:
postgrest:    +RTS     Indicates run time system options follow
postgrest:    -RTS     Indicates program arguments follow
postgrest:   --RTS     Indicates that ALL subsequent arguments will be given to the
postgrest:             program (including any of these RTS flags)
postgrest:
postgrest: The following run time system options may be available (note that some
postgrest: of these may not be usable unless this program was linked with the -rtsopts
postgrest: flag):
postgrest:
postgrest:   -?        Prints this message and exits; the program is not executed
postgrest:   --info    Print information about the RTS used by this program
postgrest:
postgrest:   --nonmoving-gc
postgrest:             Selects the non-moving mark-and-sweep garbage collector to
postgrest:             manage the oldest generation.
postgrest:   --copying-gc
postgrest:             Selects the copying garbage collector to manage all generations.
postgrest:
postgrest:   -K<size>  Sets the maximum stack size (default: 80% of the heap)
postgrest:             e.g.: -K32k -K512k -K8M
postgrest:   -ki<size> Sets the initial thread stack size (default 1k)  e.g.: -ki4k -ki2m
postgrest:   -kc<size> Sets the stack chunk size (default 32k)
postgrest:   -kb<size> Sets the stack chunk buffer size (default 1k)
postgrest:
postgrest:   -A<size>  Sets the minimum allocation area size (default 4m) e.g.: -A20m -A10k
postgrest:   -AL<size> Sets the amount of large-object memory that can be allocated
postgrest:             before a GC is triggered (default: the value of -A)
postgrest:   -F<n>     Sets the collecting threshold for old generations as a factor of
postgrest:             the live data in that generation the last time it was collected
postgrest:             (default: 2.0)
postgrest:   -Fd<n>    Sets the inverse rate which memory is returned to the OS after being
postgrest:             optimistically retained after being allocated. Subsequent major
postgrest:             collections not caused by heap overflow will return an amount of
postgrest:             memory controlled by this factor (higher is slower). Setting the factor
postgrest:             to 0 means memory is not returned.
postgrest:             (default 4.0)
postgrest:   -n<size>  Allocation area chunk size (0 = disabled, default: 0)
postgrest:   -O<size>  Sets the minimum size of the old generation (default 1M)
postgrest:   -M<size>  Sets the maximum heap size (default unlimited)  e.g.: -M256k -M1G
postgrest:   -H<size>  Sets the minimum heap size (default 0M)   e.g.: -H24m  -H1G
postgrest:   -xb<addr> Sets the address from which a suitable start for the heap memory
postgrest:             will be searched from. This is useful if the default address
postgrest:             clashes with some third-party library.
postgrest:   -xn       Use the non-moving collector for the old generation.
postgrest:   -m<n>     Minimum % of heap which must be available (default 3%)
postgrest:   -G<n>     Number of generations (default: 2)
postgrest:   -c<n>     Use in-place compaction instead of copying in the oldest generation
postgrest:             when live data is at least <n>% of the maximum heap size set with
postgrest:             -M (default: 30%)
postgrest:   -c        Use in-place compaction for all oldest generation collections
postgrest:             (the default is to use copying)
postgrest:   -w        Use mark-region for the oldest generation (experimental)
postgrest:   -I<sec>   Perform full GC after <sec> idle time (default: 0.3, 0 == off)
postgrest:
postgrest:   -T         Collect GC statistics (useful for in-program statistics access)
postgrest:   -t[<file>] One-line GC statistics (if <file> omitted, uses stderr)
postgrest:   -s[<file>] Summary  GC statistics (if <file> omitted, uses stderr)
postgrest:   -S[<file>] Detailed GC statistics (if <file> omitted, uses stderr)
postgrest:
postgrest:
postgrest:   -Z         Don't squeeze out update frames on context switch
postgrest:   -B         Sound the bell at the start of each garbage collection
postgrest:   -h       Heap residency profile (output file <program>.hp)
postgrest:   -hT      Produce a heap profile grouped by closure type
postgrest:   -po<file>  Override profiling output file name prefix (program name by default)
postgrest:   -i<sec>  Time between heap profile samples (seconds, default: 0.1)
postgrest:   --no-automatic-heap-samples
postgrest:            Do not start the heap profile interval timer on start-up,
postgrest:            Rather, the application will be responsible for triggering
postgrest:            heap profiler samples.
postgrest:   -ol<file>  Send binary eventlog to <file> (default: <program>.eventlog)
postgrest:   -l[flags]  Log events to a file
postgrest:              where [flags] can contain:
postgrest:                 s    scheduler events
postgrest:                 g    GC and heap events
postgrest:                 n    non-moving GC heap census events
postgrest:                 p    par spark events (sampled)
postgrest:                 f    par spark events (full detail)
postgrest:                 u    user events (emitted from Haskell code)
postgrest:                 a    all event classes above
postgrest:                -x    disable an event class, for any flag above
postgrest:              the initial enabled event classes are 'sgpu'
postgrest:  --eventlog-flush-interval=<secs>
postgrest:              Periodically flush the eventlog at the specified interval.
postgrest:
postgrest:   -C<secs>  Context-switch interval in seconds.
postgrest:             0 or no argument means switch as often as possible.
postgrest:             Default: 0.02 sec.
postgrest:   -V<secs>  Master tick interval in seconds (0 == disable timer).
postgrest:             This sets the resolution for -C and the heap profile timer -i,
postgrest:             and is the frequency of time profile samples.
postgrest:             Default: 0.01 sec.
postgrest:
postgrest:   -N[<n>]    Use <n> processors (default: 1, -N alone determines
postgrest:              the number of processors to use automatically)
postgrest:   -maxN[<n>] Use up to <n> processors automatically
postgrest:   -qg[<n>]   Use parallel GC only for generations >= <n>
postgrest:              (default: 0, -qg alone turns off parallel GC)
postgrest:   -qb[<n>]   Use load-balancing in the parallel GC only for generations >= <n>
postgrest:              (default: 1 for -A < 32M, 0 otherwise;
postgrest:               -qb alone turns off load-balancing)
postgrest:   -qn<n>     Use <n> threads for parallel GC (defaults to value of -N)
postgrest:   -qa        Use the OS to set thread affinity (experimental)
postgrest:   -qm        Don't automatically migrate threads between CPUs
postgrest:   -qi<n>     If a processor has been idle for the last <n> GCs, do not
postgrest:              wake it up for a non-load-balancing parallel GC.
postgrest:              (0 disables,  default: 0)
postgrest:   --numa[=<node_mask>]
postgrest:              Use NUMA, nodes given by <node_mask> (default: off)
postgrest:   --install-signal-handlers=<yes|no>
postgrest:              Install signal handlers (default: yes)
postgrest:   --io-manager=<native|posix>
postgrest:              The I/O manager subsystem to use. (default: posix)
postgrest:   -e<n>      Maximum number of outstanding local sparks (default: 4096)
postgrest:   -xp        Assume that all object files were compiled with -fPIC
postgrest:              -fexternal-dynamic-refs and load them anywhere in the address
postgrest:              space
postgrest:   -xm        Base address to mmap memory in the GHCi linker
postgrest:              (hex; must be <80000000)
postgrest:   -xq        The allocation limit given to a thread after it receives
postgrest:              an AllocationLimitExceeded exception. (default: 100k)
postgrest:
postgrest:   -Mgrace=<n>
postgrest:              The amount of allocation after the program receives a
postgrest:              HeapOverflow exception before the exception is thrown again, if
postgrest:              the program is still exceeding the heap limit.
postgrest:
postgrest: RTS options may also be specified using the GHCRTS environment variable.
postgrest:
postgrest: Other RTS options may be available for programs compiled a different way.
postgrest: The GHC User's Guide has full details.
postgrest:
+ rm -rf /tmp/nix-shell-43614-1878198251/tmp.3XtIE8mlED
```

</details>

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `fix`, bug fixes
  + `feat`, new features added
  + `perf`, performance improvements
  + `docs`, updating the documentation
  + `nix`, related to the Nix development environment
  + `ci`, related to the Continuous Integration modules
  + `test`, related to the testing modules
  + `refactor`, refactoring code
  + `deprecate`, deprecating a feature
  + `changelog`, updating the CHANGELOG
  + `chore`, maintenance (build process, updating sponsors, etc.)
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
