### PR TITLE
fix: Performance and high memory usage of relation hint calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file. From versio
 - Fix not returning `Content-Length` on empty HTTP `201` responses by @laurenceisla in #4518
 - Fix inaccurate Server-Timing header durations by @steve-chavez in #4522
 - Fix inaccurate "Schema cache queried" logs by @steve-chavez in #4522
+- Fix performance and high memory usage of relation hint calculation by @mkleczek in #4462 #4463
 
 ## [14.1] - 2025-11-05
 

--- a/src/PostgREST/Response.hs
+++ b/src/PostgREST/Response.hs
@@ -213,10 +213,10 @@ actionResponse (MaybeDbResult InspectPlan{ipHdrsOnly=headersOnly} body) _ versio
   in
   Right $ PgrstResponse HTTP.status200 (MediaType.toContentType MTOpenAPI : cLHeader ++ maybeToList (profileHeader schema negotiatedByProfile)) rsBody
 
-actionResponse (NoDbResult (RelInfoPlan qi@QualifiedIdentifier{..})) _ _ _ SchemaCache{dbTables} _ _ =
+actionResponse (NoDbResult (RelInfoPlan qi@QualifiedIdentifier{..})) _ _ _ sc@SchemaCache{dbTables} _ _ =
   case HM.lookup qi dbTables of
     Just tbl -> respondInfo $ allowH tbl
-    Nothing  -> Left $ Error.SchemaCacheErr $ Error.TableNotFound qiSchema qiName (HM.elems dbTables)
+    Nothing  -> Left $ Error.SchemaCacheErr $ Error.TableNotFound qiSchema qiName sc
   where
     allowH table =
       let hasPK = not . null $ tablePKCols table in

--- a/test/io/fixtures/big_schema.sql
+++ b/test/io/fixtures/big_schema.sql
@@ -11375,12 +11375,34 @@ ALTER TABLE ONLY apflora.zielber
 
 ALTER TABLE apflora."user" ENABLE ROW LEVEL SECURITY;
 
+
+CREATE SCHEMA fuzzysearch;
+
+-- Create many tables to test fuzzy string search
+-- computing hints for non existing tables
+DO
+$$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT
+      format('CREATE TABLE fuzzysearch.unknown_table_%s ()', n) AS ct
+    FROM
+      generate_series(1, 499) n
+    LOOP
+      EXECUTE r.ct;
+    END LOOP;
+END
+$$;
+
 DROP ROLE IF EXISTS postgrest_test_anonymous;
 CREATE ROLE postgrest_test_anonymous;
 
 GRANT postgrest_test_anonymous TO :PGUSER;
 
 GRANT USAGE ON SCHEMA apflora TO postgrest_test_anonymous;
+GRANT USAGE ON SCHEMA fuzzysearch TO postgrest_test_anonymous;
 
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA apflora
 TO postgrest_test_anonymous;


### PR DESCRIPTION
Calculation of hint message when requested relation is not present in schema cache requires creation of a FuzzySet (to use fuzzy search to find candidate tables). For schemas with many tables it is costly. This patch introduces dbTablesFuzzyIndex in SchemaCache to memoize the FuzzySet creation.

Fixes #4462
Fixes #4463 