### PR TITLE
add: per request statement timeout using prefer header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file. From versio
 - Log host, port and pg version of listener database connection by @mkleczek in #4617 #4618
 - Optimize requests with `Prefer: count=exact` that do not use ranges or `db-max-rows` by @laurenceisla in #3957
   + Removed unnecessary double count when building the `Content-Range`.
+- Add `Prefer: timeout` header for per-request `statement_timeout` by @taimoorzaeem in #4381
 
 ### Changed
 

--- a/docs/references/errors.rst
+++ b/docs/references/errors.rst
@@ -271,6 +271,10 @@ Related to the HTTP request elements.
 |               |             | See :ref:`prefer_max_affected`.                             |
 | PGRST128      |             |                                                             |
 +---------------+-------------+-------------------------------------------------------------+
+| .. _pgrst129: | 400         | ``timeout`` preference exceeds ``statement_timeout`` value  |
+|               |             | of role. See :ref:`prefer_timeout`.                         |
+| PGRST129      |             |                                                             |
++---------------+-------------+-------------------------------------------------------------+
 
 
 .. _pgrst2**:

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -169,7 +169,7 @@ postgrestResponse appState conf@AppConfig{..} maybeSchemaCache authResult@AuthRe
       prefs = ApiRequest.userPreferences conf req timezones
 
   (parseTime, apiReq@ApiRequest{..}) <- withTiming $ liftEither . mapLeft Error.ApiRequestError $ ApiRequest.userApiRequest conf prefs req body
-  (planTime, plan)                   <- withTiming $ liftEither $ Plan.actionPlan iAction conf apiReq sCache
+  (planTime, plan)                   <- withTiming $ liftEither $ Plan.actionPlan iAction conf apiReq authResult sCache
 
   let mainQ = Query.mainQuery plan conf apiReq authResult configDbPreRequest
       tx = MainTx.mainTx mainQ conf authResult apiReq plan sCache

--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -30,7 +30,7 @@ import Protolude
 main :: CLI -> IO ()
 main CLI{cliCommand, cliPath} = do
   conf <-
-    either panic identity <$> Config.readAppConfig mempty cliPath Nothing mempty mempty
+    either panic identity <$> Config.readAppConfig mempty cliPath Nothing mempty mempty mempty
   case cliCommand of
     Client adminCmd -> runClientCommand conf adminCmd
     Run runCmd      -> runAppCommand conf runCmd

--- a/src/PostgREST/Query/PreQuery.hs
+++ b/src/PostgREST/Query/PreQuery.hs
@@ -17,7 +17,9 @@ import qualified Hasql.DynamicStatements.Snippet as SQL hiding (sql)
 
 
 import PostgREST.ApiRequest              (ApiRequest (..))
