### PR TITLE
nix (add): a proper devShell in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,5 +46,52 @@
           meta.description = "REST API for any Postgres database";
         };
       });
+
+      devShells = genSystems (attrs:
+        let
+          inherit (attrs) pkgs;
+          inherit (pkgs) lib;
+          toolboxes = [
+            attrs.cabalTools
+            attrs.devTools
+            attrs.docs
+            attrs.gitTools
+            attrs.loadtest
+            attrs.nixpkgsTools
+            attrs.release
+            attrs.style
+            attrs.tests
+            attrs.withTools
+          ];
+        in
+        {
+          default = lib.overrideDerivation attrs.env (base: {
+            buildInputs =
+              base.buildInputs ++ [
+                pkgs.cabal-install
+                pkgs.cabal2nix
+                pkgs.git
+                pkgs.postgresql
+                pkgs.update-nix-fetchgit
+                attrs.hsie.bin
+              ]
+              ++ toolboxes;
+
+            shellHook =
+              ''
+                export HISTFILE=.history
+
+                source ${pkgs.bash-completion}/etc/profile.d/bash_completion.sh
+                source ${pkgs.git}/share/git/contrib/completion/git-completion.bash
+                source ${attrs.hsie.bash-completion}
+
+              ''
+              + builtins.concatStringsSep "\n" (
+                builtins.map (bash-completion: "source ${bash-completion}") (
+                  builtins.concatLists (builtins.map (toolbox: toolbox.bash-completion) toolboxes)
+                )
+              );
+          });
+        });
     };
 }


### PR DESCRIPTION
makes `nix develop` experience match `nix-shell`, so we'll have all the nice `postgrest-*` scripts in `nix develop` shell

Works so far, but I'm not a real Nix whisperer, so the feedback is more than welcome.

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `add`, Add a new feature
  + `amend`, To amend an unrealease commit
  + `change`, Breaking changes
  + `chore`, Maintenance, update sponsors, changelog, readme etc
  + `ci`, CI configuration files and scripts
  + `docs`, Documentation
  + `fix`, Bug fix
  + `nix`, Related to Nix
  + `perf`, Performance improvements
  + `refactor`, Refactoring code
  + `remove`, Remove a feature or fix
  + `test`, Adding tests
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
