### PR TITLE
test(io): move resource embedding tests to test_io.py

### DIFF
--- a/test/io/__snapshots__/test_cli/test_schema_cache_snapshot[dbRelationships].yaml
+++ b/test/io/__snapshots__/test_cli/test_schema_cache_snapshot[dbRelationships].yaml
@@ -1,1 +1,39 @@
-[]
+- - - qiName: directors
+      qiSchema: public
+    - public
+  - - relCardinality:
+        relColumns:
+        - - id
+          - director_id
+        relCons: fk_director
+        tag: O2M
+      relFTableIsView: false
+      relForeignTable:
+        qiName: films
+        qiSchema: public
+      relIsSelf: false
+      relTable:
+        qiName: directors
+        qiSchema: public
+      relTableIsView: false
+      tag: Relationship
+
+- - - qiName: films
+      qiSchema: public
+    - public
+  - - relCardinality:
+        relColumns:
+        - - director_id
+          - id
+        relCons: fk_director
+        tag: M2O
+      relFTableIsView: false
+      relForeignTable:
+        qiName: directors
+        qiSchema: public
+      relIsSelf: false
+      relTable:
+        qiName: films
+        qiSchema: public
+      relTableIsView: false
+      tag: Relationship

--- a/test/io/__snapshots__/test_cli/test_schema_cache_snapshot[dbRoutines].yaml
+++ b/test/io/__snapshots__/test_cli/test_schema_cache_snapshot[dbRoutines].yaml
@@ -106,6 +106,23 @@
       pdSchema: public
       pdVolatility: Volatile
 
+- - qiName: notify_pgrst
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: notify_pgrst
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: void
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+
 - - qiName: migrate_function
     qiSchema: public
   - - pdDescription: null

--- a/test/io/__snapshots__/test_cli/test_schema_cache_snapshot[dbTables].yaml
+++ b/test/io/__snapshots__/test_cli/test_schema_cache_snapshot[dbTables].yaml
@@ -71,6 +71,37 @@
     tableSchema: public
     tableUpdatable: true
 
+- - qiName: directors
+    qiSchema: public
+  - tableColumns:
+      id:
+        colDefault: null
+        colDescription: null
+        colEnum: []
+        colMaxLen: null
+        colName: id
+        colNominalType: integer
+        colNullable: false
+        colType: integer
+      name:
+        colDefault: null
+        colDescription: null
+        colEnum: []
+        colMaxLen: null
+        colName: name
+        colNominalType: text
+        colNullable: true
+        colType: text
+    tableDeletable: true
+    tableDescription: null
+    tableInsertable: true
+    tableIsView: false
+    tableName: directors
+    tablePKCols:
+    - id
+    tableSchema: public
+    tableUpdatable: true
+
 - - qiName: projects
     qiSchema: public
   - tableColumns: {}
@@ -94,6 +125,46 @@
     tablePKCols: []
     tableSchema: public
     tableUpdatable: false
+
+- - qiName: films
+    qiSchema: public
+  - tableColumns:
+      director_id:
+        colDefault: null
+        colDescription: null
+        colEnum: []
+        colMaxLen: null
+        colName: director_id
+        colNominalType: integer
+        colNullable: true
+        colType: integer
+      id:
+        colDefault: null
+        colDescription: null
+        colEnum: []
+        colMaxLen: null
+        colName: id
+        colNominalType: integer
+        colNullable: false
+        colType: integer
+      title:
+        colDefault: null
+        colDescription: null
+        colEnum: []
+        colMaxLen: null
+        colName: title
+        colNominalType: text
+        colNullable: true
+        colType: text
+    tableDeletable: true
+    tableDescription: null
+    tableInsertable: true
+    tableIsView: false
+    tableName: films
+    tablePKCols:
+    - id
+    tableSchema: public
+    tableUpdatable: true
 
 - - qiName: items
     qiSchema: public

--- a/test/io/fixtures.sql
+++ b/test/io/fixtures.sql
@@ -260,3 +260,41 @@ select * from infinite_recursion;
 create or replace function "true"() returns boolean as $_$
   select true;
 $_$ language sql;
+
+create or replace function notify_pgrst() returns void as $$
+  notify pgrst;
+$$ language sql;
+
+-- directors and films table can be used for resource embedding tests
+create table directors (
+  id int primary key,
+  name text
+);
+
+create table films (
+  id int primary key,
+  title text,
+  director_id int,
+
+  constraint fk_director
+    foreign key (director_id) references directors (id)
+    on update cascade
+    on delete cascade
+);
+
+-- data to test resource embedding
+truncate table directors cascade;
+insert into directors
+values (1, 'quentin tarantino'),
+       (2, 'christopher nolan'),
+       (3, 'yorgos lathinmos');
+
+truncate table films cascade;
+insert into films
+values (1, 'pulp fiction', 1),
+       (2, 'intersteller',2),
+       (3, 'dogtooth',3),
+       (4, 'reservoir dogs', 1);
+
+
+GRANT SELECT ON directors, films TO postgrest_test_anonymous, postgrest_test_w_superuser_settings;


### PR DESCRIPTION
- Adds fixtures to `test/io/fixtures.sql` to test resource embedding related queries.

- Moves the resource embedding related tests that no longer require big schema from `test_big_schema.py` to `test_io.py`.

Closes #4417.