### PR TITLE
test(io): increase statement_timeout value of anonymous role

### DIFF
--- a/test/io/fixtures/roles.sql
+++ b/test/io/fixtures/roles.sql
@@ -21,5 +21,5 @@ ALTER ROLE postgrest_test_repeatable_read SET default_transaction_isolation = 'R
 ALTER ROLE postgrest_test_w_superuser_settings SET log_min_duration_statement = 1;
 ALTER ROLE postgrest_test_w_superuser_settings SET log_min_messages = 'fatal';
 
-ALTER ROLE postgrest_test_anonymous SET statement_timeout TO '2s';
+ALTER ROLE postgrest_test_anonymous SET statement_timeout TO '5s';
 ALTER ROLE postgrest_test_author SET statement_timeout TO '10s';

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -920,11 +920,11 @@ def test_role_settings(defaultenv):
     with run(env=env) as postgrest:
         # statement_timeout for postgrest_test_anonymous
         response = postgrest.session.get("/rpc/get_guc_value?name=statement_timeout")
-        assert response.text == '"2s"'
+        assert response.text == '"5s"'
 
         # reload statement_timeout with NOTIFY
         response = postgrest.session.post(
-            "/rpc/change_role_statement_timeout", data={"timeout": "5s"}
+            "/rpc/change_role_statement_timeout", data={"timeout": "8s"}
         )
         assert response.text == ""
         assert response.status_code == 204
@@ -935,7 +935,7 @@ def test_role_settings(defaultenv):
         sleep_until_postgrest_config_reload()
 
         response = postgrest.session.get("/rpc/get_guc_value?name=statement_timeout")
-        assert response.text == '"5s"'
+        assert response.text == '"8s"'
 
         # statement_timeout for postgrest_test_author
         headers = jwtauthheader({"role": "postgrest_test_author"}, SECRET)


### PR DESCRIPTION
It is too low which leaves a small window of values to use when testing other features like #4584.