### PR TITLE
refactor(remove): schema cache load delay config

### DIFF
--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -127,8 +127,6 @@ data AppConfig = AppConfig
   , configRoleSettings             :: RoleSettings
   , configRoleIsoLvl               :: RoleIsolationLvl
   , configInternalSCQuerySleep     :: Maybe Int32
-  , configInternalSCLoadSleep      :: Maybe Int32
-  , configInternalSCRelLoadSleep   :: Maybe Int32
   }
 
 data LogLevel = LogCrit | LogError | LogWarn | LogInfo | LogDebug
@@ -328,8 +326,6 @@ parser optPath env dbSettings roleSettings roleIsolationLvl =
     <*> pure roleSettings
     <*> pure roleIsolationLvl
     <*> optInt "internal-schema-cache-query-sleep"
-    <*> optInt "internal-schema-cache-load-sleep"
-    <*> optInt "internal-schema-cache-relationship-load-sleep"
   where
     parseErrorVerbosity :: C.Key -> C.Parser C.Config Verbosity
     parseErrorVerbosity k =

--- a/src/PostgREST/SchemaCache.hs
+++ b/src/PostgREST/SchemaCache.hs
@@ -72,10 +72,9 @@ import PostgREST.SchemaCache.Table           (Column (..), ColumnMap,
 
 import qualified PostgREST.MediaType as MediaType
 
-import           Control.Arrow    ((&&&))
-import qualified Data.FuzzySet    as Fuzzy
+import           Control.Arrow ((&&&))
+import qualified Data.FuzzySet as Fuzzy
 import           Protolude
-import           System.IO.Unsafe (unsafePerformIO)
 
 type TablesFuzzyIndex = HM.HashMap Schema Fuzzy.FuzzySet
 
@@ -180,11 +179,9 @@ querySchemaCache conf@AppConfig{..} = do
   let tabsWViewsPks = addViewPrimaryKeys tabs keyDeps
       rels          = addInverseRels $ addM2MRels tabsWViewsPks $ addViewM2OAndO2ORels keyDeps m2oRels
 
-  -- Add delay in loading schema cache when internal-schema-cache-load-sleep config is set
-  return $ delayEval configInternalSCLoadSleep $ removeInternal schemas $ SchemaCache {
+  return $ removeInternal schemas $ SchemaCache {
       dbTables = tabsWViewsPks
-    -- Add delay in loading relationships when internal-schema-cache-relationship-load-sleep config is set
-    , dbRelationships = delayEval configInternalSCRelLoadSleep $ getOverrideRelationshipsMap rels cRels
+    , dbRelationships = getOverrideRelationshipsMap rels cRels
     , dbRoutines = funcs
     , dbRepresentations = reps
     , dbMediaHandlers = HM.union mHdlers initialMediaHandlers -- the custom handlers will override the initial ones
@@ -198,7 +195,6 @@ querySchemaCache conf@AppConfig{..} = do
     }
   where
     schemas = toList configDbSchemas
-    delayEval confDelay result = maybe result (unsafePerformIO . (($> result) . (threadDelay . (1000 *) . fromIntegral))) confDelay
     isLogDebug = configLogLevel == LogDebug
     sqlTimedStmt = sqlTimedStatement isLogDebug
 

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -1447,31 +1447,6 @@ def test_schema_cache_query_sleep_logs(defaultenv):
         assert 1000 < observed_ms < 2000
 
 
-def test_schema_cache_load_sleep_logs(defaultenv):
-    """Schema cache load sleep should be reflected in the logged load duration."""
-
-    env = {
-        **defaultenv,
-        "PGRST_INTERNAL_SCHEMA_CACHE_LOAD_SLEEP": "1000",
-    }
-    log_pattern = re.compile(r"Schema cache loaded in ([\d.]+) milliseconds")
-
-    with run(env=env, wait_max_seconds=3, no_startup_stdout=False) as postgrest:
-        observed_ms = None
-        collected = []
-
-        lines = postgrest.read_stdout(nlines=10)
-        collected.extend(lines)
-        for line in lines:
-            match = log_pattern.search(line)
-            if match:
-                observed_ms = float(match.group(1))
-                break
-
-        assert observed_ms is not None
-        assert 1000 < observed_ms < 2000
-
-
 @pytest.mark.parametrize("timezone_enabled", ["true", "false"])
 @pytest.mark.parametrize("level", ["crit", "error", "warn", "info", "debug"])
 def test_schema_cache_query_timings_log(level, timezone_enabled, defaultenv):
@@ -2106,54 +2081,6 @@ def test_db_pre_config_with_pg_reserved_words(defaultenv):
             'Failed to query database settings for the config parameters.{"code":"42883","details":null,"hint":"No function matches the given name and argument types. You might need to add explicit type casts.","message":"function select() does not exist"}'
             in line
             for line in output
-        )
-
-
-def test_requests_with_resource_embedding_wait_for_schema_cache_reload(defaultenv):
-    "requests that use the schema cache with resource embedding wait long for the schema cache to reload"
-
-    env = {
-        **defaultenv,
-        "PGRST_DB_POOL": "2",
-        "PGRST_INTERNAL_SCHEMA_CACHE_RELATIONSHIP_LOAD_SLEEP": "5100",
-    }
-
-    with run(env=env, wait_max_seconds=30) as postgrest:
-        # reload the schema cache
-        response = postgrest.session.get("/rpc/notify_pgrst")
-        assert response.status_code == 204
-
-        postgrest.wait_until_scache_starts_loading()
-
-        response = postgrest.session.get("/directors?select=id,name,films(title)")
-        assert response.status_code == 200
-
-        assert response.elapsed.total_seconds() > 5
-
-
-def test_requests_without_resource_embedding_wait_for_schema_cache_reload(defaultenv):
-    "requests that use the schema cache without resource embedding wait less for the schema cache to reload"
-
-    env = {
-        **defaultenv,
-        "PGRST_DB_POOL": "2",
-        "PGRST_INTERNAL_SCHEMA_CACHE_LOAD_SLEEP": "1100",
-        "PGRST_INTERNAL_SCHEMA_CACHE_RELATIONSHIP_LOAD_SLEEP": "5000",
-    }
-
-    with run(env=env, wait_max_seconds=30) as postgrest:
-        # reload the schema cache
-        response = postgrest.session.get("/rpc/notify_pgrst")
-        assert response.status_code == 204
-
-        postgrest.wait_until_scache_starts_loading()
-
-        response = postgrest.session.get("/films")
-        assert response.status_code == 200
-
-        assert (
-            response.elapsed.total_seconds() > 1
-            and response.elapsed.total_seconds() < 5
         )
 
 

--- a/test/observability/ObsHelper.hs
+++ b/test/observability/ObsHelper.hs
@@ -118,8 +118,6 @@ baseCfg = let secret = encodeUtf8 "reallyreallyreallyreallyverysafe" in
   , configRoleSettings              = mempty
   , configRoleIsoLvl                = mempty
   , configInternalSCQuerySleep      = Nothing
-  , configInternalSCLoadSleep       = Nothing
-  , configInternalSCRelLoadSleep    = Nothing
   , configServerTimingEnabled       = True
   }
 

--- a/test/spec/SpecHelper.hs
+++ b/test/spec/SpecHelper.hs
@@ -159,8 +159,6 @@ baseCfg = let secret = encodeUtf8 "reallyreallyreallyreallyverysafe" in
   , configRoleSettings              = mempty
   , configRoleIsoLvl                = mempty
   , configInternalSCQuerySleep      = Nothing
-  , configInternalSCLoadSleep       = Nothing
-  , configInternalSCRelLoadSleep    = Nothing
   , configServerTimingEnabled       = True
   }
 


### PR DESCRIPTION
Remove internal schema cache load and relationship load sleep settings plus
the delay wrappers they enabled. Drop IO tests that depended on the removed
settings.

See: https://github.com/PostgREST/postgrest/issues/4873#issuecomment-4438070600

**DISCLAIMER:**
This commit was authored entirely by a human without the assistance of LLMs.