### PR TITLE
test(io): fix freeport function to prevent failures

### DIFF
--- a/test/io/postgrest.py
+++ b/test/io/postgrest.py
@@ -113,7 +113,7 @@ def run(
             env["PGRST_SERVER_UNIX_SOCKET"] = str(socketfile)
             baseurl = "http+unix://" + urllib.parse.quote_plus(str(socketfile))
 
-        adminport = freeport(port)
+        adminport = freeport(used_ports=[port])
         env["PGRST_ADMIN_SERVER_PORT"] = str(adminport)
         adminhost = f"[{host}]" if host and is_ipv6(host) else localhost
         adminurl = f"http://{adminhost}:{adminport}"
@@ -165,14 +165,14 @@ def run(
                 process.wait()
 
 
-def freeport(used_port=None):
-    "Find a free port on localhost."
+def freeport(used_ports=None):
+    "Find an unused free port on localhost."
     while True:
         with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
             s.bind(("", 0))
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             port = s.getsockname()[1]
-            if port != used_port:
+            if used_ports is None or port not in used_ports:
                 return port
 
 

--- a/test/io/test_cli.py
+++ b/test/io/test_cli.py
@@ -286,6 +286,7 @@ def test_jwt_secret_min_length(defaultenv):
     assert "The JWT secret must be at least 32 characters long." in error
 
 
+# TODO: Improve readability of "--ready" healthcheck tests
 @pytest.mark.parametrize("host", ["127.0.0.1", "::1"], ids=["IPv4", "IPv6"])
 def test_cli_ready_flag_success(host, defaultenv):
     "test PostgREST ready flag succeeds when ready"
@@ -340,8 +341,11 @@ def test_cli_ready_flag_fail_with_http_exception(defaultenv):
 
     # when healthcheck process sends the request to a wrong endpoint
     with run(env=defaultenv, port=port) as postgrest:
-        # we set it to some freeport where admin is not running
-        postgrest.config["PGRST_ADMIN_SERVER_PORT"] = str(freeport())
+        # we set it to some freeport where server and admin server is not running
+        admin_port = int(postgrest.config["PGRST_ADMIN_SERVER_PORT"])
+        used_ports = [port, admin_port]
+
+        postgrest.config["PGRST_ADMIN_SERVER_PORT"] = str(freeport(used_ports))
         output = cli(["--ready"], env=postgrest.config, expect_error=True)
         (admin_host, admin_port) = get_admin_host_and_port_from_config(postgrest.config)
 


### PR DESCRIPTION
Sometimes, a healthcheck related test fails as occurred in https://github.com/PostgREST/postgrest/actions/runs/19771357953/job/56655949002. This happens due to freeport function accidently picking up a used port.

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `add`, Add a new feature
  + `amend`, To amend an unrealease commit
  + `change`, Breaking changes
  + `chore`, Maintenance, update sponsors, changelog, readme etc
  + `ci`, CI configuration files and scripts
  + `docs`, Documentation
  + `fix`, Bug fix
  + `nix`, Related to Nix
  + `perf`, Performance improvements
  + `refactor`, Refactoring code
  + `remove`, Remove a feature or fix
  + `test`, Adding tests
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
