### PR TITLE
docs: add migrate to v16 page in how-tos/ section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,18 +38,7 @@ All notable changes to this project will be documented in this file. From versio
 - Build a static executable for aarch64-linux by @wolfgangwalther in #4193
 - Build the minimal docker image for aarch64-linux by @wolfgangwalther in #4193
 - Config `jwt-role-claim-key` now uses RFC 9535 syntax for JSON Path by @taimoorzaeem in #4984
-
-#### Changed Syntax for JWT Role Extraction
-
-The `jwt-role-claim-key` config should be updated according to the following:
-
-- All config values must start with `$` character.
-  + Example: `.roles.read` -> `$.roles.read`
-- Keys with special characters, with the exception of `_` char must be quoted.
-  + Example: `.roles.write-role` -> `$.roles["write-role"]`
-- String comparison operators (`^==`, `==^` and `*==`) are replaced with regular expression search.
-  + Example: `.roles[?(@ ^== "postgrest_test_")]` -> `$.roles[?search(@, "^postgrest_test_")]`
-- Detailed reference for syntax: [RFC 9535](https://www.rfc-editor.org/rfc/rfc9535.html#name-jsonpath-syntax-and-semanti).
+  + See the [Changed Syntax for JWT Role Extraction](https://docs.postgrest.org/en/latest/how-tos/migrate-to-v16.html) section to update your config according to new syntax.
 
 ### Deprecated
 

--- a/docs/how-tos/migrate-to-v16.rst
+++ b/docs/how-tos/migrate-to-v16.rst
@@ -1,0 +1,27 @@
+.. _migrate_to_v16:
+
+Migrate to PostgREST v16
+========================
+
+To migrate to PostgREST ``v16`` from ``v14``, following changes are required:
+
+.. _changed_syntax_for_jwt_role_extract:
+
+Changed Syntax for JWT Role Extraction
+--------------------------------------
+
+The :ref:`jwt-role-claim-key` config should be updated according to the following rules:
+
+* All config values must start with ``$`` character.
+
+  * Example: ``.roles.read`` -> ``$.roles.read``
+
+* Keys with special characters, with the exception of ``_`` char must be quoted.
+
+  * Example: ``.roles.write-role`` -> ``$.roles["write-role"]``
+
+* String comparison operators (``^==``, ``==^`` and ``*==``) are replaced with regular expression search.
+
+  * Example: ``.roles[?(@ ^== "postgrest_test_")]`` -> ``$.roles[?search(@, "^postgrest_test_")]``
+
+* Detailed reference for syntax: `RFC 9535 <https://www.rfc-editor.org/rfc/rfc9535.html#name-jsonpath-syntax-and-semanti>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -185,6 +185,7 @@ Recipes that'll help you address specific use-cases.
    :name: how-tos
    :maxdepth: 1
 
+   how-tos/migrate-*
    how-tos/sql-user-*
    how-tos/working-*
    how-tos/*


### PR DESCRIPTION
Towards #5097.

- [x] Add the **Changed Syntax for JWT Role Extraction** section
- [ ] Add the **Update URL legacy target names** section