### PR TITLE
test: resolve pytest warning when running io tests

### DIFF
--- a/test/io/test_io.py
+++ b/test/io/test_io.py
@@ -1035,7 +1035,8 @@ def test_no_pool_connection_required_on_bad_jwt_claim(defaultenv):
 
     with run(env=env, no_pool_connection_available=True) as postgrest:
         # A JWT with an invalid signature shouldn't open a connection
-        headers = jwtauthheader({"role": "postgrest_test_author"}, "Wrong Secret")
+        wrong_secret = "This is the most wrong secret of all secrets"
+        headers = jwtauthheader({"role": "postgrest_test_author"}, wrong_secret)
         response = postgrest.session.get("/projects", headers=headers)
         assert response.status_code == 401
 


### PR DESCRIPTION
When running `postgrest-test-io`, pytest raises a `InsecureKeyLengthWarning` for a test:

```
=============================== warnings summary ===============================
test/io/test_io.py::test_no_pool_connection_required_on_bad_jwt_claim
  /nix/store/lb86cd0f18brfizp2cbs55p3wa7j4lcs-python3-3.13.13-env/lib/python3.13/site-packages/jwt/api_jwt.py:147: InsecureKeyLengthWarning: The HMAC key is 12 bytes long, which is below the minimum recommended length of 32 bytes for SHA256. See RFC 7518 Section 3.2.
    return self._jws.encode(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

 To clear that warning, this commit increases the key length to more than 32 characters.

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `add`, Add a new feature
  + `amend`, To amend an unrealease commit
  + `change`, Breaking changes
  + `chore`, Maintenance, update sponsors, changelog, readme etc
  + `ci`, CI configuration files and scripts
  + `docs`, Documentation
  + `fix`, Bug fix
  + `nix`, Related to Nix
  + `perf`, Performance improvements
  + `refactor`, Refactoring code
  + `remove`, Remove a feature or fix
  + `test`, Adding tests
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
