### PR TITLE
add: new CLI command to return SQL from a query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. From versio
 
 - Log error when `db-schemas` config contains schema `pg_catalog` or `information_schema` by @taimoorzaeem in #4359
 - Add a `HINT` when the LISTEN channel stops working due to a PostgreSQL bug by @laurenceisla in #4581
+- Add `--query-to-sql` CLI flag to translate a PostgREST URL query to SQL without running the server
 
 ## [14.3] - 2026-01-03
 

--- a/docs/references/cli.rst
+++ b/docs/references/cli.rst
@@ -7,8 +7,9 @@ PostgREST provides a CLI with the options listed below:
 
 .. code:: text
 
-  Usage: postgrest [-v|--version] [-e|--example] [--dump-config | --dump-schema | --ready]
-                 [FILENAME]
+  Usage: postgrest [-v|--version] [-e|--example]
+                   [--dump-config | --dump-schema | --query-to-sql QUERY | --ready]
+                   [FILENAME]
 
     PostgREST / create a REST API to an existing Postgres
     database
@@ -20,6 +21,8 @@ PostgREST provides a CLI with the options listed below:
     --dump-config            Dump loaded configuration and exit
     --dump-schema            Dump loaded schema as JSON and exit (for debugging,
                              output structure is unstable)
+    --query-to-sql QUERY     Translate a PostgREST URL query to SQL and exit
+                             (e.g., "/items?select=id&id=gt.5")
     --ready                  Checks the health of PostgREST by doing a request on
                              the admin server /ready endpoint
     FILENAME                 Path to configuration file
@@ -73,6 +76,22 @@ Dump Schema
   $ postgrest --dump-schema
 
 Dumps the schema cache in JSON format.
+
+Query to SQL
+------------
+
+.. code:: bash
+
+  $ postgrest --query-to-sql "/items?select=id&id=gt.5"
+
+Translates a PostgREST URL query to SQL and prints the resulting query. This is useful for debugging and understanding how PostgREST translates API requests to SQL.
+
+The command connects to the database to load the schema cache, then translates the provided query without executing it.
+
+.. code-block:: bash
+
+  $ postgrest --query-to-sql "/items?select=id,name&id=gt.5"
+  WITH pgrst_source AS ( SELECT "public"."items"."id", "public"."items"."name" FROM "public"."items" WHERE "public"."items"."id" > $1 ) ...
 
 Ready Flag
 ----------

--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -8,21 +8,40 @@ module PostgREST.CLI
   ) where
 
 import qualified Data.Aeson                 as JSON
+import qualified Data.Aeson.KeyMap          as KM
 import qualified Data.ByteString.Char8      as BS
 import qualified Data.ByteString.Lazy       as LBS
+import qualified Data.HashMap.Strict        as HM
+import qualified Data.List.NonEmpty         as NonEmpty
+import qualified Data.Set                   as S
+import qualified Data.Text                  as T
 import qualified Hasql.Transaction.Sessions as SQL
 import qualified Options.Applicative        as O
 
-import PostgREST.AppState    (AppState)
-import PostgREST.Config      (AppConfig (..))
-import PostgREST.Observation (Observation (..))
-import PostgREST.SchemaCache (querySchemaCache)
-import PostgREST.Version     (prettyVersion)
+import PostgREST.ApiRequest              (ApiRequest (..))
+import PostgREST.ApiRequest.Types        (Action (..), DbAction (..),
+                                          InvokeMethod (..), Resource (..))
+import PostgREST.AppState                (AppState)
+import PostgREST.Auth.Types              (AuthResult (..))
+import PostgREST.Config                  (AppConfig (..))
+import PostgREST.Error                   (ApiRequestError (..),
+                                          Error (..))
+import PostgREST.Logger                  (renderSnippet)
+import PostgREST.MediaType               (MediaType (..))
+import PostgREST.Observation             (Observation (..))
+import PostgREST.Plan                    (actionPlan)
+import PostgREST.Query                   (MainQuery (..), mainQuery)
+import PostgREST.RangeQuery              (allRange)
+import PostgREST.SchemaCache             (SchemaCache, querySchemaCache)
+import PostgREST.SchemaCache.Identifiers (QualifiedIdentifier (..))
+import PostgREST.Version                 (prettyVersion)
 
-import qualified PostgREST.App      as App
-import qualified PostgREST.AppState as AppState
-import qualified PostgREST.Client   as Client
-import qualified PostgREST.Config   as Config
+import qualified PostgREST.ApiRequest.Preferences as Preferences
+import qualified PostgREST.ApiRequest.QueryParams as QueryParams
+import qualified PostgREST.App                    as App
+import qualified PostgREST.AppState               as AppState
+import qualified PostgREST.Client                 as Client
+import qualified PostgREST.Config                 as Config
 
 import Protolude
 
