### PR TITLE
fix: Unmask exceptions in listener retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file. From versio
 
 - Ensure Listener connections are released by @mkleczek in #4614
 - Fix incorrectly filtering the returned representation for PATCH requests when using `or/and` filters by @laurenceisla in #3707
+- Fix listener running with exception masked after first failure #4615
 
 ## [14.3] - 2026-01-03
 

--- a/src/PostgREST/Listener.hs
+++ b/src/PostgREST/Listener.hs
@@ -31,15 +31,16 @@ runListener :: AppState -> IO ()
 runListener appState = do
   AppConfig{..} <- getConfig appState
   when configDbChannelEnabled $
-    void . forkIO $ retryingListen appState
+    void . forkIO . void $ retryingListen appState
 
 -- | Starts a LISTEN connection and handles notifications. It recovers with exponential backoff with a cap of 32 seconds, if the LISTEN connection is lost.
-retryingListen :: AppState -> IO ()
+-- | This function never returns (but can throw) and return type enforces that.
+retryingListen :: AppState -> IO Void
 retryingListen appState = do
   AppConfig{..} <- AppState.getConfig appState
   let
     dbChannel = toS configDbChannel
-    handleFinally err = do
+    onError err = do
       AppState.putIsListenerOn appState False
       observer $ DBListenFail dbChannel (Right err)
       when (isDbListenerBug err) $
@@ -53,10 +54,11 @@ retryingListen appState = do
       threadDelay (delay * oneSecondInMicro)
       unless (delay == maxDelay) $
         AppState.putNextListenerDelay appState (delay * 2)
+      -- loop running the listener
       retryingListen appState
 
-  -- forkFinally allows to detect if the thread dies
-  void . flip forkFinally handleFinally $ do
+  -- Execute the listener with with error handling
+  handle onError $ do
     -- Make sure we don't leak connections on errors
     bracket
       -- acquire connection
@@ -81,7 +83,9 @@ retryingListen appState = do
 
           observer $ DBListenStart pqHost pqPort pgFullName dbChannel
 
-          SQL.waitForNotifications handleNotification db
+          -- wait for notifications
+          -- this will never return, in case of an error it will throw and be caught by onError
+          forever $ SQL.waitForNotifications handleNotification db
 
         Left err -> do
           observer $ DBListenFail dbChannel (Left err)


### PR DESCRIPTION
forkFinally calls error handler with exceptions masked. Our handleFinally does not restore exception state before calling retryingListener so after first error the whole listener is running with exceptions masked.
This patch ensures handleFinally is run with exceptions unmasked.