### PR TITLE
refactor: only use accessibleFuncs to filter

### DIFF
--- a/src/PostgREST/Plan/CallPlan.hs
+++ b/src/PostgREST/Plan/CallPlan.hs
@@ -13,7 +13,7 @@ import qualified Data.ByteString.Lazy              as LBS
 import qualified Data.HashMap.Strict               as HM
 import           PostgREST.SchemaCache.Identifiers (FieldName,
                                                     QualifiedIdentifier)
-import           PostgREST.SchemaCache.Routine     (Routine (..),
+import           PostgREST.SchemaCache.Routine     (Routine (..), FuncIdent(..),
                                                     RoutineParam (..))
 
 import Protolude
@@ -61,4 +61,4 @@ toRpcParamValue :: Routine -> (Text, Text) -> (Text, RpcParamValue)
 toRpcParamValue proc (k, v) | prmIsVariadic k = (k, Variadic [v])
                             | otherwise       = (k, Fixed v)
   where
-    prmIsVariadic prm = isJust $ find (\RoutineParam{ppName, ppVar} -> ppName == prm && ppVar) $ pdParams proc
+    prmIsVariadic prm = isJust $ find (\RoutineParam{ppName, ppVar} -> ppName == prm && ppVar) $ pdParams (pdIdent proc)

--- a/src/PostgREST/Response.hs
+++ b/src/PostgREST/Response.hs
@@ -229,9 +229,9 @@ actionResponse (DbCallResult CallReadPlan{crMedia, crInvMthd=invMethod, crProc=p
   RSPlan plan ->
     Right $ PgrstResponse HTTP.status200 (contentLengthHeaderStrict plan : contentTypeHeaders crMedia ctxApiRequest) $ LBS.fromStrict plan
 
-actionResponse (MaybeDbResult InspectPlan{ipHdrsOnly=headersOnly} body) _ versions conf sCache schema negotiatedByProfile =
+actionResponse (MaybeDbResult InspectPlan{ipHdrsOnly=headersOnly} resOpenApi) _ versions conf sCache schema negotiatedByProfile =
   let
-    rsBody = maybe mempty (\(x, y, z) -> if headersOnly then mempty else OpenAPI.encode versions conf sCache x y z) body
+    rsBody = maybe mempty (\rs -> if headersOnly then mempty else OpenAPI.encode versions conf sCache rs) resOpenApi
     cLHeader = if headersOnly then mempty else [contentLengthHeaderLazy rsBody]
   in
   Right $ PgrstResponse HTTP.status200 (MediaType.toContentType MTOpenAPI : cLHeader ++ maybeToList (profileHeader schema negotiatedByProfile)) rsBody


### PR DESCRIPTION
Attempt towards gradually solving https://github.com/PostgREST/postgrest/issues/4226 by merging the two accessibleFuncs and accessibleTables queries into one.

Results are not good:

1) Currently fails two tests:
```
  test/spec/Feature/OpenApi/OpenApiSpec.hs:740:17:
  1) Feature.OpenApi.OpenApiSpec.OpenAPI.RPC includes function summary/description and query parameters for arguments in the get path item
       expected: Just (String "An RPC function")
        but got: Nothing

  To rerun use: --match "/Feature.OpenApi.OpenApiSpec/OpenAPI/RPC/includes function summary/description and query parameters for arguments in the get path item/" --seed 303773363

  test/spec/Feature/OpenApi/OpenApiSpec.hs:886:17:
  2) Feature.OpenApi.OpenApiSpec.OpenAPI.RPC includes function summary/description and body schema for arguments in the post path item
       expected: Just (String "An RPC function")
        but got: Nothing
```

  + This is quite hard to debug, needs resorting to debug traces

2) Performance is bad compared to main
  + `curl localhost:3000` with openapi-mode=follow-privileges takes noticeable time, maybe 3 seconds
  + Previous version was almost immediate

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `fix`, bug fixes
  + `feat`, new features added
  + `perf`, performance improvements
  + `docs`, updating the documentation
  + `nix`, related to the Nix development environment
  + `ci`, related to the Continuous Integration modules
  + `test`, related to the testing modules
  + `refactor`, refactoring code
  + `deprecate`, deprecating a feature
  + `changelog`, updating the CHANGELOG
  + `chore`, maintenance (build process, updating sponsors, etc.)
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
