### PR TITLE
add: dump schema cache after reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this project will be documented in this file. From versio
 - Add GHC runtime metrics to the metrics endpoint by @mkleczek in #4862
 - Support running the admin server on a unix socket by @wolfgangwalther in #5003
 - Add config `server-reuseport` to allow starting multiple PostgREST instances using the same port on supported platforms by @mkleczek in #4703, #4694
+- Add `--schema-cache-uri` CLI option to asynchronously load an initial schema cache from a schema cache dump source by @mkleczek in #5031
+  + Valid sources can be from a `http(s)` or local `file://` URI.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file. From versio
 - Add config `server-reuseport` to allow starting multiple PostgREST instances using the same port on supported platforms by @mkleczek in #4703, #4694
 - Add `--schema-cache-uri` CLI option to asynchronously load an initial schema cache from a schema cache dump source by @mkleczek in #5031
   + Valid sources can be from a `http(s)` or local `file://` URI.
+- Add `schema-cache-dump-path` to automatically dump the schema cache after each reload for fast restarts and scale-to-zero setups by @mkleczek in #5082
 
 ### Fixed
 

--- a/docs/references/cli.rst
+++ b/docs/references/cli.rst
@@ -75,6 +75,8 @@ Dump Schema
 
 Dumps the schema cache in JSON format.
 
+.. _cli_schema_cache_uri:
+
 Schema Cache URI
 ----------------
 

--- a/docs/references/cli.rst
+++ b/docs/references/cli.rst
@@ -8,7 +8,7 @@ PostgREST provides a CLI with the options listed below:
 .. code:: text
 
   Usage: postgrest [-v|--version] [-e|--example] [--dump-config | --dump-schema | --ready]
-                 [FILENAME]
+                   [--schema-cache-uri URI] [FILENAME]
 
     PostgREST / create a REST API to an existing Postgres
     database
@@ -22,6 +22,7 @@ PostgREST provides a CLI with the options listed below:
                              output structure is unstable)
     --ready                  Checks the health of PostgREST by doing a request on
                              the admin server /ready endpoint
+    --schema-cache-uri URI   Try pre-loading schema cache from provided URI
     FILENAME                 Path to configuration file
 
 FILENAME
@@ -73,6 +74,31 @@ Dump Schema
   $ postgrest --dump-schema
 
 Dumps the schema cache in JSON format.
+
+Schema Cache URI
+----------------
+
+.. code:: bash
+
+  $ postgrest --schema-cache-uri http://localhost/schema-cache.json
+
+Tries to load the initial :ref:`schema_cache` from the given URI when starting PostgREST to speed up its startup.
+This is useful for running PostgREST as lambda function and similar scale-to-zero setups, fast zero-downtime restarts and horizontal scaling in Kubernetes.
+The load is asynchronous. Database-backed schema cache load is started in parallel and will overwrite values loaded from the URI once finished.
+
+The supported URI schemes are:
+
+``file:``
+  Loads a schema cache dump from a local file. The URI must point to a local path, for
+  example ``file:///var/lib/postgrest/schema-cache.json``. Remote file authorities are
+  not supported.
+
+``http:`` and ``https:``
+  Loads a schema cache dump over HTTP(S). The response body must be a schema cache JSON
+  dump, such as the output of ``postgrest --dump-schema`` or the runtime cache exposed
+  by another PostgREST instance's :ref:`admin_server`.
+
+Other schemes are rejected as unsupported.
 
 Ready Flag
 ----------

--- a/docs/references/configuration.rst
+++ b/docs/references/configuration.rst
@@ -884,6 +884,33 @@ openapi-server-proxy-uri
       ]
     }
 
+.. _schema-cache-dump-path:
+
+schema-cache-dump-path
+----------------------
+
+  =============== ==========================
+  **Type**        String
+  **Default**     `n/a`
+  **Reloadable**  Y
+  **Environment** PGRST_SCHEMA_CACHE_DUMP_PATH
+  **In-Database** `n/a`
+  =============== ==========================
+
+  Specifies a local file path where PostgREST writes a JSON dump of the runtime
+  :ref:`schema_cache` after each successful schema cache load or reload.
+
+  The parent directory must already exist and be writable by the PostgREST
+  process. If writing the dump fails, PostgREST logs the failure and continues
+  serving with the loaded schema cache.
+
+  The dump can be loaded on a later start with :ref:`cli_schema_cache_uri`. See
+  :ref:`schema_cache_dumping` for a startup workflow.
+
+  .. code:: bash
+
+    schema-cache-dump-path = "/var/lib/postgrest/schema-cache.json"
+
 .. _server_cors_allowed_origins:
 
 server-cors-allowed-origins

--- a/docs/references/schema_cache.rst
+++ b/docs/references/schema_cache.rst
@@ -13,6 +13,39 @@ Getting this metadata requires expensive queries. To avoid repeating this work, 
   - If the schema cache queries are slow, the most likely cause is *system catalog bloat*, see `issue#3212 <https://github.com/PostgREST/postgrest/issues/3212>`_ for more details.
   - You can turn the :ref:`log-level` to ``debug`` to see the time of each schema cache query.
 
+.. _schema_cache_dumping:
+
+Schema Cache Dumps
+------------------
+
+PostgREST can write the runtime schema cache to a JSON dump. A new instance can
+then use this dump as its initial schema cache with :ref:`cli_schema_cache_uri`,
+which helps avoid waiting for expensive catalog queries during fast restarts or
+scale-to-zero startup.
+
+To keep a local dump updated automatically, configure :ref:`schema-cache-dump-path`:
+
+.. code:: bash
+
+  schema-cache-dump-path = "/var/lib/postgrest/schema-cache.json"
+
+After each successful schema cache load or reload, PostgREST writes the current
+schema cache to this path. The parent directory must already exist and be writable
+by the PostgREST process. If writing the dump fails, PostgREST logs the failure
+and continues serving with the loaded schema cache.
+
+On the next start, use the dump file as an initial schema cache:
+
+.. code:: bash
+
+  postgrest --schema-cache-uri file:///var/lib/postgrest/schema-cache.json /path/to/postgrest.conf
+
+The dump should be reused only by instances that serve the same database and
+compatible schema cache configuration, such as :ref:`db-schemas` and
+:ref:`db-extra-search-path`. PostgREST still performs the regular database-backed
+schema cache load, so the dump is a startup acceleration path rather than a
+replacement for database metadata loading.
+
 .. _schema_reloading:
 
 Schema Cache Reloading

