### PR TITLE
test(load): update error loadtest endpoint to generate hint

### DIFF
--- a/test/load/errors.http
+++ b/test/load/errors.http
@@ -7,7 +7,7 @@ GET http://postgrest/actors?select=*,rolws(*,films(*))
 Prefer: tx=commit
 
 # Misspelled function names
-GET http://postgrest/rpc/call_em_x?name=John
+GET http://postgrest/rpc/call_me_x?name=John
 Prefer: tx=commit
 
 # Permission denied errors


### PR DESCRIPTION
This endpoint didn't generate error hint which is not desired for loadtest. Now it does. As discussed in https://github.com/PostgREST/postgrest/pull/4837#issuecomment-4306680562.

```
postgrest-with-pg-18 -f test/load/fixtures.sql postgrest-run
```

```
curl -i localhost:3000/rpc/call_me_x?name=John
```

```http
HTTP/1.1 404 Not Found
Date: Thu, 23 Apr 2026 18:22:20 GMT
Server: postgrest/15 (pre-release)
Content-Type: application/json; charset=utf-8
Content-Length: 282
Proxy-Status: PostgREST; error=PGRST202

{
  "code":"PGRST202",
  "details":"Searched for the function test.call_me_x with parameter name, but no matches were found in the schema cache.",
  "hint":"Perhaps you meant to call the function test.call_me",
  "message":"Could not find the function test.call_me_x(name) in the schema cache"
}
```