### PR TITLE
chore(cabal): update haskell language edition to GHC2021

### DIFF
--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -38,10 +38,9 @@ flag hpc
   description: Enable HPC (dev only)
 
 library
-  default-language:   Haskell2010
+  default-language:   GHC2021
   default-extensions: OverloadedStrings
                       NoImplicitPrelude
-                      NumericUnderscores
   hs-source-dirs:     src/library
   exposed-modules:    PostgREST.Admin
                       PostgREST.App
@@ -193,7 +192,7 @@ library
       unix
 
 executable postgrest
-  default-language:   Haskell2010
+  default-language:   GHC2021
   default-extensions: OverloadedStrings
                       NoImplicitPrelude
   hs-source-dirs:     src/executable
@@ -217,11 +216,10 @@ executable postgrest
 
 test-suite spec
   type:               exitcode-stdio-1.0
-  default-language:   Haskell2010
+  default-language:   GHC2021
   default-extensions: OverloadedStrings
                       QuasiQuotes
                       NoImplicitPrelude
-                      NumericUnderscores
   hs-source-dirs:     test/spec
   main-is:            Main.hs
   other-modules:      Feature.Auth.AsymmetricJwtSpec
@@ -318,11 +316,10 @@ test-suite spec
 
 test-suite observability
   type:               exitcode-stdio-1.0
-  default-language:   Haskell2010
+  default-language:   GHC2021
   default-extensions: OverloadedStrings
                       QuasiQuotes
                       NoImplicitPrelude
-                      NumericUnderscores
   hs-source-dirs:     test/observability
   main-is:            Main.hs
   other-modules:      ObsHelper
@@ -353,7 +350,7 @@ test-suite observability
 
 test-suite doctests
   type:               exitcode-stdio-1.0
-  default-language:   Haskell2010
+  default-language:   GHC2021
   hs-source-dirs:     test/doc
   main-is:            Main.hs
   build-depends:      base              >= 4.9 && < 4.22

--- a/src/library/PostgREST/ApiRequest/QueryParams.hs
+++ b/src/library/PostgREST/ApiRequest/QueryParams.hs
@@ -4,8 +4,7 @@
 --
 -- This module is in charge of parsing all the querystring values in an url, e.g.
 -- the select, id, order in `/projects?select=id,name&id=eq.1&order=id,name.desc`.