@@ -55,6 +74,9 @@ runAppCommand conf@AppConfig{..} runCmd = do
       CmdDumpSchema -> do
         when configDbConfig $ AppState.readInDbConfig True appState
         putStrLn =<< dumpSchema appState
+      CmdQueryToSQL queryUrl -> do
+        when configDbConfig $ AppState.readInDbConfig True appState
+        queryToSQL appState queryUrl
       CmdRun -> App.run appState)
 
 -- | Dump SchemaCache schema to JSON
@@ -71,6 +93,87 @@ dumpSchema appState = do
       observer $ SchemaCacheErrorObs configDbSchemas configDbExtraSearchPath e
       exitFailure
     Right sCache -> return $ JSON.encode sCache
+
+-- | Translate a PostgREST URL query to SQL
+queryToSQL :: AppState -> Text -> IO ()
+queryToSQL appState queryUrl = do
+  conf@AppConfig{..} <- AppState.getConfig appState
+  result <-
+    let transaction = if configDbPreparedStatements then SQL.transaction else SQL.unpreparedTransaction in
+    AppState.usePool appState
+      (transaction SQL.ReadCommitted SQL.Read $ querySchemaCache conf)
+  case result of
+    Left e -> do
+      let observer = AppState.getObserver appState
+      observer $ SchemaCacheErrorObs configDbSchemas configDbExtraSearchPath e
+      exitFailure
+    Right sCache ->
+      case translateQuery conf sCache queryUrl of
+        Left err -> do
+          hPutStrLn stderr $ ("Error: " :: Text) <> show err
+          exitFailure
+        Right sql -> BS.putStrLn sql
+
+translateQuery :: AppConfig -> SchemaCache -> Text -> Either Error ByteString
+translateQuery conf@AppConfig{..} sCache queryUrl = do
+  let (path, qs) = T.breakOn "?" queryUrl
+      queryString = if T.null qs then "" else encodeUtf8 $ T.drop 1 qs
+      pathParts = filter (not . T.null) $ T.splitOn "/" path
+      schema = NonEmpty.head configDbSchemas
+
+  (resource, qi) <- case pathParts of
+    ["rpc", name] -> Right (ResourceRoutine name, QualifiedIdentifier schema name)
+    [name]        -> Right (ResourceRelation name, QualifiedIdentifier schema name)
+    _             -> Left $ ApiRequestError InvalidResourcePath
+
+  qPrms <- first (ApiRequestError . QueryParamError) $
+           QueryParams.parse (isRoutine resource) queryString
+
+  let act = case resource of
+        ResourceRoutine _ -> ActDb $ ActRoutine qi (InvRead False)
+        ResourceRelation _ -> ActDb $ ActRelationRead qi False
+        ResourceSchema -> ActDb $ ActSchemaRead schema False
+
+  let apiReq = ApiRequest
+        { iAction = act
+        , iRange = HM.empty
+        , iTopLevelRange = allRange
+        , iPayload = Nothing
+        , iPreferences = defaultPreferences
+        , iQueryParams = qPrms
+        , iColumns = S.empty
+        , iHeaders = []
+        , iCookies = []
+        , iPath = encodeUtf8 queryUrl
+        , iMethod = "GET"
+        , iSchema = schema
+        , iNegotiatedByProfile = False
+        , iAcceptMediaType = [MTApplicationJSON]
+        , iContentMediaType = MTApplicationJSON
+        }
+
+  plan <- actionPlan act conf apiReq sCache
+
+  let mainQ = mainQuery plan conf apiReq dummyAuthResult Nothing
+  Right $ renderSnippet (mqMain mainQ)
+
+  where
+    isRoutine (ResourceRoutine _) = True
+    isRoutine _ = False
+
+    dummyAuthResult = AuthResult KM.empty ""
+
+    defaultPreferences = Preferences.Preferences
+      { Preferences.preferResolution = Nothing
+      , Preferences.preferRepresentation = Nothing
+      , Preferences.preferCount = Nothing
+      , Preferences.preferTransaction = Nothing
+      , Preferences.preferMissing = Nothing
+      , Preferences.preferHandling = Nothing
+      , Preferences.preferTimezone = Nothing
+      , Preferences.preferMaxAffected = Nothing
+      , Preferences.invalidPrefs = []
+      }
 
 -- | Command line interface options
 data CLI = CLI
