### PR TITLE
fix: server-host !6 incorrectly binds to IPv4 address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. From versio
 ## Fixed
 
 - Fix `db-pre-config` function failing when function names are pg reserved words by @taimoorzaeem in #4380
+- Fix `server-host=!6` incorrectly binds to IPv4 address by @taimoorzaeem in #3202
 
 ## [14.0] - 2025-10-24
 

--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -1,1 +1,1 @@
-index-state: hackage.haskell.org 2025-10-13T04:53:27Z
+index-state: hackage.haskell.org 2025-10-29T04:02:18Z

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -60,6 +60,16 @@ let
           }
           { };
 
+      # TODO: Remove once available in nixpkgs haskellPackages
+      streaming-commons =
+        prev.callHackageDirect
+          {
+            pkg = "streaming-commons";
+            ver = "0.2.3.1";
+            sha256 = "sha256-Gl2eaJcWe1sxmcE/octWlH9uSnERguf+5H66K4fV87s=";
+          }
+          { };
+
       # Downgrade hasql and related packages while we are still on GHC 9.4 for the static build.
       hasql = lib.dontCheck (lib.doJailbreak prev.hasql_1_6_4_4);
       hasql-dynamic-statements = lib.dontCheck prev.hasql-dynamic-statements_0_3_1_5;

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -139,7 +139,7 @@ library
                     , regex-tdfa                >= 1.2.2 && < 1.4
                     , retry                     >= 0.7.4 && < 0.10
                     , scientific                >= 0.3.4 && < 0.4
-                    , streaming-commons         >= 0.1.1 && < 0.3
+                    , streaming-commons         >= 0.2.3.1 && < 0.3
                     , swagger2                  >= 2.4 && < 2.9
                     , text                      >= 1.2.2 && < 2.2
                     , time                      >= 1.6 && < 1.13

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,3 +14,4 @@ extra-deps:
   - hasql-pool-1.0.1
   - jose-jwt-0.10.0
   - postgresql-libpq-0.10.1.0
+  - streaming-commons-0.2.3.1

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -39,6 +39,13 @@ packages:
       size: 1096
   original:
     hackage: postgresql-libpq-0.10.1.0
+- completed:
+    hackage: streaming-commons-0.2.3.1@sha256:ed7999fea9e912b1211ea93d7e20a7998bf4753166370c94048885650f303bf0,4841
+    pantry-tree:
+      sha256: f08e83fb00fd45865fa8cfdef5ecef7161d5135257ee98050bfbe4b807ad65f8
+      size: 2374
+  original:
+    hackage: streaming-commons-0.2.3.1
 snapshots:
 - completed:
     sha256: 238fa745b64f91184f9aa518fe04bdde6552533d169b0da5256670df83a0f1a9


### PR DESCRIPTION
Updates streaming-commons to version 0.2.3.1. This resolves #3202.

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `add`, Add a new feature
  + `amend`, To amend an unrealease commit
  + `change`, Breaking changes
  + `chore`, Maintenance, update sponsors, changelog, readme etc
  + `ci`, CI configuration files and scripts
  + `docs`, Documentation
  + `fix`, Bug fix
  + `nix`, Related to Nix
  + `perf`, Performance improvements
  + `refactor`, Refactoring code
  + `remove`, Remove a feature or fix
  + `test`, Adding tests
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
