### PR TITLE
refactor: Failure in schema cache load should not set listener delay

### DIFF
--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -364,7 +364,6 @@ retryingSchemaCacheLoad appState@AppState{stateObserver=observer, stateMainThrea
     when (rsIterNumber > 0) $ do
       let delay = fromMaybe 0 rsPreviousDelay `div` oneSecondInUs
       observer $ ConnectionRetryObs delay
-      putNextListenerDelay appState delay
 
     flushPool appState
 


### PR DESCRIPTION
Listener has its own backoff logic independent of schema cache loading. It also uses listener delay value to identify its retries and to trigger schema cache reloads upon failures. If schema cache reloading sets listener delay it might lead to some unexpected reloading loops. That's especially important in set ups where listener connection points to master and the pool to replica(s).
