### PR TITLE
ci: build with GHC 9.10.3 (cabal & stack)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -171,7 +171,7 @@ jobs:
   cabal:
     strategy:
       matrix:
-        ghc: ['9.6.7', '9.8.4']
+        ghc: ['9.6.7', '9.8.4', '9.10.3']
       fail-fast: false
     name: Cabal - Linux x86-64 - GHC ${{ matrix.ghc }}
     runs-on: ubuntu-24.04

--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -1,1 +1,1 @@
-index-state: hackage.haskell.org 2025-10-29T04:02:18Z
+index-state: hackage.haskell.org 2026-04-18T18:42:36Z

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -21,8 +21,9 @@ tested-with:
     -- cabal on Ubuntu
   , GHC == 9.6.7
     -- cabal on Ubuntu
-    -- stack on FreeBSD, MacOS, Ubuntu, Windows
   , GHC == 9.8.4
+    -- stack on FreeBSD, MacOS, Ubuntu, Windows
+  , GHC == 9.10.3
 
 source-repository head
   type:     git
@@ -99,9 +100,9 @@ library
                       PostgREST.Response.Performance
                       PostgREST.TimeIt
                       PostgREST.Version
-  build-depends:      base                      >= 4.9 && < 4.20
+  build-depends:      base                      >= 4.9 && < 4.21
                     , HTTP                      >= 4000.3.7 && < 4000.5
-                    , Ranged-sets               >= 0.3 && < 0.5
+                    , Ranged-sets               >= 0.3 && < 0.6
                     , aeson                     >= 2.0.3 && < 2.3
                     , auto-update               >= 0.1.4 && < 0.3
                     , base64-bytestring         >= 1 && < 1.3
@@ -109,7 +110,7 @@ library
                     , case-insensitive          >= 1.2 && < 1.3
                     , cassava                   >= 0.4.5 && < 0.6
                     , configurator-pg           >= 0.2.11 && < 0.3
-                    , containers                >= 0.5.7 && < 0.7
+                    , containers                >= 0.5.7 && < 0.8
                     , cookie                    >= 0.4.2 && < 0.6
                     , directory                 >= 1.2.6 && < 1.4
                     , either                    >= 4.4.1 && < 5.1
@@ -185,8 +186,8 @@ executable postgrest
                       NoImplicitPrelude
   hs-source-dirs:     main
   main-is:            Main.hs
-  build-depends:      base                >= 4.9 && < 4.20
-                    , containers          >= 0.5.7 && < 0.7
+  build-depends:      base                >= 4.9 && < 4.21
+                    , containers          >= 0.5.7 && < 0.8
                     , postgrest
                     , protolude           >= 0.3.1 && < 0.4
   ghc-options:        -threaded -rtsopts "-with-rtsopts=-N -I0 -qg"
@@ -261,14 +262,14 @@ test-suite spec
                       Feature.RollbackSpec
                       Feature.RpcPreRequestGucsSpec
                       SpecHelper
-  build-depends:      base              >= 4.9 && < 4.20
+  build-depends:      base              >= 4.9 && < 4.21
                     , aeson             >= 2.0.3 && < 2.3
                     , aeson-qq          >= 0.8.1 && < 0.9
                     , async             >= 2.1.1 && < 2.3
                     , base64-bytestring >= 1 && < 1.3
                     , bytestring        >= 0.10.8 && < 0.13
                     , case-insensitive  >= 1.2 && < 1.3
-                    , containers        >= 0.5.7 && < 0.7
+                    , containers        >= 0.5.7 && < 0.8
                     , hasql-pool        >= 1.0.1 && < 1.1
                     , hasql-transaction >= 1.0.1 && < 1.2
                     , heredoc           >= 0.2 && < 0.3
@@ -310,7 +311,7 @@ test-suite observability
                       Observation.JwtCache
                       Observation.MetricsSpec
                       Observation.SchemaCacheSpec
-  build-depends:      base              >= 4.9 && < 4.20
+  build-depends:      base              >= 4.9 && < 4.21
                     , base64-bytestring >= 1 && < 1.3
                     , bytestring        >= 0.10.8 && < 0.13
                     , hasql-pool        >= 1.0.1 && < 1.1
@@ -339,7 +340,7 @@ test-suite doctests
                       NoImplicitPrelude
   hs-source-dirs:     test/doc
   main-is:            Main.hs
