### PR TITLE
nix: provide default file name when generating module graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ gen_jwks.json
 gen_private.json
 .pytest_cache
 .ruff_cache
+postgrest-module-graph.png

--- a/nix/tools/devTools.nix
+++ b/nix/tools/devTools.nix
@@ -129,7 +129,7 @@ let
       {
         name = "postgrest-hsie-graph-modules";
         docs = "Create a PNG graph of modules imported within the codebase.";
-        args = [ "ARG_POSITIONAL_SINGLE([outfile], [Output filename])" ];
+        args = [ "ARG_OPTIONAL_SINGLE([outfile], [o], [Output filename], [postgrest-module-graph.png])" ];
       }
       ''
         ${hsie} graph-modules main src | ${graphviz}/bin/dot -Tpng -o "$_arg_outfile"


### PR DESCRIPTION
It helps when working on #4952. Otherwise I have to explicitly name it and then delete it because it isn't ignored by git locally and becomes an untracked file.