--- a/src/library/PostgREST/AppState.hs
+++ b/src/library/PostgREST/AppState.hs
@@ -1,6 +1,8 @@
-{-# LANGUAGE NamedFieldPuns  #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE RecursiveDo     #-}
+{-# LANGUAGE NamedFieldPuns   #-}
+{-# LANGUAGE RecordWildCards  #-}
+{-# LANGUAGE RecursiveDo      #-}
+{-# LANGUAGE TupleSections    #-}
+{-# LANGUAGE TypeApplications #-}
 
 module PostgREST.AppState
   ( AppState
@@ -38,8 +40,8 @@ import           PostgREST.Version       (prettyVersion)
 
 import Control.AutoUpdate         (defaultUpdateSettings, mkAutoUpdate,
                                    updateAction)
-import Control.Concurrent.STM     (newEmptyTMVarIO)
-import Data.IORef                 (newIORef, readIORef)
+import Control.Concurrent.STM     (newEmptyTMVarIO, tryPutTMVar)
+import Data.IORef                 (atomicModifyIORef, newIORef, readIORef)
 import Data.Time.Clock            (getCurrentTime)
 import PostgREST.AppState.Pool    (destroy, initPool, usePool)
 import PostgREST.AppState.Reload  (isSchemaCacheLoaded, readInDbConfig,
@@ -50,11 +52,19 @@ import PostgREST.AppState.Types
 import PostgREST.Config           (AppConfig (..))
 import PostgREST.Config.PgVersion (minimumPgVersion)
 import PostgREST.Debounce         (makeDebouncer)
+import PostgREST.SchemaCache      (SchemaCache (..))
+
+import qualified Data.Aeson           as JSON
+import qualified Data.ByteString.Lazy as LBS
+import qualified Network.HTTP.Client  as HC
+import           Network.URI          (URI (..), URIAuth (..), parseURI,
+                                       unEscapeString)
+import           System.IO.Error      (userError)
 
 import Protolude
 
-init :: AppConfig -> IO () -> IO AppState
-init conf@AppConfig{configLogLevel, configDbPoolSize} appKiller = do
+init :: AppConfig -> IO () -> Maybe Text -> IO AppState
+init conf@AppConfig{configLogLevel, configDbPoolSize} appKiller schemaCacheLoadUri = do
   loggerState  <- Logger.init
   metricsState <- Metrics.init configDbPoolSize
   let observer = liftA2 (>>) (Logger.observationLogger loggerState configLogLevel) (Metrics.observationMetrics metricsState)
@@ -62,7 +72,47 @@ init conf@AppConfig{configLogLevel, configDbPoolSize} appKiller = do
   observer $ AppStartObs prettyVersion
 
   pool <- initPool conf observer
-  initWithPool pool conf loggerState metricsState observer appKiller
+  appState <- initWithPool pool conf loggerState metricsState observer appKiller
+
+  runInitialSchemaCacheLoader observer schemaCacheLoadUri appState
+
+  pure appState
+
+runInitialSchemaCacheLoader :: ObservationHandler -> Maybe Text -> AppState -> IO ()
+runInitialSchemaCacheLoader observer schemaCacheLoadUri AppState{stateSchemaCache, stateSCacheStatus=SchemaCacheStatus{getSCStatusTMVar}} = do
+  void $ forkIO $
+    traverse (fetchInitialSchemaCache observer) schemaCacheLoadUri >>= foldMap setInitialSchemaCache . join
+  where
+    setInitialSchemaCache sc =
+      whenM (atomically $ tryPutTMVar getSCStatusTMVar True) $
+        atomicModifyIORef stateSchemaCache $ (, ()) . maybe (Just sc) Just
+
+fetchInitialSchemaCache :: ObservationHandler -> Text -> IO (Maybe SchemaCache)
+fetchInitialSchemaCache observer uri = flip catches [
+  Handler (handleError @IOException),
+  Handler (handleError @HC.HttpException),
+  Handler (handleError @JSON.AesonException)
+  ] $ maybe (throwIO $ userError "Invalid schema cache dump URI") pure =<< traverse fetchURI (parseURI $ toS uri)
+  where
+    handleError :: Show e => e -> IO (Maybe a)
+    handleError = (Nothing <$) . observer . SchemaCacheInitialLoadFailureObs uri . show
+
+    fetchURI URI{uriScheme, ..}
+      | uriScheme == "file:" = do
+          path <- fileURIPath uriAuthority uriPath
+          Just <$> (JSON.throwDecode =<< LBS.readFile path)
+      | uriScheme `elem` ["http:", "https:"] = do
+          request <- HC.parseUrlThrow $ toS uri
+          manager <- HC.newManager HC.defaultManagerSettings
+          HC.withResponse request manager $ \response ->
+            Just <$> (JSON.throwDecode . LBS.fromChunks =<< HC.brConsume (HC.responseBody response))
+      | otherwise =
+          throwIO $ userError $ "Unsupported schema cache dump URI scheme: " <> uriScheme
+
+    fileURIPath Nothing path = pure $ unEscapeString path
+    fileURIPath (Just URIAuth{uriRegName=""}) path = pure $ unEscapeString path
+    fileURIPath (Just URIAuth{uriRegName="localhost"}) path = pure $ unEscapeString path
+    fileURIPath _ _ = throwIO $ userError "Only local file URIs are supported"
 
 initWithPool :: SQL.Pool -> AppConfig -> Logger.LoggerState -> Metrics.MetricsState -> ObservationHandler -> IO () -> IO AppState
 initWithPool pool conf loggerState metricsState observer appKiller = mdo

--- a/src/library/PostgREST/AppState/Reload.hs
+++ b/src/library/PostgREST/AppState/Reload.hs
@@ -30,15 +30,17 @@ import Data.Bitraversable      (bisequence)
 import Data.Either.Combinators (whenRight)
 import Data.IORef              (IORef, newIORef, readIORef, writeIORef)
 
+import qualified Data.ByteString.Lazy as LBS
+
 import PostgREST.AppState.Pool           (flushPool, usePool)
 import PostgREST.Auth.JwtCache           (update)
 import PostgREST.Config                  (AppConfig (..), readAppConfig)
 import PostgREST.Config.Database         (queryDbSettings, queryPgVersion,
                                           queryRoleSettings)
 import PostgREST.Config.PgVersion        (PgVersion (..), minimumPgVersion)
-import PostgREST.Observation             (Observation (..))
-import PostgREST.SchemaCache             (SchemaCache (..), querySchemaCache,
-                                          showSummary)
+import PostgREST.Observation             (Observation (..), ObservationHandler)
+import PostgREST.SchemaCache             (SchemaCache (..), dumpSchemaCache,
+                                          querySchemaCache, showSummary)
 import PostgREST.SchemaCache.Identifiers (quoteQi)
 import PostgREST.TimeIt                  (timeItT)
 
@@ -113,6 +115,8 @@ retryingSchemaCacheLoad appState@AppState{stateObserver=observer} =
           observer $ SchemaCacheQueriedObs resultTime queryTimings
           observer $ SchemaCacheLoadedObs loadTime summary
           markSchemaCacheLoaded appState
+          for_ configSchemaCacheDumpPath $ \path ->
+            writeSchemaCacheDump observer path sCache
           return $ Just sCache
 
     shouldRetry :: RetryStatus -> (Maybe PgVersion, Maybe SchemaCache) -> IO Bool
@@ -127,6 +131,15 @@ retryingSchemaCacheLoad appState@AppState{stateObserver=observer} =
       capDelay delayMicroseconds $ exponentialBackoff oneSecondInUs
 
     oneSecondInUs = 1_000_000 -- one second in microseconds
+
+writeSchemaCacheDump :: ObservationHandler -> FilePath -> SchemaCache -> IO ()
+writeSchemaCacheDump observer path sCache =
+  LBS.writeFile path (dumpSchemaCache sCache) `catch` handleWriteError
+  where
+    handleWriteError :: IOException -> IO ()
+    handleWriteError =
+      observer . SchemaCacheDumpFailureObs (toS path)
+
 
 markSchemaCachePending :: AppState -> IO ()
 markSchemaCachePending = atomically . liftA2 (*>) tryTakeTMVar (`putTMVar` False) . getSCStatusTMVar . stateSCacheStatus

--- a/src/library/PostgREST/CLI.hs
+++ b/src/library/PostgREST/CLI.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NamedFieldPuns  #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE MonadComprehensions #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RecordWildCards     #-}
 module PostgREST.CLI
   ( main
   , CLI (..)
@@ -48,7 +49,7 @@ runAppCommand conf@AppConfig{..} runCmd = do
   -- explicitly close the connections to PostgreSQL on shutdown.
   -- 'AppState.destroy' takes care of that.
   bracket
-    (AppState.init conf (killThread mainThreadId))
+    (AppState.init conf (killThread mainThreadId) [schemaCacheLoadUri | CmdRun (Just schemaCacheLoadUri) <- Just runCmd])
     AppState.destroy
     (\appState -> case runCmd of
       CmdDumpConfig -> do
@@ -57,7 +58,7 @@ runAppCommand conf@AppConfig{..} runCmd = do
       CmdDumpSchema -> do
         when configDbConfig $ AppState.readInDbConfig True appState
         putStrLn =<< dumpSchema appState
-      CmdRun -> App.run appState mainThreadIdRef)
+      CmdRun _ -> App.run appState mainThreadIdRef)
 
 -- | Dump SchemaCache schema to JSON
 dumpSchema :: AppState -> IO LBS.ByteString
@@ -86,7 +87,7 @@ data ClientCommand
   = CmdReady
 
 data RunCommand
-  = CmdRun
+  = CmdRun (Maybe Text)
   | CmdDumpConfig
   | CmdDumpSchema
 
@@ -120,8 +121,17 @@ readCLIShowHelp =
     cliParser :: O.Parser CLI
     cliParser =
       CLI
-        <$> (dumpConfigFlag <|> dumpSchemaFlag <|> readyFlag)
+        <$> (dumpConfigFlag <|> dumpSchemaFlag <|> readyFlag <|> runCommand)
         <*> O.optional configFileOption
+
+    runCommand =
+      Run . CmdRun <$> O.optional schemaCacheUriOption
+
+    schemaCacheUriOption =
+      O.strOption $
+        O.long "schema-cache-uri"
+        <> O.metavar "URI"
+        <> O.help "Try pre-loading schema cache from provided URI"
 
     configFileOption =
       O.strArgument $
@@ -129,16 +139,16 @@ readCLIShowHelp =
         <> O.help "Path to configuration file"
 
     dumpConfigFlag =
-      O.flag (Run CmdRun) (Run CmdDumpConfig) $
+      O.flag' (Run CmdDumpConfig) $
         O.long "dump-config"
         <> O.help "Dump loaded configuration and exit"
 
     dumpSchemaFlag =
-      O.flag (Run CmdRun) (Run CmdDumpSchema) $
+      O.flag' (Run CmdDumpSchema) $
         O.long "dump-schema"
         <> O.help "Dump loaded schema as JSON and exit (for debugging, output structure is unstable)"
 
     readyFlag =
-      O.flag (Run CmdRun) (Client CmdReady) $
+      O.flag' (Client CmdReady) $
         O.long "ready"
         <> O.help "Checks the health of PostgREST by doing a request on the admin server /ready endpoint"

--- a/src/library/PostgREST/CLI.hs
+++ b/src/library/PostgREST/CLI.hs
@@ -8,7 +8,6 @@ module PostgREST.CLI
   , readCLIShowHelp
   ) where
 
-import qualified Data.Aeson                 as JSON
 import qualified Data.ByteString.Char8      as BS
 import qualified Data.ByteString.Lazy       as LBS
 import qualified Hasql.Transaction.Sessions as SQL
@@ -17,7 +16,7 @@ import qualified Options.Applicative        as O
 import PostgREST.AppState    (AppState)
 import PostgREST.Config      (AppConfig (..))
 import PostgREST.Observation (Observation (..))
-import PostgREST.SchemaCache (querySchemaCache)
+import PostgREST.SchemaCache (dumpSchemaCache, querySchemaCache)
 import PostgREST.Version     (prettyVersion)
 
 import qualified PostgREST.App      as App
@@ -71,7 +70,7 @@ dumpSchema appState = do
       let observer = AppState.getObserver appState
       observer $ SchemaCacheErrorObs configDbSchemas configDbExtraSearchPath e
       exitFailure
-    Right (sCache, _) -> return $ JSON.encode sCache
+    Right (sCache, _) -> return $ dumpSchemaCache sCache
 
 -- | Command line interface options
 data CLI = CLI

--- a/src/library/PostgREST/Config.hs
+++ b/src/library/PostgREST/Config.hs
@@ -111,6 +111,7 @@ data AppConfig = AppConfig
   , configOpenApiMode               :: OpenAPIMode
   , configOpenApiSecurityActive     :: Bool
   , configOpenApiServerProxyUri     :: Maybe Text
+  , configSchemaCacheDumpPath       :: Maybe FilePath
   , configServerCorsAllowedOrigins  :: [Text]
   , configServerHost                :: Text
   , configServerPort                :: Int
@@ -199,6 +200,7 @@ toText conf =
       ,("openapi-mode",              q . dumpOpenApiMode . configOpenApiMode)
       ,("openapi-security-active",       T.toLower . show . configOpenApiSecurityActive)
       ,("openapi-server-proxy-uri",  q . fromMaybe mempty . configOpenApiServerProxyUri)
+      ,("schema-cache-dump-path",    q . maybe mempty T.pack . configSchemaCacheDumpPath)
       ,("server-cors-allowed-origins", q . T.intercalate "," . configServerCorsAllowedOrigins)
       ,("server-host",               q . configServerHost)
       ,("server-port",                   show . configServerPort)
@@ -319,6 +321,7 @@ parser optPath env dbSettings roleSettings roleIsolationLvl =
     <*> parseOpenAPIMode "openapi-mode"
     <*> (fromMaybe False <$> optBool "openapi-security-active")
     <*> parseOpenAPIServerProxyURI "openapi-server-proxy-uri"
+    <*> (fmap T.unpack <$> optString "schema-cache-dump-path")
     <*> parseCORSAllowedOrigins "server-cors-allowed-origins"
     <*> (defaultServerHost <$> optString "server-host")
     <*> parseServerPort "server-port"
@@ -781,6 +784,9 @@ exampleConfigFile = S.unlines
   , ""
   , "## Base url for the OpenAPI output"
   , "openapi-server-proxy-uri = \"\""
+  , ""
+  , "## File path for writing a schema cache dump after successful schema cache loads"
+  , "# schema-cache-dump-path = \"/var/lib/postgrest/schema-cache.json\""
   , ""
   , "## Configurable CORS origins"
   , "# server-cors-allowed-origins = \"\""

--- a/src/library/PostgREST/Logger.hs
+++ b/src/library/PostgREST/Logger.hs
@@ -158,6 +158,8 @@ observationMessages = \case
       <> " and "
       <> "db-extra-search-path=" <> T.intercalate "," extraPaths
       <> ". " <> jsonMessage usageErr
+  SchemaCacheDumpFailureObs path err ->
+    pure $ "Failed to write schema cache dump to " <> path <> ". " <> show err
   SchemaCacheInitialLoadFailureObs uri err ->
     pure $ "Failed to load schema cache dump from " <> uri <> ". " <> err
   SchemaCacheQueriedObs resultTime timings ->

--- a/src/library/PostgREST/Logger.hs
+++ b/src/library/PostgREST/Logger.hs
@@ -158,6 +158,8 @@ observationMessages = \case
       <> " and "
       <> "db-extra-search-path=" <> T.intercalate "," extraPaths
       <> ". " <> jsonMessage usageErr
+  SchemaCacheInitialLoadFailureObs uri err ->
+    pure $ "Failed to load schema cache dump from " <> uri <> ". " <> err
   SchemaCacheQueriedObs resultTime timings ->
     [ "Schema cache queried in " <> showMillis resultTime  <> " milliseconds " ] <>
     let showTimings qt = [ T.intercalate ", " $ (\(l, v) -> T.decodeUtf8 l <> ": " <> v <> " ms") <$> queryTimingsWLabels qt ] in

--- a/src/library/PostgREST/MediaType.hs
+++ b/src/library/PostgREST/MediaType.hs
@@ -43,17 +43,17 @@ data MediaType
   | MTVndSingularJSON Bool
   -- TODO MTVndPlan should only have its options as [Text]. Its ResultAggregate should have the typed attributes.
   | MTVndPlan MediaType MTVndPlanFormat [MTVndPlanOption]
-  deriving (Eq, Show, Generic, JSON.ToJSON)
+  deriving (Eq, Show, Generic, JSON.FromJSON, JSON.ToJSON)
 instance Hashable MediaType
 
 data MTVndPlanOption
   = PlanAnalyze | PlanVerbose | PlanSettings | PlanBuffers | PlanWAL
-  deriving (Eq, Show, Generic, JSON.ToJSON)
+  deriving (Eq, Show, Generic, JSON.FromJSON, JSON.ToJSON)
 instance Hashable MTVndPlanOption
 
 data MTVndPlanFormat
   = PlanJSON | PlanText
-  deriving (Eq, Show, Generic, JSON.ToJSON)
+  deriving (Eq, Show, Generic, JSON.FromJSON, JSON.ToJSON)
 instance Hashable MTVndPlanFormat
 
 -- | Convert MediaType to a Content-Type HTTP Header

--- a/src/library/PostgREST/Observation.hs
+++ b/src/library/PostgREST/Observation.hs
@@ -34,6 +34,7 @@ data Observation
   | DBConnectedObs Text
   | SchemaCacheEmptyObs
   | SchemaCacheErrorObs (NonEmpty Text) [Text] SQL.UsageError
+  | SchemaCacheInitialLoadFailureObs Text Text
   | SchemaCacheQueriedObs Double (Maybe QueryTimings)
   | SchemaCacheLoadedObs Double Text
   | ConnectionRetryObs Int

--- a/src/library/PostgREST/Observation.hs
+++ b/src/library/PostgREST/Observation.hs
@@ -33,6 +33,7 @@ data Observation
   | ExitDBFatalError ObsFatalError SQL.UsageError
   | DBConnectedObs Text
   | SchemaCacheEmptyObs
+  | SchemaCacheDumpFailureObs Text IOException
   | SchemaCacheErrorObs (NonEmpty Text) [Text] SQL.UsageError
   | SchemaCacheInitialLoadFailureObs Text Text
   | SchemaCacheQueriedObs Double (Maybe QueryTimings)

--- a/src/library/PostgREST/SchemaCache.hs
+++ b/src/library/PostgREST/SchemaCache.hs
@@ -181,16 +181,21 @@ querySchemaCache conf@AppConfig{..} = do
     , dbMediaHandlers = HM.union mHdlers initialMediaHandlers -- the custom handlers will override the initial ones
     , dbTimezones = tzones
 
-    , dbTablesFuzzyIndex =
-        -- Only build fuzzy index for schemas with a reasonable number of tables
-        -- Fuzzy.FuzzySet is memory heavy we just don't use it for large schemas
-        Fuzzy.fromList <$> HM.filter ((< maxDbTablesForFuzzySearch) . length) (HM.fromListWith (<>) ((qiSchema &&& pure . qiName) <$> HM.keys tabsWViewsPks))
+    , dbTablesFuzzyIndex = tablesFuzzyIndex tabsWViewsPks
     }, qsTime)
   where
     schemas = toList configDbSchemas
     isLogDebug = configLogLevel == LogDebug
     sqlTimedStmt = sqlTimedStatement isLogDebug
     sleepCall = SQL.Statement "select pg_sleep($1 / 1000.0)" (param HE.int4) HD.noResult True
+
+tablesFuzzyIndex :: TablesMap -> TablesFuzzyIndex
+tablesFuzzyIndex tabs =
+  -- Only build fuzzy index for schemas with a reasonable number of tables
+  -- Fuzzy.FuzzySet is memory heavy we just don't use it for large schemas
+  Fuzzy.fromList <$>
+    HM.filter ((< maxDbTablesForFuzzySearch) . length)
+      (HM.fromListWith (<>) ((qiSchema &&& pure . qiName) <$> HM.keys tabs))
 
 -- | overrides detected relationships with the computed relationships and gets the RelationshipsMap
 getOverrideRelationshipsMap :: [Relationship] -> [Relationship] -> RelationshipsMap

--- a/src/library/PostgREST/SchemaCache.hs
+++ b/src/library/PostgREST/SchemaCache.hs
@@ -28,7 +28,7 @@ module PostgREST.SchemaCache
   , queryTimingsWLabels
   ) where
 
-import           Data.Aeson ((.=))
+import           Data.Aeson ((.:), (.=))
 import qualified Data.Aeson as JSON
 
 import qualified Data.ByteString.Char8      as BS
@@ -93,6 +93,17 @@ instance JSON.ToJSON SchemaCache where
     , "dbMediaHandlers"   .= JSON.toJSON hdlers
     , "dbTimezones"       .= JSON.toJSON tzs
     ]
+
+instance JSON.FromJSON SchemaCache where
+  parseJSON = JSON.withObject "SchemaCache" $ \o -> do
+    tabs <- o .: "dbTables"
+    SchemaCache tabs
+      <$> o .: "dbRelationships"
+      <*> o .: "dbRoutines"
+      <*> o .: "dbRepresentations"
+      <*> o .: "dbMediaHandlers"
+      <*> o .: "dbTimezones"
+      <*> pure (tablesFuzzyIndex tabs)
 
 showSummary :: SchemaCache -> Text
 showSummary (SchemaCache tbls rels routs reps mediaHdlrs tzs _) =

--- a/src/library/PostgREST/SchemaCache.hs
+++ b/src/library/PostgREST/SchemaCache.hs
@@ -22,6 +22,7 @@ module PostgREST.SchemaCache
   ( SchemaCache(..)
   , TablesFuzzyIndex
   , querySchemaCache
+  , dumpSchemaCache
   , showSummary
   , decodeFuncs
   , QueryTimings(..)
@@ -32,6 +33,7 @@ import           Data.Aeson ((.:), (.=))
 import qualified Data.Aeson as JSON
 
 import qualified Data.ByteString.Char8      as BS
+import qualified Data.ByteString.Lazy       as LBS
 import qualified Data.HashMap.Strict        as HM
 import qualified Data.HashMap.Strict.InsOrd as HMI
 import qualified Data.Set                   as S
@@ -104,6 +106,9 @@ instance JSON.FromJSON SchemaCache where
       <*> o .: "dbMediaHandlers"
       <*> o .: "dbTimezones"
       <*> pure (tablesFuzzyIndex tabs)
+
+dumpSchemaCache :: SchemaCache -> LBS.ByteString
+dumpSchemaCache = JSON.encode
 
 showSummary :: SchemaCache -> Text
 showSummary (SchemaCache tbls rels routs reps mediaHdlrs tzs _) =

--- a/src/library/PostgREST/SchemaCache/Identifiers.hs
+++ b/src/library/PostgREST/SchemaCache/Identifiers.hs
@@ -20,7 +20,7 @@ import qualified Data.Text  as T
 import Protolude
 
 data RelIdentifier = RelId QualifiedIdentifier | RelAnyElement
-  deriving (Eq, Ord, Generic, JSON.ToJSON, JSON.ToJSONKey, Show)
+  deriving (Eq, Ord, Generic, JSON.FromJSON, JSON.FromJSONKey, JSON.ToJSON, JSON.ToJSONKey, Show)
 instance Hashable RelIdentifier
 
 -- | Represents a pg identifier with a prepended schema name "schema.table".
@@ -30,7 +30,7 @@ data QualifiedIdentifier = QualifiedIdentifier
   { qiSchema :: Schema
   , qiName   :: TableName
   }
-  deriving (Eq, Show, Ord, Generic, JSON.ToJSON, JSON.ToJSONKey)
+  deriving (Eq, Show, Ord, Generic, JSON.FromJSON, JSON.FromJSONKey, JSON.ToJSON, JSON.ToJSONKey)
 
 instance Hashable QualifiedIdentifier
 

--- a/src/library/PostgREST/SchemaCache/Relationship.hs
+++ b/src/library/PostgREST/SchemaCache/Relationship.hs
@@ -35,7 +35,7 @@ data Relationship = Relationship
   , relToOne        :: Bool
   , relIsSelf       :: Bool
   }
-  deriving (Eq, Show, Ord, Generic, JSON.ToJSON)
+  deriving (Eq, Show, Ord, Generic, JSON.FromJSON, JSON.ToJSON)
 
 -- | The relationship cardinality
 -- | https://en.wikipedia.org/wiki/Cardinality_(data_modeling)
@@ -48,7 +48,7 @@ data Cardinality
   -- ^ one-to-one, this is a refinement over M2O, operating on it is pretty much the same as M2O when isParent == False
   | M2M Junction
   -- ^ many-to-many
-  deriving (Eq, Show, Ord, Generic, JSON.ToJSON)
+  deriving (Eq, Show, Ord, Generic, JSON.FromJSON, JSON.ToJSON)
 
 type FKConstraint = Text
 
@@ -60,7 +60,7 @@ data Junction = Junction
   , junColsSource  :: [(FieldName, FieldName)]
   , junColsTarget  :: [(FieldName, FieldName)]
   }
-  deriving (Eq, Show, Ord, Generic, JSON.ToJSON)
+  deriving (Eq, Show, Ord, Generic, JSON.FromJSON, JSON.ToJSON)
 
 -- | Key based on the source table and the foreign table schema
 type RelationshipsMap = HM.HashMap (QualifiedIdentifier, Schema)  [Relationship]

--- a/src/library/PostgREST/SchemaCache/Routine.hs
+++ b/src/library/PostgREST/SchemaCache/Routine.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE StandaloneDeriving #-}
+-- Needed to derive orphan FromJSON and ToJSON instances for SQL.IsolationLevel
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module PostgREST.SchemaCache.Routine
@@ -35,18 +36,18 @@ import Protolude
 data PgType
   = Scalar QualifiedIdentifier
   | Composite QualifiedIdentifier Bool -- True if the composite is a domain alias(used to work around a bug in pg 11 and 12, see QueryBuilder.hs)
-  deriving (Eq, Show, Ord, Generic, JSON.ToJSON)
+  deriving (Eq, Show, Ord, Generic, JSON.FromJSON, JSON.ToJSON)
 
 data RetType
   = Single PgType
   | SetOf PgType
-  deriving (Eq, Show, Ord, Generic, JSON.ToJSON)
+  deriving (Eq, Show, Ord, Generic, JSON.FromJSON, JSON.ToJSON)
 
 data FuncVolatility
   = Volatile
   | Stable
   | Immutable
-  deriving (Eq, Show, Ord, Generic, JSON.ToJSON)
+  deriving (Eq, Show, Ord, Generic, JSON.FromJSON, JSON.ToJSON)
 
 type FuncSettings = [(Text,Text)]
 
@@ -61,11 +62,12 @@ data Routine = Function
   , pdIsoLvl       :: Maybe SQL.IsolationLevel
   , pdFuncSettings :: FuncSettings
   }
-  deriving (Eq, Show, Generic, JSON.ToJSON)
+  deriving (Eq, Show, Generic, JSON.ToJSON, JSON.FromJSON)
 
 -- SQL.IsolationLevel doesn't have a default ToJSON instance, so we derive it.
-deriving instance Generic     SQL.IsolationLevel
-deriving instance JSON.ToJSON SQL.IsolationLevel
+deriving instance Generic       SQL.IsolationLevel
+deriving instance JSON.ToJSON   SQL.IsolationLevel
+deriving instance JSON.FromJSON SQL.IsolationLevel
 
 data RoutineParam = RoutineParam
   { ppName          :: Text
@@ -74,7 +76,7 @@ data RoutineParam = RoutineParam
   , ppReq           :: Bool
   , ppVar           :: Bool
   }
-  deriving (Eq, Show, Ord, Generic, JSON.ToJSON)
+  deriving (Eq, Show, Ord, Generic, JSON.FromJSON, JSON.ToJSON)
 
 -- Order by least number of params in the case of overloaded functions
 instance Ord Routine where
@@ -99,7 +101,7 @@ data MediaHandler
    -- custom
    | CustomFunc QualifiedIdentifier RelIdentifier
    | NoAgg
-   deriving (Eq, Show, Generic, JSON.ToJSON)
+   deriving (Eq, Show, Generic, JSON.FromJSON, JSON.ToJSON)
 
 funcReturnsSingle :: Routine -> Bool
 funcReturnsSingle proc = case proc of

--- a/src/library/PostgREST/SchemaCache/Table.hs
+++ b/src/library/PostgREST/SchemaCache/Table.hs
@@ -33,7 +33,7 @@ data Table = Table
   , tablePKCols      :: [FieldName]
   , tableColumns     :: ColumnMap
   }
