### PR TITLE
refactor: use pg_basetype() for domain type resolution on PG 17+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. From versio
 
 ### Added
 
+- Use `pg_basetype()` for domain type resolution on PostgreSQL 17+ by @joelonsql in #XXXX
 - Log error when `db-schemas` config contains schema `pg_catalog` or `information_schema` by @taimoorzaeem in #4359
 
 ### Fixed

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -149,7 +149,8 @@ postgrestResponse appState conf@AppConfig{..} maybeSchemaCache authResult@AuthRe
   (parseTime, apiReq@ApiRequest{..}) <- withTiming $ liftEither . mapLeft Error.ApiRequestError $ ApiRequest.userApiRequest conf prefs req body
   (planTime, plan)                   <- withTiming $ liftEither $ Plan.actionPlan iAction conf apiReq sCache
 
-  let mainQ = Query.mainQuery plan conf apiReq authResult configDbPreRequest
+  pgVer <- lift $ AppState.getPgVersion appState
+  let mainQ = Query.mainQuery pgVer plan conf apiReq authResult configDbPreRequest
       tx = MainTx.mainTx mainQ conf authResult apiReq plan sCache
       obsQuery s = when configLogQuery $ observer $ QueryObs mainQ s
 

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -401,9 +401,10 @@ retryingSchemaCacheLoad appState@AppState{stateObserver=observer, stateMainThrea
     qSchemaCache :: IO (Maybe SchemaCache)
     qSchemaCache = do
       conf@AppConfig{..} <- getConfig appState
+      pgVer <- getPgVersion appState
       (resultTime, result) <-
         let transaction = if configDbPreparedStatements then SQL.transaction else SQL.unpreparedTransaction in
-        timeItT $ usePool appState (transaction SQL.ReadCommitted SQL.Read $ querySchemaCache conf)
+        timeItT $ usePool appState (transaction SQL.ReadCommitted SQL.Read $ querySchemaCache pgVer conf)
       case result of
         Left e -> do
           putSCacheStatus appState SCPending

--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -61,10 +61,11 @@ runAppCommand conf@AppConfig{..} runCmd = do
 dumpSchema :: AppState -> IO LBS.ByteString
 dumpSchema appState = do
   conf@AppConfig{..} <- AppState.getConfig appState
+  pgVer <- AppState.getPgVersion appState
   result <-
     let transaction = if configDbPreparedStatements then SQL.transaction else SQL.unpreparedTransaction in
     AppState.usePool appState
-      (transaction SQL.ReadCommitted SQL.Read $ querySchemaCache conf)
+      (transaction SQL.ReadCommitted SQL.Read $ querySchemaCache pgVer conf)
   case result of
     Left e -> do
       let observer = AppState.getObserver appState

--- a/src/PostgREST/SchemaCache.hs
+++ b/src/PostgREST/SchemaCache.hs
@@ -42,6 +42,7 @@ import NeatInterpolation          (trimming)
 import PostgREST.Config                      (AppConfig (..))
 import PostgREST.Config.Database             (TimezoneNames,
                                               toIsolationLevel)
+import PostgREST.Config.PgVersion            (PgVersion, pgVersion170)
 import PostgREST.SchemaCache.Identifiers     (FieldName,
                                               QualifiedIdentifier (..),
                                               RelIdentifier (..),
@@ -139,13 +140,13 @@ data KeyDep
 type SqlQuery = ByteString
 
 
-querySchemaCache :: AppConfig -> SQL.Transaction SchemaCache
-querySchemaCache conf@AppConfig{..} = do
+querySchemaCache :: PgVersion -> AppConfig -> SQL.Transaction SchemaCache
+querySchemaCache pgVer conf@AppConfig{..} = do
   SQL.sql "set local schema ''" -- This voids the search path. The following queries need this for getting the fully qualified name(schema.name) of every db object
-  tabs    <- SQL.statement conf $ allTables prepared
+  tabs    <- SQL.statement conf $ allTables pgVer prepared
   keyDeps <- SQL.statement conf $ allViewsKeyDependencies prepared
   m2oRels <- SQL.statement mempty $ allM2OandO2ORels prepared
-  funcs   <- SQL.statement conf $ allFunctions prepared
+  funcs   <- SQL.statement conf $ allFunctions pgVer prepared
   cRels   <- SQL.statement mempty $ allComputedRels prepared
   reps    <- SQL.statement conf $ dataRepresentations prepared
   mHdlers <- SQL.statement conf $ mediaHandlers prepared
@@ -353,47 +354,61 @@ dataRepresentations = SQL.Statement sql mempty decodeRepresentations
        OR (dst_t.typtype = 'd' AND c.castsource IN ('json'::regtype::oid , 'text'::regtype::oid)))
     |]
 
-allFunctions :: Bool -> SQL.Statement AppConfig RoutineMap
-allFunctions = SQL.Statement funcsSqlQuery params decodeFuncs
+allFunctions :: PgVersion -> Bool -> SQL.Statement AppConfig RoutineMap
+allFunctions pgVer = SQL.Statement (funcsSqlQuery pgVer) params decodeFuncs
   where
     params =
       (map escapeIdent . toList . configDbSchemas >$< arrayParam HE.text) <>
       (configDbHoistedTxSettings >$< arrayParam HE.text)
 
