### PR TITLE
refactor: add PreQuery module

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -71,6 +71,7 @@ library
                       PostgREST.Network
                       PostgREST.Observation
                       PostgREST.Query
+                      PostgREST.Query.PreQuery
                       PostgREST.Query.QueryBuilder
                       PostgREST.Query.SqlFragment
                       PostgREST.Query.Statements

--- a/src/PostgREST/Query/PreQuery.hs
+++ b/src/PostgREST/Query/PreQuery.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE NamedFieldPuns  #-}
+{-# LANGUAGE RecordWildCards #-}
+{-|
+Module      : PostgREST.Query.PreQuery
+Description : Builds queries that run prior to the main query
+-}
+module PostgREST.Query.PreQuery
+  ( txVarQuery
+  , preReqQuery
+  ) where
+
+import qualified Data.Aeson                      as JSON
+import qualified Data.Aeson.KeyMap               as KM
+import qualified Data.ByteString                 as BS
+import qualified Data.ByteString.Lazy.Char8      as LBS
+import qualified Data.HashMap.Strict             as HM
+import qualified Hasql.DynamicStatements.Snippet as SQL hiding (sql)
+
+
+
+import PostgREST.ApiRequest              (ApiRequest (..))
+import PostgREST.ApiRequest.Preferences  (PreferTimezone (..),
+                                          Preferences (..))
+import PostgREST.Config                  (AppConfig (..))
+import PostgREST.Plan                    (CallReadPlan (..),
+                                          DbActionPlan (..))
+import PostgREST.Query.SqlFragment       (escapeIdentList, fromQi,
+                                          intercalateSnippet,
+                                          setConfigWithConstantName,
+                                          setConfigWithConstantNameJSON,
+                                          setConfigWithDynamicName)
+import PostgREST.SchemaCache.Identifiers (QualifiedIdentifier (..))
+import PostgREST.SchemaCache.Routine     (Routine (..))
+
+import Protolude hiding (Handler)
+
+-- sets transaction variables
+txVarQuery :: DbActionPlan -> AppConfig -> KM.KeyMap JSON.Value -> BS.ByteString -> ApiRequest -> SQL.Snippet
+txVarQuery dbActPlan AppConfig{..} claims role ApiRequest{..} =
+    -- To ensure `GRANT SET ON PARAMETER <superuser_setting> TO authenticator` works, the role settings must be set before the impersonated role.
+    -- Otherwise the GRANT SET would have to be applied to the impersonated role. See https://github.com/PostgREST/postgrest/issues/3045
+    "select " <> intercalateSnippet ", " (
+      searchPathSql : roleSettingsSql ++ roleSql ++ claimsSql ++ [methodSql, pathSql] ++ headersSql ++ cookiesSql ++ timezoneSql ++ funcSettingsSql ++ appSettingsSql
+    )
+  where
+    methodSql = setConfigWithConstantName ("request.method", iMethod)
+    pathSql = setConfigWithConstantName ("request.path", iPath)
+    headersSql = setConfigWithConstantNameJSON "request.headers" iHeaders
+    cookiesSql = setConfigWithConstantNameJSON "request.cookies" iCookies
+    claimsSql = [setConfigWithConstantName ("request.jwt.claims", LBS.toStrict $ JSON.encode claims)]
+    roleSql = [setConfigWithConstantName ("role", role)]
+    roleSettingsSql = setConfigWithDynamicName <$> HM.toList (fromMaybe mempty $ HM.lookup role configRoleSettings)
+    appSettingsSql = setConfigWithDynamicName . join bimap toUtf8 <$> configAppSettings
+    timezoneSql = maybe mempty (\(PreferTimezone tz) -> [setConfigWithConstantName ("timezone", tz)]) $ preferTimezone iPreferences
+    funcSettingsSql = setConfigWithDynamicName . join bimap toUtf8 <$> funcSettings
+    searchPathSql =
+      let schemas = escapeIdentList (iSchema : configDbExtraSearchPath) in
+      setConfigWithConstantName ("search_path", schemas)
+    funcSettings = case dbActPlan of
+      DbCall CallReadPlan{crProc} -> pdFuncSettings crProc
+      _                           -> mempty
+
+-- runs the pre-request function
+preReqQuery :: QualifiedIdentifier -> SQL.Snippet
+preReqQuery preRequest = "select " <> fromQi preRequest <> "()"


### PR DESCRIPTION
Small step towards solving #3934.

Adds a module that builds pure SQL snippets for the transaction variables and the pre-request function.