### PR TITLE
chore(cabal): explain performance related build flags

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -179,6 +179,9 @@ library
   else
     ghc-options: -O2  
     if impl(ghc >= 9.12)
+      -- Makes GHC consider cross-module specialization for polymorphic functions
+      -- without explicitly needing to add INLINE, INLINABLE or SPECIALIZE pragmas.
+      -- Slightly increases the binary size but improves performance considerably.
       ghc-options: -fexpose-overloaded-unfoldings -fspecialise-aggressively
 
   if !os(windows)


### PR DESCRIPTION
These flags were added in 9f97147cc3dd0052613476bce248846aeb84ecc0. Adding a comment to clarify the use.