### PR TITLE
nix(loadtest): run all target branches almost at the same time

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -130,7 +130,7 @@ rec {
 
   # Development tools.
   devTools =
-    pkgs.callPackage nix/tools/devTools.nix { inherit tests style devCabalOptions hsie withTools; };
+    pkgs.callPackage nix/tools/devTools.nix { inherit tests style devCabalOptions hsie; };
 
   # Documentation tools.
   docs =

--- a/nix/README.md
+++ b/nix/README.md
@@ -211,9 +211,6 @@ The loadtests ensure that performance doesn't drop on a change. Underlyingly the
 # You can loadtest comparing to a different branch
 [nix-shell]$ postgrest-loadtest-against main
 
-# You can build postgrest directly with cabal for faster iteration
-[nix-shell]$ PGRST_BUILD_CABAL=1 postgrest-loadtest
-
 # Produce a markdown report to be used on CI
 [nix-shell]$ postgrest-loadtest-report
 ```

--- a/nix/tools/devTools.nix
+++ b/nix/tools/devTools.nix
@@ -6,14 +6,12 @@
 , devCabalOptions
 , entr
 , fd
-, git
 , graphviz
 , hsie
 , nix
 , stdenv
 , style
 , tests
-, withTools
 , haskellPackages
 , ctags
 , openssl
@@ -89,156 +87,6 @@ let
         ${tests}/bin/postgrest-test-replica
         ${style}/bin/postgrest-lint
         ${style}/bin/postgrest-style-check
-      '';
-
-  gitHooks =
-    let
-      name = "postgrest-git-hooks";
-    in
-    checkedShellScript
-      {
-        inherit name;
-        docs =
-          ''
-            Enable or disable git pre-commit and pre-push hooks.
-
-            Basic is faster and will only run:
-              - pre-commit: postgrest-style
-              - pre-push: postgrest-lint
-
-            Full takes a lot more time and will run:
-              - pre-commit: postgrest-style && postgrest-lint
-              - pre-push: postgrest-check
-
-            Changes made by postgrest-style will be staged automatically.
-
-            Example usage:
-              postgrest-git-hooks disable
-              postgrest-git-hooks enable basic
-              postgrest-git-hooks enable full
-
-            The "run" operation and "--hook" argument are only used internally.
-          '';
-        args =
-          [
-            "ARG_POSITIONAL_SINGLE([operation], [Operation])"
-            "ARG_TYPE_GROUP_SET([OPERATION], [OPERATION], [operation], [disable,enable,run])"
-            "ARG_POSITIONAL_SINGLE([mode], [Mode], [basic])"
-            "ARG_TYPE_GROUP_SET([MODE], [MODE], [mode], [basic,full])"
-            "ARG_OPTIONAL_SINGLE([hook], , [Hook], [pre-commit])"
-            "ARG_TYPE_GROUP_SET([HOOK], [HOOK], [hook], [pre-commit,pre-push])"
-          ];
-        positionalCompletion =
-          ''
-            if test "$prev" == "${name}"; then
-              COMPREPLY=( $(compgen -W "enable disable" -- "$cur") )
-            elif test "$prev" == "enable" || test "$prev" == "disable"; then
-              COMPREPLY=( $(compgen -W "basic full" -- "$cur") )
-            fi
-          '';
-        workingDir = "/";
-      }
-      ''
-        if [ run != "$_arg_operation" ]; then
-          # Remove all hooks first and ignore failures because the file might be missing.
-          # This assumes that we're only adding lines that include "postgrest-git-hooks"
-          # to the hook file.
-          sed -i -e '/postgrest-git-hooks/d' .git/hooks/pre-{commit,push} 2> /dev/null || true
-
-          if [ disable != "$_arg_operation" ]; then
-            # The nix-shell && + nix-shell || pattern makes sure we can run the hook
-            # in a pure nix-shell, where nix-shell itself is not available, too.
-
-            # The $(nix-shell --run "command -v ...") pattern ensures we only need to enable
-            # the hooks once and still run the latest of our hook scripts, even when we
-            # update them in the repo.
-
-            echo 'command -v nix-shell > /dev/null || postgrest-git-hooks --hook=pre-commit run' "$_arg_mode" \
-              >> .git/hooks/pre-commit
-            # shellcheck disable=SC2016
-            echo 'command -v nix-shell > /dev/null && $(nix-shell --quiet -Q --run "command -v postgrest-git-hooks") --hook=pre-commit run' "$_arg_mode" \
-             >> .git/hooks/pre-commit
-            chmod +x .git/hooks/pre-commit
-
-            echo 'command -v nix-shell > /dev/null || postgrest-git-hooks --hook=pre-push run' "$_arg_mode" \
-              >> .git/hooks/pre-push
-            # shellcheck disable=SC2016
-            echo 'command -v nix-shell > /dev/null && $(nix-shell --quiet -Q --run "command -v postgrest-git-hooks") --hook=pre-push run' "$_arg_mode" \
-             >> .git/hooks/pre-push
-            chmod +x .git/hooks/pre-push
-          fi
-        else
-          # When run from a git hook, the GIT_ environment variables conflict with our withGit helper.
-          # The following unsets all GIT_ variables.
-          unset "''${!GIT_@}"
-
-          # shellcheck disable=SC2329
-          function restore () {
-            ref="$(git stash list --format=format:%gD --grep "$1" -n1)"
-            # this will avoid merge conflicts when applying the stash
-            ${git}/bin/git restore --source="$ref" .
-            # restore untracked files, too. could fail with no files
-            if [ "$(git show --numstat --format=oneline "$ref^3" | wc -l)" -gt 1 ]; then
-              ${git}/bin/git restore --overlay --source="$ref^3" .
-            fi
-            ${git}/bin/git stash drop "$ref"
-          }
-
-          case "$_arg_mode" in
-            basic)
-              case "$_arg_hook" in
-                pre-commit)
-                  # To be able to automatically add only changes from postgrest-style to the staging area,
-                  # we need to run postgrest-style twice. Otherwise we'd risk merge conflicts when popping
-                  # the stash afterwards.
-                  ${style}/bin/postgrest-style
-
-                  stash="postgrest-git-hooks-$RANDOM"
-                  ${git}/bin/git stash push --include-untracked --keep-index -m "$stash"
-                  if [ "$(git stash list --grep $stash)" ]; then
-                    # Only create the stash pop trap, if we actually created a stash.
-                    # Otherwise stash pop will cause havoc.
-                    trap 'restore "$stash"' EXIT
-                  fi
-
-                  ${style}/bin/postgrest-style
-                  ${git}/bin/git add .
-                  ;;
-                pre-push)
-                  # Create a clean working tree without any uncommitted changes.
-                  ${withTools.withGit} HEAD ${style}/bin/postgrest-lint
-                  ;;
-              esac
-              ;;
-            full)
-              case "$_arg_hook" in
-                pre-commit)
-                  # To be able to automatically add only changes from postgrest-style to the staging area,
-                  # we need to run postgrest-style twice. Otherwise we'd risk merge conflicts when popping
-                  # the stash afterwards.
-                  ${style}/bin/postgrest-style
-
-                  stash="postgrest-git-hooks-$RANDOM"
-                  ${git}/bin/git stash push --include-untracked --keep-index -m "$stash"
-                  if [ "$(git stash list --grep $stash)" ]; then
-                    # Only create the stash pop trap, if we actually created a stash.
-                    # Otherwise stash pop will cause havoc.
-                    trap 'restore "$stash"' EXIT
-                  fi
-
-                  ${style}/bin/postgrest-style
-                  ${git}/bin/git add .
-
-                  ${style}/bin/postgrest-lint
-                  ;;
-                pre-push)
-                  # Create a clean working tree without any uncommitted changes.
-                  ${withTools.withGit} HEAD ${check}
-                  ;;
-              esac
-              ;;
-          esac
-        fi
       '';
 
   dumpMinimalImports =
@@ -395,7 +243,6 @@ buildToolbox
     inherit
       check
       dumpMinimalImports
-      gitHooks
       hsieGraphModules
       hsieGraphSymbols
       hsieMinimalImports

--- a/nix/tools/loadtest.nix
+++ b/nix/tools/loadtest.nix
@@ -146,8 +146,8 @@ let
         workingDir = "/";
       }
       ''
-        # run loadtest for every target
-        for tgt in "''${_arg_target[@]}"; do
+        # run loadtest for every target and HEAD
+        for tgt in "''${_arg_target[@]}" HEAD; do
 
         cat << EOF
 
@@ -169,22 +169,6 @@ let
         EOF
 
         done
-
-        # run loadtest once on HEAD
-
-        cat << EOF
-
-        Running "$_arg_kind" loadtest on HEAD...
-
-        EOF
-
-        ${loadtest} -k "$_arg_kind" -m "$PWD/loadtest/head.csv" --output "$PWD/loadtest/head.bin" --testdir "$PWD/test/load"
-
-        cat << EOF
-
-        Done running on HEAD.
-
-        EOF
       '';
 
   reporter =
@@ -217,7 +201,7 @@ let
 
         def evaluate_change(df):
             try:
-                return ((df['head'] / df['main'] - 1) * 100) \
+                return ((df['HEAD'] / df['main'] - 1) * 100) \
                   .map(lambda r: "{icon} {ratio:.1f} %".format(
                     ratio=r,
                     # Hardcoded failure threshold for CI is 5% here.

--- a/nix/tools/loadtest.nix
+++ b/nix/tools/loadtest.nix
@@ -1,5 +1,6 @@
 { buildToolbox
 , checkedShellScript
+, git
 , jq
 , libfaketime
 , python3Packages
@@ -43,7 +44,6 @@ let
         docs = "Run the vegeta loadtests with PostgREST.";
         args = [
           "ARG_OPTIONAL_SINGLE([output], [o], [Filename to dump json output to], [./loadtest/result.bin])"
-          "ARG_OPTIONAL_SINGLE([testdir], [t], [Directory to load tests and fixtures from], [./test/load])"
           "ARG_OPTIONAL_SINGLE([kind], [k], [Kind of loadtest], [mixed])"
           "ARG_TYPE_GROUP_SET([KIND], [KIND], [kind], [mixed,jwt-cache,jwt-cache-worst])"
           "ARG_OPTIONAL_SINGLE([monitor], [m], [Monitoring file], [./loadtest/result.csv])"
@@ -65,23 +65,23 @@ let
 
         case "$_arg_kind" in
           jwt-cache)
-            export PGRST_JWT_SECRET="@$_arg_testdir/gen_jwks.json"
+            export PGRST_JWT_SECRET="@test/load/gen_jwks.json"
 
-            ${libfaketime}/bin/faketime '2000-01-01 00:00:00' ${genTargets} "$_arg_testdir"
+            ${libfaketime}/bin/faketime '2000-01-01 00:00:00' ${genTargets} test/load
 
             # shellcheck disable=SC2145
-            ${withTools.withPg} -f "$_arg_testdir"/fixtures.sql \
+            ${withTools.withPg} -f test/load/fixtures.sql \
             ${withTools.withPgrst} --faketime '2000-01-01 00:00:00' -m "$_arg_monitor" \
-            sh -c "cd \"$_arg_testdir\" && \
+            sh -c "cd test/load && \
             ${runner} -targets gen_targets.http -output \"$abs_output\" \"''${_arg_leftovers[@]}\""
             ;;
 
           # here we sleep purposefully to check how much memory does the schema cache consume in the final report
           mixed)
             # shellcheck disable=SC2145
-            ${withTools.withPg} -f "$_arg_testdir"/fixtures.sql \
+            ${withTools.withPg} -f test/load/fixtures.sql \
             ${withTools.withPgrst} --timeout 2 --sleep 5 -m "$_arg_monitor" \
-            sh -c "cd \"$_arg_testdir\" && \
+            sh -c "cd test/load && \
             ${runner} -targets targets.http -output \"$abs_output\" \"''${_arg_leftovers[@]}\""
             ;;
         esac
@@ -146,7 +146,39 @@ let
         workingDir = "/";
       }
       ''
-        # run loadtest for every target and HEAD
+        # Build postgrest for every target and HEAD.
+        # Keeps a reference to the postgrest binary and faketime lib for every branch to run later.
+        declare -A pgrst faketime
+        for tgt in "''${_arg_target[@]}" HEAD; do
+          # not using withTmpDir here, because we don't want to keep the directory on error
+          tmpdir="$(mktemp -d)"
+          trap 'rm -rf "$tmpdir"' EXIT
+
+          ${git}/bin/git worktree add -f "$tmpdir" "$tgt" > /dev/null
+          pushd "$tmpdir" > /dev/null
+
+          build_start=$SECONDS
+          echo -n "${name}: Building postgrest (nix) on $tgt... "
+          # Using lib.getBin to also make this work with older checkouts, where .bin was not a thing, yet.
+          nix-build --no-out-link -E 'with import ./. {}; pkgs.lib.getBin postgrestPackage' > build.log 2>&1 || {
+            echo "failed, output:"
+            cat build.log
+            exit 1
+          }
+          pgrst[$tgt]="$(nix-build --no-out-link -E 'with import ./. {}; pkgs.lib.getBin postgrestPackage')/bin/postgrest"
+          # To avoid glibc mismatches with back-branches, we need to take libfaketime from the target branch.
+          faketime[$tgt]="$(nix-build --no-out-link -A pkgs.libfaketime)/lib/libfaketime.so.1"
+          build_end=$((SECONDS - build_start))
+          printf "done in %ss.\n" "$build_end"
+
+          popd > /dev/null
+          ${git}/bin/git worktree remove -f "$tmpdir" > /dev/null
+          rm -rf "$tmpdir"
+        done
+
+        # Run loadtest for every target and HEAD.
+        # Running the tests is separated from building them to reduce the chances of
+        # other processes skewing the results between two runs.
         for tgt in "''${_arg_target[@]}" HEAD; do
 
         cat << EOF
@@ -155,12 +187,7 @@ let
 
         EOF
 
-        # Runs the test files from the current working tree
-        # to make sure both tests are run with the same files.
-        # Save the results in the current working tree, too,
-        # otherwise they'd be lost in the temporary working tree
-        # created by withTools.withGit.
-        ${withTools.withGit} "$tgt" ${loadtest} -k "$_arg_kind" -m "$PWD/loadtest/$tgt.csv" --output "$PWD/loadtest/$tgt.bin" --testdir "$PWD/test/load"
+        FAKETIME_LIB="''${faketime[$tgt]}" PGRST_CMD="''${pgrst[$tgt]}" ${loadtest} -k "$_arg_kind" -m "loadtest/$tgt.csv" --output "loadtest/$tgt.bin"
 
         cat << EOF
 

--- a/nix/tools/loadtest.nix
+++ b/nix/tools/loadtest.nix
@@ -3,7 +3,9 @@
 , git
 , jq
 , libfaketime
+, python3
 , python3Packages
+, runCommand
 , vegeta
 , withTools
 , writers
@@ -65,15 +67,13 @@ let
 
         case "$_arg_kind" in
           jwt-cache)
-            export PGRST_JWT_SECRET="@test/load/gen_jwks.json"
-
-            ${libfaketime}/bin/faketime '2000-01-01 00:00:00' ${genTargets} test/load
+            export PGRST_JWT_SECRET="@${generatedTargets}/gen_jwks.json"
 
             # shellcheck disable=SC2145
             ${withTools.withPg} -f test/load/fixtures.sql \
             ${withTools.withPgrst} --faketime '2000-01-01 00:00:00' -m "$_arg_monitor" \
             sh -c "cd test/load && \
-            ${runner} -targets gen_targets.http -output \"$abs_output\" \"''${_arg_leftovers[@]}\""
+            ${runner} -targets ${generatedTargets}/gen_targets.http -output \"$abs_output\" \"''${_arg_leftovers[@]}\""
             ;;
 
           # here we sleep purposefully to check how much memory does the schema cache consume in the final report
@@ -291,13 +291,15 @@ let
           | ${mergeMonitorResults}
       '';
 
-  genTargets =
-    writers.writePython3 "postgrest-gen-loadtest-targets"
+  generatedTargets =
+    runCommand "postgrest-loadtest-targets"
       {
-        libraries = [ python3Packages.jwcrypto ];
-        doCheck = false; # postgrest-style conflicts with this
+        nativeBuildInputs = [ (python3.withPackages (pyps: [ pyps.jwcrypto ])) ];
       }
-      (builtins.readFile ./generate_targets.py);
+      ''
+        mkdir -p "$out"
+        ${libfaketime}/bin/faketime '2000-01-01 00:00:00' python3 ${./generate_targets.py} "$out"
+      '';
 
   mergeMonitorResults =
     writers.writePython3 "postgrest-merge-monitor-results"

--- a/nix/tools/withTools.nix
+++ b/nix/tools/withTools.nix
@@ -1,7 +1,6 @@
 { buildToolbox
 , checkedShellScript
 , curl
-, git
 , lib
 , libfaketime
 , postgresqlVersions
@@ -197,47 +196,6 @@ let
 
   withPg = withTmpDb (builtins.head postgresqlVersions);
 
-  withGit =
-    let
-      name = "postgrest-with-git";
-    in
-    checkedShellScript
-      {
-        inherit name;
-        docs =
-          ''
-            Create a new worktree of the postgrest repo in a temporary directory and
-            check out <commit>, then run <command> with arguments inside the temporary folder.
-          '';
-        args =
-          [
-            "ARG_POSITIONAL_SINGLE([commit], [Commit-ish reference to run command with])"
-            "ARG_POSITIONAL_SINGLE([command], [Command to run])"
-            "ARG_LEFTOVERS([command arguments])"
-          ];
-        positionalCompletion =
-          ''
-            if test "$prev" == "${name}"; then
-              __gitcomp_nl "$(__git_refs)"
-            else
-              _command_offset 2
-            fi
-          '';
-        workingDir = "/";
-      }
-      ''
-        # not using withTmpDir here, because we don't want to keep the directory on error
-        tmpdir="$(mktemp -d)"
-        trap 'rm -rf "$tmpdir"' EXIT
-
-        ${git}/bin/git worktree add -f "$tmpdir" "$_arg_commit" > /dev/null
-
-        cd "$tmpdir"
-        ("$_arg_command" "''${_arg_leftovers[@]}")
-
-        ${git}/bin/git worktree remove -f "$tmpdir" > /dev/null
-      '';
-
   waitForPgrstReady =
     checkedShellScript
       {
@@ -294,7 +252,8 @@ let
             "ARG_OPTIONAL_SINGLE([monitor], [m], [Enable CPU and memory monitoring of the PostgREST process and output to the designated file as markdown])"
             "ARG_OPTIONAL_SINGLE([timeout], [t], [Maximum time to wait for PostgREST to be ready], [5])"
             "ARG_OPTIONAL_SINGLE([sleep], [s],   [Sleep time after PostgREST is ready, this is useful for monitoring])"
-            "ARG_USE_ENV([PGRST_CMD], [], [PostgREST executable to run])"
+            "ARG_USE_ENV([FAKETIME_LIB], [${libfaketime}/lib/libfaketime.so.1], [Faketime Library to preload])"
+            "ARG_USE_ENV([PGRST_CMD], [postgrest-run], [PostgREST executable to run])"
           ];
         positionalCompletion = "_command";
         workingDir = "/";
@@ -304,27 +263,10 @@ let
       ''
         export PGRST_SERVER_UNIX_SOCKET="$tmpdir"/postgrest.socket
 
-        FAKETIME_LIB="${libfaketime}/lib/libfaketime.so.1"
-
-        if [ -z "''${PGRST_CMD:-}" ]; then
-          rm -f result
+        if [ "''${PGRST_CMD}" == "postgrest-run" ]; then
           build_start=$SECONDS
-          if [ -z "''${PGRST_BUILD_CABAL:-}" ]; then
-            echo -n "${commandName}: Building postgrest (nix)... "
-            # Using lib.getBin to also make this work with older checkouts, where .bin was not a thing, yet.
-            nix-build --no-out-link -E 'with import ./. {}; pkgs.lib.getBin postgrestPackage' > "$tmpdir"/build.log 2>&1 || {
-              echo "failed, output:"
-              cat "$tmpdir"/build.log
-              exit 1
-            }
-            PGRST_CMD="$(nix-build --no-out-link -E 'with import ./. {}; pkgs.lib.getBin postgrestPackage')/bin/postgrest"
-            # To avoid glibc mismatches with back-branches, we need to take libfaketime from the target branch.
-            FAKETIME_LIB="$(nix-build --no-out-link -A pkgs.libfaketime)/lib/libfaketime.so.1"
-          else
-            echo -n "${commandName}: Building postgrest (cabal)... "
-            postgrest-build
-            PGRST_CMD=postgrest-run
-          fi
+          echo -n "${commandName}: Building postgrest (cabal)... "
+          postgrest-build
           build_end=$((SECONDS - build_start))
           printf "done in %ss.\n" "$build_end"
         fi
@@ -387,7 +329,6 @@ buildToolbox
   name = "postgrest-with";
   tools = {
     inherit
-      withGit
       withPgAll
       withPgrst;
   } // builtins.listToAttrs (


### PR DESCRIPTION
Instead of building, running, building, running, ... we now build all executables once ahead of time and then run all loadtests right after each other. This can sometimes reduce noise when load on the GHA runner varies over time.

(a few more less meaningful commits around that as well)