### PR TITLE
ci: test NixOS' VM test for PostgREST

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,6 +68,11 @@ jobs:
           path: postgrest-docker-${{ matrix.artifact }}.tar.gz
           if-no-files-found: error
 
+      - name: Test static executable with NixOS' VM test
+        # GHA's ARM runner does not support KVM
+        if: runner.arch == 'X64'
+        run: nix-build -A nixpkgs-nixos-test
+
 
   macos:
     name: Nix - MacOS

--- a/default.nix
+++ b/default.nix
@@ -77,6 +77,16 @@ let
     "-f dev --test-show-detail=direct";
 
   inherit (pkgs.haskell) lib;
+
+  nixos-lib = import (pkgs.path + "/nixos/lib") { };
+  runTest = postgrest: test: (nixos-lib.runTest {
+    hostPkgs = pkgs;
+    # Replace the top-level `pkgs.postgrest` attribute with our current version on this branch.
+    defaults.nixpkgs.overlays = [ (_: _: { inherit postgrest; }) ];
+    # Speeds up evaluation a little bit; documentation is really not required for tests.
+    defaults.documentation.enable = pkgs.lib.mkDefault false;
+    imports = [ test ];
+  }).config.result;
 in
 rec {
   inherit nixpkgs pkgs;
@@ -162,4 +172,7 @@ rec {
   # Docker images and loading script.
   docker =
     pkgs.callPackage nix/tools/docker { postgrest = postgrestStatic; };
+
+  # NixOS VM tests
+  nixpkgs-nixos-test = runTest postgrestStatic (pkgs.path + "/nixos/tests/postgrest.nix");
 }


### PR DESCRIPTION
This adds a CI job to run our latest postgrest version against the NixOS VM test currently available in Nixpkgs. Now, this will not always be in sync, so has the potential to be failing. However, since the Nixpkgs VM test is really simple, this should only happen when we introduce a breaking change on a very fundamental level. The failing test will then be resolved once the new version is available in Nixpkgs and we have updated our lock file.

This is essentially just a sanity check to make sure we're not breaking something fundamentally - and if we do, it's a head up for me to adjust the Nixpkgs tests accordingly. Those might otherwise break unnoticed since Nixpkgs does not have a good notification system for such breakages in place.

It also gives us a first test whether NixOS VM tests work well in GitHub Actions.