### PR TITLE
docs: add redirect of the moved postgis section

### DIFF
--- a/docs/how-tos/working-with-postgresql-data-types.rst
+++ b/docs/how-tos/working-with-postgresql-data-types.rst
@@ -471,3 +471,20 @@ You can use other comparative filters and also all the `PostgreSQL special date/
       "due_date": "2022-02-27T06:00:00-05:00"
     }
   ]
+
+.. raw:: html
+
+  <script type="text/javascript">
+    let hash = window.location.hash;
+
+    const redirects = {
+      // PostGIS
+      '#postgis': '../integrations/postgis.html#postgis',
+    };
+
+    let willRedirectTo = redirects[hash];
+
+    if (willRedirectTo) {
+      window.location.href = willRedirectTo;
+    }
+  </script>


### PR DESCRIPTION
In 055921ea, we missed redirecting the old link to the new one.

As mentioned in https://github.com/PostgREST/postgrest/pull/4911#issuecomment-4455890132.