### PR TITLE
nix(shell): remove `postgrest/` directory prefix when running pg

### DIFF
--- a/nix/overlays/checked-shell-script/checked-shell-script.nix
+++ b/nix/overlays/checked-shell-script/checked-shell-script.nix
@@ -104,7 +104,6 @@ let
         ''
 
         + lib.optionalString withTmpDir ''
-          mkdir -p "''${TMPDIR:-/tmp}"
           tmpdir="$(${coreutils}/bin/mktemp -d --tmpdir ${name}-XXX)"
 
           # we keep the tmpdir when an error occurs for debugging


### PR DESCRIPTION
When running postgres from nix-shell, nix creates a directory structure like `postgrest/postgrest-with-pg-17-XXX` in the `/tmp` directory. This commit removes the extra `postgrest/` prefix to shorten length of absolute path length of filenames.

Discussed in [#4469 (comment)](https://github.com/PostgREST/postgrest/pull/4469#pullrequestreview-3468088556).