### PR TITLE
fix: db-pre-config function failing with pg reserved words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. From versio
 
 ## Unreleased
 
+## Fixed
+
+- Fix `db-pre-config` function failing when function names are pg reserved words by @taimoorzaeem #4380
+
 ## [14.0] - 2025-10-24
 
 ### Added

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -69,7 +69,7 @@ import PostgREST.Config.PgVersion        (PgVersion (..),
 import PostgREST.SchemaCache             (SchemaCache (..),
                                           querySchemaCache,
                                           showSummary)
-import PostgREST.SchemaCache.Identifiers (dumpQi)
+import PostgREST.SchemaCache.Identifiers (quoteQi)
 import PostgREST.Unix                    (createAndBindDomainSocket)
 
 import Data.Streaming.Network (bindPortTCP, bindRandomPortTCP)
@@ -441,7 +441,7 @@ readInDbConfig startingUp appState@AppState{stateObserver=observer} = do
   pgVer <- getPgVersion appState
   dbSettings <-
     if configDbConfig conf then do
-      qDbSettings <- usePool appState (queryDbSettings (dumpQi <$> configDbPreConfig conf) (configDbPreparedStatements conf))
+      qDbSettings <- usePool appState (queryDbSettings (quoteQi <$> configDbPreConfig conf) (configDbPreparedStatements conf))
       case qDbSettings of
         Left e -> do
           observer $ ConfigReadErrorObs e

--- a/src/PostgREST/SchemaCache/Identifiers.hs
+++ b/src/PostgREST/SchemaCache/Identifiers.hs
@@ -10,6 +10,7 @@ module PostgREST.SchemaCache.Identifiers
   , dumpQi
   , escapeIdent
   , isAnyElement
+  , quoteQi
   , toQi
   , trimNullChars
   ) where
@@ -40,6 +41,10 @@ isAnyElement y = QualifiedIdentifier "pg_catalog" "anyelement" == y
 dumpQi :: QualifiedIdentifier -> Text
 dumpQi (QualifiedIdentifier s i) =
   (if T.null s then mempty else s <> ".") <> i
+
+quoteQi :: QualifiedIdentifier -> Text
+quoteQi (QualifiedIdentifier s i) =
+  (if T.null s then mempty else escapeIdent s <> ".") <> escapeIdent i
 
 -- TODO: Handle a case where the QI comes like this: "my.fav.schema"."my.identifier"
 -- Right now it only handles the schema.identifier case

--- a/test/io/__snapshots__/test_cli/test_schema_cache_snapshot[dbRoutines].yaml
+++ b/test/io/__snapshots__/test_cli/test_schema_cache_snapshot[dbRoutines].yaml
@@ -461,6 +461,23 @@
       pdSchema: public
       pdVolatility: Volatile
 
+- - qiName: 'true'
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: 'true'
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: bool
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+
 - - qiName: create_function
     qiSchema: public
   - - pdDescription: null

--- a/test/io/fixtures.sql
+++ b/test/io/fixtures.sql
@@ -256,3 +256,7 @@ select * from projects;
 
 create or replace view infinite_recursion as
 select * from infinite_recursion;
+
+create or replace function "true"() returns boolean as $_$
+  select true;
+$_$ language sql;


### PR DESCRIPTION
When `db-pre-config` is accidentally set to a pg reserved word like "true", it fails with a confusing error. The function names should be properly quoted to avoid such errors. This commit resolves the mentioned issue by quoting the pre-config function name.

Closes #4380.