-baseTypesCte :: Text
-baseTypesCte = [trimming|
-  -- Recursively get the base types of domains
-  base_types AS (
-    WITH RECURSIVE
-    recurse AS (
-      SELECT
-        oid,
-        typbasetype,
-        typnamespace AS base_namespace,
-        COALESCE(NULLIF(typbasetype, 0), oid) AS base_type
-      FROM pg_type
-      UNION
-      SELECT
-        t.oid,
-        b.typbasetype,
-        b.typnamespace AS base_namespace,
-        COALESCE(NULLIF(b.typbasetype, 0), b.oid) AS base_type
-      FROM recurse t
-      JOIN pg_type b ON t.typbasetype = b.oid
-    )
-    SELECT
-      oid,
-      base_namespace,
-      base_type
-    FROM recurse
-    WHERE typbasetype = 0
-  )
-|]
+baseTypesCte :: PgVersion -> Text
+baseTypesCte pgVer
+  | pgVer >= pgVersion170 = [trimming|
+      -- Get base types using pg_basetype() (PG 17+)
+      base_types AS (
+        SELECT
+          t.oid,
+          bt.typnamespace AS base_namespace,
+          bt.oid AS base_type
+        FROM pg_type t
+        JOIN pg_type bt ON bt.oid = pg_basetype(t.oid)
+      )
+    |]
+  | otherwise = [trimming|
+      -- Recursively get the base types of domains (PG < 17)
+      base_types AS (
+        WITH RECURSIVE
+        recurse AS (
+          SELECT
+            oid,
+            typbasetype,
+            typnamespace AS base_namespace,
+            COALESCE(NULLIF(typbasetype, 0), oid) AS base_type
+          FROM pg_type
+          UNION
+          SELECT
+            t.oid,
+            b.typbasetype,
+            b.typnamespace AS base_namespace,
+            COALESCE(NULLIF(b.typbasetype, 0), b.oid) AS base_type
+          FROM recurse t
+          JOIN pg_type b ON t.typbasetype = b.oid
+        )
+        SELECT
+          oid,
+          base_namespace,
+          base_type
+        FROM recurse
+        WHERE typbasetype = 0
+      )
+    |]
 
