### PR TITLE
refactor: move role insertion in claims to PreQuery.hs

### DIFF
--- a/src/PostgREST/Auth/Jwt.hs
+++ b/src/PostgREST/Auth/Jwt.hs
@@ -16,7 +16,6 @@ module PostgREST.Auth.Jwt
   , parseClaims) where
 
 import qualified Data.Aeson                 as JSON
-import qualified Data.Aeson.KeyMap          as KM
 import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Internal   as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS
@@ -118,7 +117,7 @@ parseClaims cfg@AppConfig{configJwtRoleClaimKey, configDbAnonRole} time mclaims 
   role <- liftEither . maybeToRight (JwtErr JwtTokenRequired) $
     unquoted <$> walkJSPath (Just $ JSON.Object mclaims) configJwtRoleClaimKey <|> configDbAnonRole
   pure AuthResult
-           { authClaims = mclaims & KM.insert "role" (JSON.toJSON $ decodeUtf8 role)
+           { authClaims = mclaims
            , authRole = role
            }
   where

--- a/src/PostgREST/Auth/Types.hs
+++ b/src/PostgREST/Auth/Types.hs
@@ -6,7 +6,9 @@ import qualified Data.Aeson        as JSON
 import qualified Data.Aeson.KeyMap as KM
 import qualified Data.ByteString   as BS
 
--- | Parse result for JWT Claims
+-- |
+-- Parse and store result for JWT Claims. Can be accessed in
+-- db through GUCs (for RLS etc)
 data AuthResult = AuthResult
   { authClaims :: KM.KeyMap JSON.Value
   , authRole   :: BS.ByteString

--- a/src/PostgREST/Query/PreQuery.hs
+++ b/src/PostgREST/Query/PreQuery.hs
@@ -10,6 +10,7 @@ module PostgREST.Query.PreQuery
   ) where
 
 import qualified Data.Aeson                      as JSON
+import qualified Data.Aeson.KeyMap               as KM
 import qualified Data.ByteString.Lazy.Char8      as LBS
 import qualified Data.HashMap.Strict             as HM
 import qualified Hasql.DynamicStatements.Snippet as SQL hiding (sql)
@@ -46,7 +47,10 @@ txVarQuery dbActPlan AppConfig{..} AuthResult{..} ApiRequest{..} =
     pathSql = setConfigWithConstantName ("request.path", iPath)
     headersSql = setConfigWithConstantNameJSON "request.headers" iHeaders
     cookiesSql = setConfigWithConstantNameJSON "request.cookies" iCookies
-    claimsSql = [setConfigWithConstantName ("request.jwt.claims", LBS.toStrict $ JSON.encode authClaims)]
+    claimsSql = [setConfigWithConstantName ("request.jwt.claims", LBS.toStrict $ JSON.encode claims)]
+      where
+        claims = authClaims & KM.insert "role" (JSON.String $ decodeUtf8 authRole) -- insert "role" to claims as well
+
     roleSql = [setConfigWithConstantName ("role", authRole)]
     roleSettingsSql = setConfigWithDynamicName <$> HM.toList (fromMaybe mempty $ HM.lookup authRole configRoleSettings)
     appSettingsSql = setConfigWithDynamicName . join bimap toUtf8 <$> configAppSettings


### PR DESCRIPTION
Also add a comment on `AuthResult` type to explain that
we can also access the claims in the db using GUCs.