### PR TITLE
test: Separated query and loading internal sleep configs

### DIFF
--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -115,7 +115,9 @@ data AppConfig = AppConfig
   , configAdminServerPort          :: Maybe Int
   , configRoleSettings             :: RoleSettings
   , configRoleIsoLvl               :: RoleIsolationLvl
-  , configInternalSCSleep          :: Maybe Int32
+  , configInternalSCQuerySleep     :: Maybe Int32
+  , configInternalSCLoadSleep      :: Maybe Int32
+  , configInternalSCRelLoadSleep   :: Maybe Int32
   }
 
 data LogLevel = LogCrit | LogError | LogWarn | LogInfo | LogDebug
@@ -298,7 +300,9 @@ parser optPath env dbSettings roleSettings roleIsolationLvl =
     <*> parseAdminServerPort "admin-server-port"
     <*> pure roleSettings
     <*> pure roleIsolationLvl
-    <*> optInt "internal-schema-cache-sleep"
+    <*> optInt "internal-schema-cache-query-sleep"
+    <*> optInt "internal-schema-cache-load-sleep"
+    <*> optInt "internal-schema-cache-relationship-load-sleep"
   where
     parseAppSettings :: C.Key -> C.Parser C.Config [(Text, Text)]
     parseAppSettings key = addFromEnv . fmap (fmap coerceText) <$> C.subassocs key C.value

--- a/test/io/conftest.py
+++ b/test/io/conftest.py
@@ -61,7 +61,7 @@ def slow_schema_cache_env(defaultenv):
     "Slow schema cache load environment PostgREST."
     return {
         **defaultenv,
-        "PGRST_INTERNAL_SCHEMA_CACHE_SLEEP": "1000",  # this does a pg_sleep internally, it will cause the schema cache query to be slow
+        "PGRST_INTERNAL_SCHEMA_CACHE_QUERY_SLEEP": "1000",  # this does a pg_sleep internally, it will cause the schema cache query to be slow
         # the slow schema cache query will keep using one pool connection until it finishes
         # to prevent requests waiting for PGRST_DB_POOL_ACQUISITION_TIMEOUT we'll increase the pool size (must be >= 2)
         "PGRST_DB_POOL": "2",

--- a/test/io/test_cli.py
+++ b/test/io/test_cli.py
@@ -312,13 +312,13 @@ def test_cli_ready_flag_fail_when_schema_cache_not_loaded(defaultenv, metapostgr
         **defaultenv,
         "PGUSER": role,
         "PGRST_DB_ANON_ROLE": role,
-        "PGRST_INTERNAL_SCHEMA_CACHE_SLEEP": "500",
+        "PGRST_INTERNAL_SCHEMA_CACHE_QUERY_SLEEP": "500",
     }
 
     port = freeport()
 
     with run(env=env, port=port) as postgrest:
-        # The schema cache query takes at least 500ms, due to PGRST_INTERNAL_SCHEMA_CACHE_SLEEP above.
+        # The schema cache query takes at least 500ms, due to PGRST_INTERNAL_SCHEMA_CACHE_QUERY_SLEEP above.
         # Make it impossible to load the schema cache, by setting statement timeout to 400ms.
         set_statement_timeout(metapostgrest, role, 400)
 

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -825,11 +825,11 @@ def test_admin_ready_includes_schema_cache_state(defaultenv, metapostgrest):
         **defaultenv,
         "PGUSER": role,
         "PGRST_DB_ANON_ROLE": role,
-        "PGRST_INTERNAL_SCHEMA_CACHE_SLEEP": "500",
+        "PGRST_INTERNAL_SCHEMA_CACHE_QUERY_SLEEP": "500",
     }
 
     with run(env=env) as postgrest:
-        # The schema cache query takes at least 500ms, due to PGRST_INTERNAL_SCHEMA_CACHE_SLEEP above.
+        # The schema cache query takes at least 500ms, due to PGRST_INTERNAL_SCHEMA_CACHE_QUERY_SLEEP above.
         # Make it impossible to load the schema cache, by setting statement timeout to 400ms.
         set_statement_timeout(metapostgrest, role, 400)
 
@@ -855,11 +855,11 @@ def test_metrics_include_schema_cache_fails(defaultenv, metapostgrest):
     env = {
         **defaultenv,
         "PGUSER": role,
-        "PGRST_INTERNAL_SCHEMA_CACHE_SLEEP": "50",
+        "PGRST_INTERNAL_SCHEMA_CACHE_QUERY_SLEEP": "50",
     }
 
     with run(env=env) as postgrest:
-        # The schema cache query takes at least 20ms, due to PGRST_INTERNAL_SCHEMA_CACHE_SLEEP above.
+        # The schema cache query takes at least 20ms, due to PGRST_INTERNAL_SCHEMA_CACHE_QUERY_SLEEP above.
         # Make it impossible to load the schema cache, by setting statement timeout to 100ms.
         set_statement_timeout(metapostgrest, role, 20)
 
@@ -1320,7 +1320,7 @@ def test_schema_cache_concurrent_notifications(slow_schema_cache_env):
     "schema cache should be up-to-date whenever a notification is sent while another reload is in progress, see https://github.com/PostgREST/postgrest/issues/2791"
 
     internal_sleep = (
-        int(slow_schema_cache_env["PGRST_INTERNAL_SCHEMA_CACHE_SLEEP"]) / 1000
+        int(slow_schema_cache_env["PGRST_INTERNAL_SCHEMA_CACHE_QUERY_SLEEP"]) / 1000
     )
 
     with run(env=slow_schema_cache_env, wait_for_readiness=False) as postgrest:

--- a/test/spec/SpecHelper.hs
+++ b/test/spec/SpecHelper.hs
@@ -157,7 +157,9 @@ baseCfg = let secret = encodeUtf8 "reallyreallyreallyreallyverysafe" in
   , configAdminServerPort           = Nothing
   , configRoleSettings              = mempty
   , configRoleIsoLvl                = mempty
-  , configInternalSCSleep           = Nothing
+  , configInternalSCQuerySleep      = Nothing
+  , configInternalSCLoadSleep       = Nothing
+  , configInternalSCRelLoadSleep    = Nothing
   , configServerTimingEnabled       = True
   }
 


### PR DESCRIPTION
To make schema cache loading wait tests robust it is necessary to provide three separate internal config variables:
* "internal-schema-cache-query-sleep" - introduces delay in schema queries execution
* "internal-schema-cache-load-sleep" - introduces delay between schema queries execution and processing their results
* "internal-schema-cache-relationship-load-sleep" - introduces delay in processing relationship query results

Thanks to these changes it is now possible to test various schema loading scenarios with the right granularity robustly (eg. make sure requests wait for schema loading but not for relationship loading).