### PR TITLE
docs: add client error verbosity section to errors page

### DIFF
--- a/docs/references/configuration.rst
+++ b/docs/references/configuration.rst
@@ -208,35 +208,15 @@ client-error-verbosity
   **In-Database** pgrst.client_error_verbosity
   =============== =======================
 
-  Specifies the verbosity of PostgREST errors.
-
-  With ``verbose``, ``code``, ``message``, ``details`` and ``hint`` are returned.
+  Specifies the verbosity of PostgREST errors. See :ref:`client_error_verbosity`.
 
   .. code:: bash
 
-    curl "localhost:3000/itemsxx"
+    # Return error "code", "message", "details" and "hint"
+    client-error-verbosity = "verbose"
 
-  .. code-block:: json
-
-    {
-        "code": "PGRST205",
-        "message": "Could not find the table 'public.itemsxx' in the schema cache",
-        "details": "Perhaps you meant the table 'public.items'",
-        "hint": null
-    }
-
-  With ``minimal``, just ``code`` and ``message`` are returned.
-
-  .. code:: bash
-
-    curl "localhost:3000/itemsxx"
-
-  .. code-block:: json
-
-    {
-        "code": "PGRST205",
-        "message": "Could not find the table 'public.itemsxx' in the schema cache"
-    }
+    # Return only "code" and "message"
+    client-error-verbosity = "minimal"
 
   .. note::
 

--- a/docs/references/errors.rst
+++ b/docs/references/errors.rst
@@ -473,3 +473,38 @@ For example, doing a request on a table with high count (say 30_000_000), we get
   Proxy-Status: PostgREST; error=57014
 
 The PostgreSQL error code ``57014`` (`ref <https://www.postgresql.org/docs/current/errcodes-appendix.html>`_) reveals that the error is due to a short ``statement_timeout`` value.
+
+.. _client_error_verbosity:
+
+Client Error Verbosity
+======================
+
+For HTTP clients, the error verbosity can be set via :ref:`client-error-verbosity` config.
+
+With ``verbose``, it returns ``code``, ``message``, ``details`` and ``hint``.
+
+.. code:: bash
+
+  curl "localhost:3000/itemsxx"
+
+.. code-block:: json
+
+  {
+      "code": "PGRST205",
+      "message": "Could not find the table 'public.itemsxx' in the schema cache",
+      "details": "Perhaps you meant the table 'public.items'",
+      "hint": null
+  }
+
+With ``minimal``, just ``code`` and ``message`` is returned.
+
+.. code:: bash
+
+  curl "localhost:3000/itemsxx"
+
+.. code-block:: json
+
+  {
+      "code": "PGRST205",
+      "message": "Could not find the table 'public.itemsxx' in the schema cache"
+  }


### PR DESCRIPTION
Add a new section "Client Error Verbosity". Move the details from the config page to this section and link it.

As discussed in https://github.com/PostgREST/postgrest/pull/4667#issuecomment-3969403600.