### PR TITLE
test(io): move role fixtures to roles.sql

### DIFF
--- a/test/io/fixtures/roles.sql
+++ b/test/io/fixtures/roles.sql
@@ -1,0 +1,25 @@
+DROP ROLE IF EXISTS
+  postgrest_test_anonymous, postgrest_test_author,
+  postgrest_test_serializable, postgrest_test_repeatable_read,
+  postgrest_test_w_superuser_settings;
+
+CREATE ROLE postgrest_test_anonymous;
+CREATE ROLE postgrest_test_author;
+CREATE ROLE postgrest_test_serializable;
+CREATE ROLE postgrest_test_repeatable_read;
+CREATE ROLE postgrest_test_w_superuser_settings;
+
+GRANT
+  postgrest_test_anonymous, postgrest_test_author,
+  postgrest_test_serializable, postgrest_test_repeatable_read,
+  postgrest_test_w_superuser_settings TO :PGUSER;
+
+ALTER ROLE :PGUSER SET pgrst.db_anon_role = 'postgrest_test_anonymous';
+ALTER ROLE postgrest_test_serializable SET default_transaction_isolation = 'serializable';
+ALTER ROLE postgrest_test_repeatable_read SET default_transaction_isolation = 'REPEATABLE READ';
+
+ALTER ROLE postgrest_test_w_superuser_settings SET log_min_duration_statement = 1;
+ALTER ROLE postgrest_test_w_superuser_settings SET log_min_messages = 'fatal';
+
+ALTER ROLE postgrest_test_anonymous SET statement_timeout TO '2s';
+ALTER ROLE postgrest_test_author SET statement_timeout TO '10s';


### PR DESCRIPTION
It's uneasy to make changes in a clean way, hence cleaning up before hand. :)

This is similar to how we have in spec tests:

https://github.com/PostgREST/postgrest/blob/2bd4b07418c94ce9e197ca35e8f6cc42cf1ac950/test/spec/fixtures/roles.sql#L1-L7