### PR TITLE
docs: fix example jwt expiration epoch

### DIFF
--- a/docs/tutorials/tut1.rst
+++ b/docs/tutorials/tut1.rst
@@ -172,7 +172,7 @@ Go back to :ref:`tut1_step3` and change the payload to
 
 .. code-block:: bash
 
-  payload=$(echo -n "{\"role\":\"todo_user\",\"exp\":\"123456789\"}" | _base64)
+  payload=$(echo -n "{\"role\":\"todo_user\",\"exp\":123456789}" | _base64)
 
   echo -n "$header.$payload.$signature"
 


### PR DESCRIPTION
Issue: In Tutorial 1, the example shell code for generating an expirable JWT has the epoch date wrapped parentheses. This causes the server to return PGRST303: "The JWT 'exp' claim must be a number"

Fix: remove parentheses
<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `add`, Add a new feature
  + `amend`, To amend an unrealease commit
  + `change`, Breaking changes
  + `chore`, Maintenance, update sponsors, changelog, readme etc
  + `ci`, CI configuration files and scripts
  + `docs`, Documentation
  + `fix`, Bug fix
  + `nix`, Related to Nix
  + `perf`, Performance improvements
  + `refactor`, Refactoring code
  + `remove`, Remove a feature or fix
  + `test`, Adding tests
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
