### PR TITLE
test: Fix flakiness of test_second_request_for_non_existent_table_should_be_quick

### DIFF
--- a/test/io/test_big_schema.py
+++ b/test/io/test_big_schema.py
@@ -89,4 +89,4 @@ def test_second_request_for_non_existent_table_should_be_quick(defaultenv):
         assert data["code"] == "PGRST205"
         first_duration = response.elapsed.total_seconds()
         response = postgrest.session.get("/unknown-table")
-        assert response.elapsed.total_seconds() < first_duration / 10
+        assert response.elapsed.total_seconds() < first_duration / 2


### PR DESCRIPTION
Changed divider in assertion (response.elapsed.total_seconds() < first_duration / divider) to 2 (from 10).

See comment thread: https://github.com/PostgREST/postgrest/pull/4472#discussion_r2665677862