### PR TITLE
test(io): reset statement_timeout of anon role to correct value

### DIFF
--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -946,7 +946,7 @@ def test_role_settings(defaultenv):
 
         # reset statement timeout to original value
         response = postgrest.session.post(
-            "/rpc/change_role_statement_timeout", data={"timeout": "2s"}
+            "/rpc/change_role_statement_timeout", data={"timeout": "5s"}
         )
         assert response.status_code == 204
 
@@ -1428,7 +1428,7 @@ def test_first_hoisted_setting_is_applied(defaultenv):
             "/rpc/rpc_with_one_hoisted?select=get_work_mem,get_statement_timeout"
         )
 
-        assert response.text == '{"get_work_mem":"3000kB","get_statement_timeout":"2s"}'
+        assert response.text == '{"get_work_mem":"3000kB","get_statement_timeout":"5s"}'
 
 
 def test_second_hoisted_setting_is_applied(defaultenv):


### PR DESCRIPTION
Forgot to reset the value after changing it in bfb4f900e7cbeb129a99ddfba38d620258d81cda. My bad :crying_cat_face:.