### PR TITLE
nix(flake): add devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,5 +46,9 @@
           meta.description = "REST API for any Postgres database";
         };
       });
+
+      devShells = genSystems (postgrest: {
+        default = import ./shell.nix { inherit postgrest; };
+      });
     };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -7,11 +7,9 @@
 # We highly recommend that use the PostgREST binary cache by installing cachix
 # (https://app.cachix.org/) and running `cachix use postgrest`.
 { docker ? false
+, postgrest ? import ./default.nix { }
 }:
 let
-  postgrest =
-    import ./default.nix { };
-
   inherit (postgrest) pkgs;
 
   inherit (pkgs) lib;


### PR DESCRIPTION
Adds a devShell to the flake for use with `nix develop`.

Supersedes #4706.
