### PR TITLE
fix: functions count in startup logs not counting overloaded functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file. From versio
 - Fix unexpected results when embedding and filtering the same table more than once by @laurenceisla in #4075
 - Restore Listener query shape so it can be found in pg_stat_activity by @mkleczek in #4857 #4859
 - The LISTEN channel now automatically recovers when it stops working due to a PostgreSQL bug @laurenceisla in #3147
+- Fix misleading "Functions" name on schema cache summary in startup logs by @taimoorzaeem in #4821
 
 
 ### Changed

--- a/docs/references/observability.rst
+++ b/docs/references/observability.rst
@@ -39,7 +39,7 @@ For diagnostic information about the server itself, PostgREST logs to ``stderr``
    06/May/2024:08:16:11 -0500: Listening for database notifications on the "pgrst" channel
    06/May/2024:08:16:11 -0500: Config reloaded
    06/May/2024:08:16:11 -0500: Schema cache queried in 3.8 milliseconds
-   06/May/2024:08:16:11 -0500: Schema cache loaded 15 Relations, 8 Relationships, 8 Functions, 0 Domain Representations, 4 Media Type Handlers
+   06/May/2024:08:16:11 -0500: Schema cache loaded 15 Relations, 8 Relationships, 8 RPCs, 0 Domain Representations, 4 Media Type Handlers
    06/May/2024:14:11:27 -0500: Received a config reload message on the "pgrst" channel
    06/May/2024:14:11:27 -0500: Config reloaded
 

--- a/src/PostgREST/SchemaCache.hs
+++ b/src/PostgREST/SchemaCache.hs
@@ -108,7 +108,7 @@ showSummary (SchemaCache tbls rels routs reps mediaHdlrs tzs _ _) =
   T.intercalate ", "
   [ show (HM.size tbls)       <> " Relations"
   , show (HM.size rels)       <> " Relationships"
-  , show (HM.size routs)      <> " Functions"
+  , show (HM.size routs)      <> " RPCs"
   , show (HM.size reps)       <> " Domain Representations"
   , show (HM.size mediaHdlrs) <> " Media Type Handlers"
   , show (S.size tzs)         <> " Timezones"


### PR DESCRIPTION
Renames the "Functions" in the logs to "RPCs". This clarifies that we log number of callable functions and not the number of SQL objects.

Closes #4821.