### PR TITLE
chore: add entry for a feature which was a breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this project will be documented in this file. From versio
 
 ### Fixed
 
+### Changed
+
+- Log error when `db-schemas` config contains schema `pg_catalog` or `information_schema` by @taimoorzaeem in #4359
+  + Now fails at startup. Prior to this, it failed with `PGRST205` on requests related to these schemas.
+
 ## [14.4] - 2026-01-29
 
 ### Fixed


### PR DESCRIPTION
Adds the associated breaking change entry in `CHANGELOG.md` for #4517.