### PR TITLE
fix(admin): metrics endpoint not responding with Content-Type header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix OpenAPI broken docs link by @taimoorzaeem in #4080
 - Fix OpenAPI specification incorrectly exposing GET methods for volatile functions by @joelonsql in #4174
 - Fix empty spread embeddings return unexpected SQL error by @taimoorzaeem in #3887
+- Fix `/metrics` endpoint not responding with `Content-Type` header by @taimoorzaeem in #4271
 
 ### Changed
 

--- a/docs/references/observability.rst
+++ b/docs/references/observability.rst
@@ -128,6 +128,11 @@ The ``metrics`` endpoint on the :ref:`admin_server` endpoint provides metrics in
 
   curl "http://localhost:3001/metrics"
 
+.. code-block:: http
+
+  HTTP/1.1 200 OK
+  Content-Type: text/plain; charset=utf-8
+
   # HELP pgrst_schema_cache_query_time_seconds The query time in seconds of the last schema cache load
   # TYPE pgrst_schema_cache_query_time_seconds gauge
   pgrst_schema_cache_query_time_seconds 1.5937927e-2

--- a/src/PostgREST/Admin.hs
+++ b/src/PostgREST/Admin.hs
@@ -16,6 +16,7 @@ import Network.Socket.ByteString
 
 import PostgREST.AppState    (AppState)
 import PostgREST.Config      (AppConfig (..))
+import PostgREST.MediaType   (MediaType (..), toContentType)
 import PostgREST.Metrics     (metricsToText)
 import PostgREST.Network     (resolveHost)
 import PostgREST.Observation (Observation (..))
@@ -58,7 +59,7 @@ admin appState req respond  = do
       respond $ Wai.responseLBS HTTP.status200 [] (maybe mempty JSON.encode sCache)
     ["metrics"] -> do
       mets <- metricsToText
-      respond $ Wai.responseLBS HTTP.status200 [] mets
+      respond $ Wai.responseLBS HTTP.status200 [toContentType MTTextPlain] mets -- Content-Type is required for prometheus compliance
     _ ->
       respond $ Wai.responseLBS HTTP.status404 [] mempty
 

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -1730,6 +1730,7 @@ def test_admin_metrics(defaultenv):
     with run(env=defaultenv, port=freeport()) as postgrest:
         response = postgrest.admin.get("/metrics")
         assert response.status_code == 200
+        assert response.headers["Content-Type"] == "text/plain; charset=utf-8"
         assert "pgrst_schema_cache_query_time_seconds" in response.text
         assert 'pgrst_schema_cache_loads_total{status="SUCCESS"}' in response.text
         assert "pgrst_db_pool_max" in response.text


### PR DESCRIPTION
The prometheus metrics text format requires `Content-Type` header for correct scraping which fails otherwise. Closes #4271.

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `fix`, bug fixes
  + `feat`, new features added
  + `perf`, performance improvements
  + `docs`, updating the documentation
  + `nix`, related to the Nix development environment
  + `ci`, related to the Continuous Integration modules
  + `test`, related to the testing modules
  + `refactor`, refactoring code
  + `deprecate`, deprecating a feature
  + `changelog`, updating the CHANGELOG
  + `chore`, maintenance (build process, updating sponsors, etc.)
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