-{-# LANGUAGE LambdaCase    #-}
-{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE LambdaCase #-}
 module PostgREST.ApiRequest.QueryParams
   ( parse
   , QueryParams(..)

--- a/src/library/PostgREST/App.hs
+++ b/src/library/PostgREST/App.hs
@@ -9,12 +9,10 @@ Some of its functionality includes:
 - Producing HTTP Headers according to RFCs.
 - Content Negotiation
 -}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE ViewPatterns        #-}
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE NamedFieldPuns  #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns    #-}
 module PostgREST.App
   ( postgrest
   , run

--- a/src/library/PostgREST/Auth.hs
+++ b/src/library/PostgREST/Auth.hs
@@ -10,7 +10,6 @@ Authentication should always be implemented in an external service.
 In the test suite there is an example of simple login function that can be used for a
 very simple authentication system inside the PostgreSQL database.
 -}
-{-# LANGUAGE FlexibleContexts #-}
 module PostgREST.Auth
   ( getAuthResult )
   where

--- a/src/library/PostgREST/Auth/Jwt.hs
+++ b/src/library/PostgREST/Auth/Jwt.hs
@@ -4,8 +4,6 @@ Description : PostgREST JWT support functions.
 
 This module provides functions to deal with JWT parsing and validation (http://jwt.io).
 -}
-{-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE ImpredicativeTypes    #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE NamedFieldPuns        #-}

--- a/src/library/PostgREST/Auth/JwtCache.hs
+++ b/src/library/PostgREST/Auth/JwtCache.hs
@@ -4,13 +4,9 @@ Description : PostgREST JWT validation results Cache.
 
 This module provides functions to deal with the JWT cache.
 -}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts          #-}
-{-# LANGUAGE FlexibleInstances         #-}
-{-# LANGUAGE LambdaCase                #-}
-{-# LANGUAGE MultiParamTypeClasses     #-}
-{-# LANGUAGE NamedFieldPuns            #-}
-{-# LANGUAGE StrictData                #-}
+{-# LANGUAGE LambdaCase     #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE StrictData     #-}
 
 module PostgREST.Auth.JwtCache
   ( init

--- a/src/library/PostgREST/Cache/Sieve.hs
+++ b/src/library/PostgREST/Cache/Sieve.hs
@@ -8,11 +8,9 @@ This module provides implementation of a mutable cache on Sieve algorithm.
 {-# LANGUAGE GADTs           #-}
 {-# LANGUAGE LambdaCase      #-}
 {-# LANGUAGE NamedFieldPuns  #-}
-{-# LANGUAGE PolyKinds       #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE RecursiveDo     #-}
 {-# LANGUAGE StrictData      #-}
-{-# LANGUAGE TupleSections   #-}
 
 module PostgREST.Cache.Sieve (
       Cache

--- a/src/library/PostgREST/Config.hs
+++ b/src/library/PostgREST/Config.hs
@@ -3,13 +3,10 @@ Module      : PostgREST.Config
 Description : Manages PostgREST configuration type and parser.
 
 -}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE LambdaCase            #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
-{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE NamedFieldPuns  #-}
 
 module PostgREST.Config
   ( AppConfig (..)

--- a/src/library/PostgREST/Config/PgVersion.hs
+++ b/src/library/PostgREST/Config/PgVersion.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric  #-}
 module PostgREST.Config.PgVersion
   ( PgVersion(..)
   , minimumPgVersion

--- a/src/library/PostgREST/MediaType.hs
+++ b/src/library/PostgREST/MediaType.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# OPTIONS_GHC -Wno-unused-do-bind #-}
 module PostgREST.MediaType

--- a/src/library/PostgREST/Observation.hs
+++ b/src/library/PostgREST/Observation.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveGeneric #-}
 {-|
 Module      : PostgREST.Observation
 Description : This module holds an Observation type which is the core of Observability for PostgREST.

--- a/src/library/PostgREST/SchemaCache.hs
+++ b/src/library/PostgREST/SchemaCache.hs
@@ -8,15 +8,10 @@ The schema cache is necessary for resource embedding, foreign keys are used for 
 
 These queries are executed once at startup or when PostgREST is reloaded.
 -}
-{-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns        #-}
-{-# LANGUAGE QuasiQuotes           #-}
-{-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeSynonymInstances  #-}
+{-# LANGUAGE DeriveAnyClass  #-}
+{-# LANGUAGE NamedFieldPuns  #-}
+{-# LANGUAGE QuasiQuotes     #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module PostgREST.SchemaCache
   ( SchemaCache(..)

--- a/src/library/PostgREST/SchemaCache/Identifiers.hs
+++ b/src/library/PostgREST/SchemaCache/Identifiers.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric  #-}
 
 module PostgREST.SchemaCache.Identifiers
   ( FieldName

--- a/src/library/PostgREST/SchemaCache/Relationship.hs
+++ b/src/library/PostgREST/SchemaCache/Relationship.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric  #-}
 
 module PostgREST.SchemaCache.Relationship
   ( Cardinality(..)

--- a/src/library/PostgREST/SchemaCache/Representations.hs
+++ b/src/library/PostgREST/SchemaCache/Representations.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric  #-}
 
 module PostgREST.SchemaCache.Representations
   ( DataRepresentation(..)

--- a/src/library/PostgREST/SchemaCache/Routine.hs
+++ b/src/library/PostgREST/SchemaCache/Routine.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module PostgREST.SchemaCache.Routine

--- a/src/library/PostgREST/SchemaCache/Table.hs
+++ b/src/library/PostgREST/SchemaCache/Table.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE DeriveAnyClass    #-}
-{-# LANGUAGE DeriveGeneric     #-}
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DeriveAnyClass #-}
 
 module PostgREST.SchemaCache.Table
   ( Column(..)

--- a/test/observability/ObsHelper.hs
+++ b/test/observability/ObsHelper.hs
@@ -1,14 +1,6 @@
-{-# LANGUAGE AllowAmbiguousTypes       #-}
-{-# LANGUAGE DeriveAnyClass            #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts          #-}
-{-# LANGUAGE FlexibleInstances         #-}
-{-# LANGUAGE LambdaCase                #-}
-{-# LANGUAGE RankNTypes                #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
-{-# LANGUAGE TupleSections             #-}
-{-# LANGUAGE TypeApplications          #-}
-{-# LANGUAGE TypeOperators             #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE LambdaCase          #-}
 module ObsHelper where
 
 import qualified Data.ByteString                 as BS
@@ -175,7 +167,7 @@ accumulateUntilTimeout t f start act = do
   -- mask to make sure TimeoutException is not thrown before starting the loop
   mask $ \unmask -> do
     -- start timeout thread unmasking exceptions
-    ttid <- forkIOWithUnmask ($ (threadDelay t *> throwTo tid TimeoutException))
+    ttid <- forkIOWithUnmask (\unmask' -> unmask' (threadDelay t *> throwTo tid TimeoutException))
     -- unmask effect
     unmask (fix (\loop accum -> (act >>= loop . f accum) `onTimeout` pure accum) start)
       -- make sure we catch timeout if happens before entering the loop

--- a/test/observability/Observation/JwtCache.hs
+++ b/test/observability/Observation/JwtCache.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE DataKinds        #-}
-{-# LANGUAGE NamedFieldPuns   #-}
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE DataKinds      #-}
+{-# LANGUAGE NamedFieldPuns #-}
 module Observation.JwtCache where
 
 import Network.Wai (Application)

--- a/test/observability/Observation/MetricsSpec.hs
+++ b/test/observability/Observation/MetricsSpec.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE MonadComprehensions #-}
 {-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE TypeApplications    #-}
 
 module Observation.MetricsSpec where
 

--- a/test/spec/Feature/Auth/JwtCacheSpec.hs
+++ b/test/spec/Feature/Auth/JwtCacheSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 module Feature.Auth.JwtCacheSpec where
 
 import qualified Data.Map as M

--- a/test/spec/Feature/ConcurrentSpec.hs
+++ b/test/spec/Feature/ConcurrentSpec.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Feature.ConcurrentSpec where
 

--- a/test/spec/SpecHelper.hs
+++ b/test/spec/SpecHelper.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TupleSections #-}
 module SpecHelper where
 
 import qualified Data.Aeson             as JSON


### PR DESCRIPTION
This includes a good set of default language extensions that are often used by us. It frees us from the labor of explicitly importing and moving common extensions.

FWIW, [cabal](https://github.com/haskell/cabal/blob/10aed4eb5e3149cd25f162fd2b0def06347baa66/Cabal/Cabal.cabal#L38) also uses `GHC2021`.

Ref: https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/control.html#extension-GHC2021
