### PR TITLE
chore(changelog): update versioning scheme description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-This project adheres to [Semantic Versioning](http://semver.org/).
+All notable changes to this project will be documented in this file. From version `14.0` onwards PostgREST follows a `MAJOR.PATCH` two-part versioning. Only even-numbered MAJOR versions will be released, reserving odd-numbered MAJOR versions for development.
 
 ## Unreleased
 


### PR DESCRIPTION
The changelog description mentioned that we follow semantic versioning but from now on we don't. Hence updated the description to reflect new versioning policy.
