### PR TITLE
refactor: get rid of redundant SchemaCacheSummaryObs

### DIFF
--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -416,8 +416,7 @@ retryingSchemaCacheLoad appState@AppState{stateObserver=observer, stateMainThrea
           putSCacheStatus appState SCPending
           putSchemaCache appState $ Just sCache
           observer $ SchemaCacheQueriedObs resultTime
-          (t, _) <- timeItT $ observer $ SchemaCacheSummaryObs $ showSummary sCache
-          observer $ SchemaCacheLoadedObs t
+          observer . uncurry SchemaCacheLoadedObs =<< timeItT (evaluate $ showSummary sCache)
           putSCacheStatus appState SCLoaded
           return $ Just sCache
 

--- a/src/PostgREST/Metrics.hs
+++ b/src/PostgREST/Metrics.hs
@@ -64,7 +64,7 @@ observationMetrics MetricsState{..} obs = case obs of
     incGauge poolWaiting
   PoolRequestFullfilled ->
     decGauge poolWaiting
-  SchemaCacheLoadedObs resTime -> do
+  SchemaCacheLoadedObs resTime _ -> do
     withLabel schemaCacheLoads "SUCCESS" incCounter
     setGauge schemaCacheQueryTime resTime
   SchemaCacheErrorObs{} -> do

--- a/src/PostgREST/Observation.hs
+++ b/src/PostgREST/Observation.hs
@@ -31,8 +31,7 @@ data Observation
   | SchemaCacheEmptyObs
   | SchemaCacheErrorObs (NonEmpty Text) [Text] SQL.UsageError
   | SchemaCacheQueriedObs Double
-  | SchemaCacheSummaryObs Text
-  | SchemaCacheLoadedObs Double
+  | SchemaCacheLoadedObs Double Text
   | ConnectionRetryObs Int
   | DBListenStart (Maybe ByteString) (Maybe ByteString) Text Text -- host, port, version string, channel
   | DBListenFail Text (Either SQL.ConnectionError SomeException)

--- a/test/io/test_big_schema.py
+++ b/test/io/test_big_schema.py
@@ -34,7 +34,9 @@ def test_schema_cache_load_max_duration(defaultenv):
         assert match, f"unexpected log format: {schema_cache_lines[-1]}"
         duration_ms = float(match.group(1))
 
-        assert duration_ms < max_duration
+        # check that loading takes long enough
+        # to make sure we measure the time correctly
+        assert 100 < duration_ms < max_duration
 
 
 # TODO: This test fails now because of https://github.com/PostgREST/postgrest/pull/2122


### PR DESCRIPTION
There is unnecessary coupling between observation messages and emited log entries. This causes schema loading logic to emit redundant events: SchemaCacheSummaryObs and SchemaCacheLoadedObs.

Logically - we want to emit a single event containing both summary and timing information. How it is logged is a different matter and should be decoupled.
    
This commit
* changes observationMessage function returning Text to observationMessages returning [Text] so that it is possible to return multiple (or zero) messages to log based on an observation event
* Removes SchemaCacheSummaryObs constructor from Observation type and adds summary text to SchemaCacheLoadedObs

Stacked on top of #4677 