### PR TITLE
fix: call `pg_notification_queue_usage()` automatically when the LISTEN channel bug is detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file. From versio
 - Fix login with uppercase and mixed case role names by @taimoorzaeem in #4678
 - Remove automatic transaction retries on `40001 (serialization_failure)` errors to prevent replication lag by @laurenceisla in #3673
 - Fix unexpected results when embedding and filtering the same table more than once by @laurenceisla in #4075
+- The LISTEN channel now automatically recovers when it stops working due to a PostgreSQL bug @laurenceisla in #3147
 
 ### Changed
 

--- a/src/PostgREST/Listener.hs
+++ b/src/PostgREST/Listener.hs
@@ -30,12 +30,12 @@ runListener :: AppState -> IO ()
 runListener appState = do
   AppConfig{..} <- getConfig appState
   when configDbChannelEnabled $
-    void . forkIO . void $ retryingListen appState
+    void . forkIO . void $ retryingListen appState False
 
 -- | Starts a LISTEN connection and handles notifications. It recovers with exponential backoff with a cap of 32 seconds, if the LISTEN connection is lost.
 -- | This function never returns (but can throw) and return type enforces that.
-retryingListen :: AppState -> IO Void
-retryingListen appState = do
+retryingListen :: AppState -> Bool -> IO Void
+retryingListen appState hasDbListenerBug = do
   cfg@AppConfig{..} <- AppState.getConfig appState
   let
     dbChannel = toS configDbChannel
@@ -43,7 +43,7 @@ retryingListen appState = do
       AppState.putIsListenerOn appState False
       observer $ DBListenFail dbChannel (Right err)
       when (isDbListenerBug err) $
-        observer DBListenBugHint
+        observer DBListenBugCallQueryFix
       unless configDbPoolAutomaticRecovery $
         killThread mainThreadId
 
@@ -54,7 +54,7 @@ retryingListen appState = do
       unless (delay == maxDelay) $
         AppState.putNextListenerDelay appState (delay * 2)
       -- loop running the listener
-      retryingListen appState
+      retryingListen appState (isDbListenerBug err)
 
   -- Execute the listener with with error handling
   handle onError $ do
@@ -68,6 +68,7 @@ retryingListen appState = do
       -- use connection
       \case
         Right db -> do
+          when hasDbListenerBug $ SQL.run callNotifQueryUsage db >>= either throwIO pure
           SQL.listen db $ SQL.toPgIdentifier dbChannel
           (pqHost, pqPort) <- SQL.withLibPQConnection db $ bisequence . (LibPQ.host &&& LibPQ.port)
           pgFullName <- SQL.run queryPgVersion db >>= either throwIO (pure . pgvFullName)
@@ -108,3 +109,8 @@ retryingListen appState = do
     releaseConnection = void . forkIO . handle (observer . DBListenerConnectionCleanupFail) . SQL.release
 
     isDbListenerBug e = "could not access status of transaction" `T.isInfixOf` show e
+
+    -- Used to fix a Postgres bug in the listener, see: https://github.com/PostgREST/postgrest/issues/3147#issuecomment-3494591361
+    -- This query advances the async notification query tail, which solves this issue.
+    callNotifQueryUsage :: SQL.Session ()
+    callNotifQueryUsage = SQL.sql "SELECT pg_notification_queue_usage();"

--- a/src/PostgREST/Logger.hs
+++ b/src/PostgREST/Logger.hs
@@ -188,8 +188,8 @@ observationMessages = \case
       either showListenerConnError showListenerException listenErr
   DBListenRetry delay ->
     pure $ "Retrying listening for database notifications in " <> (show delay::Text) <> " seconds..."
-  DBListenBugHint ->
-    pure "HINT:  This is likely a bug in the notification queue, try executing the following to solve it: select pg_notification_queue_usage();"
+  DBListenBugCallQueryFix ->
+    pure "This is likely a bug in the notification queue, executing the following to solve it: SELECT pg_notification_queue_usage();"
   DBListenerGotSCacheMsg channel ->
     pure $ "Received a schema cache reload message on the " <> show channel <> " channel"
   DBListenerGotConfigMsg channel ->

--- a/src/PostgREST/Logger.hs
+++ b/src/PostgREST/Logger.hs
@@ -189,7 +189,7 @@ observationMessages = \case
   DBListenRetry delay ->
     pure $ "Retrying listening for database notifications in " <> (show delay::Text) <> " seconds..."
   DBListenBugCallQueryFix ->
-    pure "This is likely a bug in the notification queue, executing the following to solve it: SELECT pg_notification_queue_usage();"
+    pure "This is likely a PostgreSQL bug in the notification queue, executing the following to try to solve it: SELECT pg_notification_queue_usage();"
   DBListenerGotSCacheMsg channel ->
     pure $ "Received a schema cache reload message on the " <> show channel <> " channel"
   DBListenerGotConfigMsg channel ->

--- a/src/PostgREST/Observation.hs
+++ b/src/PostgREST/Observation.hs
@@ -38,7 +38,7 @@ data Observation
   | DBListenStart (Maybe ByteString) (Maybe ByteString) Text Text -- host, port, version string, channel
   | DBListenFail Text (Either SQL.ConnectionError SomeException)
   | DBListenRetry Int
-  | DBListenBugHint -- https://github.com/PostgREST/postgrest/issues/3147
+  | DBListenBugCallQueryFix
   | DBListenerGotSCacheMsg ByteString
   | DBListenerGotConfigMsg ByteString
   | DBListenerConnectionCleanupFail SomeException


### PR DESCRIPTION
(WIP) Closes #3147

Implements what is mentioned in https://github.com/PostgREST/postgrest/issues/3147#issuecomment-4289368179.