-  deriving (Show, Generic, JSON.ToJSON)
+  deriving (Show, Generic, JSON.FromJSON, JSON.ToJSON)
 
 tableColumnsList :: Table -> [Column]
 tableColumnsList = HMI.elems . tableColumns
@@ -51,7 +51,7 @@ data Column = Column
   , colDefault     :: Maybe Text
   , colEnum        :: [Text]
   }
-  deriving (Eq, Show, Ord, Generic, JSON.ToJSON)
+  deriving (Eq, Show, Ord, Generic, JSON.FromJSON, JSON.ToJSON)
 
 type TablesMap = HM.HashMap QualifiedIdentifier Table
 type ColumnMap = HMI.InsOrdHashMap FieldName Column

--- a/test/io/configs/expected/aliases.config
+++ b/test/io/configs/expected/aliases.config
@@ -35,6 +35,7 @@ log-query = false
 openapi-mode = "follow-privileges"
 openapi-security-active = false
 openapi-server-proxy-uri = ""
+schema-cache-dump-path = ""
 server-cors-allowed-origins = ""
 server-host = "!4"
 server-port = 3000

--- a/test/io/configs/expected/boolean-numeric.config
+++ b/test/io/configs/expected/boolean-numeric.config
@@ -35,6 +35,7 @@ log-query = false
 openapi-mode = "follow-privileges"
 openapi-security-active = false
 openapi-server-proxy-uri = ""
