### PR TITLE
refactor(config): use correct data type for server-cors-allowed-origins

### DIFF
--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -115,7 +115,7 @@ data AppConfig = AppConfig
   , configOpenApiMode              :: OpenAPIMode
   , configOpenApiSecurityActive    :: Bool
   , configOpenApiServerProxyUri    :: Maybe Text
-  , configServerCorsAllowedOrigins :: Maybe [Text]
+  , configServerCorsAllowedOrigins :: [Text]
   , configServerHost               :: Text
   , configServerPort               :: Int
   , configServerTraceHeader        :: Maybe (CI.CI BS.ByteString)
@@ -198,7 +198,7 @@ toText conf =
       ,("openapi-mode",              q . dumpOpenApiMode . configOpenApiMode)
       ,("openapi-security-active",       T.toLower . show . configOpenApiSecurityActive)
       ,("openapi-server-proxy-uri",  q . fromMaybe mempty . configOpenApiServerProxyUri)
-      ,("server-cors-allowed-origins",      q . maybe "" (T.intercalate ",") . configServerCorsAllowedOrigins)
+      ,("server-cors-allowed-origins", q . T.intercalate "," . configServerCorsAllowedOrigins)
       ,("server-host",               q . configServerHost)
       ,("server-port",                   show . configServerPort)
       ,("server-trace-header",       q . T.decodeUtf8 . maybe mempty CI.original . configServerTraceHeader)
@@ -424,8 +424,8 @@ parser optPath env dbSettings roleSettings roleIsolationLvl =
 
     parseCORSAllowedOrigins k =
       optString k >>= \case
-        Nothing   -> pure Nothing
-        Just orig -> pure $ Just (T.strip <$> T.splitOn "," orig)
+        Nothing   -> pure []
+        Just orig -> pure (T.strip <$> T.splitOn "," orig)
 
     optWithAlias :: C.Parser C.Config (Maybe a) -> C.Parser C.Config (Maybe a) -> C.Parser C.Config (Maybe a)
     optWithAlias orig alias =

--- a/src/PostgREST/Cors.hs
+++ b/src/PostgREST/Cors.hs
@@ -2,9 +2,6 @@
 Module      : PostgREST.Cors
 Description : Wai Middleware to set cors policy.
 -}
-
-{-# LANGUAGE TupleSections #-}
-
 module PostgREST.Cors (middleware) where
 
 import qualified Data.ByteString.Char8       as BS
@@ -26,11 +23,13 @@ middleware appState app req res = do
   Wai.cors (corsPolicy $ configServerCorsAllowedOrigins conf) app req res
 
 -- | CORS policy to be used in by Wai Cors middleware
-corsPolicy :: Maybe [Text] -> Wai.Request -> Maybe Wai.CorsResourcePolicy
+corsPolicy :: [Text] -> Wai.Request -> Maybe Wai.CorsResourcePolicy
 corsPolicy corsAllowedOrigins req = case lookup "origin" headers of
   Just _ ->
     Just Wai.CorsResourcePolicy
-    { Wai.corsOrigins = (, True) . map T.encodeUtf8 <$> corsAllowedOrigins
+    { Wai.corsOrigins = case corsAllowedOrigins of
+        []      -> Nothing
+        origins -> Just (map T.encodeUtf8 origins, True)
     , Wai.corsMethods = ["GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"]
     , Wai.corsRequestHeaders = "Authorization" : accHeaders
     , Wai.corsExposedHeaders = Just

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -1642,7 +1642,7 @@ def test_preflight_request_with_cors_allowed_origin_config(defaultenv):
 
 
 def test_preflight_request_with_empty_cors_allowed_origin_config(defaultenv):
-    "OPTIONS preflight request should allow all origins when config is present but empty"
+    "OPTIONS preflight request should allow all origins when config is not set or empty"
 
     env = {
         **defaultenv,

--- a/test/observability/ObsHelper.hs
+++ b/test/observability/ObsHelper.hs
@@ -105,7 +105,7 @@ baseCfg = let secret = encodeUtf8 "reallyreallyreallyreallyverysafe" in
   , configOpenApiMode               = OAFollowPriv
   , configOpenApiSecurityActive     = False
   , configOpenApiServerProxyUri     = Nothing
-  , configServerCorsAllowedOrigins  = Nothing
+  , configServerCorsAllowedOrigins  = []
   , configServerHost                = "localhost"
   , configServerPort                = 3000
   , configServerTraceHeader         = Nothing

--- a/test/spec/SpecHelper.hs
+++ b/test/spec/SpecHelper.hs
@@ -146,7 +146,7 @@ baseCfg = let secret = encodeUtf8 "reallyreallyreallyreallyverysafe" in
   , configOpenApiMode               = OAFollowPriv
   , configOpenApiSecurityActive     = False
   , configOpenApiServerProxyUri     = Nothing
-  , configServerCorsAllowedOrigins  = Nothing
+  , configServerCorsAllowedOrigins  = []
   , configServerHost                = "localhost"
   , configServerPort                = 3000
   , configServerTraceHeader         = Nothing


### PR DESCRIPTION
Replaces the `Maybe [Text]` with `[Text]`. The `Maybe` is unnecessary because we handle `Just []` and `Nothing` the same way.

As discussed in https://github.com/PostgREST/postgrest/pull/4996#discussion_r3378639865.