### PR TITLE
fix: Do not clear the schema cache during retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file. From versio
 - Shutdown should wait for in flight requests by @mkleczek in #4702
 - Remove automatic transaction retries on `40001 (serialization_failure)` errors to prevent replication lag by @laurenceisla in #3673
 - Fix unexpected results when embedding and filtering the same table more than once by @laurenceisla in #4075
+- If the schema cache fails to reload, PostgREST will no longer stop serving requests and will continue doing so in a "best effort" basis by @mkleczek in #4873 #4869
 
 ### Changed
 

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -347,7 +347,6 @@ retryingSchemaCacheLoad appState@AppState{stateObserver=observer, stateMainThrea
       case result of
         Left e -> do
           markSchemaCachePending appState
-          putSchemaCache appState Nothing
           observer $ SchemaCacheErrorObs configDbSchemas configDbExtraSearchPath e
           return Nothing
 

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -763,7 +763,7 @@ def test_admin_ready_includes_schema_cache_state(defaultenv, metapostgrest):
         assert response.status_code == 503
 
         response = postgrest.session.get("/projects", timeout=1)
-        assert response.status_code == 503
+        assert response.status_code == 200
 
     reset_statement_timeout(metapostgrest, role)
 


### PR DESCRIPTION
**DISCLAIMER:**
This commit was authored entirely by a human without the assistance of LLMs.

`retryingSchemaCacheLoad` should not clear existing schema cache upon failure - there is no reason to do that.
If there is a communication issue with the database server or db is down, clients are going to get 502 anyway. If it was a glitch when loading the schema cache - the clients are going to use old (stale) schema cache for some time until next retry re-loads it successfully.

Fixes https://github.com/PostgREST/postgrest/issues/4873