### PR TITLE
add(metrics): expose db pool flushes counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file. From versio
 - Log host, port and pg version of listener database connection by @mkleczek in #4617 #4618
 - Optimize requests with `Prefer: count=exact` that do not use ranges or `db-max-rows` by @laurenceisla in #3957
   + Removed unnecessary double count when building the `Content-Range`.
+- Expose db pool flushes counter by @mkleczek in #4658
 
 ### Changed
 

--- a/docs/references/observability.rst
+++ b/docs/references/observability.rst
@@ -177,6 +177,16 @@ pgrst_db_pool_timeouts_total
 
 The total number of pool connection timeouts.
 
+pgrst_db_pool_flushes_total
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+======== =======
+**Type** Counter
+======== =======
+
+The total number of times the pool was flushed.
+The pool is flushed after successful schema cache reload.
+
 pgrst_db_pool_available
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -219,6 +219,7 @@ test-suite spec
                       Feature.ConcurrentSpec
                       Feature.CorsSpec
                       Feature.ExtraSearchPathSpec
+                      Feature.MetricsSpec
                       Feature.NoSuperuserSpec
                       Feature.ObservabilitySpec
                       Feature.OpenApi.DisabledOpenApiSpec

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -270,10 +270,14 @@ usePool AppState{stateObserver=observer, stateMainThreadId=mainThreadId, ..} ses
 
 -- | Flush the connection pool so that any future use of the pool will
 -- use connections freshly established after this call.
+-- | Emits PoolFlushed observation
 flushPool :: AppState -> IO ()
-flushPool AppState{..} = SQL.release statePool
+flushPool AppState{..} = do
+  SQL.release statePool
+  stateObserver PoolFlushed
 
 -- | Destroy the pool on shutdown.
+-- | Differs from flushPool in not emiting PoolFlushed observation.
 destroyPool :: AppState -> IO ()
 destroyPool AppState{..} = SQL.release statePool
 

--- a/src/PostgREST/Logger.hs
+++ b/src/PostgREST/Logger.hs
@@ -102,6 +102,9 @@ observationLogger loggerState logLevel obs = case obs of
   o@PoolRequestFullfilled ->
     when (logLevel >= LogDebug) $ do
       logWithZTime loggerState $ observationMessage o
+  o@PoolFlushed ->
+    when (logLevel >= LogDebug) $ do
+      logWithZTime loggerState $ observationMessage o
   o@JwtCacheEviction ->
     when (logLevel >= LogDebug) $ do
       logWithZTime loggerState $ observationMessage o

--- a/src/PostgREST/Observation.hs
+++ b/src/PostgREST/Observation.hs
@@ -63,6 +63,7 @@ data Observation
   | HasqlPoolObs SQL.Observation
   | PoolRequest
   | PoolRequestFullfilled
+  | PoolFlushed
   | JwtCacheLookup Bool
   | JwtCacheEviction
   | WarpErrorObs Text
@@ -157,6 +158,8 @@ observationMessage = \case
     "Trying to borrow a connection from pool"
   PoolRequestFullfilled ->
     "Borrowed a connection from the pool"
+  PoolFlushed ->
+    "Database connection pool flushed"
   JwtCacheLookup _ ->
     "Looked up a JWT in JWT cache"
   JwtCacheEviction ->

--- a/test/spec/Feature/MetricsSpec.hs
+++ b/test/spec/Feature/MetricsSpec.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE TypeApplications #-}
+module Feature.MetricsSpec
+
+where
+
+import Network.Wai (Application)
+
+import qualified PostgREST.AppState    as AppState
+import           PostgREST.Metrics     (MetricsState (..))
+import           PostgREST.Observation
+import           Protolude
+import           SpecHelper
+import           System.Timeout        (timeout)
+import           Test.Hspec            (SpecWith, describe,
+                                        expectationFailure, it)
+import           Test.Hspec.Wai        (getState)
+
+untilM :: Int -> (a -> Bool) -> IO a -> IO (Maybe a)
+untilM t cond act = timeout t $ fix $
+  \loop -> do
+    value <- act
+    if cond value then
+      pure value
+    else
+      loop
+
+waitForSchemaReload :: Int -> IO Observation -> IO (Maybe Observation)
+waitForSchemaReload t = untilM t $ \case
+  SchemaCacheLoadedObs _ -> True
+  _ -> False
+
+spec :: SpecWith ((MetricsState, AppState.AppState, IO Observation), Application)
+spec = describe "Server started with metrics enabled" $
+  it "Should increase pool flushes metric when schema cache is reloaded" $ do
+    (metrics, appState, readObs) <- getState
+
+    checkState' metrics
+
+      [
+        expectCounter @"poolFlushes" (+1)
+      ] $
+
+      liftIO $ do
+        AppState.schemaCacheLoader appState
+        waitForSchemaReload 1000000 readObs >>=
+          maybe (expectationFailure "Timeout waiting for schema reloading") mempty


### PR DESCRIPTION
Emit a dedicated PoolFlushed observation when the DB pool is released during schema cache reload and expose it as `pgrst_db_pool_flushes_total`.

Stacked on top of https://github.com/PostgREST/postgrest/pull/4659 to make tests more readable