### PR TITLE
add: Log pg version details of listener connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file. From versio
 - Log error when `db-schemas` config contains schema `pg_catalog` or `information_schema` by @taimoorzaeem in #4359
 - Add a `HINT` when the LISTEN channel stops working due to a PostgreSQL bug by @laurenceisla in #4581
 - Add string slicing operator for `jwt-role-claim-key` by @taimoorzaeem in #4599
-- Log the actual host and port of listener database connection by @mkleczek in #4617
+- Log host, port and pg version of listener database connection by @mkleczek in #4617 #4618
 
 ### Fixed
 

--- a/src/PostgREST/Observation.hs
+++ b/src/PostgREST/Observation.hs
@@ -44,7 +44,7 @@ data Observation
   | SchemaCacheSummaryObs Text
   | SchemaCacheLoadedObs Double
   | ConnectionRetryObs Int
-  | DBListenStart (Maybe ByteString) (Maybe ByteString) Text -- host, port, channel
+  | DBListenStart (Maybe ByteString) (Maybe ByteString) Text Text -- host, port, version string, channel
   | DBListenFail Text (Either SQL.ConnectionError (Either SomeException ()))
   | DBListenRetry Int
   | DBListenBugHint -- https://github.com/PostgREST/postgrest/issues/3147
@@ -110,8 +110,8 @@ observationMessage = \case
     "Attempting to reconnect to the database in " <> (show delay::Text) <> " seconds..."
   QueryPgVersionError usageErr ->
     "Failed to query the PostgreSQL version. " <> jsonMessage usageErr
-  DBListenStart host port channel -> do
-    "Listener connected to " <> show (fold $ host <> fmap (":" <>) port) <> " and listening for database notifications on the " <> show channel <> " channel"
+  DBListenStart host port fullName channel -> do
+    "Listener connected to " <> fullName <> " on " <> show (fold $ host <> fmap (":" <>) port) <> " and listening for database notifications on the " <> show channel <> " channel"
   DBListenFail channel listenErr ->
     "Failed listening for database notifications on the " <> show channel <> " channel. " <>
       either showListenerConnError showListenerException listenErr

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -1649,9 +1649,11 @@ def test_log_listener_connection_start(defaultenv):
     }
 
     with run(env=env, no_startup_stdout=False, wait_for_readiness=True) as postgrest:
-        output = postgrest.read_stdout(nlines=5)
+        output = postgrest.read_stdout(nlines=10)
+        # Check for the listener start message containing host and port
+        # Do not check if pg version is displayed properly as it is tricky to test it
         assert any(
-            f'Listener connected to "{defaultenv["PGHOST"]}:5432" and listening for database notifications on the "pgrst" channel'
+            f'"{defaultenv["PGHOST"]}:5432" and listening for database notifications on the "pgrst" channel'
             in line
             for line in output
         )


### PR DESCRIPTION
Follow-up to #4617 adding more information to log entry produced upon successful listener connection establishement.
