### PR TITLE
chore: remove split-sections

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,2 @@
 packages: postgrest.cabal
 tests: true
-package *
-  ghc-options: -split-sections


### PR DESCRIPTION
It's a problem for macos on x86_64 and it's no longer needed as mentioned on https://github.com/PostgREST/postgrest/discussions/4384#discussioncomment-14614110
