### PR TITLE
refactor: merge observationLogger and observationMessages functions

### DIFF
--- a/src/PostgREST/Logger.hs
+++ b/src/PostgREST/Logger.hs
@@ -56,8 +56,10 @@ init = mdo
     loggerState = LoggerState zTime debouncePoolTimeout
   zTime <- mkAutoUpdate defaultUpdateSettings { updateAction = getZonedTime }
   debouncePoolTimeout <- makeDebouncer $
-    logWithZTime loggerState (observationMessages PoolAcqTimeoutObs) *> threadDelay (5 * oneSecond)
+    logWithZTime loggerState poolAcqTimeoutObsMessage *> threadDelay (5 * oneSecond) -- Enclose the log action in the debouncer, call stateLogDebouncePoolTimeout to actually run the log action
   pure loggerState
+    where
+      poolAcqTimeoutObsMessage = [jsonMessage SQL.AcquisitionTimeoutUsageError]
 
 shouldLogResponse :: LogLevel -> Status -> Bool
 shouldLogResponse logLevel = case logLevel of
@@ -66,49 +68,6 @@ shouldLogResponse logLevel = case logLevel of
   LogWarn  -> (>= status400)
   LogInfo  -> const True
   LogDebug -> const True
-
--- All observations are logged except some that depend on the log-level
-observationLogger :: LoggerState -> LogLevel -> ObservationHandler
-observationLogger loggerState logLevel obs = case obs of
-  PoolAcqTimeoutObs -> do
-    when (logLevel >= LogError) $
-      stateLogDebouncePoolTimeout loggerState
-  o@(QueryErrorCodeHighObs _) -> do
-    when (logLevel >= LogError) $ do
-      logWithZTime loggerState $ observationMessages o
-  o@SchemaCacheEmptyObs ->
-    when (logLevel >= LogError) $ do
-    logWithZTime loggerState $ observationMessages o
-  o@(HasqlPoolObs _) -> do
-    when (logLevel >= LogDebug) $ do
-      logWithZTime loggerState $ observationMessages o
-  o@(QueryObs _ status) -> do
-    when (shouldLogResponse logLevel status) $
-      logWithZTime loggerState $ observationMessages o
-  o@PoolRequest ->
-    when (logLevel >= LogDebug) $ do
-      logWithZTime loggerState $ observationMessages o
-  o@PoolRequestFullfilled ->
-    when (logLevel >= LogDebug) $ do
-      logWithZTime loggerState $ observationMessages o
-  ResponseObs maybeRole req status contentLen ->
-    when (shouldLogResponse logLevel status) $ do
-      zTime <- stateGetZTime loggerState
-      putStr $ apacheFormat maybeRole (BS.pack $ formatZonedTime zTime) req status contentLen -- putStr prints to stdout
-  o@PoolFlushed ->
-    when (logLevel >= LogDebug) $ do
-      logWithZTime loggerState $ observationMessages o
-  o@JwtCacheEviction ->
-    when (logLevel >= LogDebug) $ do
-      logWithZTime loggerState $ observationMessages o
-  o@(JwtCacheLookup _) ->
-    when (logLevel >= LogDebug) $ do
-      logWithZTime loggerState $ observationMessages o
-  o@(WarpServerObs _) ->
-    when (logLevel >= LogDebug) $ do
-      logWithZTime loggerState $ observationMessages o
-  o ->
-    logWithZTime loggerState $ observationMessages o
 
 logWithZTime :: LoggerState -> [Text] -> IO ()
 logWithZTime loggerState txts = do
@@ -128,119 +87,142 @@ renderSnippet snippet =
   in
     sql
 
-observationMessages :: Observation -> [Text]
-observationMessages = \case
+-- | Log Observations using LoggerState
+observationLogger :: LoggerState -> LogLevel -> Observation -> IO ()
+observationLogger loggerState logLevel = \case
+  -- Log on all Log Levels
+  -- =====================
   AdminStartObs address ->
-    pure $ "Admin server listening on " <> address
+    logAnyLvl ["Admin server listening on " <> address]
   AppStartObs ver ->
-    pure $ "Starting PostgREST " <> T.decodeUtf8 ver <> "..."
+    logAnyLvl ["Starting PostgREST " <> T.decodeUtf8 ver <> "..."]
   AppServerAddressObs address ->
-    pure $ "API server listening on " <> address
+    logAnyLvl ["API server listening on " <> address]
   DBConnectedObs ver ->
-    pure $ "Successfully connected to " <> ver
+    logAnyLvl ["Successfully connected to " <> ver]
   ExitUnsupportedPgVersion pgVer minPgVer ->
