### PR TITLE
nix: show wait time on withPgrst

### DIFF
--- a/nix/tools/withTools.nix
+++ b/nix/tools/withTools.nix
@@ -413,12 +413,14 @@ let
         }
         trap cleanup EXIT
 
+        wait_start=$SECONDS
         timeout -s TERM "$_arg_timeout" ${waitForPgrstReady} || {
           echo "timed out, output:"
           cat "$tmpdir"/run.log
           exit 1
         }
-        echo "done."
+        wait_duration=$((SECONDS - wait_start))
+        printf "done in %ss.\n" "$wait_duration"
 
         if [[ -n "$_arg_monitor" ]]; then
           ${monitorPid} "$pid" > "$_arg_monitor" &


### PR DESCRIPTION
Split some commits from https://github.com/PostgREST/postgrest/pull/4576 to isolate the coverage error on https://github.com/PostgREST/postgrest/pull/4576.

**Edit**: no failures, this revealed the cause on https://github.com/PostgREST/postgrest/pull/4576#discussion_r2642043094