### PR TITLE
fix: misleading logs on unsupported postgresql versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. From versio
 
 ## Unreleased
 
+### Fixed
+
+- Fix misleading logs on unsupported PostgreSQL versions by @taimoorzaeem in #4519
+
 ## [14.1] - 2025-11-05
 
 ## Fixed

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -382,14 +382,16 @@ retryingSchemaCacheLoad appState@AppState{stateObserver=observer, stateMainThrea
             observer ExitDBNoRecoveryObs
             killThread mainThreadId
           return Nothing
-        Right actualPgVersion -> do
-          when (actualPgVersion < minimumPgVersion) $ do
+        Right actualPgVersion ->
+          if actualPgVersion < minimumPgVersion then do
             observer $ ExitUnsupportedPgVersion actualPgVersion minimumPgVersion
             killThread mainThreadId
-          observer $ DBConnectedObs $ pgvFullName actualPgVersion
-          observer $ PoolInit configDbPoolSize
-          putPgVersion appState actualPgVersion
-          return $ Just actualPgVersion
+            return Nothing
+          else do
+            observer $ DBConnectedObs $ pgvFullName actualPgVersion
+            observer $ PoolInit configDbPoolSize
+            putPgVersion appState actualPgVersion
+            return $ Just actualPgVersion
 
     qInDbConfig :: IO ()
     qInDbConfig = do


### PR DESCRIPTION
Postgrest fails on unsupported pg versions. However before killing the thread, it continues to print a few more log messages which were misleading. This commit fixes this by making sure that the no log message should be printed after the unsupported pg version observation and kill the thread immediately.

Closes #4519.