### PR TITLE
nix: setup linter to lint python files

### DIFF
--- a/nix/tools/style.nix
+++ b/nix/tools/style.nix
@@ -8,6 +8,7 @@
 , hsie
 , nixpkgs-fmt
 , python3Packages
+, ruff
 , silver-searcher
 , statix
 , stylish-haskell
@@ -64,9 +65,13 @@ let
         echo "Scanning nix files for unused code..."
         ${deadnix}/bin/deadnix -f
 
+        # ruff has gaps in scanning for unused code, so we use vulture
         echo "Scanning python files for unused code..."
         ${silver-searcher}/bin/ag -l --vimgrep -g '\.l?py$' . \
           | xargs ${python3Packages.vulture}/bin/vulture --exclude docs/conf.py
+
+        echo "Linting python files..."
+        ${ruff}/bin/ruff check .
 
         echo "Checking consistency of import aliases in Haskell code..."
         ${hsie} check-aliases main src


### PR DESCRIPTION
This sets up the `ruff` linter for python code linting.

Closes #4342.