### PR TITLE
[NEEDS DISCUSSION] docs: add note to resource embedding and vertical filtering section

### DIFF
--- a/docs/references/api/resource_embedding.rst
+++ b/docs/references/api/resource_embedding.rst
@@ -5,6 +5,10 @@ Resource Embedding
 
 PostgREST allows including related resources in a single API call. This reduces the need for many API requests.
 
+.. note::
+
+  It is **not** possible to perform mutations *on* related resources. When combining mutations and resource embedding, the mutation is performed first and then the related resource is returned in combination with :ref:`prefer_return`.
+
 .. _fk_join:
 
 Foreign Key Joins

--- a/docs/references/api/tables_views.rst
+++ b/docs/references/api/tables_views.rst
@@ -246,6 +246,10 @@ When certain columns are wide (such as those holding binary data), it is more ef
 
 The default is ``*``, meaning all columns. This value will become more important below in :ref:`resource_embedding`.
 
+.. note::
+
+  It is **not** possible to perform mutations *on* filtered data. When combining mutations and vertical filtering, the mutation is performed first and then the filter is applied in combination with :ref:`prefer_return`.
+
 .. _renaming_columns:
 
 Renaming Columns


### PR DESCRIPTION
Adds a note about resource embedding and vertical filtering sections that they are top-level operations. This resolves #4352.

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `add`, Add a new feature
  + `amend`, To amend an unrealease commit
  + `change`, Breaking changes
  + `chore`, Maintenance, update sponsors, changelog, readme etc
  + `ci`, CI configuration files and scripts
  + `docs`, Documentation
  + `fix`, Bug fix
  + `nix`, Related to Nix
  + `perf`, Performance improvements
  + `refactor`, Refactoring code
  + `remove`, Remove a feature or fix
  + `test`, Adding tests
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
