### PR TITLE
chore: run doctests in parallel

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run doctests
         if: always()
-        run: postgrest-test-doctests
+        run: nix-shell --run postgrest-test-doctests
 
       - name: Check the spec tests for idempotence
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ gen_private.json
 .pytest_cache
 .ruff_cache
 postgrest-module-graph.png
+.ghc.environment.*

--- a/cabal.project
+++ b/cabal.project
@@ -2,3 +2,6 @@ packages: postgrest.cabal
 tests: true
 allow-newer:
   hasql:postgresql-libpq
+
+-- https://github.com/martijnbastiaan/doctest-parallel/blob/main/example/README.md#cabalproject
+write-ghc-environment-files: always

--- a/nix/tools/tests.nix
+++ b/nix/tools/tests.nix
@@ -55,8 +55,6 @@ let
         withEnv = postgrest.env;
       }
       ''
-        # This makes nix-env -iA tests.doctests.bin work.
-        export NIX_GHC=${postgrest.env.NIX_GHC}
         ${cabal-install}/bin/cabal v2-run ${devCabalOptions} test:doctests
       '';
 

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -352,14 +352,11 @@ test-suite observability
 test-suite doctests
   type:               exitcode-stdio-1.0
   default-language:   Haskell2010
-  default-extensions: OverloadedStrings
-                      NoImplicitPrelude
   hs-source-dirs:     test/doc
   main-is:            Main.hs
   build-depends:      base              >= 4.9 && < 4.22
-                    , doctest           >= 0.8
+                    , doctest-parallel  >= 0.4
                     , postgrest
                     , pretty-simple
-                    , protolude         >= 0.3.1 && < 0.4
   ghc-options:        -threaded -O0 -Werror -Wall -fwarn-identities
                       -fno-spec-constr -optP-Wno-nonportable-include-path

--- a/src/PostgREST/ApiRequest/Preferences.hs
+++ b/src/PostgREST/ApiRequest/Preferences.hs
@@ -21,6 +21,7 @@ module PostgREST.ApiRequest.Preferences
   , shouldCount
   , shouldExplainCount
   , prefAppliedHeader
+  , toHeaderValue
   ) where
 
 import qualified Data.ByteString.Char8     as BS
@@ -34,7 +35,10 @@ import Protolude
 
 -- $setup
 -- Setup for doctests
+-- >>> :set -XStandaloneDeriving
 -- >>> import Text.Pretty.Simple (pPrint)
+-- >>> import qualified Data.Set as S
+-- >>> import Protolude
 -- >>> deriving instance Show PreferResolution
 -- >>> deriving instance Show PreferRepresentation
 -- >>> deriving instance Show PreferCount

--- a/src/PostgREST/ApiRequest/QueryParams.hs
+++ b/src/PostgREST/ApiRequest/QueryParams.hs
@@ -9,7 +9,18 @@
 module PostgREST.ApiRequest.QueryParams
   ( parse
   , QueryParams(..)
+  , pFieldForest
+  , pFieldName
+  , pFieldSelect
+  , pJsonPath
+  , pLogicTree
+  , pOpExpr
+  , pOrder
+  , pRelationSelect
+  , pRequestFilter
   , pRequestRange
+  , pSingleVal
+  , pSpreadRelationSelect
   ) where
 
 import qualified Data.ByteString.Char8         as BS