+schema-cache-dump-path = ""
 server-cors-allowed-origins = ""
 server-host = "!4"
 server-port = 3000

--- a/test/io/configs/expected/boolean-string.config
+++ b/test/io/configs/expected/boolean-string.config
@@ -35,6 +35,7 @@ log-query = false
 openapi-mode = "follow-privileges"
 openapi-security-active = false
 openapi-server-proxy-uri = ""
+schema-cache-dump-path = ""
 server-cors-allowed-origins = ""
 server-host = "!4"
 server-port = 3000

--- a/test/io/configs/expected/defaults.config
+++ b/test/io/configs/expected/defaults.config
@@ -35,6 +35,7 @@ log-query = false
 openapi-mode = "follow-privileges"
 openapi-security-active = false
 openapi-server-proxy-uri = ""
+schema-cache-dump-path = ""
 server-cors-allowed-origins = ""
 server-host = "!4"
 server-port = 3000

--- a/test/io/configs/expected/no-defaults-with-db-other-authenticator.config
+++ b/test/io/configs/expected/no-defaults-with-db-other-authenticator.config
@@ -37,6 +37,7 @@ log-query = true
 openapi-mode = "disabled"
 openapi-security-active = false
 openapi-server-proxy-uri = "https://otherexample.org/api"
+schema-cache-dump-path = ""
 server-cors-allowed-origins = "http://otherorigin.com"
 server-host = "0.0.0.0"
 server-port = 80

