### PR TITLE
Add partial schema-cache reload notifications for tables and relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file. From versio
 - Log host, port and pg version of listener database connection by @mkleczek in #4617 #4618
 - Optimize requests with `Prefer: count=exact` that do not use ranges or `db-max-rows` by @laurenceisla in #3957
   + Removed unnecessary double count when building the `Content-Range`.
+- Add partial schema cache reload notifications via LISTEN/NOTIFY:
+  + `NOTIFY pgrst, 'reload tables'` refreshes tables/columns/functions metadata.
+  + `NOTIFY pgrst, 'reload relationships'` refreshes relationships metadata.
+  by @nothankyouzzz in #4613
 
 ### Fixed
 
@@ -19,6 +23,8 @@ All notable changes to this project will be documented in this file. From versio
 
 - Log error when `db-schemas` config contains schema `pg_catalog` or `information_schema` by @taimoorzaeem in #4359
   + Now fails at startup. Prior to this, it failed with `PGRST205` on requests related to these schemas.
+- Reduce duplicate work during full schema reloads by reusing intermediate
+  schema-cache phase data by @nothankyouzzz in #4613.
 
 ## [14.4] - 2026-01-29
 

--- a/docs/references/errors.rst
+++ b/docs/references/errors.rst
@@ -306,7 +306,11 @@ Related to a :ref:`schema_cache`. Most of the time, these errors are solved by :
 | PGRST204      |             |                                                             |
 +---------------+-------------+-------------------------------------------------------------+
 | .. _pgrst205: | 404         | Caused when the :ref:`table specified <tables_views>` in    |
-|               |             | the URI is not found.                                       |
+|               |             | the URI is not found. A common cause is a stale schema      |
+|               |             | cache (the table exists in PostgreSQL but is not in the     |
+|               |             | cache yet). :ref:`Reload the schema cache                   |
+|               |             | <schema_reloading>` and for table-only updates, consider    |
+|               |             | ``NOTIFY pgrst, 'reload tables'``.                          |
 | PGRST205      |             |                                                             |
 +---------------+-------------+-------------------------------------------------------------+
 

--- a/docs/references/listener.rst
+++ b/docs/references/listener.rst
@@ -10,8 +10,10 @@ Like on cloud managed containers or on Windows systems.
 .. code:: postgresql
 
   NOTIFY pgrst, 'reload schema'; -- reload schema cache
+  NOTIFY pgrst, 'reload tables'; -- reload table/function metadata only
+  NOTIFY pgrst, 'reload relationships'; -- reload relationships only
   NOTIFY pgrst, 'reload config'; -- reload config
-  NOTIFY pgrst;                  -- reload both
+  NOTIFY pgrst;                  -- empty payload, reload schema cache
 
 By default, the LISTEN channel is enabled (:ref:`db-channel-enabled`) and named ``pgrst`` (:ref:`db-channel`).
 

--- a/src/PostgREST/Listener.hs
+++ b/src/PostgREST/Listener.hs
@@ -99,10 +99,18 @@ retryingListen appState = do
     handleNotification channel msg =
       if | BS.null msg            -> observer (DBListenerGotSCacheMsg channel) >> cacheReloader
          | msg == "reload schema" -> observer (DBListenerGotSCacheMsg channel) >> cacheReloader
+         | msg == "reload tables" -> observer (DBListenerGotSCacheMsg channel) >> cacheTablesReloader
+         | msg == "reload relationships" -> observer (DBListenerGotSCacheMsg channel) >> cacheRelationshipsReloader
          | msg == "reload config" -> observer (DBListenerGotConfigMsg channel) >> AppState.readInDbConfig False appState
          | otherwise              -> pure () -- Do nothing if anything else than an empty message is sent
 
     cacheReloader =
       AppState.schemaCacheLoader appState
+
+    cacheTablesReloader =
+      AppState.schemaCacheTablesLoader appState
+
+    cacheRelationshipsReloader =
+      AppState.schemaCacheRelationshipsLoader appState
 
     releaseConnection = void . forkIO . handle (observer . DBListenerConnectionCleanupFail) . SQL.release


### PR DESCRIPTION
## Summary

This PR adds partial schema-cache reload notifications so high-frequency DDL workloads do not need to trigger a full schema reload every time:

- `NOTIFY pgrst, 'reload tables'`
- `NOTIFY pgrst, 'reload relationships'`

It also keeps full reload as explicit Phase1 + Phase2, while reusing phase data to reduce duplicate catalog work.

## Context

Issue #4613 reports `PGRST205` in dynamic-table workloads on very large schemas, where full reload per change is too expensive.

In the issue discussion, maintainers proposed adding partial reload notifications and using trigger classification (table changes vs FK/relationship changes). This PR implements that direction.

## What Changed

- Listener:
  - handle `reload tables` and `reload relationships` payloads.
- AppState:
  - add dedicated loaders for schema/tables/relationships reload paths.
  - coalesce pending reload requests and process them serially.
  - keep full reload as phased execution while reusing phase-1 outputs in phase-2.
- SchemaCache:
  - add phased query functions:
    - `querySchemaCacheTablesWithDeps`
    - `querySchemaCacheRelationshipsWithDeps`
  - keep compatibility wrappers:
    - `querySchemaCacheTables`
    - `querySchemaCacheRelationships`
- IO fixtures/tests:
  - add SQL helpers for partial/full reload notification scenarios.
  - add tests:
    - `test_reload_tables_notify`
    - `test_reload_relationships_notify`
    - `test_reload_schema_notify_after_fk`
    - `test_schema_cache_concurrent_partial_notifications`
  - adjust timing assertions in phased-reload related tests for suite stability.
- Docs/Changelog:
  - document supported schema-cache notification payloads and trigger guidance.
  - clarify listener empty payload behavior.
  - improve `PGRST205` docs with stale-cache guidance.
  - add changelog entries for partial reload support and full-reload optimization.

## Compatibility

- No HTTP API changes.
- Existing payloads remain supported (`reload schema`, `reload config`).
- Empty payload behavior is documented consistently.