### PR TITLE
test(load): jwt loadtests with complex jwt-role-claim-key

### DIFF
--- a/nix/tools/generate_targets.py
+++ b/nix/tools/generate_targets.py
@@ -34,7 +34,7 @@ def generate_jwt(
     payload = {
         "sub": f"user_{random.getrandbits(32)}",
         "iat": now,
-        "role": "postgrest_test_author",
+        "postgrest": {"roles": ["postgrest_test_author", "other"]},
     }
 
     if exp_inc is not None:

--- a/nix/tools/loadtest.nix
+++ b/nix/tools/loadtest.nix
@@ -61,6 +61,7 @@ let
         export PGRST_DB_TX_END="rollback-allow-override"
         export PGRST_LOG_LEVEL="crit"
         export PGRST_JWT_SECRET="reallyreallyreallyreallyverysafe"
+        export PGRST_JWT_ROLE_CLAIM_KEY=".postgrest.roles[?(@ ^== \"postgrest\")]"
 
         mkdir -p "$(dirname "$_arg_output")"
         abs_output="$(realpath "$_arg_output")"


### PR DESCRIPTION
Using a slightly complex `jwt-role-claim-key` so performance impact can be seen when logic or syntax related to this config changes.