### PR TITLE
test(io): remove unused config variables from config test

### DIFF
--- a/test/io/test_cli.py
+++ b/test/io/test_cli.py
@@ -195,24 +195,11 @@ def test_stable_config(tmp_path, config, defaultenv):
 
     """
 
-    # Set environment variables that some of the configs expect. Using a
-    # complex ROLE_CLAIM_KEY to make sure quoting works.
-    env = {
-        **defaultenv,
-        "ROLE_CLAIM_KEY": '."https://www.example.com/roles"[0].value',
-        "POSTGREST_TEST_SOCKET": "/tmp/postgrest.sock",
-        "POSTGREST_TEST_PORT": "80",
-        "JWT_SECRET_FILE": "a_file",
-    }
-
-    # Some configs expect input from stdin, at least on base64.
-    stdin = b"Y29ubmVjdGlvbl9zdHJpbmc="
-
-    dumped = dumpconfig(config, env=env, stdin=stdin)
+    dumped = dumpconfig(config, env=defaultenv)
 
     tmpconfigpath = tmp_path / "config"
     tmpconfigpath.write_text(dumped)
-    redumped = dumpconfig(tmpconfigpath, env=env)
+    redumped = dumpconfig(tmpconfigpath, env=defaultenv)
 
     assert dumped == redumped
 


### PR DESCRIPTION
Config variables are tested already via reading the config files in the `configs/` directory.

If more are to be tested, it should be done via adding a file in `configs/` and compare it with its associated file in `configs/expected/`.

I noticed this when working on #4914.