### PR TITLE
docs: catch invalid target references

### DIFF
--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -1,8 +1,14 @@
 name: Linkcheck
 
 on:
+  pull_request: # Temporarily test using PR, remove this before merge
+    branches:
+      - main
   schedule:
     - cron: '1 2 * * 3'
+
+permissions:
+  issues: write
 
 jobs:
   linkcheck:
@@ -15,3 +21,15 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         tools: docs.linkcheck.bin
     - run: postgrest-docs-linkcheck
+
+  on-linkcheck-fail:
+    runs-on: ubuntu-latest
+    needs: linkcheck
+    if: ${{ always() && needs.linkcheck.result == 'failure' }}
+    steps:
+    - name: Notify on linkcheck failure by commenting
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        issue-number: 4106
+        body: |
+          ❌ **Linkcheck Job Failed!**

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -214,6 +214,7 @@ Here are some companies that use PostgREST in production.
   - See how Nimbus uses PostgREST in `Paul Copplestone's blog post <https://paul.copplest.one/blog/nimbus-tech-2019-04.html>`_.
 * `OpenBooking <https://openbooking.ch>`_
 * `Supabase <https://supabase.com>`_
+* `Fake link <https://fake.postgrest.com>`_ .. TODD remove this before merge
 
 Testimonials
 ------------


### PR DESCRIPTION
The scheduled linkcheck job fails without notification. To catch the failure, a github workflow has been added which comments on issue #4106 so that the maintainers get notified.

