### PR TITLE
fix: don't mention retrying in the database connection error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this project will be documented in this file. From versio
 - Shutdown should wait for in flight requests by @mkleczek in #4702
 - Remove automatic transaction retries on `40001 (serialization_failure)` errors to prevent replication lag by @laurenceisla in #3673
 - Fix unexpected results when embedding and filtering the same table more than once by @laurenceisla in #4075
+- Fix connection retrying message in `PGRST000` error by @netqo in #4980
+  + Remove redundant "Retrying the connection." from message because it is logged separately
 
 ### Changed
 

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -475,7 +475,7 @@ instance ErrorBody SQL.UsageError where
   code    (SQL.SessionUsageError (SQL.QueryError _ _ e)) = code e
   code    SQL.AcquisitionTimeoutUsageError               = "PGRST003"
 
-  message (SQL.ConnectionUsageError _) = "Database connection error. Retrying the connection."
+  message (SQL.ConnectionUsageError _) = "Database connection error."
   message (SQL.SessionUsageError (SQL.PipelineError e))  = message e
   message (SQL.SessionUsageError (SQL.QueryError _ _ e)) = message e
   message SQL.AcquisitionTimeoutUsageError = "Timed out acquiring connection from connection pool."

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -2058,6 +2058,15 @@ def test_log_listener_connection_start(defaultenv):
         )
 
 
+def test_connection_error_message_does_not_claim_retry(defaultenv):
+    "The connection error message should not claim retrying, since PostgREST stops on fatal errors."
+    uri = f'postgresql://?dbname={defaultenv["PGDATABASE"]}&host={defaultenv["PGHOST"]}&user=some_protected_user&password=invalid_pass'
+    env = {**defaultenv, "PGRST_DB_URI": uri}
+    with run(env=env, no_startup_stdout=False, wait_for=None) as postgrest:
+        output = postgrest.read_stdout(nlines=8)
+        assert any('"message":"Database connection error."' in line for line in output)
+
+
 def test_db_pre_config_with_pg_reserved_words(defaultenv):
     "The db-pre-config should not fail unexpectedly when function name is a postgres reserved word"
 


### PR DESCRIPTION
Closes #2895

The connection error message (PGRST000) was "Database connection error. Retrying the connection.", but the "Retrying the connection." part is misleading.

On fatal errors like an auth failure (`fe_sendauth: no password supplied`), PostgREST doesn't retry, it just stops. And when it does retry, that's already logged separately by the reconnection observation ("Attempting to reconnect to the database in N seconds..."). So the "Retrying" bit was redundant when we do retry and wrong when we don't.

So I dropped it, leaving just "Database connection error.", which also lines up with the existing "Database client error." message.

I also added an IO test that points PostgREST at a password-protected role with a wrong password (same setup as `test_fail_with_invalid_password`) and checks that the message no longer claims it's retrying.