-  build-depends:      base              >= 4.9 && < 4.20
+  build-depends:      base              >= 4.9 && < 4.21
                     , doctest           >= 0.8
                     , postgrest
                     , pretty-simple

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -22,6 +22,7 @@ tested-with:
   , GHC == 9.6.7
     -- cabal on Ubuntu
   , GHC == 9.8.4
+    -- cabal on Ubuntu
     -- stack on FreeBSD, MacOS, Ubuntu, Windows
   , GHC == 9.10.3
 
@@ -112,6 +113,9 @@ library
                     , configurator-pg           >= 0.2.11 && < 0.3
                     , containers                >= 0.5.7 && < 0.8
                     , cookie                    >= 0.4.2 && < 0.6
+                    -- crypton 1.1.0 moved from `memory` to `ram`, which jose-jwt fails to build with right now.
+                    -- should be possible to remove this once jose-jwt had a new release.
+                    , crypton                   < 1.1.0
                     , directory                 >= 1.2.6 && < 1.4
                     , either                    >= 4.4.1 && < 5.1
                     , extra                     >= 1.7.0 && < 2.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-23.28 # 2025-08-17, GHC 9.8.4
+resolver: lts-24.37 # 2026-04-15, GHC 9.10.3
 
 nix:
   packages:
@@ -18,9 +18,8 @@ extra-deps:
   - hasql-pool-1.0.1
   - hasql-transaction-1.1.0.1
   - postgresql-binary-0.13.1.3
-  - streaming-commons-0.2.3.1
-  # fix build with GCC 15-ish; https://github.com/gregorycollins/hashtables/issues/98 for details
-  - hashtables-1.4.2@sha256:4940cab94a15d469845ccf5225f9cb3d354c15e8127ebb58425c8b681f7721d9,10386
+  - text-builder-0.6.10
+  - text-builder-dev-0.3.10
 
 allow-newer: true
 allow-newer-deps:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -68,22 +68,22 @@ packages:
   original:
     hackage: postgresql-binary-0.13.1.3
 - completed:
-    hackage: streaming-commons-0.2.3.1@sha256:ed7999fea9e912b1211ea93d7e20a7998bf4753166370c94048885650f303bf0,4841
+    hackage: text-builder-0.6.10@sha256:24e403038fb6b885c8a0f310e782d40ca80eb1b5359b90fbe74db98b84e1094b,2348
     pantry-tree:
-      sha256: f08e83fb00fd45865fa8cfdef5ecef7161d5135257ee98050bfbe4b807ad65f8
-      size: 2374
+      sha256: 18cea18e1e6bfba7fe6ff36926bafa6963ef2ba3f20dcfe3f25e9afef5ca8bf8
+      size: 515
   original:
-    hackage: streaming-commons-0.2.3.1
+    hackage: text-builder-0.6.10
 - completed:
-    hackage: hashtables-1.4.2@sha256:4940cab94a15d469845ccf5225f9cb3d354c15e8127ebb58425c8b681f7721d9,10386
+    hackage: text-builder-dev-0.3.10@sha256:eb86d38ad19eb27ea5db1a9652330d6b0511bccc10a9fac43fedf8e65ba8b7f5,2973
     pantry-tree:
-      sha256: 65107f0c970351b971ea1f676a5e00b61e37c298a4c83c867d937f2a774501eb
-      size: 2895
+      sha256: 136ef4106267630f4b43d6b35076e15a16c6c8d1790fa45cca20a2def4d6b404
+      size: 736
   original:
-    hackage: hashtables-1.4.2@sha256:4940cab94a15d469845ccf5225f9cb3d354c15e8127ebb58425c8b681f7721d9,10386
+    hackage: text-builder-dev-0.3.10
 snapshots:
 - completed:
-    sha256: 7e724f347d5969cb5e8dde9f9aae30996e3231c29d1dafd45f21f1700d4c4fcb
-    size: 684460
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/28.yaml
-  original: lts-23.28
+    sha256: 655e468f774beee1badf07dc4c45fb50288d5c66ce7bef6f487b7f92891a90b0
+    size: 728965
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/24/37.yaml
+  original: lts-24.37


### PR DESCRIPTION
Not sure whether FreeBSD is happily providing GHC 9.10.3, yet.

Edit: Seems like FreeBSD does indeed have that GHC version. Still need to fix regular Cabal builds, though.