### PR TITLE
fix(test): harden io readiness polling for local IPv6

### DIFF
--- a/test/io/postgrest.py
+++ b/test/io/postgrest.py
@@ -40,8 +40,7 @@ class PostgrestSession(requests_unixsocket.Session):
 
     def __init__(self, baseurl, *args, **kwargs):
         super(PostgrestSession, self).__init__(*args, **kwargs)
-        # Keep local test requests independent from host proxy env vars.
-        self.trust_env = False
+        disable_env_proxy(self)
         self.baseurl = baseurl
 
     def request(self, method, url, *args, **kwargs):
@@ -49,6 +48,20 @@ class PostgrestSession(requests_unixsocket.Session):
         # well with our 'http+unix://' unix domain socket urls.
         fullurl = self.baseurl + url
         return super(PostgrestSession, self).request(method, fullurl, *args, **kwargs)
+
+
+def disable_env_proxy(session):
+    # `trust_env` controls whether proxy/env vars are honored by the client.
+    # Ref: https://www.python-httpx.org/environment_variables/
+    # We disable it so local probes never use HTTP(S)_PROXY/NO_PROXY.
+    session.trust_env = False
+    _ = session.trust_env
+    return session
+
+
+def new_local_session():
+    "Session used by local test helpers, ignoring host proxy env vars."
+    return disable_env_proxy(requests_unixsocket.Session())
 
 
 @dataclasses.dataclass
@@ -188,8 +201,7 @@ def wait_until_exit(postgrest):
 
 def wait_until_status_code(url, max_seconds, status_code):
     "Wait for the given HTTP endpoint to return a status code"
-    session = requests_unixsocket.Session()
-    session.trust_env = False
+    session = new_local_session()
     response = None
 
     for _ in range(max_seconds * 10):
@@ -210,8 +222,7 @@ def wait_until_status_code(url, max_seconds, status_code):
 
 def sleep_pool_connection(url, seconds):
     "Sleep a pool connection by calling an RPC that uses pg_sleep"
-    session = requests_unixsocket.Session()
-    session.trust_env = False
+    session = new_local_session()
 
     # The try/except is a hack for not waiting for the response,
     # taken from https://stackoverflow.com/a/45601591/4692662


### PR DESCRIPTION
Initialize response in `wait_until_status_code` to avoid `UnboundLocalError` when no response is received.

Disable proxy env usage for test harness sessions so local admin/API probes are not routed through HTTP(S)_PROXY, which broke IPv6 readiness checks in proxied environments.

Validated with targeted tests:

```text
test/io/test_cli.py::test_cli_ready_flag_success[IPv6]
test/io/test_io.py::test_admin_works_with_host_special_values[*6]
test/io/test_io.py::test_admin_works_with_host_special_values[!6]
test/io/test_io.py::test_log_postgrest_host_and_port[IPv6]
```