@@ -61,6 +72,10 @@ import PostgREST.ApiRequest.Types (AggregateFunction (..),
 import PostgREST.Error (QPError (..))
 
 import Protolude hiding (Sum, try)
+
+-- $setup
+-- >>> import qualified Text.ParserCombinators.Parsec as P
+-- >>> import Protolude hiding (Sum, try)
 
 data QueryParams =
   QueryParams

--- a/src/PostgREST/Config.hs
+++ b/src/PostgREST/Config.hs
@@ -597,6 +597,7 @@ pgConnString conn | uriDesignator `T.isPrefixOf` conn || shortUriDesignator `T.i
 
 -- | Adds a `fallback_application_name` value to the connection string. This allows querying the PostgREST version on pg_stat_activity.
 --
+-- >>> import Protolude
 -- >>> let ver = "11.1.0 (5a04ec7)"::ByteString
 -- >>> let strangeVer = "11'1&0@#$%,.:\"[]{}?+^()=asdfqwer"::ByteString
 --

--- a/src/PostgREST/Error.hs
+++ b/src/PostgREST/Error.hs
@@ -19,6 +19,8 @@ module PostgREST.Error
   , JwtClaimsError(..)
   , errorPayload
   , status
+  , noRelBetweenHint
+  , noRpcHint
   ) where
 
 import qualified Data.Aeson                as JSON
@@ -56,6 +58,12 @@ import PostgREST.SchemaCache.Routine      (Routine (..),
 import PostgREST.Error.Types
 
 import Protolude
+
+-- $setup
+-- >>> import qualified Data.HashMap.Strict as HM
+-- >>> import PostgREST.SchemaCache.Identifiers (QualifiedIdentifier (..))
+-- >>> import PostgREST.SchemaCache.Relationship (Relationship (..))
+-- >>> import PostgREST.SchemaCache.Routine (Routine (..), RoutineParam (..))
 
 -- | Encode Error to ByteString
 errorPayload :: (ErrorBody a, ErrorHeaders a) => Verbosity -> a -> LByteString

--- a/src/PostgREST/MediaType.hs
+++ b/src/PostgREST/MediaType.hs
@@ -9,6 +9,7 @@ module PostgREST.MediaType
   , toContentType
   , toMime
   , decodeMediaType
+  , tokenizeMediaType
   ) where
 
 import qualified Data.Aeson                    as JSON
@@ -21,6 +22,9 @@ import Data.Text.Encoding        (decodeLatin1)
 import Network.HTTP.Types.Header (Header, hContentType)
 
 import Protolude
+
+-- $setup
+-- >>> import qualified Text.ParserCombinators.Parsec as P
 
 -- | Enumeration of currently supported media types
 data MediaType

--- a/src/PostgREST/Network.hs
+++ b/src/PostgREST/Network.hs
@@ -20,23 +20,7 @@ import Protolude
 resolveSocketToAddress :: NS.Socket -> IO Text
 resolveSocketToAddress sock = do
   sn <- NS.getSocketName sock
-  return $ showSocketAddr sn
-
--- |
--- >>> let addr_ipv4 = NS.SockAddrInet 80 (NS.tupleToHostAddress (127,0,0,1))
--- >>> let addr_ipv6 = NS.SockAddrInet6 80 0 (0,0,0,1) 0
--- >>> let addr_unix = NS.SockAddrUnix "/tmp/pgrst.sock"
---
--- >>> showSocketAddr addr_ipv4
--- "127.0.0.1:80"
-
--- >>> showSocketAddr addr_ipv6
--- "[::1]:80"
---
--- >>> showSocketAddr addr_unix
--- "/tmp/pgrst.sock"
-showSocketAddr :: NS.SockAddr -> Text
-showSocketAddr = fromString . show
+  return $ fromString $ show sn
 
 -- | When printing special addresses like !4 or *6, we use the following mapping.
 --   These special addresses come from:

--- a/src/PostgREST/Plan.hs
+++ b/src/PostgREST/Plan.hs
@@ -24,6 +24,7 @@ module PostgREST.Plan
   , InfoPlan(..)
   , CrudPlan(..)
   , legacyWarnings
+  , addNullEmbedFilters
   ) where
 
 import qualified Data.HashMap.Strict           as HM
@@ -87,7 +88,16 @@ import Protolude hiding (from)
 
 -- $setup
 -- Setup for doctests
+-- >>> :set -XDuplicateRecordFields
 -- >>> import Data.Ranged.Ranges (fullRange)
+-- >>> import Data.Tree (Tree (..))
+-- >>> import PostgREST.SchemaCache.Identifiers (QualifiedIdentifier (..))
+-- >>> import PostgREST.ApiRequest.Types
+-- >>> import PostgREST.Plan.CallPlan
+-- >>> import PostgREST.Plan.MutatePlan
+-- >>> import PostgREST.Plan.ReadPlan as ReadPlan
+-- >>> import PostgREST.Plan.Types
+-- >>> import Protolude
 
 -- Plan for reading or writing to the db
 data CrudPlan

--- a/src/PostgREST/Response/Performance.hs
+++ b/src/PostgREST/Response/Performance.hs
@@ -8,6 +8,9 @@ import qualified Network.HTTP.Types    as HTTP
 import           Numeric               (showFFloat)
 import           Protolude
 
+-- $setup
+-- >>> import Protolude
+
 -- | ServerTiming represents the timing data for a request, in seconds.
 data ServerTiming =
   ServerTiming

--- a/test/doc/Main.hs
+++ b/test/doc/Main.hs
@@ -1,27 +1,7 @@
-module Main (main) where
+module Main where
 
-import Test.DocTest (doctest)
-
-import Protolude
-
+import System.Environment (getArgs)
+import Test.DocTest       (mainFromCabal)
 
 main :: IO ()
-main =
-  doctest
-    [ "-XOverloadedStrings"
-    , "-XNoImplicitPrelude"
-    , "-XStandaloneDeriving"
-    , "-XDuplicateRecordFields"
-    , "-isrc"
-    , "src/PostgREST/ApiRequest/Preferences.hs"
-    , "src/PostgREST/ApiRequest/QueryParams.hs"
-    , "src/PostgREST/Config.hs"
-    , "src/PostgREST/Error.hs"
-    , "src/PostgREST/MediaType.hs"
-    , "src/PostgREST/Network.hs"
-    , "src/PostgREST/Plan.hs"
-    , "src/PostgREST/Query/SqlFragment.hs"
-    , "src/PostgREST/Response.hs"
-    , "src/PostgREST/Response/Performance.hs"
-    , "src/PostgREST/SchemaCache/Identifiers.hs"
-    ]
+main = mainFromCabal "postgrest" =<< getArgs


### PR DESCRIPTION
Runs the doctests much faster, which is potentially useful in combination with postgrest-watch for local development.

This implies that doctests run on compiled code, not in a GHCi session, which has some implications:
- Only exported functions can be tested.
- Imports need to be made explicit in doctests themselves.

On the flipside, this would allow us to potentially include doctest results in code coverage, I believe.

This change is a requirement to [vendor hasql](https://github.com/PostgREST/postgrest/pull/5084), which otherwise breaks the existing doctests: hasql contains a .hsc file, which *needs* to be compiled - not interpreted - to make the tests work.