### PR TITLE
v14: fix: Do not clear the schema cache during retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. From versio
 
 ## Unreleased
 
+### Fixed
+
+- If the schema cache fails to reload, PostgREST will no longer stop serving requests and will continue doing so in a "best effort" basis by @mkleczek in #4873 #4869
+
 ## [14.13] - 2026-06-04
 
 ### Fixed

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -352,7 +352,6 @@ retryingSchemaCacheLoad appState@AppState{stateObserver=observer, stateMainThrea
       case result of
         Left e -> do
           putSCacheStatus appState SCPending
-          putSchemaCache appState Nothing
           observer $ SchemaCacheErrorObs configDbSchemas configDbExtraSearchPath e
           return Nothing
 

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -623,7 +623,7 @@ def test_admin_ready_includes_schema_cache_state(defaultenv, metapostgrest):
         assert response.status_code == 503
 
         response = postgrest.session.get("/projects", timeout=1)
-        assert response.status_code == 503
+        assert response.status_code == 200
 
     reset_statement_timeout(metapostgrest, role)
 


### PR DESCRIPTION
Backport #4869.