### PR TITLE
refactor: bind transaction settings in static statement

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -136,9 +136,11 @@ library
                     , network-uri               >= 2.6.1 && < 2.8
                     , optparse-applicative      >= 0.13 && < 0.19
                     , parsec                    >= 3.1.11 && < 3.2
+                    , postgresql-binary         >= 0.14 && < 0.15
                     , postgresql-libpq          >= 0.10
                     , prometheus-client         >= 1.1.1 && < 1.2.0
                     , prometheus-metrics-ghc    >= 1.0.1.2 && < 1.2
+                    , profunctors               >= 5.6 && < 6
                     , protolude                 >= 0.3.1 && < 0.4
                     , regex-tdfa                >= 1.2.2 && < 1.4
                     , retry                     >= 0.7.4 && < 0.10

--- a/src/PostgREST/Logger.hs
+++ b/src/PostgREST/Logger.hs
@@ -128,6 +128,10 @@ renderSnippet snippet =
   in
     sql
 
+renderStatement :: SQL.Statement () () -> ByteString
+renderStatement (SQL.Statement sql _ _ _) =
+  sql
+
 observationMessages :: Observation -> [Text]
 observationMessages = \case
   AdminStartObs address ->
@@ -187,7 +191,7 @@ observationMessages = \case
   DBListenerConnectionCleanupFail ex ->
     pure $ "Failed during listener connection cleanup: " <> showOnSingleLine '\t' (show ex)
   (QueryObs MainQuery{mqOpenAPI=(x, y, z),..} _) ->
-      let snipts  = renderSnippet <$> [mqTxVars, fromMaybe mempty mqPreReq, mqMain, x, y, z, fromMaybe mempty mqExplain]
+      let snipts  = renderStatement mqTxVars : (renderSnippet <$> [fromMaybe mempty mqPreReq, mqMain, x, y, z, fromMaybe mempty mqExplain])
       in
         showOnSingleLine '\n' . T.decodeUtf8 <$> filter (/= mempty) snipts
   ConfigReadErrorObs usageErr ->

--- a/src/PostgREST/MainTx.hs
+++ b/src/PostgREST/MainTx.hs
@@ -96,8 +96,7 @@ mainTx genQ@MainQuery{..} conf@AppConfig{..} AuthResult{..} apiReq (Db plan) sCa
     isoLvl = planIsoLvl conf authRole plan
     txMode = planTxMode plan
     dbHandler = do
-      lift $ SQL.statement mempty $ SQL.dynamicallyParameterized mqTxVars
-          HD.noResult configDbPreparedStatements
+      lift $ SQL.statement () mqTxVars
       lift $ whenJust mqPreReq $ \q ->
         SQL.statement mempty $ SQL.dynamicallyParameterized q
           HD.noResult configDbPreparedStatements

--- a/src/PostgREST/Query.hs
+++ b/src/PostgREST/Query.hs
@@ -10,7 +10,10 @@ module PostgREST.Query
   , MainQuery (..)
   ) where
 
+import qualified Hasql.Decoders                  as HD
 import qualified Hasql.DynamicStatements.Snippet as SQL hiding (sql)
+import qualified Hasql.Encoders                  as HE
+import qualified Hasql.Statement                 as SQL
 
 import qualified PostgREST.Query.PreQuery     as PreQuery
 import qualified PostgREST.Query.QueryBuilder as QueryBuilder
@@ -33,7 +36,7 @@ import Protolude hiding (Handler)
 
 -- The Queries that run on every request
 data MainQuery = MainQuery
