### PR TITLE
perf: add ghc 9.12 options -fexpose-overloaded-unfoldings -fspecialise-aggressively

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -177,7 +177,9 @@ library
     if flag(hpc)
       ghc-options: -fhpc -hpcdir .hpc
   else
-    ghc-options: -O2
+    ghc-options: -O2  
+    if impl(ghc >= 9.12)
+      ghc-options: -fexpose-overloaded-unfoldings -fspecialise-aggressively
 
   if !os(windows)
     build-depends:


### PR DESCRIPTION
Before 9.12.1 it was necessary to mark functions as INLINABLE or INLINE to make GHC consider cross-module specialization of polymorphic functions.
9.12 added a new -fexpose-overloaded-unfoldings flag that exposes optimized polymorphic functions in interface files. -fspecialise-aggressively then makes GHC apply aggresive specialization.

Looking at load test results it gives some performance improvements across the board.

- [x] compare executable size with `main` - `-fspecialise-aggressively` can increase it quite badly