### PR TITLE
fix(admin): log admin server exceptions and close admin socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file. From versio
 - Fix unexpected results when embedding and filtering the same table more than once by @laurenceisla in #4075
 - If the schema cache fails to reload, PostgREST will no longer stop serving requests and will continue doing so in a "best effort" basis by @mkleczek in #4873 #4869
 - Stop reporting 503s errors unnecessarily while the schema cache is loading at startup by @mkleczek in #4880
+- Fix admin server not logging cause of failure by @taimoorzaeem in #5012
 
 ### Changed
 

--- a/src/PostgREST/Admin.hs
+++ b/src/PostgREST/Admin.hs
@@ -28,7 +28,8 @@ runAdmin appState maybeAdminSocket getSocketREST settings = do
   conf <- getConfig appState
   whenJust maybeAdminSocket $ \adminSocket -> do
     address <- resolveSocketToAddress adminSocket
-    void . forkIO $ Warp.runSettingsSocket (adminServerSettings conf address) adminSocket adminApp
+    void . forkIO $ handle (onError adminSocket) $
+      Warp.runSettingsSocket (adminServerSettings conf address) adminSocket adminApp
   where
     adminApp = admin appState getSocketREST
     observer = AppState.getObserver appState
@@ -36,6 +37,10 @@ runAdmin appState maybeAdminSocket getSocketREST settings = do
       settings
         & Warp.setBeforeMainLoop (observer $ AdminStartObs addr)
         & maybe identity Warp.setPort (configAdminServerPort config)
+
+    onError adminSock ex = do
+      observer $ AdminServerCrashedObs ex
+      NS.close adminSock -- we close the socket so request doesn't hang
 
 -- | PostgREST admin application
 admin :: AppState.AppState -> IO (Maybe NS.Socket) -> Wai.Application

--- a/src/PostgREST/Logger.hs
+++ b/src/PostgREST/Logger.hs
@@ -132,6 +132,8 @@ observationMessages :: Observation -> [Text]
 observationMessages = \case
   AdminStartObs address ->
     pure $ "Admin server listening on " <> address
+  AdminServerCrashedObs ex ->
+    pure $ "FAILURE: Admin server crashed unexpectedly: " <> (showOnSingleLine '\t' . show) ex
   AppStartObs ver ->
     pure $ "Starting PostgREST " <> T.decodeUtf8 ver <> "..."
   AppServerAddressObs address ->

--- a/src/PostgREST/Observation.hs
+++ b/src/PostgREST/Observation.hs
@@ -25,6 +25,7 @@ import Protolude hiding (toList)
 
 data Observation
   = AdminStartObs Text
+  | AdminServerCrashedObs SomeException
   | AppStartObs ByteString
   | AppServerAddressObs Text
   | ExitUnsupportedPgVersion PgVersion PgVersion


### PR DESCRIPTION
Admin server was crashing silently and requests hang indefinitely.
With this fix, we are now logging the admin server exceptions and also
close the socket afterwards so admin request don't hang.

- [x] Implementation
- [ ] Tests
- [x] Changelog

Closes #5012.