### PR TITLE
refactor: log server listening observations after listening socket is ready

### DIFF
--- a/src/PostgREST/Admin.hs
+++ b/src/PostgREST/Admin.hs
@@ -28,15 +28,14 @@ runAdmin appState maybeAdminSocket getSocketREST settings = do
   conf <- getConfig appState
   whenJust maybeAdminSocket $ \adminSocket -> do
     address <- resolveSocketToAddress adminSocket
-    observer $ AdminStartObs address
-    void . forkIO $ Warp.runSettingsSocket (adminServerSettings conf) adminSocket adminApp
+    void . forkIO $ Warp.runSettingsSocket (adminServerSettings conf address) adminSocket adminApp
   where
     adminApp = admin appState getSocketREST
     observer = AppState.getObserver appState
-    adminServerSettings config =
-      case configAdminServerPort config of
-        Just p  -> settings & Warp.setPort p
-        Nothing -> settings
+    adminServerSettings config addr=
+      settings
+        & Warp.setBeforeMainLoop (observer $ AdminStartObs addr)
+        & maybe identity Warp.setPort (configAdminServerPort config)
 
 -- | PostgREST admin application
 admin :: AppState.AppState -> IO (Maybe NS.Socket) -> Wai.Application

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -29,8 +29,8 @@ import Data.Either.Combinators  (mapLeft, whenLeft)
 import Data.IORef               (atomicWriteIORef, newIORef,
                                  readIORef)
 import Data.String              (IsString (..), String)
-import Network.Wai.Handler.Warp (defaultSettings, setHost,
-                                 setOnException, setPort,
+import Network.Wai.Handler.Warp (defaultSettings, setBeforeMainLoop,
+                                 setHost, setOnException, setPort,
                                  setServerName)
 
 import qualified Data.Text.Encoding       as T
@@ -104,12 +104,12 @@ run appState = do
   let app = postgrest appState (AppState.schemaCacheLoader appState)
 
   address <- resolveSocketToAddress mainSocket
-  observer $ AppServerAddressObs address
 
   let
     appServerSettings = serverSettings conf
       & setPort (configServerPort conf)
       & setOnException onWarpException
+      & setBeforeMainLoop (observer $ AppServerAddressObs address)
 
   Warp.runSettingsSocket appServerSettings mainSocket app
   where


### PR DESCRIPTION
We were logging these observations before running the server. If the server fails to startup, it was a bit misleading because one could think that something went wrong after the listening has already started which might not be true.

Previous behaviour that was tested manually by instrumenting the code:

```hs
  observer $ AdminServerObs address
  void . forkIO $ do
    _ <- throwIO $ ErrorCall "admin crash"
    Warp.runSettingsSocket settings adminSocket adminApp
```

The observation got logged even though the server didn't start at all. With the fix, that doesn't happen.

Related #5012.