### PR TITLE
fix: duplicated words in Listener and Plan comments

### DIFF
--- a/src/PostgREST/Listener.hs
+++ b/src/PostgREST/Listener.hs
@@ -56,7 +56,7 @@ retryingListen appState hasDbListenerBug = do
       -- loop running the listener
       retryingListen appState (isDbListenerBug err)
 
-  -- Execute the listener with with error handling
+  -- Execute the listener with error handling
   handle onError $ do
     -- Make sure we don't leak connections on errors
     bracket

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -126,7 +126,7 @@ data InspectPlan = InspectPlan {
   , ipSchema   :: Schema
   }
 
--- A Plan may use the the database or not
+-- A Plan may use the database or not
 data ActionPlan
   = Db DbActionPlan
   | NoDb InfoPlan


### PR DESCRIPTION
Two one-line typo fixes for duplicated words in source comments:
- `src/PostgREST/Listener.hs` — "-- Execute the listener with with error handling" → "-- Execute the listener with error handling"
- `src/PostgREST/Plan.hs` — "-- A Plan may use the the database or not" → "-- A Plan may use the database or not"

No code/behavior change.