### PR TITLE
ci(test): fail loadtest correctly

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -162,9 +162,9 @@ jobs:
         # The loadtest reporter writes them when any of individual steps fails the performance
         # regression threshold.
         run: |
-          postgrest-loadtest-report -g ${{ matrix.kind }} -p 50 \
-            | tee "$GITHUB_STEP_SUMMARY" \
-            | grep -v ':x:'
+          ! (postgrest-loadtest-report -g ${{ matrix.kind }} -p 50 \
+              | tee "$GITHUB_STEP_SUMMARY" \
+              | grep ':x:')
 
       - name: Report P0
         if: always()


### PR DESCRIPTION
Previously this would only fail if *each* row had `:x:` in it, which was never the case, because the header never has it. It is supposed to fail when *at least one* row has an :x:.