@@ -89,6 +192,7 @@ data RunCommand
   = CmdRun
   | CmdDumpConfig
   | CmdDumpSchema
+  | CmdQueryToSQL Text
 
 -- | Read command line interface options. Also prints help.
 readCLIShowHelp :: IO CLI
@@ -120,7 +224,7 @@ readCLIShowHelp =
     cliParser :: O.Parser CLI
     cliParser =
       CLI
-        <$> (dumpConfigFlag <|> dumpSchemaFlag <|> readyFlag)
+        <$> (dumpConfigFlag <|> dumpSchemaFlag <|> queryToSQLOption <|> readyFlag)
         <*> O.optional configFileOption
 
     configFileOption =
@@ -137,6 +241,13 @@ readCLIShowHelp =
       O.flag (Run CmdRun) (Run CmdDumpSchema) $
         O.long "dump-schema"
         <> O.help "Dump loaded schema as JSON and exit (for debugging, output structure is unstable)"
+
+    queryToSQLOption =
+      Run . CmdQueryToSQL <$> O.strOption
+        ( O.long "query-to-sql"
+        <> O.metavar "QUERY"
+        <> O.help "Translate a PostgREST URL query to SQL and exit (e.g., \"/items?select=id&id=gt.5\")"
+        )
 
     readyFlag =
       O.flag (Run CmdRun) (Client CmdReady) $

--- a/src/PostgREST/Logger.hs
+++ b/src/PostgREST/Logger.hs
@@ -9,6 +9,7 @@ module PostgREST.Logger
   , observationLogger
   , init
   , LoggerState
+  , renderSnippet
   ) where
 
 import           Control.AutoUpdate                (defaultUpdateSettings,

--- a/test/io/test_cli.py
+++ b/test/io/test_cli.py
@@ -405,3 +405,36 @@ def test_cli_ready_flag_fail_when_no_admin_server(defaultenv):
             "ERROR: Admin server is not running. Please check admin-server-port config."
             in output
         )
+
+
+def test_query_to_sql_simple_select(baseenv):
+    "Test basic table select query translation."
+    output = cli(["--query-to-sql", "/cats?select=id"], env=baseenv)
+    assert "SELECT" in output
+    assert '"public"."cats"' in output
+
+
+def test_query_to_sql_with_filter(baseenv):
+    "Test query with filter operators."
+    output = cli(["--query-to-sql", "/cats?select=id,name&id=neq.null"], env=baseenv)
+    assert "SELECT" in output
+    assert '"public"."cats"."id"' in output
+
+
+def test_query_to_sql_rpc(baseenv):
+    "Test RPC function call translation."
+    output = cli(["--query-to-sql", "/rpc/default_isolation_level"], env=baseenv)
+    assert "SELECT" in output
+    assert '"public"."default_isolation_level"' in output
+
+
+def test_query_to_sql_invalid_path(baseenv):
+    "Test error on invalid resource path (too many segments)."
+    output = cli(["--query-to-sql", "/invalid/path/too/deep"], env=baseenv, expect_error=True)
+    assert "Error" in output
+
+
+def test_query_to_sql_table_not_found(baseenv):
+    "Test error when table doesn't exist."
+    output = cli(["--query-to-sql", "/nonexistent_table"], env=baseenv, expect_error=True)
+    assert "Error" in output


### PR DESCRIPTION
Add a new CLI command to return SQL from Query:

```
# Basic table query
$ postgrest --query-to-sql "/items?select=id,name"
WITH pgrst_source AS ( SELECT "public"."items"."id", "public"."items"."name" FROM "public"."items" ) SELECT null::bigint AS total_result_set, pg_catalog.count(_postgrest_t) AS page_total, coalesce(json_agg(_postgrest_t), '[]') AS body, nullif(current_setting('response.headers', true), '') AS response_headers, nullif(current_setting('response.status', true), '') AS response_status, '' AS response_inserted FROM ( SELECT * FROM pgrst_source ) _postgrest_t

# Query with filters
$ postgrest --query-to-sql "/items?select=id&id=gt.5"
WITH pgrst_source AS ( SELECT "public"."items"."id" FROM "public"."items" WHERE "public"."items"."id" > $1 ) ...

# RPC function call
$ postgrest --query-to-sql "/rpc/my_function?arg1=value"
SELECT "public"."my_function"($1) ...

# With environment variables for connection
$ PGRST_DB_URI="postgres://user:pass@localhost:5432/mydb" \
  PGRST_DB_SCHEMAS="api" \
  postgrest --query-to-sql "/users?select=id,email&role=eq.admin"
```