--- a/test/io/configs/expected/no-defaults-with-db.config
+++ b/test/io/configs/expected/no-defaults-with-db.config
@@ -37,6 +37,7 @@ log-query = true
 openapi-mode = "ignore-privileges"
 openapi-security-active = true
 openapi-server-proxy-uri = "https://example.org/api"
+schema-cache-dump-path = ""
 server-cors-allowed-origins = "http://origin.com"
 server-host = "0.0.0.0"
 server-port = 80

--- a/test/io/configs/expected/no-defaults.config
+++ b/test/io/configs/expected/no-defaults.config
@@ -37,6 +37,7 @@ log-query = true
 openapi-mode = "ignore-privileges"
 openapi-security-active = true
 openapi-server-proxy-uri = "https://postgrest.org"
+schema-cache-dump-path = ""
 server-cors-allowed-origins = "http://example.com"
 server-host = "0.0.0.0"
 server-port = 80

--- a/test/io/configs/expected/types.config
+++ b/test/io/configs/expected/types.config
@@ -36,6 +36,7 @@ log-query = false
 openapi-mode = "follow-privileges"
 openapi-security-active = false
 openapi-server-proxy-uri = ""
+schema-cache-dump-path = ""
 server-cors-allowed-origins = ""
 server-host = "!4"
 server-port = 3000

