### PR TITLE
refactor: Simplify schema cache loading triggering logic

### DIFF
--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -117,13 +117,19 @@ init conf@AppConfig{configLogLevel, configDbPoolSize} = do
   pool <- initPool conf observer
   initWithPool pool conf loggerState metricsState observer --{ stateSocketREST = sock, stateSocketAdmin = adminSock}
 
-simpleDebounce :: IO () -> IO (IO ())
-simpleDebounce act = do
+-- Make a new debouncer action. An internal "worker" thread runs forever ensuring "action" runs when the "trigger" is called. The "action" is only executed once over a burst of calls.
+makeDebouncer :: IO () -> IO (IO ())
+makeDebouncer action = do
   flag <- newEmptyMVar
-  void $ forkIO $ forever $ do
-    takeMVar flag
-    act
-  pure (void $ tryPutMVar flag ())
+
+  let worker = forever $ do
+        takeMVar flag
+        action
+
+  let trigger = void $ tryPutMVar flag ()
+
+  void $ forkIO worker
+  pure trigger
 
 initWithPool :: SQL.Pool -> AppConfig -> Logger.LoggerState -> Metrics.MetricsState -> ObservationHandler -> IO AppState
 initWithPool pool conf loggerState metricsState observer = mdo
@@ -133,7 +139,7 @@ initWithPool pool conf loggerState metricsState observer = mdo
     <*> newIORef Nothing
     <*> newSchemaCacheStatus
     <*> newIORef False
-    <*> simpleDebounce (retryingSchemaCacheLoad appState *> threadDelay 100000)  -- 100ms cooldown
+    <*> makeDebouncer (retryingSchemaCacheLoad appState *> threadDelay 100000)  -- 100ms cooldown
     <*> newIORef conf
     <*> mkAutoUpdate defaultUpdateSettings { updateAction = getCurrentTime }
     <*> myThreadId


### PR DESCRIPTION
**DISCLAIMER:**
`This commit was authored entirely by a human without the assistance of LLMs.`

Using debouncer to trigger schema cache loading makes it difficult to understand when exactly it is triggered.

This change is supposed to make this logic explicit. The idea is to heave a single thread waiting on an MVar and executing schema reload once the MVar is set. To trigger reload tryPutMvar is used.

There are also some issues with the way how `MVar`s are used in `Control.Debounce`. See eg. https://github.com/yesodweb/wai/issues/1027