### PR TITLE
refactor: move escapeIdent function to Identifiers.hs

### DIFF
--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -90,7 +90,8 @@ import PostgREST.RangeQuery              (NonnegRange, allRange,
                                           rangeLimit, rangeOffset)
 import PostgREST.SchemaCache.Identifiers (FieldName,
                                           QualifiedIdentifier (..),
-                                          RelIdentifier (..))
+                                          RelIdentifier (..),
+                                          escapeIdent, trimNullChars)
 import PostgREST.SchemaCache.Routine     (MediaHandler (..),
                                           Routine (..),
                                           funcReturnsScalar,
@@ -163,9 +164,6 @@ pgBuildArrayLiteral vals =
 pgFmtIdent :: Text -> SQL.Snippet
 pgFmtIdent x = SQL.sql . encodeUtf8 $ escapeIdent x
 
-escapeIdent :: Text -> Text
-escapeIdent x = "\"" <> T.replace "\"" "\"\"" (trimNullChars x) <> "\""
-
 -- Only use it if the input comes from the database itself, like on `jsonb_build_object('column_from_a_table', val)..`
 pgFmtLit :: Text -> Text
 pgFmtLit x =
@@ -175,9 +173,6 @@ pgFmtLit x =
   if "\\" `T.isInfixOf` escaped
     then "E" <> slashed
     else slashed
-
-trimNullChars :: Text -> Text
-trimNullChars = T.takeWhile (/= '\x0')
 
 -- |
 -- Format a list of identifiers and separate them by commas.

--- a/src/PostgREST/SchemaCache.hs
+++ b/src/PostgREST/SchemaCache.hs
@@ -42,11 +42,11 @@ import NeatInterpolation          (trimming)
 import PostgREST.Config                      (AppConfig (..))
 import PostgREST.Config.Database             (TimezoneNames,
                                               toIsolationLevel)
-import PostgREST.Query.SqlFragment           (escapeIdent)
 import PostgREST.SchemaCache.Identifiers     (FieldName,
                                               QualifiedIdentifier (..),
                                               RelIdentifier (..),
-                                              Schema, isAnyElement)
+                                              Schema, escapeIdent,
+                                              isAnyElement)
 import PostgREST.SchemaCache.Relationship    (Cardinality (..),
                                               Junction (..),
                                               Relationship (..),

--- a/src/PostgREST/SchemaCache/Identifiers.hs
+++ b/src/PostgREST/SchemaCache/Identifiers.hs
@@ -8,8 +8,10 @@ module PostgREST.SchemaCache.Identifiers
   , Schema
   , TableName
   , dumpQi
+  , escapeIdent
   , isAnyElement
   , toQi
+  , trimNullChars
   ) where
 
 import qualified Data.Aeson as JSON
@@ -45,6 +47,12 @@ toQi :: Text -> QualifiedIdentifier
 toQi txt = case T.drop 1 <$> T.breakOn "." txt of
   (i, "") -> QualifiedIdentifier mempty i
   (s, i)  -> QualifiedIdentifier s i
+
+escapeIdent :: Text -> Text
+escapeIdent x = "\"" <> T.replace "\"" "\"\"" (trimNullChars x) <> "\""
+
+trimNullChars :: Text -> Text
+trimNullChars = T.takeWhile (/= '\x0')
 
 type Schema = Text
 type TableName = Text


### PR DESCRIPTION
Moves the functions `escapeIdent` and `trimNullChars` to `SchemaCache/Identifiers.hs` module.

This should help with #4420.

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `add`, Add a new feature
  + `amend`, To amend an unrealease commit
  + `change`, Breaking changes
  + `chore`, Maintenance, update sponsors, changelog, readme etc
  + `ci`, CI configuration files and scripts
  + `docs`, Documentation
  + `fix`, Bug fix
  + `nix`, Related to Nix
  + `perf`, Performance improvements
  + `refactor`, Refactoring code
  + `remove`, Remove a feature or fix
  + `test`, Adding tests
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
