### PR TITLE
fix: not logging OpenAPI queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+
+- Fix not logging OpenAPI queries when `log-query=main-query` is enabled by @steve-chavez in #4226
+
 ### Added
 
 - Improve the `PGRST106` error when the requested schema is invalid by @laurenceisla in #4089

--- a/src/PostgREST/Query.hs
+++ b/src/PostgREST/Query.hs
@@ -106,7 +106,7 @@ data ResultSet
 
 query :: AppConfig -> AuthResult -> ApiRequest -> ActionPlan -> SchemaCache -> Query
 query _ _ _ (NoDb x) _ = NoDbQuery $ NoDbResult x
-query conf@AppConfig{..} AuthResult{..} apiReq (Db plan) sCache =
+query conf@AppConfig{..} auth@AuthResult{..} apiReq (Db plan) sCache =
   DbQuery isoLvl txMode dbHandler transaction mainSQLQuery
   where
     transaction = if configDbPreparedStatements then SQL.transaction else SQL.unpreparedTransaction
@@ -115,7 +115,7 @@ query conf@AppConfig{..} AuthResult{..} apiReq (Db plan) sCache =
     (mainActionQuery, mainSQLQuery) = actionQuery plan conf apiReq sCache
     dbHandler = do
       lift $ SQL.statement mempty $ SQL.dynamicallyParameterized
-        (PreQuery.txVarQuery plan conf authClaims authRole apiReq)
+        (PreQuery.txVarQuery plan conf auth apiReq)
         HD.noResult configDbPreparedStatements
       lift $ whenJust configDbPreRequest $ \prereq -> do
         SQL.statement mempty $ SQL.dynamicallyParameterized (PreQuery.preReqQuery prereq) HD.noResult configDbPreparedStatements

--- a/src/PostgREST/Query/PreQuery.hs
+++ b/src/PostgREST/Query/PreQuery.hs
@@ -16,10 +16,10 @@ import qualified Hasql.DynamicStatements.Snippet as SQL hiding (sql)
 
 
 
-import PostgREST.Auth.Types              (AuthResult (..))
 import PostgREST.ApiRequest              (ApiRequest (..))
 import PostgREST.ApiRequest.Preferences  (PreferTimezone (..),
                                           Preferences (..))
+import PostgREST.Auth.Types              (AuthResult (..))
 import PostgREST.Config                  (AppConfig (..))
 import PostgREST.Plan                    (CallReadPlan (..),
                                           DbActionPlan (..))


### PR DESCRIPTION
Closes https://github.com/PostgREST/postgrest/issues/4226.

This requires moving query generation to the top App.hs module.

At this point is also simple to log the transaction variables + the pre-request function call but this is not done here to reduce scope.