--- a/test/io/configs/expected/utf-8.config
+++ b/test/io/configs/expected/utf-8.config
@@ -35,6 +35,7 @@ log-query = false
 openapi-mode = "follow-privileges"
 openapi-security-active = false
 openapi-server-proxy-uri = ""
+schema-cache-dump-path = ""
 server-cors-allowed-origins = ""
 server-host = "!4"
 server-port = 3000

--- a/test/io/test_cli.py
+++ b/test/io/test_cli.py
@@ -1,8 +1,16 @@
 "Unit tests for Input/Ouput of PostgREST seen as a black box."
 
+import contextlib
+from functools import partial
+from http.server import (
+    BaseHTTPRequestHandler,
+    SimpleHTTPRequestHandler,
+    ThreadingHTTPServer,
+)
 from operator import attrgetter
 import signal
 import subprocess
+from threading import Event, Thread
 import pytest
 import yaml
 
@@ -43,6 +51,72 @@ def itemgetter(*items):
 
 class PostgrestError(Exception):
     "Postgrest exited unexpectedly."
+
+
+class QuietSimpleHTTPRequestHandler(SimpleHTTPRequestHandler):
+    "SimpleHTTPRequestHandler without stderr logging."
+
+    def log_message(self, _format, *args):
+        pass
+
+
+@contextlib.contextmanager
+def serve_directory(directory):
+    "Serve a directory from a local HTTP URI."
+
+    handler = partial(QuietSimpleHTTPRequestHandler, directory=str(directory))
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        host, port = server.server_address
+        yield f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=1)
+        server.server_close()
+
+
+@contextlib.contextmanager
+def serve_blocking_response(body):
+    "Serve a local HTTP response that blocks until released."
+
+    request_started = Event()
+    release_response = Event()
+
+    class BlockingResponseHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            request_started.set()
+            release_response.wait(timeout=30)
+
+            try:
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            except OSError:
+                pass
+
+        def log_message(self, _format, *args):
+            pass
+
+    class Server(ThreadingHTTPServer):
+        daemon_threads = True
+
+    server = Server(("127.0.0.1", 0), BlockingResponseHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        host, port = server.server_address
+        yield f"http://{host}:{port}/schema-cache.json", request_started, release_response
+    finally:
+        release_response.set()
+        server.shutdown()
+        thread.join(timeout=1)
+        server.server_close()
 
 
 def cli(args, env=None, stdin=None, expect_error=False):
@@ -251,6 +325,122 @@ def test_schema_cache_snapshot(baseenv, key, snapshot_yaml):
         Dumper=yaml.SafeDumper if key == "dbTimezones" else ExtraNewLinesDumper,
     )
     assert formatted == snapshot_yaml
