### PR TITLE
refactor: correct admin server port setting

### DIFF
--- a/src/PostgREST/Admin.hs
+++ b/src/PostgREST/Admin.hs
@@ -11,7 +11,8 @@ import Control.Monad.Extra       (whenJust)
 import Network.Socket            hiding (addrFamily)
 import Network.Socket.ByteString
 
-import PostgREST.AppState    (AppState)
+import PostgREST.AppState    (AppState, getConfig)
+import PostgREST.Config      (AppConfig (..))
 import PostgREST.MediaType   (MediaType (..), toContentType)
 import PostgREST.Metrics     (metricsToText)
 import PostgREST.Network     (resolveSocketToAddress)
@@ -24,13 +25,18 @@ import           Protolude
 
 runAdmin :: AppState -> Maybe NS.Socket -> IO (Maybe NS.Socket) -> Warp.Settings -> IO ()
 runAdmin appState maybeAdminSocket getSocketREST settings = do
+  conf <- getConfig appState
   whenJust maybeAdminSocket $ \adminSocket -> do
     address <- resolveSocketToAddress adminSocket
     observer $ AdminStartObs address
-    void . forkIO $ Warp.runSettingsSocket settings adminSocket adminApp
+    void . forkIO $ Warp.runSettingsSocket (adminServerSettings conf) adminSocket adminApp
   where
     adminApp = admin appState getSocketREST
     observer = AppState.getObserver appState
+    adminServerSettings config =
+      case configAdminServerPort config of
+        Just p  -> settings & Warp.setPort p
+        Nothing -> settings
 
 -- | PostgREST admin application
 admin :: AppState.AppState -> IO (Maybe NS.Socket) -> Wai.Application

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -106,7 +106,12 @@ run appState = do
   address <- resolveSocketToAddress mainSocket
   observer $ AppServerAddressObs address
 
-  Warp.runSettingsSocket (serverSettings conf & setOnException onWarpException) mainSocket app
+  let
+    appServerSettings = serverSettings conf
+      & setPort (configServerPort conf)
+      & setOnException onWarpException
+
+  Warp.runSettingsSocket appServerSettings mainSocket app
   where
     observer = AppState.getObserver appState
 
@@ -129,7 +134,6 @@ serverSettings :: AppConfig -> Warp.Settings
 serverSettings AppConfig{..} =
   defaultSettings
     & setHost (fromString $ toS configServerHost)
-    & setPort configServerPort
     & setServerName ("postgrest/" <> prettyVersion)
 
 -- | PostgREST application


### PR DESCRIPTION
For admin server, port server-setting was set to the same port as app server port. This doesn't have any effect because it is overridden by the already initialized admin server socket, but it's better to explicitly correct it to avoid anything unexpected.

Towards #5012.