### PR TITLE
chore(ci): correct slightly misleading name of coverage workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - run: postgrest-cabal-update
 
-      - name: Run coverage (IO tests and Spec tests against PostgreSQL 15)
+      - name: Run coverage (IO tests and Spec tests against latest supported PostgreSQL)
         run: postgrest-coverage
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2


### PR DESCRIPTION
The coverage workflow mentions that we run the tests against PG 15, however that is incorrect and misleading. We actually run it against the latest supported PostgreSQL version according to the nix scripts.