### PR TITLE
refactor: deduplicate host resolution logic and observations

### DIFF
--- a/src/PostgREST/Observation.hs
+++ b/src/PostgREST/Observation.hs
@@ -21,19 +21,16 @@ import qualified Hasql.Connection           as SQL
 import qualified Hasql.Pool                 as SQL
 import qualified Hasql.Pool.Observation     as SQL
 import           Network.HTTP.Types.Status  (Status)
-import qualified Network.Socket             as NS
 import           Numeric                    (showFFloat)
 import           PostgREST.Config.PgVersion
 import qualified PostgREST.Error            as Error
 
-import Protolude         hiding (toList)
-import Protolude.Partial (fromJust)
+import Protolude hiding (toList)
 
 data Observation
-  = AdminStartObs (Maybe Text) (Maybe Int)
+  = AdminStartObs Text
   | AppStartObs ByteString
-  | AppServerPortObs Text NS.PortNumber
-  | AppServerUnixObs FilePath
+  | AppServerAddressObs Text
   | ExitUnsupportedPgVersion PgVersion PgVersion
   | ExitDBNoRecoveryObs
   | ExitDBFatalError ObsFatalError SQL.UsageError
@@ -69,14 +66,12 @@ type ObservationHandler = Observation -> IO ()
 
 observationMessage :: Observation -> Text
 observationMessage = \case
-  AdminStartObs host port ->
-    "Admin server listening on " <> fromJust host <> ":" <> show (fromIntegral (fromJust port) :: Integer)
+  AdminStartObs address ->
+    "Admin server listening on " <> address
   AppStartObs ver ->
     "Starting PostgREST " <> T.decodeUtf8 ver <> "..."
-  AppServerPortObs host port ->
-    "API server listening on " <> host <> ":" <> show port
-  AppServerUnixObs sock ->
-    "API server listening on unix socket " <> show sock
+  AppServerAddressObs address ->
+    "API server listening on " <> address
   DBConnectedObs ver ->
     "Successfully connected to " <> ver
   ExitUnsupportedPgVersion pgVer minPgVer ->

--- a/test/doc/Main.hs
+++ b/test/doc/Main.hs
@@ -18,6 +18,7 @@ main =
     , "src/PostgREST/Config.hs"
     , "src/PostgREST/Error.hs"
     , "src/PostgREST/MediaType.hs"
+    , "src/PostgREST/Network.hs"
     , "src/PostgREST/Plan.hs"
     , "src/PostgREST/Query/SqlFragment.hs"
     , "src/PostgREST/Response.hs"

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -1378,7 +1378,7 @@ def test_log_postgrest_host_and_port(host, defaultenv):
         output = postgrest.read_stdout(nlines=10)
 
         if is_unix:
-            re.match(r'API server listening on unix socket "/tmp/.*\.sock"', output[2])
+            re.match(r'API server listening on "/tmp/.*\.sock"', output[2])
         elif is_ipv6(host):
             assert f"API server listening on [{host}]:{port}" in output[2]
         else:  # IPv4


### PR DESCRIPTION
While working on #4269, I noticed some redundant code in `Network` and `Observation` modules. This commit deduplicates the code in those modules.
