### PR TITLE
fix: Admin server dies silently

### DIFF
--- a/src/PostgREST/Admin.hs
+++ b/src/PostgREST/Admin.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE MonadComprehensions #-}
 module PostgREST.Admin
   ( runAdmin
   ) where
 
 import qualified Data.Aeson                as JSON
+import           Foreign.C.Error           (Errno (..), eMFILE)
+import           GHC.IO.Exception
 import qualified Network.HTTP.Types.Status as HTTP
 import qualified Network.Wai               as Wai
 import qualified Network.Wai.Handler.Warp  as Warp
@@ -11,6 +14,7 @@ import Control.Monad.Extra (whenJust)
 
 import PostgREST.AppState    (AppState, getConfig)
 import PostgREST.Config      (AppConfig (..))
+import PostgREST.Debounce    (makeDebouncer)
 import PostgREST.MediaType   (MediaType (..), toContentType)
 import PostgREST.Metrics     (metricsToText)
 import PostgREST.Network     (resolveSocketToAddress)
@@ -21,18 +25,41 @@ import qualified PostgREST.AppState as AppState
 import qualified Network.Socket as NS
 import           Protolude
 
-runAdmin :: AppState -> Maybe NS.Socket -> IO Bool -> Warp.Settings -> IO ()
-runAdmin appState maybeAdminSocket checkMainAppLive settings = do
+runAdmin :: AppState -> Maybe NS.Socket -> IO Bool -> Warp.ServerState -> Warp.Settings -> IO ()
+runAdmin appState maybeAdminSocket checkMainAppLive serverState settings = do
   conf <- getConfig appState
   whenJust maybeAdminSocket $ \adminSocket -> do
     address <- resolveSocketToAddress adminSocket
+    -- log EMFILE at most once every 10s
+    logEMFILE <- makeDebouncer $ observer AdminServerAcceptEMFILEFailure *> threadDelay 10_000_000
+    let
+      safeAccept sock = NS.accept sock `catchEMFile` do
+        -- Keep accepting on eMFILE
+        logEMFILE
+
+        connCount <- Warp.currentOpenConnections serverState
+        if connCount > 0 then
+          -- There are open connections. Wait for closing some.
+          atomically $
+            check . (connCount >) =<< Warp.currentOpenConnectionsSTM serverState
+        else
+          -- Backoff for 1ms so that we don't enter busy accept loop
+          -- this should let the system recover fd's once the pressure is gone
+          threadDelay 1_000
+
+        -- Restart accepting
+        safeAccept sock
+
     void . forkIO $ handle (onError adminSocket) $
-      Warp.runSettingsSocket (adminServerSettings conf address) adminSocket adminApp
+      Warp.runSettingsSocket (adminServerSettings conf address safeAccept) adminSocket adminApp
   where
     adminApp = admin appState checkMainAppLive
     observer = AppState.getObserver appState
-    adminServerSettings config addr=
+    isEMFILE err = Just eMFILE == fmap Errno (ioe_errno err)
+    catchEMFile action handler = handleJust (\e -> [ e | isEMFILE e]) (const handler) action
+    adminServerSettings config addr safeAccept = do
       settings
+        & Warp.setAccept safeAccept
         & Warp.setBeforeMainLoop (observer $ AdminStartObs addr)
         & maybe identity Warp.setPort (configAdminServerPort config)
 

--- a/src/PostgREST/App.hs
+++ b/src/PostgREST/App.hs
@@ -92,7 +92,8 @@ run appState = do
           ensureSocketClosed =<< readIORef mainSocketRef
     Unix.installSignalHandlers observer closeSockets (AppState.schemaCacheLoader appState) (AppState.readInDbConfig False appState)
 
-    Admin.runAdmin appState adminSocket (checkMainAppLive (readIORef mainSocketRef)) (serverSettings conf)
+    (adminState, adminSettings) <- fmap (serverSettings conf) <$> Warp.makeSettingsAndServerState
+    Admin.runAdmin appState adminSocket (checkMainAppLive (readIORef mainSocketRef)) adminState adminSettings
 
     Listener.runListener appState
 
@@ -108,7 +109,7 @@ run appState = do
       address <- resolveSocketToAddress mainSocket
 
       let
-        appServerSettings = serverSettings conf
+        appServerSettings = serverSettings conf defaultSettings
           & setPort (configServerPort conf)
           & setOnException onWarpException
           & setBeforeMainLoop (setMainSocketRef mainSocket *> observer (AppServerAddressObs address))
@@ -135,9 +136,9 @@ run appState = do
         | Just (ioeGetErrorType -> et) <- fromException se, et == ResourceVanished || et == InvalidArgument = False
         | otherwise = True
 
-serverSettings :: AppConfig -> Warp.Settings
-serverSettings AppConfig{..} =
-  defaultSettings
+serverSettings :: AppConfig -> Warp.Settings -> Warp.Settings
+serverSettings AppConfig{..} settings =
+  settings
     & setHost (fromString $ toS configServerHost)
     & setServerName ("postgrest/" <> prettyVersion)
 

