### PR TITLE
refactor: move dumpQi to Config.hs and clarify quoteQi

### DIFF
--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -63,7 +63,7 @@ import PostgREST.Config.JSPath           (FilterExp (..), JSPath,
                                           pRoleClaimKey)
 import PostgREST.Config.Proxy            (Proxy (..),
                                           isMalformedProxyUri, toURI)
-import PostgREST.SchemaCache.Identifiers (QualifiedIdentifier, dumpQi,
+import PostgREST.SchemaCache.Identifiers (QualifiedIdentifier (..),
                                           toQi)
 
 import Protolude hiding (Proxy, toList)
@@ -197,6 +197,10 @@ toText conf =
 
     -- quote strings and replace " with \"
     q s = "\"" <> T.replace "\"" "\\\"" s <> "\""
+
+    dumpQi :: QualifiedIdentifier -> Text
+    dumpQi (QualifiedIdentifier s i) =
+      (if T.null s then mempty else s <> ".") <> i
 
     showTxEnd c = case (configDbTxRollbackAll c, configDbTxAllowOverride c) of
       ( False, False ) -> "commit"

--- a/src/PostgREST/SchemaCache/Identifiers.hs
+++ b/src/PostgREST/SchemaCache/Identifiers.hs
@@ -7,7 +7,6 @@ module PostgREST.SchemaCache.Identifiers
   , RelIdentifier(..)
   , Schema
   , TableName
-  , dumpQi
   , escapeIdent
   , isAnyElement
   , quoteQi
@@ -38,10 +37,12 @@ instance Hashable QualifiedIdentifier
 isAnyElement :: QualifiedIdentifier -> Bool
 isAnyElement y = QualifiedIdentifier "pg_catalog" "anyelement" == y
 
-dumpQi :: QualifiedIdentifier -> Text
-dumpQi (QualifiedIdentifier s i) =
-  (if T.null s then mempty else s <> ".") <> i
-
+-- |
+-- Quote the qualified identifier when preparing the SQL. This avoids parse
+-- errors by postgres, for example on pg reserved words like "true" or "select".
+--
+-- >>> quoteQi (QualifiedIdentifier "" "true")
+-- "\"true\""
 quoteQi :: QualifiedIdentifier -> Text
 quoteQi (QualifiedIdentifier s i) =
   (if T.null s then mempty else escapeIdent s <> ".") <> escapeIdent i

--- a/test/doc/Main.hs
+++ b/test/doc/Main.hs
@@ -23,4 +23,5 @@ main =
     , "src/PostgREST/Query/SqlFragment.hs"
     , "src/PostgREST/Response.hs"
     , "src/PostgREST/Response/Performance.hs"
+    , "src/PostgREST/SchemaCache/Identifiers.hs"
     ]


### PR DESCRIPTION
The `dumpQi` function is only used in the `Config.hs` module, so it is moved there. This also adds a doctest for `quoteQi` and clarifies its usage.

As discussed in https://github.com/PostgREST/postgrest/pull/4420#discussion_r2475672556.