### PR TITLE
fix: JWT validation uses wrong current time due to a bug in auto-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. From versio
 
 ## Unreleased
 
+### Fixed
+
+- JWT validation uses wrong current time due to a bug in auto-update by @mkleczek in #5159
+
 ## [16.0] - 2026-08-07
 
 ### Changes

--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -1,1 +1,1 @@
-index-state: hackage.haskell.org 2026-07-11T17:34:10Z
+index-state: hackage.haskell.org 2026-08-10T16:58:32Z

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -50,6 +50,16 @@ let
       fuzzyset = prev.fuzzyset_0_2_4;
 
       # TODO: Remove once available in nixpkgs
+      auto-update =
+        prev.callHackageDirect
+          {
+            pkg = "auto-update";
+            ver = "0.2.7";
+            sha256 = "sha256-fHX/OqF/cB9rbpGpLUtA29bcEJS43HUWHcK55yUxKoo=";
+          }
+          { };
+
+      # TODO: Remove once available in nixpkgs
       aeson-jsonpath =
         prev.callHackageDirect
           {

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -106,7 +106,7 @@ library
                     , Ranged-sets               >= 0.3 && < 0.6
                     , aeson                     >= 2.0.3 && < 2.3
                     , aeson-jsonpath            >= 0.4.2 && < 0.5
-                    , auto-update               >= 0.1.4 && < 0.3
+                    , auto-update               >= 0.2.7 && < 0.3
                     , base64-bytestring         >= 1 && < 1.3
                     , bytestring                >= 0.10.8 && < 0.13
                     , case-insensitive          >= 1.2 && < 1.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,6 +10,7 @@ nix:
 
 extra-deps:
   - aeson-jsonpath-0.4.2.0
+  - auto-update-0.2.7
   - configurator-pg-0.2.11
   - fuzzyset-0.2.4
   - hasql-notifications-0.2.4.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,6 +12,13 @@ packages:
   original:
     hackage: aeson-jsonpath-0.4.2.0
 - completed:
+    hackage: auto-update-0.2.7@sha256:32ca6ce351604a17ee79e4086939f798f958f8407478288e9adb7adeb194c6ea,1670
+    pantry-tree:
+      sha256: 641faa7d5ee516195ecd4b538f170722d56f84e3bc5714c6bbe8123849b49983
+      size: 1105
+  original:
+    hackage: auto-update-0.2.7
+- completed:
     hackage: configurator-pg-0.2.11@sha256:de0c56386591e85159436b0af04a8f15a4f4e156354e99709676c2c2ee959505,2850
     pantry-tree:
       sha256: 7b4daa4ea970335414f26b313a168cd12182b7b34ea8af2616c83d38699c4301


### PR DESCRIPTION
Upgrade auto-update to 0.2.7 which contains a fix to a bug causing some threads not seeing updates to the cached values.