### PR TITLE
fix: Restore showing  LISTEN pgrst in pg_stat_activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file. From versio
 - Fix login with uppercase and mixed case role names by @taimoorzaeem in #4678
 - Remove automatic transaction retries on `40001 (serialization_failure)` errors to prevent replication lag by @laurenceisla in #3673
 - Fix unexpected results when embedding and filtering the same table more than once by @laurenceisla in #4075
+- Make sure `LISTEN <db-channel>` query is present in pg_stat_activity row corresponding to session established by notification listening thread by @mkleczek in #4857 #4859
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file. From versio
 - Fix login with uppercase and mixed case role names by @taimoorzaeem in #4678
 - Remove automatic transaction retries on `40001 (serialization_failure)` errors to prevent replication lag by @laurenceisla in #3673
 - Fix unexpected results when embedding and filtering the same table more than once by @laurenceisla in #4075
-- Make sure `LISTEN <db-channel>` query is present in pg_stat_activity row corresponding to session established by notification listening thread by @mkleczek in #4857 #4859
+- Restore Listener query shape so it can be found in pg_stat_activity by @mkleczek in #4857 #4859
 
 ### Changed
 

--- a/src/PostgREST/Listener.hs
+++ b/src/PostgREST/Listener.hs
@@ -68,9 +68,9 @@ retryingListen appState = do
       -- use connection
       \case
         Right db -> do
-          SQL.listen db $ SQL.toPgIdentifier dbChannel
           (pqHost, pqPort) <- SQL.withLibPQConnection db $ bisequence . (LibPQ.host &&& LibPQ.port)
           pgFullName <- SQL.run queryPgVersion db >>= either throwIO (pure . pgvFullName)
+          SQL.listen db $ SQL.toPgIdentifier dbChannel
 
           AppState.putIsListenerOn appState True
 

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -3,6 +3,7 @@
 import os
 import re
 import signal
+import subprocess
 import time
 import pytest
 
@@ -688,6 +689,39 @@ def test_admin_ready_w_channel(defaultenv):
     with run(env=env) as postgrest:
         response = postgrest.admin.get("/ready")
         assert response.status_code == 200
+
+
+def test_listener_query_is_visible_in_pg_stat_activity(defaultenv):
+    "The listener connection should show the LISTEN pgrst statement in pg_stat_activity"
+
+    env = {
+        **defaultenv,
+        "PGRST_DB_CHANNEL_ENABLED": "true",
+        "PGAPPNAME": "listener-query-test",
+    }
+
+    with run(env=env):
+        query = """
+select query
+from pg_stat_activity
+where application_name = 'listener-query-test'
+  and query = 'LISTEN "pgrst"'
+limit 1;
+"""
+        output = subprocess.check_output(
+            [
+                "psql",
+                "--set",
+                "ON_ERROR_STOP=1",
+                "--tuples-only",
+                "--no-align",
+                "-c",
+                query,
+            ],
+            text=True,
+        ).strip()
+
+        assert output == 'LISTEN "pgrst"'
 
 
 def test_admin_ready_wo_channel(defaultenv):


### PR DESCRIPTION
**DISCLAIMER:**
This commit was authored entirely by a human without the assistance of LLMs.

Fixes #4857

Stacked on top of #4860 to enable testing.