### PR TITLE
docs(install): update postgresql minimum supported version

### DIFF
--- a/docs/explanations/install.rst
+++ b/docs/explanations/install.rst
@@ -16,7 +16,7 @@ Supported PostgreSQL versions
 =============================
 
 =============== =================================
-**Supported**   PostgreSQL >= 12
+**Supported**   PostgreSQL >= 13
 =============== =================================
 
 PostgREST works with all PostgreSQL versions still `officially supported <https://www.postgresql.org/support/versioning/>`_.


### PR DESCRIPTION
PostgREST dropped support for PostgreSQL version 12 however, it was not reflected in the docs.