-import PostgREST.ApiRequest.Preferences  (PreferTimezone (..),
+import PostgREST.ApiRequest.Preferences  (PreferHandling (..),
+                                          PreferTimeout (..),
+                                          PreferTimezone (..),
                                           Preferences (..))
 import PostgREST.Auth.Types              (AuthResult (..))
 import PostgREST.Config                  (AppConfig (..))
@@ -35,11 +37,11 @@ import Protolude hiding (Handler)
 
 -- sets transaction variables
 txVarQuery :: DbActionPlan -> AppConfig -> AuthResult -> ApiRequest -> SQL.Snippet
-txVarQuery dbActPlan AppConfig{..} AuthResult{..} ApiRequest{..} =
+txVarQuery dbActPlan AppConfig{..} AuthResult{..} ApiRequest{iPreferences=Preferences{..}, ..} =
     -- To ensure `GRANT SET ON PARAMETER <superuser_setting> TO authenticator` works, the role settings must be set before the impersonated role.
     -- Otherwise the GRANT SET would have to be applied to the impersonated role. See https://github.com/PostgREST/postgrest/issues/3045
     "select " <> intercalateSnippet ", " (
-      searchPathSql : roleSettingsSql ++ roleSql ++ claimsSql ++ [methodSql, pathSql] ++ headersSql ++ cookiesSql ++ timezoneSql ++ funcSettingsSql ++ appSettingsSql
+      searchPathSql : roleSettingsSql ++ roleSql ++ claimsSql ++ [methodSql, pathSql] ++ headersSql ++ cookiesSql ++ timezoneSql ++ timeoutSql ++ funcSettingsSql ++ appSettingsSql
     )
   where
     methodSql = setConfigWithConstantName ("request.method", iMethod)
@@ -50,7 +52,12 @@ txVarQuery dbActPlan AppConfig{..} AuthResult{..} ApiRequest{..} =
     roleSql = [setConfigWithConstantName ("role", authRole)]
     roleSettingsSql = setConfigWithDynamicName <$> HM.toList (fromMaybe mempty $ HM.lookup authRole configRoleSettings)
     appSettingsSql = setConfigWithDynamicName . join bimap toUtf8 <$> configAppSettings
-    timezoneSql = maybe mempty (\(PreferTimezone tz) -> [setConfigWithConstantName ("timezone", tz)]) $ preferTimezone iPreferences
+    timezoneSql = maybe mempty (\(PreferTimezone tz) -> [setConfigWithConstantName ("timezone", tz)]) preferTimezone
+    timeoutSql = maybe mempty (\(PreferTimeout t) ->
+      if preferHandling == Just Strict
+        then [setConfigWithConstantName ("statement_timeout", show t <> "s")]
+        else mempty
+      ) preferTimeout
     funcSettingsSql = setConfigWithDynamicName . join bimap toUtf8 <$> funcSettings
     searchPathSql =
       let schemas = escapeIdentList (iSchema : configDbExtraSearchPath) in

--- a/src/PostgREST/Response.hs
+++ b/src/PostgREST/Response.hs
@@ -299,4 +299,4 @@ responsePreferences plan ApiRequest{iPreferences=Preferences{..}, iQueryParams=Q
       CallReadPlan{}                            -> preferMaxAffected
       _                                         -> Nothing
 
-    in Preferences preferResolution' preferRepresentation' preferCount preferTransaction preferMissing' preferHandling preferTimezone preferMaxAffected' []
+    in Preferences preferResolution' preferRepresentation' preferCount preferTransaction preferMissing' preferHandling preferTimezone preferMaxAffected' preferTimeout []

--- a/test/io/__snapshots__/test_cli/test_schema_cache_snapshot[dbRoutines].yaml
+++ b/test/io/__snapshots__/test_cli/test_schema_cache_snapshot[dbRoutines].yaml
@@ -252,6 +252,23 @@
       pdSchema: public
       pdVolatility: Volatile
 
+- - qiName: reload_pgrst_schema
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdName: reload_pgrst_schema
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: void
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+
 - - qiName: one_sec_timeout
     qiSchema: public
   - - pdDescription: null

--- a/test/io/fixtures/roles.sql
+++ b/test/io/fixtures/roles.sql
@@ -1,18 +1,23 @@
 DROP ROLE IF EXISTS
   postgrest_test_anonymous, postgrest_test_author,
   postgrest_test_serializable, postgrest_test_repeatable_read,
-  postgrest_test_w_superuser_settings;
+  postgrest_test_w_superuser_settings, postgrest_test_timeout_ms,
+  postgrest_test_timeout_s, postgrest_test_no_timeout;
 
 CREATE ROLE postgrest_test_anonymous;
 CREATE ROLE postgrest_test_author;
 CREATE ROLE postgrest_test_serializable;
 CREATE ROLE postgrest_test_repeatable_read;
 CREATE ROLE postgrest_test_w_superuser_settings;
+CREATE ROLE postgrest_test_timeout_ms;
+CREATE ROLE postgrest_test_timeout_s;
+CREATE ROLE postgrest_test_no_timeout; -- no timeout for this role, default to db or cluster level statement_timeout
 
 GRANT
   postgrest_test_anonymous, postgrest_test_author,
   postgrest_test_serializable, postgrest_test_repeatable_read,
-  postgrest_test_w_superuser_settings TO :PGUSER;
+  postgrest_test_w_superuser_settings, postgrest_test_timeout_ms,
+  postgrest_test_timeout_s, postgrest_test_no_timeout TO :PGUSER;
 
 ALTER ROLE :PGUSER SET pgrst.db_anon_role = 'postgrest_test_anonymous';
 ALTER ROLE postgrest_test_serializable SET default_transaction_isolation = 'serializable';
@@ -23,3 +28,6 @@ ALTER ROLE postgrest_test_w_superuser_settings SET log_min_messages = 'fatal';
 
 ALTER ROLE postgrest_test_anonymous SET statement_timeout TO '5s';
 ALTER ROLE postgrest_test_author SET statement_timeout TO '10s';
+
+ALTER ROLE postgrest_test_timeout_ms SET statement_timeout TO '10ms';
+ALTER ROLE postgrest_test_timeout_s SET statement_timeout TO '10s';

--- a/test/io/fixtures/schema.sql
+++ b/test/io/fixtures/schema.sql
@@ -111,6 +111,11 @@ end $_$ volatile security definer language plpgsql ;
 create function reload_pgrst_config() returns void as $_$
 begin
   perform pg_notify('pgrst', 'reload config');
+end $_$ language plpgsql;
+
+create function reload_pgrst_schema() returns void as $_$
+begin
+  perform pg_notify('pgrst', 'reload schema');
 end $_$ language plpgsql ;
 
 create or replace function sleep(seconds double precision) returns void as $$

--- a/test/io/test_prefer_header.py
+++ b/test/io/test_prefer_header.py
@@ -1,0 +1,163 @@
+"Prefer: timeout header tests for PostgREST (involves IO)"
+
+from config import SECRET
+from util import jwtauthheader, execute_sql_statement_using_superuser
+from postgrest import (
+    run,
+    sleep_until_postgrest_scache_reload,
+    sleep_until_postgrest_config_reload,
+)
+
+
+def test_prefer_timeout_header_with_strict_handling(defaultenv):
+    "Test Prefer: timeout header with handling=strict"
+
+    with run(env=defaultenv) as postgrest:
+        # Fails when hits timeout
+        headers = {"Prefer": "handling=strict, timeout=1"}
+        response = postgrest.session.get("/rpc/sleep?seconds=2", headers=headers)
+        assert response.status_code == 500
+        assert response.json() == {
+            "code": "57014",
+            "message": "canceling statement due to statement timeout",
+            "details": None,
+            "hint": None,
+        }
+
+        # Fails when sleep equals the timeout
+        headers = {"Prefer": "handling=strict, timeout=2"}
+        response = postgrest.session.get("/rpc/sleep?seconds=2", headers=headers)
+        assert response.status_code == 500
+        assert response.json() == {
+            "code": "57014",
+            "message": "canceling statement due to statement timeout",
+            "details": None,
+            "hint": None,
+        }
+
+        # Succeeds when timeout is not hit
+        headers = {"Prefer": "handling=strict, timeout=2"}
+        response = postgrest.session.get("/rpc/sleep?seconds=1", headers=headers)
+        assert response.status_code == 204
+        assert response.headers["Preference-Applied"] == "handling=strict, timeout=2"
+
+
+def test_prefer_timeout_header_with_lenient_handling(defaultenv):
+    "Test Prefer: timeout header with handling=lenient"
+
+    with run(env=defaultenv) as postgrest:
+        # Timeout header is ignored for lenient handling
+        headers = {"Prefer": "handling=lenient, timeout=1"}
+        response = postgrest.session.get("/rpc/sleep?seconds=2", headers=headers)
+
+        assert response.status_code == 204
+        assert response.headers["Preference-Applied"] == "handling=lenient"
+
+
+def test_prefer_timeout_header_with_role_timeout(defaultenv):
+    "Test Prefer: timeout header with role timeout"
+
+    env = {
+        **defaultenv,
+        "PGRST_JWT_SECRET": SECRET,
+    }
+
+    with run(env=env) as postgrest:
+        # should fail when timeout is more than role's statement timeout
+        authheader = jwtauthheader({"role": "postgrest_test_timeout_ms"}, SECRET)
+        headers = {
+            **authheader,
+            "Prefer": "handling=strict, timeout=5",  # role timeout is 10ms, so this should fail
+        }
+
+        response = postgrest.session.get("/rpc/sleep?seconds=2", headers=headers)
+        assert response.status_code == 400
+        assert response.json() == {
+            "code": "PGRST129",
+            "message": "Timeout preference exceeded maximum allowed",
+            "details": "The maximum timeout allowed is 0s",
+            "hint": "Reduce the timeout",
+        }
+
+        # should fail when timeout is more than role's statement timeout
+        authheader = jwtauthheader({"role": "postgrest_test_timeout_s"}, SECRET)
+        headers = {
+            **authheader,
+            "Prefer": "handling=strict, timeout=15",  # role timeout is 10s, so this should fail
+        }
+
+        response = postgrest.session.get("/rpc/sleep?seconds=2", headers=headers)
+        assert response.json() == {
+            "code": "PGRST129",
+            "message": "Timeout preference exceeded maximum allowed",
+            "details": "The maximum timeout allowed is 10s",
+            "hint": "Reduce the timeout",
+        }
+        assert response.status_code == 400
+
+        # should succeed when timeout is less than role's statement timeout
+        authheader = jwtauthheader({"role": "postgrest_test_timeout_s"}, SECRET)
+        headers = {
+            **authheader,
+            "Prefer": "handling=strict, timeout=5",  # role timeout is 10s, so this should succeed
+        }
+
+        response = postgrest.session.get("/rpc/sleep?seconds=2", headers=headers)
+        assert response.status_code == 204
+        assert response.headers["Preference-Applied"] == "handling=strict, timeout=5"
+
+
+def test_prefer_timeout_header_with_global_timeout(defaultenv):
+    "Test Prefer: timeout header with database or cluster level timeout"
+
+    env = {**defaultenv, "PGRST_JWT_SECRET": SECRET}
+
+    with run(env=env) as postgrest:
+        # set global statement_timeout to 3s using postgres superuser
+        execute_sql_statement_using_superuser(
+            env, "ALTER DATABASE postgres SET statement_timeout TO '3s';"
+        )
+
+        # reload schema and config
+        response = postgrest.session.post("/rpc/reload_pgrst_schema")
+        assert response.status_code == 204
+        sleep_until_postgrest_scache_reload()
+
+        response = postgrest.session.post("/rpc/reload_pgrst_config")
+        assert response.status_code == 204
+        sleep_until_postgrest_config_reload()
+
+        # should fail when timeout is more than global statement timeout
+        authheader = jwtauthheader({"role": "postgrest_test_no_timeout"}, SECRET)
+        headers = {
+            **authheader,
+            "Prefer": "handling=strict, timeout=5",  # global timeout is 3s, so this should fail
+        }
+        response = postgrest.session.get("/rpc/sleep?seconds=4", headers=headers)
+        assert response.json() == {
+            "code": "PGRST129",
+            "message": "Timeout preference exceeded maximum allowed",
+            "details": "The maximum timeout allowed is 3s",
+            "hint": "Reduce the timeout",
+        }
+        assert response.status_code == 400
+
+        # reset global statement_timeout using postgres superuser
+        execute_sql_statement_using_superuser(
+            env, "ALTER DATABASE postgres RESET statement_timeout;"
+        )
+
+
+def test_prefer_timeout_header_with_negative_timeout(defaultenv):
+    "Test Prefer: timeout header with negative and zero timeout"
+
+    with run(env=defaultenv) as postgrest:
+        # -ve timeout values are ignored
+        headers = {"Prefer": "handling=strict, timeout=-1"}
+        response = postgrest.session.get("/rpc/sleep?seconds=2", headers=headers)
+        assert response.status_code == 204
+
+        # 0 timeout value is ignored
+        headers = {"Prefer": "handling=stricte timeout=0"}
+        response = postgrest.session.get("/rpc/sleep?seconds=2", headers=headers)
+        assert response.status_code == 204

--- a/test/io/util.py
+++ b/test/io/util.py
@@ -1,5 +1,6 @@
 import threading
 import jwt
+import os
 
 
 class Thread(threading.Thread):
@@ -46,3 +47,12 @@ def parse_server_timings_header(header):
         _, duration = duration_text.split("=")
         timings[name.strip()] = float(duration)
     return timings
+
+
+def execute_sql_statement_using_superuser(env, statement):
+    "Execute SQL statement with psql using superuser"
+
+    superuser = "postgres"
+    os.system(
+        f'psql -d {env["PGDATABASE"]} -U {superuser} -h {env["PGHOST"]} --set ON_ERROR_STOP=1 -a -c "{statement}"'
+    )

--- a/test/spec/SpecHelper.hs
+++ b/test/spec/SpecHelper.hs
@@ -164,6 +164,7 @@ baseCfg = let secret = encodeUtf8 "reallyreallyreallyreallyverysafe" in
   , configAdminServerHost           = "localhost"
   , configAdminServerPort           = Nothing
   , configRoleSettings              = mempty
+  , configRoleTimeoutSettings       = mempty
   , configRoleIsoLvl                = mempty
   , configInternalSCQuerySleep      = Nothing
   , configInternalSCLoadSleep       = Nothing


### PR DESCRIPTION
Adds a feature to set `statement_timeout` using `Prefer: timeout` header. This also introduces a `PGRST129` error which is returned when the timeout preferred exceeds the per-role timeout, which prevents misuse of this feature.

Closes #4381.

- [ ] Implementation
- [ ] Tests
- [ ] Docs
