### PR TITLE
nix(loadtest): avoid hitting the database when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file. From versio
 - Log schema cache queries timings on `log-level=debug` by @steve-chavez in #4805
 - Add GHC runtime metrics to the metrics endpoint by @mkleczek in #4862
 - Support running the admin server on a unix socket by @wolfgangwalther in #5003
+- Support returning the request's SQL query when setting `Accept: application/vnd.pgrst.sql` by @wolfgangwalther in #3580
 
 ### Fixed
 

--- a/docs/references/observability.rst
+++ b/docs/references/observability.rst
@@ -477,3 +477,22 @@ For example, to only allow requests from an IP address to get the execution plan
       window.location.href = willRedirectTo;
     }
   </script>
+
+.. _sql_query:
+
+SQL query
+---------
+
+You can get the raw SQL query of a request by adding the ``Accept: application/sql`` header.
+This is enabled by :ref:`db-plan-enabled` (false by default).
+
+.. code-block:: bash
+
+  curl "http://localhost:3000/projects" \
+    -H "Accept: application/sql"
+
+.. code-block:: postgres
+
+  select set_config('search_path', $1, true), set_config('role', $2, true), set_config('request.jwt.claims', $3, true), set_config('request.method', $4, true), set_config('request.path', $5, true), set_config('request.headers', $6, true), set_config('request.cookies', $7, true)
+
+  WITH pgrst_source AS ( SELECT "test"."projects".* FROM "test"."projects"    )  SELECT null::bigint AS total_result_set, pg_catalog.count(_postgrest_t) AS page_total, coalesce(json_agg(_postgrest_t), '[]') AS body, nullif(current_setting('response.headers', true), '') AS response_headers, nullif(current_setting('response.status', true), '') AS response_status, '' AS response_inserted FROM ( SELECT * FROM pgrst_source ) _postgrest_t

--- a/nix/tools/loadtest.nix
+++ b/nix/tools/loadtest.nix
@@ -57,6 +57,7 @@ let
         export PGRST_DB_ANON_ROLE="postgrest_test_anonymous"
         export PGRST_DB_CONFIG="false"
         export PGRST_DB_POOL="1"
+        export PGRST_DB_PLAN_ENABLED="1"
         export PGRST_DB_SCHEMAS="test"
         export PGRST_DB_TX_END="rollback-allow-override"
         export PGRST_LOG_LEVEL="crit"

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -264,6 +264,7 @@ test-suite spec
                       Feature.Query.RawOutputTypesSpec
                       Feature.Query.RelatedQueriesSpec
                       Feature.Query.RpcSpec
+                      Feature.Query.SQLSpec
                       Feature.Query.ServerTimingSpec
                       Feature.Query.SingularSpec
                       Feature.Query.SpreadQueriesSpec

--- a/src/PostgREST/MainTx.hs
+++ b/src/PostgREST/MainTx.hs
@@ -22,8 +22,10 @@ import qualified Data.ByteString.Char8             as BS
 import qualified Data.HashMap.Strict               as HM
 import qualified Data.Set                          as S
 import qualified Hasql.Decoders                    as HD
+import qualified Hasql.DynamicStatements.Snippet   as SQL hiding (sql)
 import qualified Hasql.DynamicStatements.Statement as SQL
 import qualified Hasql.Session                     as SQL (Session)
+import qualified Hasql.Statement                   as SQL
 import qualified Hasql.Transaction                 as SQL
 import qualified Hasql.Transaction.Sessions        as SQL
 
@@ -65,6 +67,7 @@ data MainTx
 data DbResult
   = DbCrudResult  CrudPlan ResultSet
   | DbPlanResult  MediaType BS.ByteString
+  | SQLResult     MediaType BS.ByteString
   | MaybeDbResult InspectPlan  (Maybe (TablesMap, RoutineMap, Maybe Text))
   | NoDbResult    InfoPlan
 
