### PR TITLE
add: Oidc Connect Discovery

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -164,6 +164,8 @@ library
                     , focus                     >= 1.0 && < 2
                     , some                      >= 1.0.4.1 && < 2
                     , uuid                      >= 1.3 && < 2
+                    , oidc-client               >= 0.8.0.0 && < 0.9
+                    , http-client-tls           >= 0.3.6.4 && < 0.4
                       -- -fno-spec-constr may help keep compile time memory use in check,
                       --   see https://gitlab.haskell.org/ghc/ghc/issues/16017#note_219304
                       -- -optP-Wno-nonportable-include-path

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -73,6 +73,9 @@ import PostgREST.SchemaCache.Identifiers (QualifiedIdentifier (..),
 
 import PostgREST.Version (prettyVersion)
 import Protolude         hiding (Proxy, toList)
+import Web.OIDC.Client (Provider(..), discover)
+import Network.HTTP.Client.TLS (newTlsManager)
+import Network.HTTP.Client (HttpException (InvalidUrlException))
 
 audMatchesCfg :: AppConfig -> Text -> Bool
 audMatchesCfg =  maybe (const True) (==) . configJwtAudience
@@ -264,6 +267,7 @@ readAppConfig dbSettings optPath prevDbUri roleSettings roleIsolationLvl = do
     decodeLoadFiles parsedConfig = try $
       decodeJWKS =<<
       decodeSecret =<<
+      oidcConnectDiscovery =<<
       readSecretFile =<<
       readDbUriFile prevDbUri parsedConfig
 
@@ -503,6 +507,18 @@ parser optPath env dbSettings roleSettings roleIsolationLvl =
     defaultServerHost :: Maybe Text -> Text
     defaultServerHost = fromMaybe "!4"
 
+oidcConnectDiscovery :: AppConfig -> IO AppConfig
+oidcConnectDiscovery conf = maybe (pure conf) (performDiscovery . decodeUtf8) (configJwtSecret conf)
+  where
+    performDiscovery uri = oidcDiscover uri `catches` [
+      Handler (\case
+        InvalidUrlException _ _ -> pure conf
+        _ -> fail "OIDC discovery failed")
+      ]
+    oidcDiscover uri = do
+      manager <- newTlsManager
+      (Provider _ keys) <- discover uri manager
+      pure $ conf { configJWKS = Just $ JWT.JwkSet keys }
 -- | Read the JWT secret from a file if configJwtSecret is actually a
 -- filepath(has @ as its prefix). To check if the JWT secret is provided is
 -- in fact a file path, it must be decoded as 'Text' to be processed.


### PR DESCRIPTION
**DISCLAIMER:**
`This commit was authored entirely by a human without the assistance of LLMs.`

Fixes #1130
Fixes #4137

Currently configuring JWT keys is cumbersome and in practice requires implementing Oidc Connect Discovery in a shell script that writes retrieved keys to a file and reloads PostgREST configuration.
Having this implemented in PostgREST would simplify deployment.

OIDC Connect discovery is widely adopted and implemented by practically all OAuth providers (Supabase as well: https://supabase.com/docs/guides/auth/oauth-server#supported-standards)

Next step is to periodically reload keys to facilitate key rotation.