### PR TITLE
test(spec): add comment on media type related bugs

### DIFF
--- a/test/spec/Feature/Query/CustomMediaSpec.hs
+++ b/test/spec/Feature/Query/CustomMediaSpec.hs
@@ -28,6 +28,7 @@ spec = describe "custom media types" $ do
         simpleBody r `shouldBe` readFixtureFile "1.twkb"
         simpleHeaders r `shouldContain` [("Content-Type", "application/vnd.twkb")]
 
+    -- FIXME: This is a bug, twkb_agg exists for "lines" table
     it "will fail if there's no aggregate defined for the table" $ do
       request methodGet "/lines" (acceptHdrs "text/plain") ""
         `shouldRespondWith`
@@ -116,6 +117,7 @@ spec = describe "custom media types" $ do
         , matchHeaders = ["Content-Type" <:> "text/xml; charset=utf-8"]
         }
 
+    -- FIXME: This is a bug, this should return text/plain
     it "should fail with function returning text and Accept: text/xml" $ do
       request methodGet "/rpc/welcome" (acceptHdrs "text/xml") ""
         `shouldRespondWith`
@@ -160,6 +162,7 @@ spec = describe "custom media types" $ do
         simpleBody r `shouldBe` readFixtureFile "lines.twkb"
         simpleHeaders r `shouldContain` [("Content-Type", "application/vnd.twkb")]
 
+    -- FIXME: This is a bug, application/vnd.twkb aggregate exists for "get_lines" table
     it "fails if doesn't have an aggregate defined" $ do
       request methodGet "/rpc/get_lines"
           (acceptHdrs "application/octet-stream") ""

--- a/test/spec/Feature/Query/RawOutputTypesSpec.hs
+++ b/test/spec/Feature/Query/RawOutputTypesSpec.hs
@@ -23,10 +23,13 @@ spec = describe "When raw-media-types config variable is missing or left empty" 
       `shouldRespondWith` [json| [{"id":1}] |]
         { matchHeaders= ["Content-Type" <:> "application/json; charset=utf-8"] }
 
+  -- FIXME: This shouldn't default to application/json because text/tab-separated-values aggregate exist
   it "responds json to a GET request to RPC with Firefox Accept headers" $
     request methodGet "/rpc/get_projects_below?id=3" firefoxAcceptHdrs ""
       `shouldRespondWith` [json|[{"id":1,"name":"Windows 7","client_id":1}, {"id":2,"name":"Windows 10","client_id":1}]|]
         { matchHeaders= ["Content-Type" <:> "application/json; charset=utf-8"] }
+
+  -- FIXME: This shouldn't default to application/json because text/tab-separated-values aggregate exist
   it "responds json to a GET request to RPC with Chrome Accept headers" $
     request methodGet "/rpc/get_projects_below?id=3" chromeAcceptHdrs ""
       `shouldRespondWith` [json|[{"id":1,"name":"Windows 7","client_id":1}, {"id":2,"name":"Windows 10","client_id":1}]|]


### PR DESCRIPTION
About 5 media type related test cases in our spec tests are actually bugs, but it is not documented. This commit adds a comment to point it out and that they should be fixed.

I think before working on #4498, we need to discuss and establish that these test cases are bugs. Looking for feedback.