### PR TITLE
remove: drop support for PostgreSQL 13

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,6 +1,0 @@
-# TODO: Remove this once a new actionlint release has been cut
-# and made its way to us through nixpkgs.
-self-hosted-runner:
-  labels:
-    - macos-15-intel
-    - ubuntu-24.04-arm

--- a/.github/actions/cache-on-main/action.yaml
+++ b/.github/actions/cache-on-main/action.yaml
@@ -8,7 +8,6 @@ inputs:
     required: true
   save-prs:
     description: Whether to additionally store the cache in a pull request, too. Should only be used for very small caches.
-    type: boolean
   prefix:
     description: Cache key prefix to be used in both primary key and restore-keys.
     required: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pgVersion: [13, 14, 15, 16, 17]
+        pgVersion: [14, 15, 16, 17]
     name: PG ${{ matrix.pgVersion }}
     runs-on: ubuntu-24.04
     defaults:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pgVersion: [14, 15, 16, 17]
+        pgVersion: [14, 15, 16, 17, 18]
     name: PG ${{ matrix.pgVersion }}
     runs-on: ubuntu-24.04
     defaults:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file. From versio
 
 ### Changed
 
+- Drop support for PostgreSQL EOL version 13 by @wolfgangwalther in #4193
 - All responses now include a `Vary` header by @develop7 in #4609
 - Log error when `db-schemas` config contains schema `pg_catalog` or `information_schema` by @taimoorzaeem in #4359
   + Now fails at startup. Prior to this, it failed with `PGRST205` on requests related to these schemas.

--- a/default.nix
+++ b/default.nix
@@ -56,7 +56,6 @@ let
       { name = "pg-16"; postgresql = pkgs.postgresql_16.withPackages (p: [ p.postgis p.pg_safeupdate ]); }
       { name = "pg-15"; postgresql = pkgs.postgresql_15.withPackages (p: [ p.postgis p.pg_safeupdate ]); }
       { name = "pg-14"; postgresql = pkgs.postgresql_14.withPackages (p: [ p.postgis p.pg_safeupdate ]); }
-      { name = "pg-13"; postgresql = pkgs.postgresql_13.withPackages (p: [ p.postgis p.pg_safeupdate ]); }
     ];
 
   haskellPackages = pkgs.haskell.packages."${compiler}";