-    pure $ "Cannot run in this PostgreSQL version (" <> pgvName pgVer <> "), PostgREST needs at least " <> pgvName minPgVer
+    logAnyLvl ["Cannot run in this PostgreSQL version (" <> pgvName pgVer <> "), PostgREST needs at least " <> pgvName minPgVer]
   ExitDBNoRecoveryObs ->
-    pure "Automatic recovery disabled, exiting."
+    logAnyLvl ["Automatic recovery disabled, exiting."]
   ExitDBFatalError ServerAuthError usageErr ->
-    pure $ "Failed to establish a connection. " <> jsonMessage usageErr
+    logAnyLvl ["Failed to establish a connection. " <> jsonMessage usageErr]
   ExitDBFatalError ServerPgrstBug usageErr ->
-    pure $ "This is probably a bug in PostgREST, please report it at https://github.com/PostgREST/postgrest/issues. " <> jsonMessage usageErr
+    logAnyLvl ["This is probably a bug in PostgREST, please report it at https://github.com/PostgREST/postgrest/issues. " <> jsonMessage usageErr]
   ExitDBFatalError ServerError42P05 usageErr ->
-    pure $ "If you are using connection poolers in transaction mode, try setting db-prepared-statements to false. " <> jsonMessage usageErr
+    logAnyLvl ["If you are using connection poolers in transaction mode, try setting db-prepared-statements to false. " <> jsonMessage usageErr]
   ExitDBFatalError ServerError08P01 usageErr ->
-    pure $ "Connection poolers in statement mode are not supported." <> jsonMessage usageErr
-  SchemaCacheEmptyObs ->
-    pure $ T.decodeUtf8 . LBS.toStrict . Error.errorPayload Verbose $ Error.NoSchemaCacheError
+    logAnyLvl ["Connection poolers in statement mode are not supported." <> jsonMessage usageErr]
   SchemaCacheErrorObs dbSchemas extraPaths usageErr ->
-    pure $ "Failed to load the schema cache using "
+    logAnyLvl ["Failed to load the schema cache using "
       <> "db-schemas=" <> T.intercalate "," (toList dbSchemas)
       <> " and "
       <> "db-extra-search-path=" <> T.intercalate "," extraPaths
       <> ". " <> jsonMessage usageErr
+    ]
   SchemaCacheQueriedObs resultTime timings ->
-    [ "Schema cache queried in " <> showMillis resultTime  <> " milliseconds " ] <>
+    logAnyLvl $ [ "Schema cache queried in " <> showMillis resultTime  <> " milliseconds " ] <>
     let showTimings qt = [ T.intercalate ", " $ (\(l, v) -> T.decodeUtf8 l <> ": " <> v <> " ms") <$> queryTimingsWLabels qt ] in
     maybe mempty showTimings timings
   SchemaCacheLoadedObs resultTime summary ->
