### PR TITLE
docs: clarify postgrest reserved characters in url grammar

### DIFF
--- a/docs/references/api/url_grammar.rst
+++ b/docs/references/api/url_grammar.rst
@@ -51,7 +51,7 @@ You can request table/columns with spaces in them by percent encoding the spaces
 Reserved characters
 ~~~~~~~~~~~~~~~~~~~
 
-If filters include PostgREST reserved characters(``,``, ``.``, ``:``, ``(``, ``)``) you'll have to surround them in percent encoded double quotes ``%22`` for correct processing.
+If filters include PostgREST reserved characters(``,``, ``.``, ``:``, ``*``, ``(``, ``)``) you'll have to surround them in percent encoded double quotes ``%22`` for correct processing.
 
 Here ``Hebdon,John`` and ``Williams,Mary`` are values.
 


### PR DESCRIPTION
Fixes a typo in the documentation where it said that `()` is a reserved character, when we actually meant to say that `(` and `)` are reserved characters.

Related discussion in #4254.