### PR TITLE
chore(changelog): move incorrectly placed fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,11 @@ All notable changes to this project will be documented in this file. From versio
 ### Fixed
 
 - Fix misleading logs on unsupported PostgreSQL versions by @taimoorzaeem in #4519
-
-## [14.1] - 2025-11-05
-
 - Fix regression where the `PGRST103` error response was truncated by @laurenceisla in #4455
   + Happened when an `offset` was greater than the rows requested and `Prefer: count=exact` was sent.
 - Fix not returning `Content-Length` on empty HTTP `201` responses by @laurenceisla in #4518
+
+## [14.1] - 2025-11-05
 
 ## Fixed
 


### PR DESCRIPTION
As title says. I mistakenly put it under 14.1 instead of under the "Unreleased" fixes.