### PR TITLE
fix: hashtables <1.4.1 fail to build with GCC 15

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -2,3 +2,7 @@ packages: postgrest.cabal
 tests: true
 package *
   ghc-options: -split-sections
+
+-- avoid hashtables pre-1.4.1 that fail to build with GCC 15; see https://github.com/gregorycollins/hashtables/issues/98
+constraints:
+  hashtables >= 1.4.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,6 +9,7 @@ nix:
   pure: false
 
 extra-deps:
+  - hashtables-1.4.2@sha256:4940cab94a15d469845ccf5225f9cb3d354c15e8127ebb58425c8b681f7721d9,10386 # fixes build with GCC 15-ish; https://github.com/gregorycollins/hashtables/issues/98 for details
   - fuzzyset-0.2.4
   - hasql-pool-1.0.1
   - jose-jwt-0.10.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,6 +5,13 @@
 
 packages:
 - completed:
+    hackage: hashtables-1.4.2@sha256:4940cab94a15d469845ccf5225f9cb3d354c15e8127ebb58425c8b681f7721d9,10386
+    pantry-tree:
+      sha256: 65107f0c970351b971ea1f676a5e00b61e37c298a4c83c867d937f2a774501eb
+      size: 2895
+  original:
+    hackage: hashtables-1.4.2@sha256:4940cab94a15d469845ccf5225f9cb3d354c15e8127ebb58425c8b681f7721d9,10386
+- completed:
     hackage: fuzzyset-0.2.4@sha256:f1b6de8bf33277bf6255207541d65028f1f1ea93af5541b654c86b5674995485,1618
     pantry-tree:
       sha256: cee68e8d88f530e9e0588b81b260236936fe3318ef9a66e9f43f680b4cd5f76e


### PR DESCRIPTION
Repro: 

1. Install GCC 15 (openSUSE Tumbleweed has it for a while now)
2. run `stack build`

Expected: compilation succeds

Instead: build fails building `hashtables-1.3.1`, reproducing https://github.com/gregorycollins/hashtables/issues/98

This PR makes sure `hashtables`' version is  >= 1.4.1, one with the issue fixed. Stack.yaml specifies 1.4.2 because it's the next version after in the stackage snapshots: https://github.com/commercialhaskell/stackage-snapshots/blob/master/lts/24/0.yaml#L5300

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `fix`, bug fixes
  + `feat`, new features added
  + `perf`, performance improvements
  + `docs`, updating the documentation
  + `nix`, related to the Nix development environment
  + `ci`, related to the Continuous Integration modules
  + `test`, related to the testing modules
  + `refactor`, refactoring code
  + `deprecate`, deprecating a feature
  + `changelog`, updating the CHANGELOG
  + `chore`, maintenance (build process, updating sponsors, etc.)
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
