### PR TITLE
test(io): remove unused module imports

### DIFF
--- a/test/io/config.py
+++ b/test/io/config.py
@@ -1,8 +1,6 @@
 import os
 import pathlib
 import shutil
-import signal
-
 import pytest
 import uuid
 import yaml

--- a/test/io/test_cli.py
+++ b/test/io/test_cli.py
@@ -1,25 +1,8 @@
 "Unit tests for Input/Ouput of PostgREST seen as a black box."
 
-import contextlib
-import dataclasses
-from datetime import datetime
 from operator import attrgetter
-import os
-import pathlib
-import re
-import shutil
-import signal
-import socket
 import subprocess
-import tempfile
-import threading
-import time
-import urllib.parse
-
-import jwt
 import pytest
-import requests
-import requests_unixsocket
 from syrupy.extensions.json import SingleFileSnapshotExtension
 import yaml
 

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -5,9 +5,7 @@ from operator import attrgetter
 import os
 import re
 import signal
-import socket
 import time
-
 import pytest
 
 from config import *

--- a/test/io/test_replica.py
+++ b/test/io/test_replica.py
@@ -1,7 +1,5 @@
 "IO tests for PostgREST started on replicas"
 
-import pytest
-
 from config import *
 from util import *
 from postgrest import *

--- a/test/io/test_sanity.py
+++ b/test/io/test_sanity.py
@@ -1,13 +1,5 @@
 "Sanity checks for the PostgREST black box testing infrastructure."
 
-from datetime import datetime
-from operator import attrgetter
-import os
-import re
-import signal
-import socket
-import time
-
 import pytest
 
 from config import *

--- a/test/io/util.py
+++ b/test/io/util.py
@@ -1,7 +1,4 @@
-import contextlib
-import socket
 import threading
-
 import jwt
 
 


### PR DESCRIPTION
Towards #4342. Doing some cleanup, so when we actually integrate `pylint`, it applies cleanly.