-funcsSqlQuery :: SqlQuery
-funcsSqlQuery = encodeUtf8 [trimming|
+funcsSqlQuery :: PgVersion -> SqlQuery
+funcsSqlQuery pgVer =
+  let baseCte = baseTypesCte pgVer
+  in encodeUtf8 [trimming|
   WITH
-  $baseTypesCte,
+  $baseCte,
   arguments AS (
     SELECT
       oid,
@@ -566,22 +581,23 @@ addViewPrimaryKeys tabs keyDeps =
     takeFirstPK = mapMaybe (head . snd)
     indexedDeps = HM.fromListWith (++) $ fmap ((keyDepType &&& keyDepView) &&& pure) keyDeps
 
-allTables :: Bool -> SQL.Statement AppConfig TablesMap
-allTables = SQL.Statement tablesSqlQuery params decodeTables
+allTables :: PgVersion -> Bool -> SQL.Statement AppConfig TablesMap
+allTables pgVer = SQL.Statement (tablesSqlQuery pgVer) params decodeTables
   where
     params = map escapeIdent . toList . configDbSchemas >$< arrayParam HE.text
 
 -- | Gets tables with their PK cols
-tablesSqlQuery :: SqlQuery
-tablesSqlQuery =
+tablesSqlQuery :: PgVersion -> SqlQuery
+tablesSqlQuery pgVer =
   -- the tbl_constraints/key_col_usage CTEs are based on the standard "information_schema.table_constraints"/"information_schema.key_column_usage" views,
   -- we cannot use those directly as they include the following privilege filter:
   -- (pg_has_role(ss.relowner, 'USAGE'::text) OR has_column_privilege(ss.roid, a.attnum, 'SELECT, INSERT, UPDATE, REFERENCES'::text));
   -- on the "columns" CTE, left joining on pg_depend and pg_class is used to obtain the sequence name as a column default in case there are GENERATED .. AS IDENTITY,
   -- generated columns are only available from pg >= 10 but the query is agnostic to versions. dep.deptype = 'i' is done because there are other 'a' dependencies on PKs
-  encodeUtf8 [trimming|
+  let baseCte = baseTypesCte pgVer
+  in encodeUtf8 [trimming|
   WITH
-  $baseTypesCte,
+  $baseCte,
   columns AS (
       SELECT
           c.oid AS relid,

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -759,7 +759,7 @@ def test_log_query(level, defaultenv):
         )
         infinite_recursion_5xx_regx = r'.+: WITH pgrst_source AS.+SELECT "public"\."infinite_recursion"\.\* FROM "public"\."infinite_recursion".+_postgrest_t'
         root_tables_regx = r".+: SELECT   n.nspname AS table_schema, .+ FROM pg_class c .+ ORDER BY table_schema, table_name"
-        root_procs_regx = r".+: WITH base_types AS \(.+\) SELECT   pn.nspname AS proc_schema, .+ FROM pg_proc p.+AND p.pronamespace = \$1::regnamespace"
+        root_procs_regx = r".+: WITH.+base_types AS.+pn\.nspname AS proc_schema.+FROM pg_proc p.+p\.pronamespace = \$1::regnamespace"
         root_descr_regx = r".+: SELECT pg_catalog\.obj_description\(\$1::regnamespace, 'pg_namespace'\)"
         set_config_regx = (
             r".+: select set_config\('search_path', \$1, true\), set_config\("

--- a/test/spec/Main.hs
+++ b/test/spec/Main.hs
@@ -83,7 +83,7 @@ main = do
   actualPgVersion <- either (panic . show) id <$> P.use pool (queryPgVersion False)
 
   -- cached schema cache so most tests run fast
-  baseSchemaCache <- loadSCache pool testCfg
+  baseSchemaCache <- loadSCache pool actualPgVersion testCfg
   sockets <- AppState.initSockets testCfg
   loggerState <- Logger.init
   metricsState <- Metrics.init (configDbPoolSize testCfg)
@@ -100,7 +100,7 @@ main = do
 
     -- For tests that run with a different SchemaCache (depends on configSchemas)
     appDbs config = do
-      customSchemaCache <- loadSCache pool config
+      customSchemaCache <- loadSCache pool actualPgVersion config
       initApp customSchemaCache () config
 
   let withApp              = app testCfg
@@ -279,5 +279,5 @@ main = do
       describe "Feature.Auth.JwtCacheSpec" Feature.Auth.JwtCacheSpec.spec
 
   where
-    loadSCache pool conf =
-      either (panic.show) id <$> P.use pool (HT.transaction HT.ReadCommitted HT.Read $ querySchemaCache conf)
+    loadSCache pool pgVer conf =
+      either (panic.show) id <$> P.use pool (HT.transaction HT.ReadCommitted HT.Read $ querySchemaCache pgVer conf)


### PR DESCRIPTION
PostgreSQL 17 introduced pg_basetype() which natively resolves domain types to their base types. Use this instead of the recursive CTE when available, falling back to the recursive approach for older versions.

I've verified tests still works against PostgreSQL 16 and 17.

Note: I see an opportunity of reducing SQL code duplication between SchemaCache.hs and SqlFragment.hs, most of the big query is the same, with the below differences, however, if this is worth doing I'm not sure, and even if so, should probably be a separate commit anyway.
```diff
diff --git a/SqlFragment.sql b/SchemaCache.sql
index ffc24d78..db552451 100644
--- a/SqlFragment.sql
+++ b/SchemaCache.sql
@@ -42,8 +42,8 @@ WITH
     bt.oid <> bt.base_type as rettype_is_composite_alias,
     p.provolatile,
     p.provariadic > 0 as hasvariadic,
-    'ignored' AS transaction_isolation_level,
-    '{}'::text[] as kvs
+    lower((regexp_split_to_array((regexp_split_to_array(iso_config, '='))[2], ','))[1]) AS transaction_isolation_level,
+    coalesce(func_settings.kvs, '{}') as kvs
   FROM pg_proc p
   LEFT JOIN arguments a ON a.oid = p.oid
   JOIN pg_namespace pn ON pn.oid = p.pronamespace
@@ -52,6 +52,16 @@ WITH
   JOIN pg_namespace tn ON tn.oid = t.typnamespace
   LEFT JOIN pg_class comp ON comp.oid = t.typrelid
   LEFT JOIN pg_description as d ON d.objoid = p.oid AND d.classoid = 'pg_proc'::regclass
+  LEFT JOIN LATERAL unnest(proconfig) iso_config ON iso_config LIKE 'default_transaction_isolation%'
+  LEFT JOIN LATERAL (
+    SELECT
+      array_agg(row(
+        substr(setting, 1, strpos(setting, '=') - 1),
+        substr(setting, strpos(setting, '=') + 1)
+      )) as kvs
+    FROM unnest(proconfig) setting
+    WHERE setting ~ ANY($$2)
+  ) func_settings ON TRUE
   WHERE t.oid <> 'trigger'::regtype AND COALESCE(a.callable, true)
-  AND has_function_privilege(p.oid, 'execute')
   AND prokind = 'f'
+  AND p.pronamespace = ANY($$1::regnamespace[])
```

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `add`, Add a new feature
  + `amend`, To amend an unrealease commit
  + `change`, Breaking changes
  + `chore`, Maintenance, update sponsors, changelog, readme etc
  + `ci`, CI configuration files and scripts
  + `docs`, Documentation
  + `fix`, Bug fix
  + `nix`, Related to Nix
  + `perf`, Performance improvements
  + `refactor`, Refactoring code
  + `remove`, Remove a feature or fix
  + `test`, Adding tests
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
