### PR TITLE
refactor(auth): use wildcard type constructor import

### DIFF
--- a/src/PostgREST/Auth/Jwt.hs
+++ b/src/PostgREST/Auth/Jwt.hs
@@ -32,8 +32,7 @@ import Data.Time.Clock.POSIX   (utcTimeToPOSIXSeconds)
 import PostgREST.Auth.Types    (AuthResult (..))
 import PostgREST.Config        (AppConfig (..), audMatchesCfg)
 import PostgREST.Config.JSPath (walkJSPath)
-import PostgREST.Error         (Error (..),
-                                JwtClaimsError (AudClaimNotStringOrArray, ExpClaimNotNumber, IatClaimNotNumber, JWTExpired, JWTIssuedAtFuture, JWTNotInAudience, JWTNotYetValid, NbfClaimNotNumber, ParsingClaimsFailed),
+import PostgREST.Error         (Error (..), JwtClaimsError (..),
                                 JwtDecodeError (..), JwtError (..))
 
 import Data.Aeson       ((.:?))


### PR DESCRIPTION
Use wildcard import instead of explicitly importing all type constructors. Not a huge deal I think, just confusing to look at.

**Note:** I looked at ways to prevent this with `hlint`, it doesn't support it yet.