### PR TITLE
fix: format of IPv6 address logged at PostgREST startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix logging the Haskell type instead of the listener error message directly by @laurenceisla in #3588
+- Fix format of `IPv6` address logged at PostgREST startup by @taimoorzaeem in #4291
 
 ### Changed
 

--- a/src/PostgREST/Network.hs
+++ b/src/PostgREST/Network.hs
@@ -13,5 +13,9 @@ resolveHost sock = do
   sn <- NS.getSocketName sock
   case sn of
     NS.SockAddrInet _ hostAddr ->  pure $ Just $ fromString $ show $ fromHostAddress hostAddr
-    NS.SockAddrInet6 _ _ hostAddr6 _ -> pure $ Just $ fromString $ show $ fromHostAddress6 hostAddr6
+    -- The IPv6 addresses are wrapped in [] brackets. This is done in accordance
+    -- to RFC 3986 (https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2).
+    -- In short, we did this to have a clear separation between the port and host
+    -- because the components of an IPv6 are separated with the ':' character.
+    NS.SockAddrInet6 _ _ hostAddr6 _ -> pure $ Just $ fromString $ "[" ++ show (fromHostAddress6 hostAddr6) ++ "]"
     _ -> pure Nothing

--- a/test/io/postgrest.py
+++ b/test/io/postgrest.py
@@ -97,7 +97,9 @@ def run(
         if port:
             env["PGRST_SERVER_PORT"] = str(port)
             env["PGRST_SERVER_HOST"] = host or "localhost"
-            baseurl = f"http://localhost:{port}"
+            # When constructing IPv6 address, host address should be bracketed like [host]
+            apihost = f"[{host}]" if host and is_ipv6(host) else "localhost"
+            baseurl = f"http://{apihost}:{port}"
         else:
             socketfile = pathlib.Path(tmpdir) / "postgrest.sock"
             env["PGRST_SERVER_UNIX_SOCKET"] = str(socketfile)
@@ -105,7 +107,8 @@ def run(
 
         adminport = freeport(port)
         env["PGRST_ADMIN_SERVER_PORT"] = str(adminport)
-        adminurl = f"http://localhost:{adminport}"
+        adminhost = f"[{host}]" if host and is_ipv6(host) else "localhost"
+        adminurl = f"http://{adminhost}:{adminport}"
 
         command = [POSTGREST_BIN]
         env["HPCTIXFILE"] = hpctixfile()
@@ -219,3 +222,11 @@ def sleep_pool_connection(url, seconds):
         session.get(url + f"/rpc/sleep?seconds={seconds}", timeout=0.1)
     except requests.exceptions.ReadTimeout:
         pass
+
+
+def is_ipv6(addr):
+    try:
+        socket.inet_pton(socket.AF_INET6, addr)
+        return True
+    except OSError:
+        return False

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -1362,9 +1362,9 @@ def test_log_postgrest_version(defaultenv):
         assert "Starting PostgREST %s..." % version in output[0]
 
 
-def test_log_postgrest_host_and_port(defaultenv):
+@pytest.mark.parametrize("host", ["127.0.0.1", "::1"])
+def test_log_postgrest_host_and_port(host, defaultenv):
     "PostgREST should output the host and port it is bound to."
-    host = "127.0.0.1"
     port = freeport()
 
     with run(
@@ -1372,7 +1372,10 @@ def test_log_postgrest_host_and_port(defaultenv):
     ) as postgrest:
         output = postgrest.read_stdout(nlines=10)
 
-        assert f"API server listening on {host}:{port}" in output[2]  # output-sensitive
+        if is_ipv6(host):  # IPv6
+            assert f"API server listening on [{host}]:{port}" in output[2]
+        else:  # IPv4
+            assert f"API server listening on {host}:{port}" in output[2]
 
 
 def test_succeed_w_role_having_superuser_settings(defaultenv):


### PR DESCRIPTION
The IPv6 address logged at the startup like `::1:80` was wrong because the port isn't clearly separated. This commit corrects it, now logging as `[::1]:80` as discussed in [#4288 (comment)](https://github.com/PostgREST/postgrest/pull/4288#discussion_r2308273098).

This also allows the refactor on #4288 to go smoothly without changing any behavior.

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `fix`, bug fixes
  + `feat`, new features added
  + `perf`, performance improvements
  + `docs`, updating the documentation
  + `nix`, related to the Nix development environment
  + `ci`, related to the Continuous Integration modules
  + `test`, related to the testing modules
  + `refactor`, refactoring code
  + `deprecate`, deprecating a feature
  + `changelog`, updating the CHANGELOG
  + `chore`, maintenance (build process, updating sponsors, etc.)
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
