### PR TITLE
perf: cache schema description for OpenAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   + The exposed schemas are now listed in the `hint` instead of the `message` field.
 - Improve error details of `PGRST301` error by @taimoorzaeem in #4051
 - Bounded JWT cache using the SIEVE algorithm by @mkleczek in #4084
+- Cache schema descriptions to avoid a query each time OpenAPI is requested by @steve-chavez in #4226
 
 ### Fixed
 


### PR DESCRIPTION
Previously we use to query the schema descriptions on each request for OpenAPI.

Partly addresses https://github.com/PostgREST/postgrest/issues/4226