+
+
+def test_load_schema_cache_dump_from_http_uri_at_startup(tmp_path, defaultenv):
+    "A valid schema cache dump should be loaded from an HTTP URI."
+
+    schema_cache_dump = tmp_path / "schema-cache.json"
+    schema_cache_dump.write_text(cli(["--dump-schema"], env=defaultenv))
+
+    env = {
+        **defaultenv,
+        "PGRST_DB_CONFIG": "false",
+        "PGRST_DB_ANON_ROLE": "postgrest_test_anonymous",
+        "PGRST_DB_SCHEMAS": "public",
+        "PGRST_INTERNAL_SCHEMA_CACHE_QUERY_SLEEP": "5000",
+    }
+
+    with serve_directory(tmp_path) as schema_cache_base_uri:
+        with run(
+            env=env,
+            args=[
+                "--schema-cache-uri",
+                f"{schema_cache_base_uri}/{schema_cache_dump.name}",
+            ],
+            wait_max_seconds=2,
+        ) as postgrest:
+            response = postgrest.session.get("/projects")
+            assert response.status_code == 200
+
+
+def test_load_schema_cache_dump_from_postgrest_admin_server_at_startup(defaultenv):
+    "A schema cache dump should be loaded from another PostgREST admin server."
+
+    env = {
+        **defaultenv,
+        "PGRST_DB_CONFIG": "false",
+        "PGRST_DB_ANON_ROLE": "postgrest_test_anonymous",
+        "PGRST_DB_SCHEMAS": "public",
+        "PGRST_INTERNAL_SCHEMA_CACHE_QUERY_SLEEP": "5000",
+    }
+
+    with run(env={**defaultenv}, admin_port=freeport()) as source:
+        with run(
+            env=env,
+            args=[
+                "--schema-cache-uri",
+                f"{source.admin.baseurl}/schema_cache",
+            ],
+            wait_max_seconds=2,
+        ) as postgrest:
+            response = postgrest.session.get("/projects")
+            assert response.status_code == 200
+
+
+def test_load_schema_cache_dump_from_file_uri_at_startup(tmp_path, defaultenv):
+    "A valid schema cache dump should be loaded from a local file URI."
+
+    schema_cache_dump = tmp_path / "schema-cache.json"
+    schema_cache_dump.write_text(cli(["--dump-schema"], env=defaultenv))
+
+    env = {
+        **defaultenv,
+        "PGRST_DB_CONFIG": "false",
+        "PGRST_DB_ANON_ROLE": "postgrest_test_anonymous",
+        "PGRST_DB_SCHEMAS": "public",
+        "PGRST_INTERNAL_SCHEMA_CACHE_QUERY_SLEEP": "5000",
+    }
+
+    with run(
+        env=env,
+        args=["--schema-cache-uri", schema_cache_dump.as_uri()],
+        wait_max_seconds=2,
+    ) as postgrest:
+        response = postgrest.session.get("/projects")
+        assert response.status_code == 200
+
+
+def test_load_schema_cache_dump_missing_file_falls_back_to_database(
+    tmp_path, defaultenv
+):
+    "A missing schema cache dump should be ignored during startup."
+
+    env = {**defaultenv}
+
+    with serve_directory(tmp_path) as schema_cache_base_uri:
+        with run(
+            env=env,
+            args=[
+                "--schema-cache-uri",
+                f"{schema_cache_base_uri}/missing-schema-cache.json",
+            ],
+        ) as postgrest:
+            response = postgrest.session.get("/projects")
+            assert response.status_code == 200
+
+
+def test_slow_schema_cache_dump_uri_does_not_delay_startup(defaultenv):
+    "A slow schema cache dump URI should not delay database-backed startup."
+
+    schema_cache_dump = cli(["--dump-schema"], env=defaultenv).encode()
+
+    with serve_blocking_response(schema_cache_dump) as (
+        schema_cache_uri,
+        request_started,
+        release_response,
+    ):
+        with run(
+            env={**defaultenv},
+            args=["--schema-cache-uri", schema_cache_uri],
+            wait_max_seconds=2,
+        ) as postgrest:
+            assert request_started.wait(timeout=2)
+            assert not release_response.is_set()
+
+            response = postgrest.session.get("/projects")
+            assert response.status_code == 200
+            assert not release_response.is_set()
 
 
 def test_jwt_aud_config_set_to_invalid_uri(defaultenv):

