### PR TITLE
test(load): reduce num of tables in errors loadtest

### DIFF
--- a/test/load/errors.sql
+++ b/test/load/errors.sql
@@ -1,7 +1,7 @@
 \ir fixtures.sql
 
 SELECT format('CREATE TABLE test.actors_%s ();', n)
-FROM generate_series(1, 20000) n
+FROM generate_series(1, 450) n -- 500 is the upper limit for table not found error hint generation
 \gexec
 
 -- TODO add many function for fuzzy search (somehow this is making the loadtest start slow)


### PR DESCRIPTION
The table not found error only generates hint when the total number of tables in a schema are less than 500.

Similar to #4839, this also should be updated.

<pre>
postgrest-with-pg-18 -f <b>test/load/errors.sql</b> postgrest-run
</pre>

```
curl -i localhost:3000/actoxs?actor=eq.1
```

```http
HTTP/1.1 404 Not Found
Date: Sat, 25 Apr 2026 07:23:54 GMT
Server: postgrest/15 (pre-release)
Content-Type: application/json; charset=utf-8
Content-Length: 156
Proxy-Status: PostgREST; error=PGRST205

{
  "code":"PGRST205",
  "details":null,
  "hint":"Perhaps you meant the table 'test.actors'",
  "message":"Could not find the table 'test.actoxs' in the schema cache"
}
```