### PR TITLE
fix: don't hide async exceptions in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file. From versio
 
 ### Fixed
 
+- Don't hide async exceptions in logs by @stevechavez in #4646
+
 ### Changed
 
 - Log error when `db-schemas` config contains schema `pg_catalog` or `information_schema` by @taimoorzaeem in #4359

--- a/src/PostgREST/Observation.hs
+++ b/src/PostgREST/Observation.hs
@@ -65,6 +65,7 @@ data Observation
   | PoolRequestFullfilled
   | JwtCacheLookup Bool
   | JwtCacheEviction
+  | WarpErrorObs Text
 
 data ObsFatalError = ServerAuthError | ServerPgrstBug | ServerError42P05 | ServerError08P01
 
@@ -161,6 +162,8 @@ observationMessage = \case
     "Looked up a JWT in JWT cache"
   JwtCacheEviction ->
     "Evicted entry from JWT cache"
+  WarpErrorObs txt ->
+    "Warp server error: " <> txt
   where
     showMillis :: Double -> Text
     showMillis x = toS $ showFFloat (Just 1) x ""


### PR DESCRIPTION
Fixes #4646. Using the repro on #4646, this now produces the log:

```
11/Feb/2026:09:40:08 -0500: Warp server error: stack overflow
```

When:
```
$ curl localhost:3000/
curl: (52) Empty reply from server
```

### TODO

- [x] Filtering exceptions, some that are safely ignorable and others that could potentially cause flooding.
- [x] Tests

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `add`, Add a new feature
  + `amend`, To amend an unrealease commit
  + `change`, Breaking changes
  + `chore`, Maintenance, update sponsors, changelog, readme etc
  + `ci`, CI configuration files and scripts
  + `docs`, Documentation
  + `fix`, Bug fix
  + `nix`, Related to Nix
  + `perf`, Performance improvements
  + `refactor`, Refactoring code
  + `remove`, Remove a feature or fix
  + `test`, Adding tests
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
