### PR TITLE
nix: add script and ci workflow to enforce changelog entries

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -98,7 +98,7 @@ postgrest-lint                    postgrest-with-pg-16
 postgrest-loadtest                postgrest-with-pg-17
 postgrest-loadtest-against        postgrest-with-slow-pg
 postgrest-loadtest-report         postgrest-with-slow-postgrest
-postgrest-nixpkgs-upgrade
+postgrest-nixpkgs-upgrade         postgrest-changelog-check
 ...
 
 [nix-shell]$


### PR DESCRIPTION
Closes #4590.

- [ ] Create nix script.
- [ ] Add this to CI.

I would love some feedback on this.