-    [
+    logAnyLvl [
       "Schema cache loaded " <> summary
     , "Schema cache loaded in " <> showMillis resultTime <> " milliseconds"
     ]
   ConnectionRetryObs delay ->
-    pure $ "Attempting to reconnect to the database in " <> (show delay::Text) <> " seconds..."
+    logAnyLvl ["Attempting to reconnect to the database in " <> (show delay::Text) <> " seconds..."]
   QueryPgVersionError usageErr ->
-    pure $ "Failed to query the PostgreSQL version. " <> jsonMessage usageErr
+    logAnyLvl ["Failed to query the PostgreSQL version. " <> jsonMessage usageErr]
   DBListenStart host port fullName channel -> do
-    pure $ "Listener connected to " <> fullName <> " on " <> show (fold $ host <> fmap (":" <>) port) <> " and listening for database notifications on the " <> show channel <> " channel"
+    logAnyLvl ["Listener connected to " <> fullName <> " on " <> show (fold $ host <> fmap (":" <>) port) <> " and listening for database notifications on the " <> show channel <> " channel"]
   DBListenFail channel listenErr ->
-    pure $ "Failed listening for database notifications on the " <> show channel <> " channel. " <>
+    logAnyLvl ["Failed listening for database notifications on the " <> show channel <> " channel. " <>
       either showListenerConnError showListenerException listenErr
+    ]
   DBListenRetry delay ->
-    pure $ "Retrying listening for database notifications in " <> (show delay::Text) <> " seconds..."
+    logAnyLvl ["Retrying listening for database notifications in " <> (show delay::Text) <> " seconds..."]
   DBListenBugCallQueryFix ->
-    pure "This is likely a PostgreSQL bug in the notification queue, executing the following to try to solve it: SELECT pg_notification_queue_usage();"
+    logAnyLvl ["This is likely a PostgreSQL bug in the notification queue, executing the following to try to solve it: SELECT pg_notification_queue_usage();"]
   DBListenerGotSCacheMsg channel ->
-    pure $ "Received a schema cache reload message on the " <> show channel <> " channel"
+    logAnyLvl ["Received a schema cache reload message on the " <> show channel <> " channel"]
   DBListenerGotConfigMsg channel ->
-    pure $ "Received a config reload message on the " <> show channel <> " channel"
+    logAnyLvl ["Received a config reload message on the " <> show channel <> " channel"]
   DBListenerConnectionCleanupFail ex ->
-    pure $ "Failed during listener connection cleanup: " <> showOnSingleLine '\t' (show ex)
-  (QueryObs MainQuery{mqOpenAPI=(x, y, z),..} _) ->
+    logAnyLvl ["Failed during listener connection cleanup: " <> showOnSingleLine '\t' (show ex)]
+  ConfigReadErrorObs usageErr ->
+    logAnyLvl ["Failed to query database settings for the config parameters." <> jsonMessage usageErr]
+  QueryRoleSettingsErrorObs usageErr ->
+    logAnyLvl ["Failed to query the role settings. " <> jsonMessage usageErr]
+  ConfigInvalidObs err ->
+    logAnyLvl ["Failed reloading config: " <> err]
+  ConfigSucceededObs ->
+     logAnyLvl ["Config reloaded"]
+  PoolInit poolSize ->
+     logAnyLvl ["Connection Pool initialized with a maximum size of " <> show poolSize <> " connections"]
+  TerminationUnixSignalObs signal ->
+    logAnyLvl ["Received termination unix signal " <> signal]
+
+  -- Log on Log Level >= Debug
+  -- =========================
+  HasqlPoolObs (SQL.ConnectionObservation uuid status) ->
+    logAboveLvl LogDebug ["Connection " <> show uuid <> connStatus]
+      where
+        connStatus = case status of
+          SQL.ConnectingConnectionStatus   -> " is being established"
+          SQL.ReadyForUseConnectionStatus reason -> " is available due to " <> case reason of
+            SQL.EstablishedConnectionReadyForUseReason      -> "connection establishment"
+            SQL.SessionFailedConnectionReadyForUseReason _  -> "session failure"
+            SQL.SessionSucceededConnectionReadyForUseReason -> "session success"
+          SQL.InUseConnectionStatus        -> " is used"
+          SQL.TerminatedConnectionStatus reason -> " is terminated due to " <> case reason of
+            SQL.AgingConnectionTerminationReason          -> "max lifetime"
+            SQL.IdlenessConnectionTerminationReason       -> "max idletime"
+            SQL.ReleaseConnectionTerminationReason        -> "release"
+            SQL.NetworkErrorConnectionTerminationReason _ -> "network error" -- usage error is already logged, no need to repeat the same message.
+            SQL.InitializationErrorTerminationReason _    -> "init failure"
+
+  JwtCacheEviction ->
+    logAboveLvl LogDebug ["Evicted entry from JWT cache"]
+  JwtCacheLookup _ ->
+    logAboveLvl LogDebug ["Looked up a JWT in JWT cache"]
+  PoolFlushed ->
+    logAboveLvl LogDebug ["Database connection pool flushed"]
+  PoolRequest ->
+    logAboveLvl LogDebug ["Trying to borrow a connection from pool"]
+  PoolRequestFullfilled ->
+    logAboveLvl LogDebug ["Borrowed a connection from the pool"]
+  WarpServerObs txt ->
+    logAboveLvl LogDebug ["Warp server: " <> txt]
+
+  -- Log on Log Level >= Error
+  -- =========================
+  QueryErrorCodeHighObs usageErr ->
+    logAboveLvl LogError [jsonMessage usageErr]
+  SchemaCacheEmptyObs ->
+    logAboveLvl LogError [T.decodeUtf8 . LBS.toStrict . Error.errorPayload Verbose $ Error.NoSchemaCacheError]
+
+  -- Log on Log Level >= Error with Debounce
+  -- =======================================
+  PoolAcqTimeoutObs ->
+    when (logLevel >= LogError) $ stateLogDebouncePoolTimeout loggerState -- The log message is enclosed inside the debouncer at logger initialization time
+
+  -- Log based on Log Level and HTTP status
+  -- ======================================
+  (QueryObs MainQuery{mqOpenAPI=(x, y, z),..} status) ->
       let snipts  = renderSnippet <$> [mqTxVars, fromMaybe mempty mqPreReq, mqMain, x, y, z, fromMaybe mempty mqExplain]
       in
-        showOnSingleLine '\n' . T.decodeUtf8 <$> filter (/= mempty) snipts
-  ConfigReadErrorObs usageErr ->
-    pure $ "Failed to query database settings for the config parameters." <> jsonMessage usageErr
-  QueryRoleSettingsErrorObs usageErr ->
-    pure $ "Failed to query the role settings. " <> jsonMessage usageErr
-  QueryErrorCodeHighObs usageErr ->
-    pure $ jsonMessage usageErr
-  ConfigInvalidObs err ->
-    pure $ "Failed reloading config: " <> err
-  ConfigSucceededObs ->
-     pure "Config reloaded"
-  PoolInit poolSize ->
-     pure $ "Connection Pool initialized with a maximum size of " <> show poolSize <> " connections"
-  PoolAcqTimeoutObs -> pure $ jsonMessage SQL.AcquisitionTimeoutUsageError
-  HasqlPoolObs (SQL.ConnectionObservation uuid status) ->
-    pure $ "Connection " <> show uuid <> (
-      case status of
-        SQL.ConnectingConnectionStatus   -> " is being established"
-        SQL.ReadyForUseConnectionStatus reason -> " is available due to " <> case reason of
-          SQL.EstablishedConnectionReadyForUseReason      -> "connection establishment"
-          SQL.SessionFailedConnectionReadyForUseReason _  -> "session failure"
-          SQL.SessionSucceededConnectionReadyForUseReason -> "session success"
-        SQL.InUseConnectionStatus        -> " is used"
-        SQL.TerminatedConnectionStatus reason -> " is terminated due to " <> case reason of
-          SQL.AgingConnectionTerminationReason          -> "max lifetime"
-          SQL.IdlenessConnectionTerminationReason       -> "max idletime"
-          SQL.ReleaseConnectionTerminationReason        -> "release"
-          SQL.NetworkErrorConnectionTerminationReason _ -> "network error" -- usage error is already logged, no need to repeat the same message.
-          SQL.InitializationErrorTerminationReason _    -> "init failure"
-    )
-  PoolRequest ->
-    pure "Trying to borrow a connection from pool"
-  PoolRequestFullfilled ->
-    pure "Borrowed a connection from the pool"
-  PoolFlushed ->
-    pure "Database connection pool flushed"
-  JwtCacheLookup _ ->
-    pure "Looked up a JWT in JWT cache"
-  JwtCacheEviction ->
-    pure "Evicted entry from JWT cache"
-  TerminationUnixSignalObs signal ->
-    pure $ "Received termination unix signal " <> signal
-  WarpServerObs txt ->
-    pure $ "Warp server: " <> txt
-  ResponseObs {} ->
-    mempty -- TODO this message is produced on observationLogger since it depends on Logger state. Merge observationMessages with observationLogger to clear this.
+        when (shouldLogResponse logLevel status) $ logWithZTime loggerState $ showOnSingleLine '\n' . T.decodeUtf8 <$> filter (/= mempty) snipts
+  ResponseObs maybeRole req status contentLen ->
+    when (shouldLogResponse logLevel status) $ do
+      zTime <- stateGetZTime loggerState
+      putStr $ apacheFormat maybeRole (BS.pack $ formatZonedTime zTime) req status contentLen -- putStr prints to stdout
   where
+    logAnyLvl = logWithZTime loggerState
+
+    logAboveLvl :: LogLevel -> [Text] -> IO ()
+    logAboveLvl lvl obs = when (logLevel >= lvl) $ logWithZTime loggerState obs
+
     showMillis :: Double -> Text
     showMillis x = toS $ showFFloat (Just 1) x ""
-
-    jsonMessage err = T.decodeUtf8 . LBS.toStrict . Error.errorPayload Verbose $ Error.PgError False err
-
 
     showListenerConnError :: SQL.ConnectionError -> Text
     showListenerConnError = maybe "Connection error" (showOnSingleLine '\t' . T.decodeUtf8)
@@ -248,6 +230,8 @@ observationMessages = \case
     showListenerException :: SomeException -> Text
     showListenerException = showOnSingleLine '\t' . show
 
+jsonMessage :: SQL.UsageError -> Text
+jsonMessage err = T.decodeUtf8 . LBS.toStrict . Error.errorPayload Verbose $ Error.PgError False err
 
 showOnSingleLine :: Char -> Text -> Text
 showOnSingleLine split txt = T.intercalate " " $ T.filter (/= split) <$> T.lines txt -- the errors from hasql-notifications come intercalated with "\t\n"


### PR DESCRIPTION
Centralizes the logging of observations under one function. This also groups the observation logging by log level, HTTP status and debounced messages.

As discussed in https://github.com/PostgREST/postgrest/pull/4884#discussion_r3197345457.