@@ -106,6 +109,7 @@ mainTx genQ@MainQuery{..} conf@AppConfig{..} AuthResult{..} apiReq (Db plan) sCa
 planTxMode :: DbActionPlan -> SQL.Mode
 planTxMode (DbCrud _ x) = pTxMode x
 planTxMode (MayUseDb x) = ipTxmode x
+planTxMode (SQLOnly x)  = planTxMode x
 
 planIsoLvl :: AppConfig -> ByteString -> DbActionPlan -> SQL.IsolationLevel
 planIsoLvl AppConfig{configRoleIsoLvl} role actPlan = case actPlan of
@@ -114,11 +118,27 @@ planIsoLvl AppConfig{configRoleIsoLvl} role actPlan = case actPlan of
   where
     roleIsoLvl = HM.findWithDefault SQL.ReadCommitted role configRoleIsoLvl
 
+-- TODO: maybe patch upstream hasql-dynamic-statements so we have a less hackish way to convert
+-- the SQL.Snippet or maybe don't use hasql-dynamic-statements and resort to plain strings for the queries and use regular hasql
+renderSnippet :: SQL.Snippet -> ByteString
+renderSnippet snippet =
+  let SQL.Statement sql _ _ _ = SQL.dynamicallyParameterized snippet decoder False
+      decoder = HD.noResult -- unused
+  in
+    sql
+
 actionResult :: MainQuery -> DbActionPlan -> AppConfig -> ApiRequest -> SchemaCache -> ExceptT Error SQL.Transaction DbResult
 actionResult MainQuery{..} (DbCrud True plan) conf@AppConfig{..} apiReq _ = do
   explRes <- lift $ SQL.statement mempty $ SQL.dynamicallyParameterized mqMain planRow configDbPreparedStatements
   optionalRollback conf apiReq
   pure $ DbPlanResult (pMedia plan) explRes
+
+actionResult MainQuery{..} (SQLOnly (DbCrud _ plan)) _ _ _ =
+  pure $ SQLResult (pMedia plan) $ BS.intercalate "\n\n" $ filter (/= mempty) snipts
+  where
+    snipts = renderSnippet <$> [mqTxVars, fromMaybe mempty mqPreReq, mqMain, fromMaybe mempty mqExplain]
+
+actionResult mq (SQLOnly dbplan) conf apiReq sCache = actionResult mq dbplan conf apiReq sCache
 
 actionResult MainQuery{..} (DbCrud _ plan@WrappedReadPlan{..}) conf@AppConfig{..} apiReq@ApiRequest{iPreferences=Preferences{..}} _ = do
   resultSet@RSStandard{rsTableTotal=tableTotal} <- lift $ SQL.statement mempty $ dynStmt (HD.singleRow $ standardRow True)

--- a/src/PostgREST/MediaType.hs
+++ b/src/PostgREST/MediaType.hs
@@ -39,6 +39,7 @@ data MediaType
   | MTVndSingularJSON Bool
   -- TODO MTVndPlan should only have its options as [Text]. Its ResultAggregate should have the typed attributes.
   | MTVndPlan MediaType MTVndPlanFormat [MTVndPlanOption]
+  | MTVndSQL MediaType
   deriving (Eq, Show, Generic, JSON.ToJSON)
 instance Hashable MediaType
 
@@ -80,6 +81,9 @@ toMime (MTVndPlan mt fmt opts)   =
   "application/vnd.pgrst.plan+" <> toMimePlanFormat fmt <>
   ("; for=\"" <> toMime mt <> "\"") <>
   (if null opts then mempty else "; options=" <> BS.intercalate "|" (toMimePlanOption <$> opts))
+toMime (MTVndSQL mt) =
+  "application/vnd.pgrst.sql" <>
+  ("; for=\"" <> toMime mt <> "\"")
 
 toMimePlanOption :: MTVndPlanOption -> ByteString
 toMimePlanOption PlanAnalyze  = "analyze"
@@ -127,6 +131,12 @@ toMimePlanFormat PlanText = "text"
 --
 -- >>> decodeMediaType "application/vnd.twkb"
 -- MTOther "application/vnd.twkb"