--- a/default.nix
+++ b/default.nix
@@ -52,6 +52,7 @@ let
 
   postgresqlVersions =
     [
+      { name = "pg-18"; postgresql = pkgs.postgresql_18.withPackages (p: [ p.postgis p.pg_safeupdate ]); }
       { name = "pg-17"; postgresql = pkgs.postgresql_17.withPackages (p: [ p.postgis p.pg_safeupdate ]); }
       { name = "pg-16"; postgresql = pkgs.postgresql_16.withPackages (p: [ p.postgis p.pg_safeupdate ]); }
       { name = "pg-15"; postgresql = pkgs.postgresql_15.withPackages (p: [ p.postgis p.pg_safeupdate ]); }

--- a/docs/explanations/install.rst
+++ b/docs/explanations/install.rst
@@ -16,7 +16,7 @@ Supported PostgreSQL versions
 =============================
 
 =============== =================================
-**Supported**   PostgreSQL >= 13
+**Supported**   PostgreSQL >= 14
 =============== =================================
 
 PostgREST works with all PostgreSQL versions still `officially supported <https://www.postgresql.org/support/versioning/>`_.

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752006229,
-        "narHash": "sha256-BeuAPwNM2RBc5bvUTb0j4GRs2yBkDeRCw/8Y3v9Xesc=",
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c80edd02003fe3d8af527215a3ac069be9cfd47f",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-25.05-darwin",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "REST API for any Postgres database";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-25.05-darwin";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   };
 
   nixConfig = {

--- a/nix/README.md
+++ b/nix/README.md
@@ -95,9 +95,9 @@ postgrest-hsie-graph-modules      postgrest-with-pg-14
 postgrest-hsie-graph-symbols      postgrest-with-pg-15
 postgrest-hsie-minimal-imports    postgrest-with-pg-16
 postgrest-lint                    postgrest-with-pg-17
-postgrest-loadtest                postgrest-with-slow-pg
-postgrest-loadtest-against        postgrest-with-slow-postgrest
-postgrest-loadtest-report
+postgrest-loadtest                postgrest-with-pg-18
+postgrest-loadtest-against        postgrest-with-slow-pg
+postgrest-loadtest-report         postgrest-with-slow-postgrest
 postgrest-nixpkgs-upgrade
 ...
 

--- a/nix/README.md
+++ b/nix/README.md
@@ -91,13 +91,13 @@ postgrest-gen-ctags               postgrest-watch
 postgrest-gen-jwt                 postgrest-with-all
 postgrest-gen-secret              postgrest-with-git
 postgrest-git-hooks               postgrest-with-pgrst
-postgrest-hsie-graph-modules      postgrest-with-pg-13
-postgrest-hsie-graph-symbols      postgrest-with-pg-14
-postgrest-hsie-minimal-imports    postgrest-with-pg-15
-postgrest-lint                    postgrest-with-pg-16
-postgrest-loadtest                postgrest-with-pg-17
-postgrest-loadtest-against        postgrest-with-slow-pg
-postgrest-loadtest-report         postgrest-with-slow-postgrest
+postgrest-hsie-graph-modules      postgrest-with-pg-14
+postgrest-hsie-graph-symbols      postgrest-with-pg-15
+postgrest-hsie-minimal-imports    postgrest-with-pg-16
+postgrest-lint                    postgrest-with-pg-17
+postgrest-loadtest                postgrest-with-slow-pg
+postgrest-loadtest-against        postgrest-with-slow-postgrest
+postgrest-loadtest-report
 postgrest-nixpkgs-upgrade
 ...
 
@@ -174,7 +174,7 @@ $ nix-shell --run "postgrest-with-all postgrest-test-spec"
 
 # Run the tests against a specific version of PostgreSQL (use tab-completion in
 # nix-shell to see all available versions):
-$ nix-shell --run "postgrest-with-pg-13 postgrest-test-spec"
+$ nix-shell --run "postgrest-with-pg-17 postgrest-test-spec"
 
 ```
 

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -49,26 +49,6 @@ let
       # Before upgrading fuzzyset to 0.3, check: https://github.com/PostgREST/postgrest/issues/3329
       fuzzyset = prev.fuzzyset_0_2_4;
 
-      # TODO: Remove once available in nixpkgs haskellPackages
-      configurator-pg =
-        prev.callHackageDirect
-          {
-            pkg = "configurator-pg";
-            ver = "0.2.11";
-            sha256 = "sha256-mtGtNawDJgz2ZIEVca+IYXVu4oNw9xsfJiYWAqAbbgc=";
-          }
-          { };
-
-      # TODO: Remove once available in nixpkgs haskellPackages
-      streaming-commons =
-        prev.callHackageDirect
-          {
-            pkg = "streaming-commons";
-            ver = "0.2.3.1";
-            sha256 = "sha256-Gl2eaJcWe1sxmcE/octWlH9uSnERguf+5H66K4fV87s=";
-          }
-          { };
-
       # Downgrade hasql and related packages while we are still on GHC 9.4 for the static build.
       hasql = lib.dontCheck (lib.doJailbreak prev.hasql_1_6_4_4);
       hasql-dynamic-statements = lib.dontCheck prev.hasql-dynamic-statements_0_3_1_5;
@@ -77,6 +57,8 @@ let
       hasql-pool = lib.dontCheck prev.hasql-pool_1_0_1;
       hasql-transaction = lib.dontCheck prev.hasql-transaction_1_1_0_1;
       postgresql-binary = lib.dontCheck (lib.doJailbreak prev.postgresql-binary_0_13_1_3);
+      text-builder = prev.text-builder_0_6_10;
+      text-builder-dev = prev.text-builder-dev_0_3_10;
     };
 in
 {

--- a/nix/tools/devTools.nix
+++ b/nix/tools/devTools.nix
@@ -172,7 +172,7 @@ let
           # The following unsets all GIT_ variables.
           unset "''${!GIT_@}"
 
-          # shellcheck disable=SC2317
+          # shellcheck disable=SC2329
           function restore () {
             ref="$(git stash list --format=format:%gD --grep "$1" -n1)"
             # this will avoid merge conflicts when applying the stash

--- a/nix/tools/style.nix
+++ b/nix/tools/style.nix
@@ -83,7 +83,7 @@ let
         # ruff has gaps in scanning for unused code, so we use vulture
         echo "Scanning python files for unused code..."
         ${silver-searcher}/bin/ag -l --vimgrep -g '\.l?py$' . \
-          | xargs ${python3Packages.vulture}/bin/vulture --exclude docs/conf.py
+          | xargs ${python3Packages.vulture}/bin/vulture --exclude docs/conf.py --min-confidence 80
 
         echo "Linting python files..."
         ${ruff}/bin/ruff check .

--- a/nix/tools/tests.nix
+++ b/nix/tools/tests.nix
@@ -7,7 +7,6 @@
 , glibcLocales ? null
 , gnugrep
 , hpc-codecov
-, hostPlatform
 , jq
 , lib
 , postgrest
@@ -159,7 +158,7 @@ let
       }
       (
         # required for `hpc markup` in CI; glibcLocales is not available e.g. on Darwin
-        lib.optionalString (stdenv.isLinux && hostPlatform.libc == "glibc") ''
+        lib.optionalString (stdenv.isLinux && stdenv.hostPlatform.libc == "glibc") ''
           export LOCALE_ARCHIVE="${glibcLocales}/lib/locale/locale-archive"
         '' +
 

--- a/nix/tools/withTools.nix
+++ b/nix/tools/withTools.nix
@@ -116,7 +116,7 @@ let
             export PGRST_DB_URI="postgres:///$PGDATABASE?host=$PGREPLICAHOST,$PGHOST"
           fi
 
-          # shellcheck disable=SC2317
+          # shellcheck disable=SC2329
           stop () {
             log "Stopping the database cluster..."
             pg_ctl stop --mode=immediate >> "$setuplog"
@@ -329,7 +329,7 @@ let
 
         $PGRST_CMD ${legacyConfig} > "$tmpdir"/run.log 2>&1 &
         pid=$!
-        # shellcheck disable=SC2317
+        # shellcheck disable=SC2329
         cleanup() {
           # Send INT to all postgrest processes.
           # Workaround to trigger dumping postgrest.prof for postgrest-profiled-run

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -362,7 +362,7 @@ parser optPath env dbSettings roleSettings roleIsolationLvl =
           | otherwise -> pure $ fromList schemas
           where
             schemas = splitOnCommas s
-            errMsg x = ("db-schemas does not allow schema: '" <> x <> "'")
+            errMsg x = "db-schemas does not allow schema: '" <> x <> "'"
 
     parseSocketFileMode :: C.Key -> C.Parser C.Config FileMode
     parseSocketFileMode k =

--- a/src/PostgREST/Config/PgVersion.hs
+++ b/src/PostgREST/Config/PgVersion.hs
@@ -3,7 +3,6 @@
 module PostgREST.Config.PgVersion
   ( PgVersion(..)
   , minimumPgVersion
-  , pgVersion140
   , pgVersion150
   , pgVersion170
   ) where
@@ -25,10 +24,7 @@ instance Ord PgVersion where
 
 -- | Tells the minimum PostgreSQL version required by this version of PostgREST
 minimumPgVersion :: PgVersion
-minimumPgVersion = pgVersion130
-
-pgVersion130 :: PgVersion
-pgVersion130 = PgVersion 130000 "13.0" "13.0"
+minimumPgVersion = pgVersion140
 
 pgVersion140 :: PgVersion
 pgVersion140 = PgVersion 140000 "14.0" "14.0"

--- a/src/PostgREST/Config/PgVersion.hs
+++ b/src/PostgREST/Config/PgVersion.hs
@@ -5,6 +5,7 @@ module PostgREST.Config.PgVersion
   , minimumPgVersion
   , pgVersion150
   , pgVersion170
+  , pgVersion180
   ) where
 
 import qualified Data.Aeson as JSON
@@ -34,3 +35,6 @@ pgVersion150 = PgVersion 150000 "15.0" "15.0"
 
 pgVersion170 :: PgVersion
 pgVersion170 = PgVersion 170000 "17.0" "17.0"
+
+pgVersion180 :: PgVersion
+pgVersion180 = PgVersion 180000 "18.0" "18.0"

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,10 +3,9 @@ resolver: lts-24.37 # 2026-04-15, GHC 9.10.3
 nix:
   packages:
     - libpq
+    - libpq.pg_config
     - pkg-config
     - zlib
-  # disable pure by default so that the test environment can be passed
-  pure: false
 
 extra-deps:
   - configurator-pg-0.2.11

--- a/test/io/conftest.py
+++ b/test/io/conftest.py
@@ -87,7 +87,7 @@ def metapostgrest():
 
 
 class YamlSnapshotExtension(SingleFileSnapshotExtension):
-    _file_extension = "yaml"
+    file_extension = "yaml"
 
 
 @pytest.fixture

--- a/test/spec/Feature/Query/InsertSpec.hs
+++ b/test/spec/Feature/Query/InsertSpec.hs
@@ -11,13 +11,11 @@ import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 import Text.Heredoc
 
-import PostgREST.Config.PgVersion (PgVersion, pgVersion140)
-
 import Protolude  hiding (get)
 import SpecHelper
 
-spec :: PgVersion -> SpecWith ((), Application)
-spec actualPgVersion = do
+spec :: SpecWith ((), Application)
+spec = do
   describe "Posting new record" $ do
     context "disparate json types" $ do
       it "accepts disparate json types" $ do
@@ -554,19 +552,12 @@ spec actualPgVersion = do
                 {"a": "val", "b": "val"}
               ]|]
             `shouldRespondWith`
-              (if actualPgVersion < pgVersion140
-                then [json| {
-                  "code": "42601",
-                  "details": "Column \"b\" is a generated column.",
-                  "hint": null,
-                  "message": "cannot insert into column \"b\""
-                }|]
-                else [json| {
-                  "code": "428C9",
-                  "details": "Column \"b\" is a generated column.",
-                  "hint": null,
-                  "message": "cannot insert a non-DEFAULT value into column \"b\""
-                }|])
+              [json| {
+                "code": "428C9",
+                "details": "Column \"b\" is a generated column.",
+                "hint": null,
+                "message": "cannot insert a non-DEFAULT value into column \"b\""
+              }|]
               { matchStatus  = 400 }
 
         it "inserts a default on a DOMAIN with default" $

--- a/test/spec/Feature/Query/RpcSpec.hs
+++ b/test/spec/Feature/Query/RpcSpec.hs
@@ -11,11 +11,13 @@ import Test.Hspec.Wai
 import Test.Hspec.Wai.JSON
 import Text.Heredoc
 
+import PostgREST.Config.PgVersion (PgVersion, pgVersion180)
+
 import Protolude  hiding (get)
 import SpecHelper
 
-spec :: SpecWith ((), Application)
-spec =
+spec :: PgVersion -> SpecWith ((), Application)
+spec actualPgVersion =
   describe "remote procedure call" $ do
     context "a proc that returns a set" $ do
       context "returns paginated results" $ do
@@ -1445,10 +1447,13 @@ spec =
       let auth = authHeaderJWT "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoicG9zdGdyZXN0X3Rlc3Rfc3VwZXJ1c2VyIiwiaWQiOiJqZG9lIn0.LQ-qx0ArBnfkwQQhIHKF5cS-lzl0gnTPI8NLoPbL5Fg" in
       it "should return http status 500" $
         request methodGet "/rpc/temp_file_limit" [auth] "" `shouldRespondWith`
-          [json|{"code":"53400","message":"temporary file size exceeds temp_file_limit (1kB)","details":null,"hint":null}|]
+          (if actualPgVersion < pgVersion180 then
+            [json|{"code":"53400","message":"temporary file size exceeds temp_file_limit (1kB)","details":null,"hint":null}|]
+           else
+            [json|{"code":"53400","message":"temporary file size exceeds \"temp_file_limit\" (1kB)","details":null,"hint":null}|]
+          )
           { matchStatus = 500
-          , matchHeaders = [ "Content-Length" <:> "105"
-                           , matchContentTypeJson ]
+          , matchHeaders = [ matchContentTypeJson ]
           }
 
     context "test table valued function with filter" $ do

--- a/test/spec/Main.hs
+++ b/test/spec/Main.hs
@@ -150,7 +150,7 @@ main = do
         , ("Feature.Query.DeleteSpec"                    , Feature.Query.DeleteSpec.spec)
         , ("Feature.Query.EmbedDisambiguationSpec"       , Feature.Query.EmbedDisambiguationSpec.spec)
         , ("Feature.Query.EmbedInnerJoinSpec"            , Feature.Query.EmbedInnerJoinSpec.spec)
-        , ("Feature.Query.InsertSpec"                    , Feature.Query.InsertSpec.spec actualPgVersion)
+        , ("Feature.Query.InsertSpec"                    , Feature.Query.InsertSpec.spec)
         , ("Feature.Query.JsonOperatorSpec"              , Feature.Query.JsonOperatorSpec.spec)
         , ("Feature.Query.NullsStripSpec"                , Feature.Query.NullsStripSpec.spec)
         , ("Feature.Query.PgErrorCodeMappingSpec"        , Feature.Query.ErrorSpec.pgErrorCodeMapping)

--- a/test/spec/Main.hs
+++ b/test/spec/Main.hs
@@ -161,7 +161,7 @@ main = do
         , ("Feature.Query.QuerySpec"                     , Feature.Query.QuerySpec.spec)
         , ("Feature.Query.RawOutputTypesSpec"            , Feature.Query.RawOutputTypesSpec.spec)
         , ("Feature.Query.RelatedQueriesSpec"            , Feature.Query.RelatedQueriesSpec.spec)
-        , ("Feature.Query.RpcSpec"                       , Feature.Query.RpcSpec.spec)
+        , ("Feature.Query.RpcSpec"                       , Feature.Query.RpcSpec.spec actualPgVersion)
         , ("Feature.Query.SingularSpec"                  , Feature.Query.SingularSpec.spec)
         , ("Feature.Query.SpreadQueriesSpec"             , Feature.Query.SpreadQueriesSpec.spec)
         , ("Feature.Query.UpdateSpec"                    , Feature.Query.UpdateSpec.spec)


### PR DESCRIPTION
This updates the pin to the latest nixpkgs-unstable, which does not contain the EOL PostgreSQL 13 anymore, so we need to drop it. The new pin also contains PostgreSQL 18, ~~which will still need to be added to the dev tools and CI~~ - some tests need adjustments there.