--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -1049,6 +1049,61 @@ def test_notify_reloading_catalog_cache(defaultenv):
         assert response.status_code == 200
 
 
+def test_dump_schema_cache_after_reload_used_on_startup(
+    tmp_path, defaultenv, metapostgrest
+):
+    "A schema cache dump written after reload should be usable on startup."
+
+    role = defaultenv["PGUSER"]
+    table = "schema_cache_dump_reload_items"
+    schema_cache_dump = tmp_path / "schema-cache.json"
+    env = {
+        **defaultenv,
+        "PGRST_DB_CONFIG": "false",
+        "PGRST_DB_ANON_ROLE": "postgrest_test_anonymous",
+        "PGRST_DB_SCHEMAS": "public",
+        "PGRST_SCHEMA_CACHE_DUMP_PATH": str(schema_cache_dump),
+    }
+
+    try:
+        psql_as_superuser(f"drop table if exists {table};")
+
+        with run(env=env) as postgrest:
+            response = postgrest.session.get(f"/{table}")
+            assert response.status_code == 404
+            assert response.json()["code"] == "PGRST205"
+
+            psql_as_superuser(
+                f"""
+                create table {table}(id int primary key);
+                insert into {table} values (1);
+                grant select on {table} to postgrest_test_anonymous;
+                notify pgrst, 'reload schema';
+                """
+            )
+            sleep_until_postgrest_scache_reload()
+
+            response = postgrest.session.get(f"/{table}")
+            assert response.status_code == 200
+
+        set_statement_timeout(metapostgrest, role, 400)
+        slow_start_env = {
+            **env,
+            "PGRST_INTERNAL_SCHEMA_CACHE_QUERY_SLEEP": "500",
+        }
+
+        with run(
+            env=slow_start_env,
+            args=["--schema-cache-uri", schema_cache_dump.as_uri()],
+            wait_max_seconds=2,
+        ) as postgrest:
+            response = postgrest.session.get(f"/{table}")
+            assert response.status_code == 200
+    finally:
+        reset_statement_timeout(metapostgrest, role)
+        psql_as_superuser(f"drop table if exists {table};")
+
+
 def test_stale_schema_cache_dropped_table_returns_database_error(defaultenv):
     "dropped table should return a database error while schema cache is stale"
 

--- a/test/observability/ObsHelper.hs
+++ b/test/observability/ObsHelper.hs
@@ -104,6 +104,7 @@ baseCfg = let secret = encodeUtf8 "reallyreallyreallyreallyverysafe" in
   , configOpenApiMode               = OAFollowPriv
   , configOpenApiSecurityActive     = False
   , configOpenApiServerProxyUri     = Nothing
+  , configSchemaCacheDumpPath       = Nothing
   , configServerCorsAllowedOrigins  = []
   , configServerHost                = "localhost"
   , configServerPort                = 3000

--- a/test/spec/SpecHelper.hs
+++ b/test/spec/SpecHelper.hs
@@ -166,6 +166,7 @@ baseCfg = let secret = encodeUtf8 "reallyreallyreallyreallyverysafe" in
   , configOpenApiMode               = OAFollowPriv
   , configOpenApiSecurityActive     = False
   , configOpenApiServerProxyUri     = Nothing
+  , configSchemaCacheDumpPath       = Nothing
   , configServerCorsAllowedOrigins  = []
   , configServerHost                = "localhost"
   , configServerPort                = 3000


### PR DESCRIPTION
Make PostgREST write a schema cache dump after each reload, so that later on it can load it on startup via a schema cache URI. This simplifies setup for fast restarts and scale-to-zero configurations.

This is a #5031 follow-up.