+--
+-- >>> decodeMediaType "application/vnd.pgrst.sql"
+-- MTVndSQL MTApplicationJSON
+--
+-- >>> decodeMediaType "application/vnd.pgrst.sql;for=\"text/csv\""
+-- MTVndSQL MTTextCSV
 
 decodeMediaType :: ByteString -> MediaType
 decodeMediaType mt = decodeMediaType' $ decodeLatin1 mt
@@ -145,6 +155,7 @@ decodeMediaType mt = decodeMediaType' $ decodeLatin1 mt
         ("application", "vnd.pgrst.plan", _)        -> getPlan PlanText
         ("application", "vnd.pgrst.plan+text", _)   -> getPlan PlanText
         ("application", "vnd.pgrst.plan+json", _)   -> getPlan PlanJSON
+        ("application", "vnd.pgrst.sql", _)         -> MTVndSQL $ decodeMediaType' $ fromMaybe "application/json" (params !? "for")
         ("application", "vnd.pgrst.object+json", _) -> MTVndSingularJSON strippedNulls
         ("application", "vnd.pgrst.object", _)      -> MTVndSingularJSON strippedNulls
         ("application", "vnd.pgrst.array+json", _)  -> checkArrayNullStrip

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -118,7 +118,7 @@ data CrudPlan
   , crQi       :: QualifiedIdentifier
   }
 
