### PR TITLE
chore: enable GHC NumericUnderscores language extension

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -41,6 +41,7 @@ library
   default-language:   Haskell2010
   default-extensions: OverloadedStrings
                       NoImplicitPrelude
+                      NumericUnderscores
   hs-source-dirs:     src
   exposed-modules:    PostgREST.Admin
                       PostgREST.App
@@ -218,6 +219,7 @@ test-suite spec
   default-extensions: OverloadedStrings
                       QuasiQuotes
                       NoImplicitPrelude
+                      NumericUnderscores
   hs-source-dirs:     test/spec
   main-is:            Main.hs
   other-modules:      Feature.Auth.AsymmetricJwtSpec
@@ -317,6 +319,7 @@ test-suite observability
   default-extensions: OverloadedStrings
                       QuasiQuotes
                       NoImplicitPrelude
+                      NumericUnderscores
   hs-source-dirs:     test/observability
   main-is:            Main.hs
   other-modules:      ObsHelper

--- a/src/PostgREST/AppState.hs
+++ b/src/PostgREST/AppState.hs
@@ -371,7 +371,7 @@ retryingSchemaCacheLoad appState@AppState{stateObserver=observer, stateMainThrea
       let delayMicroseconds = 32*oneSecondInUs {-32 seconds-} in
       capDelay delayMicroseconds $ exponentialBackoff oneSecondInUs
 
-    oneSecondInUs = 1000000 -- one second in microseconds
+    oneSecondInUs = 1_000_000 -- one second in microseconds
 
 newSchemaCacheStatus :: IO SchemaCacheStatus
 newSchemaCacheStatus = SchemaCacheStatus <$> newEmptyTMVarIO

--- a/src/PostgREST/Listener.hs
+++ b/src/PostgREST/Listener.hs
@@ -97,7 +97,7 @@ retryingListen appState nextDelay hasDbListenerBug = do
   where
     observer = AppState.getObserver appState
     mainThreadId = AppState.getMainThreadId appState
-    oneSecondInMicro = 1000000
+    oneSecondInMicro = 1_000_000
     maxDelay = 32
 
     handleNotification channel msg =

--- a/src/PostgREST/Logger.hs
+++ b/src/PostgREST/Logger.hs
@@ -52,7 +52,7 @@ data LoggerState = LoggerState
 init :: IO LoggerState
 init = mdo
   let
-    oneSecond = 1000000
+    oneSecond = 1_000_000
     loggerState = LoggerState zTime debouncePoolTimeout
   zTime <- mkAutoUpdate defaultUpdateSettings { updateAction = getZonedTime }
   debouncePoolTimeout <- makeDebouncer $

--- a/test/observability/ObsHelper.hs
+++ b/test/observability/ObsHelper.hs
@@ -206,7 +206,7 @@ waitForObs (ObsChan orig copy) t msg f =
     -- duplicate the provided channel and construct wairFor function binding both channels
     -- accumulate effecful computation results into a list for specified time
     takeUntilTimeout t' = fmap reverse . accumulateUntilTimeout t' (flip (:)) []
-    decisecond = 100000
+    decisecond = 100_000
 
 obsDiagMessage :: Observation -> Text
 obsDiagMessage = \case

--- a/test/observability/Observation/SchemaCacheSpec.hs
+++ b/test/observability/Observation/SchemaCacheSpec.hs
@@ -46,4 +46,4 @@ spec = describe "Server started with metrics enabled" $ do
         waitFor (1 * sec) "SchemaCacheQueriedObs" $ \x -> [ o | o@SchemaCacheQueriedObs{} <- pure x ]
         waitFor (1 * sec) "SchemaCacheLoadedObs" $ \x -> [ o | o@SchemaCacheLoadedObs{} <- pure x ]
   where
-    sec = 1000000
+    sec = 1_000_000

--- a/test/spec/SpecHelper.hs
+++ b/test/spec/SpecHelper.hs
@@ -250,7 +250,7 @@ planCost :: SResponse -> Float
 planCost resp =
   let res = simpleBody resp ^? nth 0 . key "Plan" . key "Total Cost" in
   -- big value in case parsing fails
-  fromMaybe 1000000000.0 $ unbox =<< res
+  fromMaybe 1_000_000_000.0 $ unbox =<< res
   where
     unbox :: JSON.Value -> Maybe Float
     unbox (JSON.Number n) = Just $ toRealFloat n


### PR DESCRIPTION
Enables the [NumericUnderscores](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/numeric_underscores.html#numeric-underscores) extension. The `_` character between numeric literals improve their readablity.