-  { mqTxVars  :: SQL.Snippet       -- ^ the transaction variables that always run on each query
+  { mqTxVars  :: SQL.Statement () () -- ^ the transaction variables that always run on each query
   , mqPreReq  :: Maybe SQL.Snippet -- ^ the pre-request function that runs if enabled
   -- TODO only one of the following queries actually runs on each request, once OpenAPI is removed from core it will be easier to refactor this
   , mqMain    :: SQL.Snippet
@@ -42,7 +45,7 @@ data MainQuery = MainQuery
   }
 
 mainQuery :: ActionPlan -> AppConfig -> ApiRequest -> AuthResult -> Maybe QualifiedIdentifier -> MainQuery
-mainQuery (NoDb _) _ _ _ _ = MainQuery mempty Nothing mempty (mempty, mempty, mempty) mempty
+mainQuery (NoDb _) _ _ _ _ = MainQuery (SQL.Statement mempty HE.noParams HD.noResult False) Nothing mempty (mempty, mempty, mempty) mempty
 mainQuery (Db plan) conf@AppConfig{..} apiReq@ApiRequest{iTopLevelRange=range, iPreferences=Preferences{..}} authRes preReq =
   let genQ = MainQuery (PreQuery.txVarQuery plan conf authRes apiReq) (PreQuery.preReqQuery <$> preReq) in
   case plan of

--- a/src/PostgREST/Query/PreQuery.hs
+++ b/src/PostgREST/Query/PreQuery.hs
@@ -12,10 +12,16 @@ module PostgREST.Query.PreQuery
 import qualified Data.Aeson                      as JSON
 import qualified Data.Aeson.KeyMap               as KM
 import qualified Data.ByteString.Lazy.Char8      as LBS
+import           Data.Functor.Contravariant
 import qualified Data.HashMap.Strict             as HM
+import           Data.Profunctor
+import           Data.Tuple.Extra
+import qualified Hasql.Decoders                  as HD
 import qualified Hasql.DynamicStatements.Snippet as SQL hiding (sql)
-
-
+import qualified Hasql.Encoders                  as HE
+import qualified Hasql.Statement                 as SQL
+import qualified PostgreSQL.Binary.Encoding      as PGBinary
+import           Unsafe.Coerce                   (unsafeCoerce)
 
 import PostgREST.ApiRequest              (ApiRequest (..))
 import PostgREST.ApiRequest.Preferences  (PreferTimezone (..),
@@ -24,44 +30,88 @@ import PostgREST.Auth.Types              (AuthResult (..))
 import PostgREST.Config                  (AppConfig (..))
 import PostgREST.Plan                    (CrudPlan (..),
                                           DbActionPlan (..))
-import PostgREST.Query.SqlFragment       (escapeIdentList, fromQi,
-                                          intercalateSnippet,
-                                          setConfigWithConstantName,
-                                          setConfigWithConstantNameJSON,
-                                          setConfigWithDynamicName)
+import PostgREST.Query.SqlFragment       (escapeIdentList, fromQi)
 import PostgREST.SchemaCache.Identifiers (QualifiedIdentifier (..))
 import PostgREST.SchemaCache.Routine     (Routine (..))
 
-import Protolude hiding (Handler)
+import Protolude
 
 -- sets transaction variables
-txVarQuery :: DbActionPlan -> AppConfig -> AuthResult -> ApiRequest -> SQL.Snippet
+txVarQuery :: DbActionPlan -> AppConfig -> AuthResult -> ApiRequest -> SQL.Statement () ()
 txVarQuery dbActPlan AppConfig{..} AuthResult{..} ApiRequest{..} =
-    -- To ensure `GRANT SET ON PARAMETER <superuser_setting> TO authenticator` works, the role settings must be set before the impersonated role.
-    -- Otherwise the GRANT SET would have to be applied to the impersonated role. See https://github.com/PostgREST/postgrest/issues/3045
-    "select " <> intercalateSnippet ", " (
-      searchPathSql : roleSettingsSql ++ roleSql ++ claimsSql ++ [methodSql, pathSql] ++ headersSql ++ cookiesSql ++ timezoneSql ++ funcSettingsSql ++ appSettingsSql
-    )
+    lmap (const settings) $ SQL.Statement txSettingsSql txSettingsParams HD.noResult configDbPreparedStatements
   where
-    methodSql = setConfigWithConstantName ("request.method", iMethod)
-    pathSql = setConfigWithConstantName ("request.path", iPath)
-    headersSql = setConfigWithConstantNameJSON "request.headers" iHeaders
-    cookiesSql = setConfigWithConstantNameJSON "request.cookies" iCookies
-    claimsSql = [setConfigWithConstantName ("request.jwt.claims", LBS.toStrict $ JSON.encode claims)]
+    settings = unzip $
+      -- To ensure `GRANT SET ON PARAMETER <superuser_setting> TO authenticator` works, the role settings must be set before the impersonated role.
+      -- Otherwise the GRANT SET would have to be applied to the impersonated role. See https://github.com/PostgREST/postgrest/issues/3045
+      searchPathSetting : roleSettings ++
+      [ roleSetting
+      , claimsSetting
+      , methodSetting
+      , pathSetting
+      , headersSetting
+      , cookiesSetting
+      ] ++
+      timezoneSetting ++
+      funcSettings ++
+      appSettings
+
+    methodSetting = ("request.method", iMethod)
+    pathSetting = ("request.path", iPath)
+    headersSetting = ("request.headers", gucJsonVal iHeaders)
+    cookiesSetting = ("request.cookies", gucJsonVal iCookies)
+    claimsSetting = ("request.jwt.claims", LBS.toStrict $ JSON.encode claims)
       where
         claims = authClaims & KM.insert "role" (JSON.String $ decodeUtf8 authRole) -- insert "role" to claims as well
 
-    roleSql = [setConfigWithConstantName ("role", authRole)]
-    roleSettingsSql = setConfigWithDynamicName <$> HM.toList (fromMaybe mempty $ HM.lookup authRole configRoleSettings)
-    appSettingsSql = setConfigWithDynamicName . join bimap toUtf8 <$> configAppSettings
-    timezoneSql = maybe mempty (\(PreferTimezone tz) -> [setConfigWithConstantName ("timezone", tz)]) $ preferTimezone iPreferences
-    funcSettingsSql = setConfigWithDynamicName . join bimap toUtf8 <$> funcSettings
-    searchPathSql =
-      let schemas = escapeIdentList (iSchema : configDbExtraSearchPath) in
-      setConfigWithConstantName ("search_path", schemas)
+    roleSetting = ("role", authRole)
+    roleSettings = HM.toList $ fromMaybe mempty $ HM.lookup authRole configRoleSettings
+    appSettings = join bimap toUtf8 <$> configAppSettings
+    timezoneSetting = maybe mempty (\(PreferTimezone tz) -> [("timezone", tz)]) $ preferTimezone iPreferences
     funcSettings = case dbActPlan of
-      DbCrud _ CallReadPlan{crProc} -> pdFuncSettings crProc
+      DbCrud _ CallReadPlan{crProc} -> join bimap toUtf8 <$> pdFuncSettings crProc
       _                             -> mempty
+    searchPathSetting =
+      let schemas = escapeIdentList (iSchema : configDbExtraSearchPath) in
+      ("search_path", schemas)
+
+txSettingsSql :: ByteString
+txSettingsSql =
+  "select set_config(setting, value, true) " <>
+  "from unnest($1::text[], $2::text[]) with ordinality as _(setting, value, ordinality) " <>
+  "order by ordinality"
+txSettingsParams :: HE.Params ([ByteString], [ByteString])
+txSettingsParams =
+    (fst >$< txSettingsParameter) <>
+    (snd >$< txSettingsParameter)
+txSettingsParameter :: HE.Params [ByteString]
+txSettingsParameter =
+  HE.param $ HE.nonNullable txSettingsArray
+
+data HasqlValue a = HasqlValue !Any !Any !(Bool -> a -> PGBinary.Encoding) !Any
+
+txSettingsArray :: HE.Value [ByteString]
+txSettingsArray =
+  -- hasql-1.9.3.1 does not expose a custom Value constructor; this mirrors its hidden Value/OID layout.
+  unsafeCoerce $ HasqlValue textArrayValueOid textArrayArrayOid textArrayEncoding textArrayRender
+  where
+    hasqlTextArrayValue :: HE.Value [Text]
+    hasqlTextArrayValue = HE.foldableArray $ HE.nonNullable HE.text
+
+    HasqlValue textArrayValueOid textArrayArrayOid _ textArrayRender = unsafeCoerce hasqlTextArrayValue
+
+textArrayEncoding :: Bool -> [ByteString] -> PGBinary.Encoding
+textArrayEncoding _ =
+  PGBinary.array_foldable textOid (Just . PGBinary.bytea_strict)
+
+textOid :: Word32
+textOid = 25
+
+-- Starting from PostgreSQL v14, some characters are not allowed for config names (mostly affecting headers with "-").
+-- A JSON format string is used to avoid this problem. See https://github.com/PostgREST/postgrest/issues/1857
+gucJsonVal :: [(ByteString, ByteString)] -> ByteString
+gucJsonVal =
+  LBS.toStrict . JSON.encode . HM.fromList . fmap (both decodeUtf8)
 
 -- runs the pre-request function
 preReqQuery :: QualifiedIdentifier -> SQL.Snippet

--- a/src/PostgREST/Query/SqlFragment.hs
+++ b/src/PostgREST/Query/SqlFragment.hs
@@ -37,25 +37,18 @@ module PostgREST.Query.SqlFragment
   , responseStatusF
   , returningF
   , schemaDescription
-  , setConfigWithConstantName
-  , setConfigWithConstantNameJSON
-  , setConfigWithDynamicName
   , singleParameter
   , sourceCTE
   , sourceCTEName
   , unknownEncoder
   ) where
 
-import qualified Data.Aeson                      as JSON
 import qualified Data.ByteString.Char8           as BS
 import qualified Data.ByteString.Lazy            as LBS
-import qualified Data.HashMap.Strict             as HM
 import qualified Data.Text                       as T
-import qualified Data.Text.Encoding              as T
 import qualified Hasql.DynamicStatements.Snippet as SQL
 import qualified Hasql.Encoders                  as HE
 
-import Control.Arrow ((***))
 
 import Data.Foldable     (foldr1)
 import NeatInterpolation (trimming)
@@ -562,30 +555,6 @@ explainF fmt opts snip =
 
     fmtPlanFmt PlanText = "FORMAT TEXT"
     fmtPlanFmt PlanJSON = "FORMAT JSON"
-
--- | Do a pg set_config(setting, value, true) call. This is equivalent to a SET LOCAL.
-setConfigLocal :: (SQL.Snippet, ByteString) -> SQL.Snippet
-setConfigLocal (k, v) =
-  "set_config(" <> k <> ", " <> unknownEncoder v <> ", true)"
-
--- | For when the settings are hardcoded and not parameterized
-setConfigWithConstantName :: (SQL.Snippet, ByteString) -> SQL.Snippet
-setConfigWithConstantName (k, v) = setConfigLocal ("'" <> k <> "'", v)
-
--- | For when the settings need to be parameterized
-setConfigWithDynamicName :: (ByteString, ByteString) -> SQL.Snippet
-setConfigWithDynamicName (k, v) =
-  setConfigLocal (unknownEncoder k, v)
-
--- | Starting from PostgreSQL v14, some characters are not allowed for config names (mostly affecting headers with "-").
--- | A JSON format string is used to avoid this problem. See https://github.com/PostgREST/postgrest/issues/1857
-setConfigWithConstantNameJSON :: SQL.Snippet -> [(ByteString, ByteString)] -> [SQL.Snippet]
-setConfigWithConstantNameJSON prefix keyVals = [setConfigWithConstantName (prefix, gucJsonVal keyVals)]
-  where
-    gucJsonVal :: [(ByteString, ByteString)] -> ByteString
-    gucJsonVal = LBS.toStrict . JSON.encode . HM.fromList . arrayByteStringToText
-    arrayByteStringToText :: [(ByteString, ByteString)] -> [(Text,Text)]
-    arrayByteStringToText keyVal = (T.decodeUtf8 *** T.decodeUtf8) <$> keyVal
 
 handlerF :: Maybe Routine -> MediaHandler -> SQL.Snippet
 handlerF rout = \case

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -957,7 +957,9 @@ def test_log_query(level, defaultenv):
         root_procs_regx = r".+: WITH base_types AS \(.+\) SELECT   pn.nspname AS proc_schema, .+ FROM pg_proc p.+AND p.pronamespace = \$1::regnamespace"
         root_descr_regx = r".+: SELECT pg_catalog\.obj_description\(\$1::regnamespace, 'pg_namespace'\)"
         set_config_regx = (
-            r".+: select set_config\('search_path', \$1, true\), set_config\("
+            r".+: select set_config\(setting, value, true\) "
+            r"from unnest\(\$1::text\[\], \$2::text\[\]\) with ordinality as _\(setting, value, ordinality\) "
+            r"order by ordinality"
         )
 
         output = drain_stdout(postgrest)


### PR DESCRIPTION
Build the transaction GUC setup as a static SQL statement that binds setting names and values as two text arrays.

The change is to avoid growth in the number of prepared statements for each combination of preferred timezone, role settings, application settings, and function settings.