--- Plan for reading db object metadadta
+-- Plan for reading db object metadata
 data InspectPlan = InspectPlan {
     ipMedia    :: MediaType
   , ipTxmode   :: SQL.Mode

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -137,6 +137,7 @@ type IsDbExplain = Bool
 data DbActionPlan
   = DbCrud   IsDbExplain CrudPlan
   | MayUseDb InspectPlan
+  | SQLOnly  DbActionPlan -- return the SQL query for a hypothetical request as text; does not actually *use* the DB
 
 -- Plans that don't use the database
 data InfoPlan
@@ -165,8 +166,10 @@ dbActionPlan dbAct conf apiReq sCache = case dbAct of
     MayUseDb <$> inspectPlan apiReq headersOnly tSchema
   where
     toDbActPlan pl = case pMedia pl of
-      MTVndPlan{} -> DbCrud True pl
-      _           -> DbCrud False pl
+      MTVndPlan{}          -> DbCrud True pl
+      MTVndSQL MTVndPlan{} -> SQLOnly $ DbCrud True pl
+      MTVndSQL{}           -> SQLOnly $ DbCrud False pl
+      _                    -> DbCrud False pl
 
 wrappedReadPlan :: QualifiedIdentifier -> AppConfig -> SchemaCache -> ApiRequest -> Bool -> Either Error CrudPlan
 wrappedReadPlan  identifier conf sCache apiRequest@ApiRequest{iPreferences=Preferences{..},..} headersOnly = do

--- a/src/PostgREST/Plan/Negotiate.hs
+++ b/src/PostgREST/Plan/Negotiate.hs
@@ -70,6 +70,10 @@ negotiateContent conf ApiRequest{iAction=act, iPreferences=Preferences{preferRep
       m@(MTVndPlan MTVndArrayJSONStrip _ _)       -> mtPlanToNothing $ Just (BuiltinAggArrayJsonStrip, m)
       -- TODO the plan should have its own MediaHandler instead of relying on MediaType
       m@(MTVndPlan mType _ _)                     -> mtPlanToNothing $ ((,) . fst <$> lookupHandler mType) <*> pure m
+      m@(MTVndSQL (MTVndSingularJSON strip))      -> mtPlanToNothing $ Just (BuiltinAggSingleJson strip, m)
+      m@(MTVndSQL MTVndArrayJSONStrip)            -> mtPlanToNothing $ Just (BuiltinAggArrayJsonStrip, m)
+      -- TODO the plan should have its own MediaHandler instead of relying on MediaType
+      m@(MTVndSQL mType)                          -> mtPlanToNothing $ ((,) . fst <$> lookupHandler mType) <*> pure m
       -- all the other media types can be overridden
       x                                           -> lookupHandler x
     mtPlanToNothing x = if configDbPlanEnabled conf then x else Nothing -- don't find anything if the plan media type is not allowed

--- a/src/PostgREST/Query.hs
+++ b/src/PostgREST/Query.hs
@@ -56,3 +56,4 @@ mainQuery (Db plan) conf@AppConfig{..} apiReq@ApiRequest{iTopLevelRange=range, i
       genQ (Statements.mainCall crProc crCallPlan crReadPlan preferCount configDbMaxRows range pMedia crHandler) (mempty, mempty, mempty) mempty
     MayUseDb InspectPlan{ipSchema=tSchema} ->
       genQ mempty (SqlFragment.accessibleTables tSchema, SqlFragment.accessibleFuncs tSchema, SqlFragment.schemaDescription tSchema) mempty
+    SQLOnly dbplan -> mainQuery (Db dbplan) conf apiReq authRes preReq

--- a/src/PostgREST/Response.hs
+++ b/src/PostgREST/Response.hs
@@ -206,6 +206,10 @@ actionResponse (DbPlanResult media plan) ctxApiRequest _ _ _ =
   let body = LBS.fromStrict plan in
   Right $ PgrstResponse HTTP.status200 (contentLengthHeader body : contentTypeHeaders media ctxApiRequest) body
 
+actionResponse (SQLResult media sql) ctxApiRequest _ _ _ =
+  let body = LBS.fromStrict sql in
+  Right $ PgrstResponse HTTP.status200 (contentLengthHeader body : contentTypeHeaders media ctxApiRequest) body
+
 actionResponse (MaybeDbResult InspectPlan{ipHdrsOnly=headersOnly} body) ApiRequest{..} versions conf sCache =
   let
     rsBody = maybe mempty (\(x, y, z) -> if headersOnly then mempty else OpenAPI.encode versions conf sCache x y z) body

--- a/test/load/targets.http
+++ b/test/load/targets.http
@@ -1,51 +1,47 @@
 GET http://postgrest/
-Prefer: tx=commit
 
 HEAD http://postgrest/actors?actor=eq.1
-Prefer: tx=commit
 
 GET http://postgrest/actors?select=*,roles(*,films(*))
-Prefer: tx=commit
+Accept: application/vnd.pgrst.sql
 
 POST http://postgrest/films?columns=id,title
-Prefer: tx=rollback
+Accept: application/vnd.pgrst.sql
 @post.json
 
 POST http://postgrest/films?columns=id,title,year,runtime,genres,director,actors,plot,posterUrl
-Prefer: tx=rollback
+Accept: application/vnd.pgrst.sql
 # this bulk.json was obtained from https://github.com/erik-sytnyk/movies-list/blob/master/db.json
 @bulk.json
 
 PUT http://postgrest/actors?actor=eq.1&columns=name
-Prefer: tx=rollback
+Accept: application/vnd.pgrst.sql
 @put.json
 
 PATCH http://postgrest/actors?actor=eq.1
-Prefer: tx=rollback
+Accept: application/vnd.pgrst.sql
 @patch.json
 
 DELETE http://postgrest/roles
-Prefer: tx=rollback
+Accept: application/vnd.pgrst.sql
 
 GET http://postgrest/rpc/call_me?name=John
+Accept: application/vnd.pgrst.sql
 
 POST http://postgrest/rpc/call_me
+Accept: application/vnd.pgrst.sql
 @rpc.json
 
 OPTIONS http://postgrest/actors
 
 # Misspelled relations
 GET http://postgrest/actoxs?actor=eq.1
-Prefer: tx=commit
 
 # Misspelled relations on embeds
 GET http://postgrest/actors?select=*,rolws(*,films(*))
-Prefer: tx=commit
 
 # Misspelled function names
 GET http://postgrest/rpc/call_me_x?name=John
-Prefer: tx=commit
 
 # Permission denied errors
 GET http://postgrest/actors_1
-Prefer: tx=commit

--- a/test/spec/Feature/Query/SQLSpec.hs
+++ b/test/spec/Feature/Query/SQLSpec.hs
@@ -1,0 +1,138 @@
+module Feature.Query.SQLSpec where
+
+import Network.Wai.Test (SResponse (..))
+
+import Network.HTTP.Types
+import Test.Hspec          hiding (pendingWith)
+import Test.Hspec.Wai
+import Test.Hspec.Wai.JSON
+
+import PostgREST.Config (AppConfig (..))
+
+import Protolude  hiding (get)
+import SpecHelper
+
+spec :: SpecWithConfig
+spec withConfig = withConfig (baseCfg { configDbPlanEnabled = True }) $ do
+  describe "read table/view query" $ do
+    it "outputs the query" $ do
+      r <- request methodGet "/projects"
+             (acceptHdrs "application/vnd.pgrst.sql") ""
+
+      let resHeaders = simpleHeaders r
+          resStatus  = simpleStatus r
+
+      liftIO $ do
+        resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.sql; for=\"application/json\"; charset=utf-8")
+        resHeaders `shouldSatisfy` notZeroContentLength
+        resStatus `shouldBe` Status { statusCode = 200, statusMessage="OK" }
+
+  describe "write query" $ do
+    it "outputs the query for an insert" $ do
+      r <- request methodPost "/projects"
+             (acceptHdrs "application/vnd.pgrst.sql") [json|{"id":100, "name": "Project 100"}|]
+
+      let resHeaders = simpleHeaders r
+          resStatus  = simpleStatus r
+
+      liftIO $ do
+        resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.sql; for=\"application/json\"; charset=utf-8")
+        resHeaders `shouldSatisfy` notZeroContentLength
+        resStatus `shouldBe` Status { statusCode = 200, statusMessage="OK" }
+
+    it "outputs the query for an update" $ do
+      r <- request methodPatch "/projects?id=eq.3"
+             (acceptHdrs "application/vnd.pgrst.sql") [json|{"name": "Patched Project"}|]
+
+      let resHeaders = simpleHeaders r
+          resStatus  = simpleStatus r
+
+      liftIO $ do
+        resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.sql; for=\"application/json\"; charset=utf-8")
+        resHeaders `shouldSatisfy` notZeroContentLength
+        resStatus `shouldBe` Status { statusCode = 200, statusMessage="OK" }
+
+    it "outputs the query for a delete" $ do
+      r <- request methodDelete "/projects?id=in.(1,2,3)"
+             (acceptHdrs "application/vnd.pgrst.sql") ""
+
+      let resHeaders = simpleHeaders r
+          resStatus  = simpleStatus r
+
+      liftIO $ do
+        resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.sql; for=\"application/json\"; charset=utf-8")
+        resHeaders `shouldSatisfy` notZeroContentLength
+        resStatus `shouldBe` Status { statusCode = 200, statusMessage="OK" }
+
+    it "outputs the query for a single upsert" $ do
+      r <- request methodPut "/tiobe_pls?name=eq.Go"
+            (acceptHdrs "application/vnd.pgrst.sql")
+            [json| [ { "name": "Go", "rank": 19 } ]|]
+
+      let resHeaders = simpleHeaders r
+          resStatus  = simpleStatus r
+
+      liftIO $ do
+        resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.sql; for=\"application/json\"; charset=utf-8")
+        resHeaders `shouldSatisfy` notZeroContentLength
+        resStatus `shouldBe` Status { statusCode = 200, statusMessage="OK" }
+
+    it "outputs the query for 2 upserts" $ do
+      r <- request methodPost "/tiobe_pls"
+            [("Prefer","resolution=merge-duplicates"), ("Accept","application/vnd.pgrst.sql")]
+            [json| [ { "name": "Python", "rank": 19 }, { "name": "Go", "rank": 20} ]|]
+
+      let resStatus  = simpleStatus r
+          resHeaders = simpleHeaders r
+
+      liftIO $ do
+        resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.sql; for=\"application/json\"; charset=utf-8")
+        resHeaders `shouldSatisfy` notZeroContentLength
+        resStatus `shouldBe` Status { statusCode = 200, statusMessage="OK" }
+
+  describe "function query" $ do
+    it "outputs the query for a function call" $ do
+      r <- request methodGet "/rpc/getallprojects?id=in.(1,2,3)"
+             (acceptHdrs "application/vnd.pgrst.sql") ""
+
+      let resHeaders = simpleHeaders r
+          resStatus  = simpleStatus r
+
+      liftIO $ do
+        resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.sql; for=\"application/json\"; charset=utf-8")
+        resHeaders `shouldSatisfy` notZeroContentLength
+        resStatus `shouldBe` Status { statusCode = 200, statusMessage="OK" }
+
+  describe "custom media types" $ do
+    it "outputs the query for a scalar function text/xml" $ do
+      r <- request methodGet "/rpc/return_scalar_xml"
+        (acceptHdrs "application/vnd.pgrst.sql; for=\"text/xml\"") ""
+
+      let resHeaders = simpleHeaders r
+
+      liftIO $
+        resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.sql; for=\"text/xml\"; charset=utf-8")
+
+    it "outputs the query for an aggregate application/vnd.twkb" $ do
+      r <- request methodGet "/lines"
+        (acceptHdrs "application/vnd.pgrst.sql; for=\"application/vnd.twkb\"") ""
+
+      let resHeaders = simpleHeaders r
+
+      liftIO $
+        resHeaders `shouldSatisfy` elem ("Content-Type", "application/vnd.pgrst.sql; for=\"application/vnd.twkb\"; charset=utf-8")
+
+disabledSpec :: SpecWithConfig
+disabledSpec withConfig = withConfig baseCfg $
+  it "doesn't work if db-plan-enabled=false(the default)" $ do
+    request methodGet "/projects?id=in.(1,2,3)"
+         (acceptHdrs "application/vnd.pgrst.sql") ""
+      `shouldRespondWith` 406
+
+    request methodGet "/rpc/getallprojects?id=in.(1,2,3)"
+      (acceptHdrs "application/vnd.pgrst.sql") ""
+      `shouldRespondWith` 406
+
+    request methodDelete "/projects?id=in.(1,2,3)"
+           (acceptHdrs "application/vnd.pgrst.sql") ""
+      `shouldRespondWith` 406

