### PR TITLE
test(pytest): remove star imports to please ruff linter

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/test/io/postgrest.py
+++ b/test/io/postgrest.py
@@ -13,7 +13,7 @@ import urllib.parse
 import requests
 import requests_unixsocket
 
-from config import *
+from config import POSTGREST_BIN, hpctixfile
 
 
 def sleep_until_postgrest_scache_reload():

--- a/test/io/test_big_schema.py
+++ b/test/io/test_big_schema.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from util import *
-from postgrest import *
+from util import parse_server_timings_header
+from postgrest import run
 
 
 def test_requests_with_resource_embedding_wait_for_schema_cache_reload(defaultenv):

--- a/test/io/test_cli.py
+++ b/test/io/test_cli.py
@@ -6,8 +6,14 @@ import subprocess
 import pytest
 import yaml
 
-from config import *
-from postgrest import *
+from config import (
+    CONFIGSDIR,
+    FIXTURES,
+    POSTGREST_BIN,
+    get_admin_host_and_port_from_config,
+    hpctixfile,
+)
+from postgrest import freeport, is_ipv6, run, set_statement_timeout
 
 
 class ExtraNewLinesDumper(yaml.SafeDumper):

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -8,9 +8,19 @@ import signal
 import time
 import pytest
 
-from config import *
-from util import *
-from postgrest import *
+from config import BASEDIR, CONFIGSDIR, FIXTURES, SECRET
+from util import Thread, authheader, jwtauthheader, parse_server_timings_header
+from postgrest import (
+    freeport,
+    is_ipv6,
+    reset_statement_timeout,
+    run,
+    set_statement_timeout,
+    sleep_until_postgrest_config_reload,
+    sleep_until_postgrest_full_reload,
+    sleep_until_postgrest_scache_reload,
+    wait_until_exit,
+)
 
 
 @pytest.mark.parametrize(

--- a/test/io/test_replica.py
+++ b/test/io/test_replica.py
@@ -1,7 +1,6 @@
 "IO tests for PostgREST started on replicas"
 
-from util import *
-from postgrest import *
+from postgrest import run
 
 
 def test_sanity_replica(replicaenv):

--- a/test/io/test_sanity.py
+++ b/test/io/test_sanity.py
@@ -2,8 +2,7 @@
 
 import pytest
 
-from util import *
-from postgrest import *
+from postgrest import freeport, run
 
 
 def test_port_connection(defaultenv):


### PR DESCRIPTION
As discussed in comment https://github.com/PostgREST/postgrest/pull/4377#issuecomment-3366430230

I’m not sure how to pick your PR https://github.com/PostgREST/postgrest/pull/4363 (i.e. fork branch [`taimoorzaeem:test/pylint`](https://github.com/taimoorzaeem/postgrest/tree/test/pylint)) as base, though. Short of forking your fork 🤔