### PR TITLE
test(io): remove unused duplicate freeport() function

### DIFF
--- a/test/io/util.py
+++ b/test/io/util.py
@@ -24,14 +24,6 @@ class Thread(threading.Thread):
             raise self._exception
 
 
-def freeport():
-    "Find a free port on localhost."
-    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-        s.bind(("", 0))
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        return s.getsockname()[1]
-
-
 def authheader(token):
     "Bearer token HTTP authorization header."
     return {"Authorization": f"Bearer {token}"}


### PR DESCRIPTION
Removes dead code essentially. We have this function in `postgrest.py` already.

https://github.com/PostgREST/postgrest/blob/2b8f8c4c47023174a69a92eab0ebfa89a7b5f1ee/test/io/postgrest.py#L176-L184

**Side note:** Maybe we should set up some kind of linter like `pylint` to detect similar issues. These aren't huge issues though, but I think it adds up to the tech debt a little bit.