### PR TITLE
v14: test: correct test_admin_ready_includes_schema_cache_state

### DIFF
--- a/test/io/fixtures/roles.sql
+++ b/test/io/fixtures/roles.sql
@@ -15,6 +15,8 @@ GRANT
   postgrest_test_serializable, postgrest_test_repeatable_read,
   postgrest_test_w_superuser_settings, postgrest_test_work_mem TO :"PGUSER";
 
+GRANT postgrest_test_anonymous TO timeout_authenticator;
+
 ALTER ROLE :"PGUSER" SET pgrst.db_anon_role = 'postgrest_test_anonymous';
 ALTER ROLE postgrest_test_serializable SET default_transaction_isolation = 'serializable';
 ALTER ROLE postgrest_test_repeatable_read SET default_transaction_isolation = 'REPEATABLE READ';

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -605,7 +605,7 @@ def test_admin_ready_includes_schema_cache_state(defaultenv, metapostgrest):
     env = {
         **defaultenv,
         "PGUSER": role,
-        "PGRST_DB_ANON_ROLE": role,
+        "PGRST_DB_ANON_ROLE": "postgrest_test_anonymous",
         "PGRST_INTERNAL_SCHEMA_CACHE_QUERY_SLEEP": "500",
     }
 


### PR DESCRIPTION
Backport e7c8d70333a6e4c38a3cb9e64b10dc9bb72c96e2 and 1ebf4802584160110576588dac72388ca238e23e.