### PR TITLE
docs: update server-host config in docker-compose example

### DIFF
--- a/docs/explanations/install.rst
+++ b/docs/explanations/install.rst
@@ -146,7 +146,7 @@ To avoid having to install the database at all, you can run both it and the serv
       ports:
         - "3000:3000"
       environment:
-        PGRST_SERVER_HOST: localhost # necessary for `postgrest --ready` flag to work
+        PGRST_SERVER_HOST: 0.0.0.0 # necessary for `postgrest --ready` flag to work
         PGRST_DB_URI: postgres://app_user:password@db:5432/app_db
         PGRST_OPENAPI_SERVER_PROXY_URI: http://127.0.0.1:3000
       depends_on:


### PR DESCRIPTION
The docker-compose example did not work with multiple containers when PGRST_SERVER_HOST is set to `localhost`. This updates the value to `0.0.0.0` allowing other containers to connect.

Closes #4470.