### PR TITLE
chore: build haskell source modules in parallel

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -171,7 +171,7 @@ library
                       -- -optP-Wno-nonportable-include-path
                       --   prevents build failures on case-insensitive filesystems (macos),
                       --   see https://github.com/commercialhaskell/stack/issues/3918
-  ghc-options:        -Werror -Wall -fwarn-identities
+  ghc-options:        -j -Werror -Wall -fwarn-identities
                       -fno-spec-constr -optP-Wno-nonportable-include-path
 
   if flag(dev)
@@ -200,7 +200,7 @@ executable postgrest
                     , containers          >= 0.5.7 && < 0.8
                     , postgrest
                     , protolude           >= 0.3.1 && < 0.4
-  ghc-options:        -threaded -rtsopts "-with-rtsopts=-N -I0 -qg"
+  ghc-options:        -j -threaded -rtsopts "-with-rtsopts=-N -I0 -qg"
                       -O2 -Werror -Wall -fwarn-identities
                       -fno-spec-constr -optP-Wno-nonportable-include-path
 
@@ -307,7 +307,7 @@ test-suite spec
                     , transformers-base >= 0.4.4 && < 0.5
                     , wai               >= 3.2.1 && < 3.3
                     , wai-extra         >= 3.0.19 && < 3.2
-  ghc-options:        -threaded -O0 -Werror -Wall -fwarn-identities
+  ghc-options:        -j -threaded -O0 -Werror -Wall -fwarn-identities
                       -fno-spec-constr -optP-Wno-nonportable-include-path
                       -fno-warn-missing-signatures
                       -fwrite-ide-info
@@ -343,7 +343,7 @@ test-suite observability
                     , protolude         >= 0.3.1 && < 0.4
                     , text              >= 1.2.2 && < 2.2
                     , wai               >= 3.2.1 && < 3.3
-  ghc-options:        -threaded -O0 -Werror -Wall -fwarn-identities
+  ghc-options:        -j -threaded -O0 -Werror -Wall -fwarn-identities
                       -fno-spec-constr -optP-Wno-nonportable-include-path
                       -fwrite-ide-info
                       -- https://github.com/PostgREST/postgrest/issues/387
@@ -358,5 +358,5 @@ test-suite doctests
                     , doctest-parallel  >= 0.4
                     , postgrest
                     , pretty-simple
-  ghc-options:        -threaded -O0 -Werror -Wall -fwarn-identities
+  ghc-options:        -j -threaded -O0 -Werror -Wall -fwarn-identities
                       -fno-spec-constr -optP-Wno-nonportable-include-path


### PR DESCRIPTION
`postgrest-build` now builds around twice as fast as compared to previous build time. This can be tested by running `rm -rf dist-newstyle/` and then run `postgrest-build`.