### PR TITLE
test(doctests): remove redundant doctests in Error.hs

### DIFF
--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -299,9 +299,6 @@ instance ErrorBody SchemaCacheError where
 -- >>> noRelBetweenHint "films" "role" "api" rels
 -- Just "Perhaps you meant 'roles' instead of 'role'."
 --
--- >>> noRelBetweenHint "films" "role" "api" rels
--- Just "Perhaps you meant 'roles' instead of 'role'."
---
 -- >>> noRelBetweenHint "films" "actors" "api" rels
 -- Nothing
 --


### PR DESCRIPTION
The same test case is done just above it, so this can be removed.