--- a/test/spec/Main.hs
+++ b/test/spec/Main.hs
@@ -67,6 +67,7 @@ import qualified Feature.Query.RpcSpec
 import qualified Feature.Query.ServerTimingSpec
 import qualified Feature.Query.SingularSpec
 import qualified Feature.Query.SpreadQueriesSpec
+import qualified Feature.Query.SQLSpec
 import qualified Feature.Query.UnicodeSpec
 import qualified Feature.Query.UpdateSpec
 import qualified Feature.Query.UpsertSpec
@@ -154,6 +155,8 @@ main = do
         , ("Feature.Query.RawOutputTypesSpec"                  , Feature.Query.RawOutputTypesSpec.spec)
         , ("Feature.Query.RelatedQueriesSpec"                  , Feature.Query.RelatedQueriesSpec.spec)
         , ("Feature.Query.RpcSpec"                             , Feature.Query.RpcSpec.spec actualPgVersion)
+        , ("Feature.Query.SQLSpec.disabledSpec"               , Feature.Query.SQLSpec.disabledSpec)
+        , ("Feature.Query.SQLSpec.spec"                       , Feature.Query.SQLSpec.spec)
         , ("Feature.Query.ServerTimingSpec"                    , Feature.Query.ServerTimingSpec.spec)
         , ("Feature.Query.SingularSpec"                        , Feature.Query.SingularSpec.spec)
         , ("Feature.Query.SpreadQueriesSpec"                   , Feature.Query.SpreadQueriesSpec.spec)


### PR DESCRIPTION
Since the mixed loadtests are dominated by the OpenAPI, #5054 needs to support that as well first. Once it does, the loadtests will be much more balanced between the requests.

It should be a good change, but I'm not sure whether this will have the desired stabilization effect in GHA.