### PR TITLE
remove(feat): fail schema cache lookup with invalid db-schemas config

### DIFF
--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -595,8 +595,14 @@ handlerF rout = \case
   NoAgg                      -> "''::text"
 
 schemaDescription :: Text -> SQL.Snippet
-schemaDescription schema =
-  "SELECT pg_catalog.obj_description(" <> encoded <> "::regnamespace, 'pg_namespace')"
+schemaDescription schema = SQL.sql (encodeUtf8 [trimming|
+  SELECT
+    description
+  FROM
+    pg_namespace n
+    left join pg_description d on d.objoid = n.oid
+  WHERE
+    n.nspname = |]) <> encoded
   where
     encoded = SQL.encoderAndParam (HE.nonNullable HE.unknown) $ encodeUtf8 schema
 
@@ -608,7 +614,7 @@ accessibleTables schema = SQL.sql (encodeUtf8 [trimming|
   FROM pg_class c
   JOIN pg_namespace n ON n.oid = c.relnamespace
   WHERE c.relkind IN ('v','r','m','f','p')
-  AND c.relnamespace = |]) <> encodedSchema <> "::regnamespace " <> SQL.sql (encodeUtf8 [trimming|
+  AND n.nspname = |]) <> encodedSchema <> " " <> SQL.sql (encodeUtf8 [trimming|
   AND (
     pg_has_role(c.relowner, 'USAGE')
     or has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
@@ -620,7 +626,7 @@ accessibleTables schema = SQL.sql (encodeUtf8 [trimming|
     encodedSchema = SQL.encoderAndParam (HE.nonNullable HE.text) schema
 
 accessibleFuncs :: Text -> SQL.Snippet
-accessibleFuncs schema = baseFuncSqlQuery <> "AND p.pronamespace = " <> encodedSchema <> "::regnamespace"
+accessibleFuncs schema = baseFuncSqlQuery <> "AND pn.nspname = " <> encodedSchema
   where
     encodedSchema = SQL.encoderAndParam (HE.nonNullable HE.text) schema
 

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -1051,8 +1051,10 @@ def test_log_query(level, defaultenv):
         )
         infinite_recursion_5xx_regx = r'.+: WITH pgrst_source AS.+SELECT "public"\."infinite_recursion"\.\* FROM "public"\."infinite_recursion".+_postgrest_t'
         root_tables_regx = r".+: SELECT   n.nspname AS table_schema, .+ FROM pg_class c .+ ORDER BY table_schema, table_name"
-        root_procs_regx = r".+: WITH base_types AS \(.+\) SELECT   pn.nspname AS proc_schema, .+ FROM pg_proc p.+AND p.pronamespace = \$1::regnamespace"
-        root_descr_regx = r".+: SELECT pg_catalog\.obj_description\(\$1::regnamespace, 'pg_namespace'\)"
+        root_procs_regx = r".+: WITH base_types AS \(.+\) SELECT   pn.nspname AS proc_schema, .+ FROM pg_proc p.+AND pn.nspname = \$1"
+        root_descr_regx = (
+            r".+: SELECT.+description.+FROM.+pg_namespace n.+WHERE.+n.nspname =\$1"
+        )
         set_config_regx = (
             r".+: select set_config\('search_path', \$1, true\), set_config\("
         )
@@ -2010,23 +2012,30 @@ def test_allow_configs_to_be_set_to_empty(defaultenv):
         assert response.status_code == 200
 
 
-def test_schema_cache_error_observation(defaultenv):
+def test_schema_cache_error_observation(defaultenv, metapostgrest):
     "schema cache error observation should be logged with invalid db-schemas or db-extra-search-path"
+
+    role = "timeout_authenticator"
 
     env = {
         **defaultenv,
-        "PGRST_DB_EXTRA_SEARCH_PATH": "x",
+        "PGUSER": role,
+        "PGRST_DB_ANON_ROLE": role,
+        "PGRST_INTERNAL_SCHEMA_CACHE_SLEEP": "500",
     }
 
     with run(env=env, no_startup_stdout=False, wait_for_readiness=False) as postgrest:
         # TODO: postgrest should exit here, instead it keeps retrying
         # exitCode = wait_until_exit(postgrest)
         # assert exitCode == 1
+        set_statement_timeout(metapostgrest, role, 400)
 
-        output = postgrest.read_stdout(nlines=9)
+        output = postgrest.read_stdout(nlines=10)
+
         assert (
-            "Failed to load the schema cache using db-schemas=public and db-extra-search-path=x"
-            in output[7]
+            "Failed to load the schema cache using db-schemas=public and db-extra-search-path=public"
+            in line
+            for line in output
         )
 
 

--- a/test/spec/Feature/Query/ErrorSpec.hs
+++ b/test/spec/Feature/Query/ErrorSpec.hs
@@ -10,6 +10,59 @@ import Test.Hspec.Wai.JSON
 import Protolude  hiding (get)
 import SpecHelper
 
+nonExistentSchema :: SpecWith ((), Application)
+nonExistentSchema = do
+  describe "Non existent api schema" $ do
+    it "succeeds when requesting root path" $
+      get "/" `shouldRespondWith` 200
+
+    it "gives 404 when requesting a nonexistent table in this nonexistent schema" $
+      get "/nonexistent_table" `shouldRespondWith` 404
+
+  describe "Non existent URL" $ do
+    it "gives 404 on a single nested route" $
+      get "/projects/nested" `shouldRespondWith` 404
+
+    it "gives 404 on a double nested route" $
+      get "/projects/nested/double" `shouldRespondWith` 404
+
+  describe "Unsupported HTTP methods" $ do
+    it "should return 405 for CONNECT method" $
+      request methodConnect "/"
+          []
+          ""
+        `shouldRespondWith`
+          [json|
+            {"hint": null,
+             "details": null,
+             "code": "PGRST117",
+             "message":"Unsupported HTTP method: CONNECT"}|]
+          { matchStatus = 405 }
+
+    it "should return 405 for TRACE method" $
+      request methodTrace "/"
+          []
+          ""
+        `shouldRespondWith`
+          [json|
+            {"hint": null,
+             "details": null,
+             "code": "PGRST117",
+             "message":"Unsupported HTTP method: TRACE"}|]
+          { matchStatus = 405 }
+
+    it "should return 405 for OTHER method" $
+      request "OTHER" "/"
+          []
+          ""
+        `shouldRespondWith`
+          [json|
+            {"hint": null,
+             "details": null,
+             "code": "PGRST117",
+             "message":"Unsupported HTTP method: OTHER"}|]
+          { matchStatus = 405 }
+
 pgErrorCodeMapping :: SpecWith ((), Application)
 pgErrorCodeMapping = do
   describe "PostreSQL error code mappings" $ do

--- a/test/spec/Main.hs
+++ b/test/spec/Main.hs
@@ -126,6 +126,7 @@ main = do
 
       extraSearchPathApp   = appDbs testCfgExtraSearchPath
       unicodeApp           = appDbs testUnicodeCfg
+      nonexistentSchemaApp = appDbs testNonexistentSchemaCfg
       multipleSchemaApp    = appDbs testMultipleSchemaCfg
       ignorePrivOpenApi    = appDbs testIgnorePrivOpenApiCfg
 
@@ -220,6 +221,10 @@ main = do
     -- this test runs with asymmetric JWKSet
     parallel $ before asymJwkSetApp $
       describe "Feature.Auth.AsymmetricJwtSpec" Feature.Auth.AsymmetricJwtSpec.spec
+
+    -- this test runs with a nonexistent db-schema
+    parallel $ before nonexistentSchemaApp $
+      describe "Feature.Query.NonExistentSchemaErrorSpec" Feature.Query.ErrorSpec.nonExistentSchema
 
     -- this test runs with an extra search path
     parallel $ before extraSearchPathApp $ do

--- a/test/spec/SpecHelper.hs
+++ b/test/spec/SpecHelper.hs
@@ -238,6 +238,9 @@ testCfgAsymJWKSet =
   , configJWKS = rightToMaybe $ parseSecret secret
   }
 
+testNonexistentSchemaCfg :: AppConfig
+testNonexistentSchemaCfg = baseCfg { configDbSchemas = fromList ["nonexistent"] }
+
 testCfgExtraSearchPath :: AppConfig
 testCfgExtraSearchPath = baseCfg { configDbExtraSearchPath = ["public", "extensions", "EXTRA \"@/\\#~_-"] }
 


### PR DESCRIPTION
Closes #4364 by reverting 86c3257f5496688196be33a465d6cacaf89f62cf

As discussed on #4364, 86c3257f5496688196be33a465d6cacaf89f62cf generates several problems:

1. We diverge from database as source of truth because once a schema is dropped, it's not automatically removed from `db-schemas` and then postgREST fails. Reducing its reliability.
2. We diverge from PostgreSQL `search_path` lenient behavior:
```sql
set search_path to anything, here, even, nonexistent; -- this doesn't fail
```
3. Schema-based multitenancy becomes more complicated because of 1.

There are no noticeable gains from 86c3257f5496688196be33a465d6cacaf89f62cf:

- No gains in performance for the schema cache queries.
- No user report about it ever being a problem. In fact the leniency was a feature.

## Implementation details

Essentially it removes the `$1::regnamespace[]` casting for `db-schemas` that was introduced on 86c3257f5496688196be33a465d6cacaf89f62cf