--- a/src/PostgREST/Logger.hs
+++ b/src/PostgREST/Logger.hs
@@ -134,6 +134,8 @@ observationMessages = \case
     pure $ "Admin server listening on " <> address
   AdminServerCrashedObs ex ->
     pure $ "FAILURE: Admin server crashed unexpectedly: " <> (showOnSingleLine '\t' . show) ex
+  AdminServerAcceptEMFILEFailure ->
+    pure "Admin server failed to accept connection due to file descriptor exhaustion (EMFILE)"
   AppStartObs ver ->
     pure $ "Starting PostgREST " <> T.decodeUtf8 ver <> "..."
   AppServerAddressObs address ->

--- a/src/PostgREST/Observation.hs
+++ b/src/PostgREST/Observation.hs
@@ -26,6 +26,7 @@ import Protolude hiding (toList)
 data Observation
   = AdminStartObs Text
   | AdminServerCrashedObs SomeException
+  | AdminServerAcceptEMFILEFailure
   | AppStartObs ByteString
   | AppServerAddressObs Text
   | ExitUnsupportedPgVersion PgVersion PgVersion

--- a/test/io/postgrest.py
+++ b/test/io/postgrest.py
@@ -5,6 +5,7 @@ import dataclasses
 import enum
 import os
 import pathlib
+import resource
 import socket
 import subprocess
 import tempfile
@@ -101,6 +102,7 @@ def run(
     wait_max_seconds=1,
     no_pool_connection_available=False,
     no_startup_stdout=True,
+    rlimit_nofile=None,
 ):
     "Run PostgREST and yield an endpoint that is ready for connections."
 
@@ -142,12 +144,16 @@ def run(
         if configpath:
             command.append(configpath)
 
+        def set_rlimit_nofile():
+            resource.setrlimit(resource.RLIMIT_NOFILE, (rlimit_nofile, rlimit_nofile))
+
         process = subprocess.Popen(
             command,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             env=env,
+            preexec_fn=set_rlimit_nofile if rlimit_nofile else None,
         )
 
         os.set_blocking(process.stdout.fileno(), False)

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -1,8 +1,10 @@
 "Unit tests for Input/Ouput of PostgREST seen as a black box."
 
+import contextlib
 import os
 import re
 import signal
+import socket
 import subprocess
 import time
 import pytest
@@ -29,6 +31,7 @@ from postgrest import (
     sleep_until_postgrest_full_reload,
     sleep_until_postgrest_scache_reload,
     wait_until_exit,
+    wait_until_status_code,
 )
 
 
@@ -820,6 +823,53 @@ def test_admin_live_dependent_on_main_app(defaultenv):
         os.remove(defaultenv["PGRST_SERVER_UNIX_SOCKET"])
         response = postgrest.admin.get("/live")
         assert response.status_code == 500
+
+
+@pytest.mark.xfail(
+    reason="Admin server crashes when the first admin accept hits EMFILE",
+    strict=True,
+)
+def test_admin_server_does_not_crash_when_file_limit_is_reached(defaultenv):
+    "Admin server should keep running when accept reaches the open file limit."
+
+    nofile_limit = 64
+    env = {**defaultenv, "PGRST_LOG_LEVEL": "info"}
+
+    with run(env=env, wait_for=None, rlimit_nofile=nofile_limit) as postgrest:
+        wait_until_status_code(postgrest.session.baseurl + "/", 5, 200)
+
+        main_socket = postgrest.config["PGRST_SERVER_UNIX_SOCKET"]
+
+        with contextlib.ExitStack() as stack:
+            opened_sockets = 0
+            for _ in range(nofile_limit * 3):
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                sock.settimeout(0.2)
+                try:
+                    sock.connect(main_socket)
+                    sock.sendall(b"GET /projects HTTP/1.1\r\nHost: localhost\r\n")
+                except OSError:
+                    sock.close()
+                    break
+                stack.callback(sock.close)
+                opened_sockets += 1
+
+            assert opened_sockets >= nofile_limit
+            time.sleep(0.2)
+
+            # This is the first admin request after startup. The held
+            # sockets are connected to the main server, so the admin server has
+            # no active accepted connections when accept hits EMFILE.
+            with pytest.raises(requests.RequestException):
+                postgrest.admin.get("/live", timeout=0.2)
+
+        # Once fd pressure is over, admin server should respond successfully
+        wait_until_status_code(postgrest.admin.baseurl + "/live", 5, 200)
+
+        output = drain_stdout(postgrest)
+
+        assert any("EMFILE" in line for line in output)
+        assert not any("Admin server crashed unexpectedly" in line for line in output)
 
 
 @pytest.mark.parametrize("specialhostvalue", FIXTURES["specialhostvalues"])

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -825,10 +825,6 @@ def test_admin_live_dependent_on_main_app(defaultenv):
         assert response.status_code == 500
 
 
-@pytest.mark.xfail(
-    reason="Admin server crashes when the first admin accept hits EMFILE",
-    strict=True,
-)
 def test_admin_server_does_not_crash_when_file_limit_is_reached(defaultenv):
     "Admin server should keep running when accept reaches the open file limit."
 


### PR DESCRIPTION
This is a workaround for Warp crashing with "thread blocked indefinitely in an STM transaction" when receiving eMFILE from accept.

The fix is to provide Warp with a custom accept function that handles eMFILE by logging it and keeping accepting connections.

Fixes #5012.