### PR TITLE
ci: avoid useless download of GHC during stack builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -132,7 +132,7 @@ jobs:
       - uses: haskell-actions/setup@cd0d9bdd65b20557f41bea4dbe43d0b5fbbfe553 # v2.11.0
         with:
           # This must match the version in stack.yaml's resolver
-          ghc-version: 9.8.4
+          ghc-version: 9.10.3
           enable-stack: true
           stack-no-global: true
           stack-setup-ghc: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,4 @@
+# When updating, update GHC version in .github/workflows/build.yaml as well.
 resolver: lts-24.37 # 2026-04-15, GHC 9.10.3
 
 nix:


### PR DESCRIPTION
Forgot to adjust when updating stackage. Thanks @taimoorzaeem!