### PR TITLE
docs: add another project to the list of Example Apps

### DIFF
--- a/docs/ecosystem.rst
+++ b/docs/ecosystem.rst
@@ -37,6 +37,7 @@ Example Apps
 * `archtika <https://github.com/thiloho/archtika>`_ - self-hosted CMS
 * `delibrium-postgrest <https://gitlab.com/delibrium/delibrium-postgrest/>`_ - example school API and front-end in Vue.js
 * `ETH-transactions-storage <https://github.com/Adamant-im/ETH-transactions-storage>`_ - indexer for Ethereum to get transaction list by ETH address
+* `fullstack template <https://github.com/jenstroeger/fullstack-webapp-template>`_ - a complete fullstack webapp template using PG as db and message queue, Python and Dramatiq to implement async jobs, db migrations, test runners, and more.
 * `general <https://github.com/PierreRochard/general>`_ - example auth back-end
 * `guild-operators <https://github.com/cardano-community/koios-artifacts/tree/main/files/grest>`_ - example queries and functions that the Cardano Community uses for their Guild Operators' Repository
 * `PostGUI <https://github.com/priyank-purohit/PostGUI>`_ - React Material UI admin panel

--- a/docs/postgrest.dict
+++ b/docs/postgrest.dict
@@ -4,6 +4,7 @@ API's
 APIs
 APISIX
 AST
+async
 aud
 Auth
 auth
@@ -30,6 +31,7 @@ DDL
 DOM
 DSL
 DevOps
+Dramatiq
 dockerize
 enum
 Enums
@@ -41,6 +43,7 @@ EveryLayout
 filename
 FreeBSD
 fts
+fullstack
 GeoJSON
 Github
 Google
@@ -188,6 +191,7 @@ verifier
 versioning
 Vondra
 Vue
+webapp
 webhooks
 websearch
 Websockets


### PR DESCRIPTION
As discussed and agreed on in https://github.com/PostgREST/postgrest/discussions/4198 I wanted to add the PostgREST based fullstack webapp template ([link](https://github.com/jenstroeger/fullstack-webapp-template)) to the list of Example Apps.