### PR TITLE
test(io): move reusable functions to postgrest.py

### DIFF
--- a/test/io/postgrest.py
+++ b/test/io/postgrest.py
@@ -230,3 +230,20 @@ def is_ipv6(addr):
         return True
     except OSError:
         return False
+
+
+def set_statement_timeout(postgrest, role, milliseconds):
+    """Set the statement timeout for the given role.
+    For this to work reliably with low previous timeout settings,
+    use a postgrest instance that doesn't use the affected role."""
+
+    response = postgrest.session.post(
+        "/rpc/set_statement_timeout", data={"role": role, "milliseconds": milliseconds}
+    )
+    assert response.text == ""
+    assert response.status_code == 204
+
+
+def reset_statement_timeout(postgrest, role):
+    "Reset the statement timeout for the given role to the default 0 (no timeout)"
+    set_statement_timeout(postgrest, role, 0)

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -595,23 +595,6 @@ def test_db_prepared_statements_disable(defaultenv):
         assert response.text == "false"
 
 
-def set_statement_timeout(postgrest, role, milliseconds):
-    """Set the statement timeout for the given role.
-    For this to work reliably with low previous timeout settings,
-    use a postgrest instance that doesn't use the affected role."""
-
-    response = postgrest.session.post(
-        "/rpc/set_statement_timeout", data={"role": role, "milliseconds": milliseconds}
-    )
-    assert response.text == ""
-    assert response.status_code == 204
-
-
-def reset_statement_timeout(postgrest, role):
-    "Reset the statement timeout for the given role to the default 0 (no timeout)"
-    set_statement_timeout(postgrest, role, 0)
-
-
 def test_statement_timeout(defaultenv, metapostgrest):
     "Statement timeout times out slow statements"
 


### PR DESCRIPTION
Moves the `set_statement_timeout` and `reset_statement_timeout` function to postgrest.py. This cleans up test_io.py so it only contains tests. Also makes these functions reusable in other other tests like test_cli.py.

Also makes #4269 a bit easier to review, avoiding doing something like `import test_io` because that would be weird.
