### PR TITLE
docs: document config file parameter on CLI page

### DIFF
--- a/docs/references/cli.rst
+++ b/docs/references/cli.rst
@@ -3,23 +3,45 @@
 CLI
 ===
 
-PostgREST provides a CLI with the commands listed below:
+PostgREST provides a CLI with the options listed below:
+
+.. code:: text
+
+  Usage: postgrest [-v|--version] [-e|--example] [--dump-config | --dump-schema] 
+                 [FILENAME]
+
+    PostgREST / create a REST API to an existing Postgres
+    database
+
+  Available options:
+    -h,--help                Show this help text
+    -v,--version             Show the version information
+    -e,--example             Show an example configuration file
+    --dump-config            Dump loaded configuration and exit
+    --dump-schema            Dump loaded schema as JSON and exit (for debugging,
+                             output structure is unstable)
+    FILENAME                 Path to configuration file
+
+FILENAME
+--------
+
+Runs PostgREST with the given :ref:`file_config`.
 
 Help
 ----
 
 .. code:: bash
 
-  $ postgrest [-h|--help]
+  $ postgrest --help
 
-Shows all the commands available.
+Shows all the options available.
 
 Version
 -------
 
 .. code:: bash
 
-  $ postgrest [-v|--version]
+  $ postgrest --version
 
 Prints the PostgREST version.
 
@@ -28,16 +50,16 @@ Example
 
 .. code:: bash
 
-  $ postgrest [-e|--example]
+  $ postgrest --example
 
-Shows example configuration options.
+Shows example configuration settings.
 
 Dump Config
 -----------
 
 .. code:: bash
 
-  $ postgrest [--dump-config]
+  $ postgrest --dump-config
 
 Dumps the loaded :ref:`configuration` values, considering the configuration file, environment variables and :ref:`in_db_config`.
 
@@ -46,6 +68,6 @@ Dump Schema
 
 .. code:: bash
 
-  $ postgrest [--dump-schema]
+  $ postgrest --dump-schema
 
 Dumps the schema cache in JSON format.


### PR DESCRIPTION
The CLI page had the config file parameter missing. This commit adds that. Also adds the CLI usage output which shows all available options. Closes #4300.