### PR TITLE
Revert "fix: geojson invalid query on unavailable PostGIS"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix OpenAPI broken docs link by @taimoorzaeem in #4080
 - Fix OpenAPI specification incorrectly exposing GET methods for volatile functions by @joelonsql in #4174
 - Fix empty spread embeddings return unexpected SQL error by @taimoorzaeem in #3887
-- Fix `Accept: application/geo+json` generating an invalid query when PostGIS is not available by @steve-chavez in #4245
 
 ### Changed
 

--- a/test/io/__snapshots__/test_cli/test_schema_cache_snapshot[dbMediaHandlers].yaml
+++ b/test/io/__snapshots__/test_cli/test_schema_cache_snapshot[dbMediaHandlers].yaml
@@ -4,6 +4,11 @@
     - tag: MTTextCSV
 
 - - - tag: RelAnyElement
+    - tag: MTGeoJSON
+  - - tag: BuiltinOvAggGeoJson
+    - tag: MTGeoJSON
+
+- - - tag: RelAnyElement
     - tag: MTApplicationJSON
   - - tag: BuiltinOvAggJson
     - tag: MTApplicationJSON

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -1137,18 +1137,6 @@ def test_no_pool_connection_required_on_bad_embedding(defaultenv):
         assert response.status_code == 400
 
 
-def test_no_pool_connection_required_on_unavailable_postgis(defaultenv):
-    "no pool connection should be consumed when PostGIS is not available, the request should be quickly rejected at the plan level"
-
-    headers = {
-        "Accept": "application/geo+json",
-    }
-
-    with run(env=defaultenv, no_pool_connection_available=True) as postgrest:
-        response = postgrest.session.get("/projects", headers=headers)
-        assert response.status_code == 406
-
-
 # https://github.com/PostgREST/postgrest/issues/2620
 def test_notify_reloading_catalog_cache(defaultenv):
     "notify should reload the connection catalog cache"


### PR DESCRIPTION
This reverts commit 0f1ca8faac630518b343f195464beff47fe32c78.

Reverting for now as it adds one more query to the schema cache and there's no clear way forward on how to integrate the fix with the current schema cache queries.

See discussion on https://github.com/PostgREST/postgrest/pull/4246#pullrequestreview-3093174224.

Should reopen https://github.com/PostgREST/postgrest/issues/4245 after merge.