### PR TITLE
v14: fix: JWT validation uses wrong current time due to a bug in auto-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. From versio
 
 ## Unreleased
 
+### Fixed
+
+- JWT validation uses wrong current time due to a bug in auto-update by @mkleczek in #5159
+
 ## [14.16] - 2026-07-27
 
 ### Fixed

--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -1,1 +1,1 @@
-index-state: hackage.haskell.org 2026-07-11T17:34:10Z
+index-state: hackage.haskell.org 2026-08-10T16:58:32Z

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -50,6 +50,16 @@ let
       # jailbreak, because hspec limit for tests
       fuzzyset = prev.fuzzyset_0_2_4;
 
+      # TODO: Remove once available in nixpkgs
+      auto-update =
+        prev.callHackageDirect
+          {
+            pkg = "auto-update";
+            ver = "0.2.7";
+            sha256 = "sha256-fHX/OqF/cB9rbpGpLUtA29bcEJS43HUWHcK55yUxKoo=";
+          }
+          { };
+
       # TODO: Remove once available in nixpkgs haskellPackages
       configurator-pg =
         prev.callHackageDirect

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -100,7 +100,7 @@ library
                     , HTTP                      >= 4000.3.7 && < 4000.5
                     , Ranged-sets               >= 0.3 && < 0.5
                     , aeson                     >= 2.0.3 && < 2.3
-                    , auto-update               >= 0.1.4 && < 0.3
+                    , auto-update               >= 0.2.7 && < 0.3
                     , base64-bytestring         >= 1 && < 1.3
                     , bytestring                >= 0.10.8 && < 0.13
                     , case-insensitive          >= 1.2 && < 1.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,7 @@ nix:
   pure: false
 
 extra-deps:
-  - auto-update-0.2.6
+  - auto-update-0.2.7
   - configurator-pg-0.2.11
   - fuzzyset-0.2.4
   - hasql-pool-1.0.1

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: auto-update-0.2.6@sha256:4adf0d523c8b8fbd53f32b79f115d5f304da7e1a2b35b66625497add8e9abbb5,1670
+    hackage: auto-update-0.2.7@sha256:32ca6ce351604a17ee79e4086939f798f958f8407478288e9adb7adeb194c6ea,1670
     pantry-tree:
-      sha256: ce58248c2d6d83cf0dfcfe0aec20c238b279e70926f49108a38fe6917dc0c532
+      sha256: 641faa7d5ee516195ecd4b538f170722d56f84e3bc5714c6bbe8123849b49983
       size: 1105
   original:
-    hackage: auto-update-0.2.6
+    hackage: auto-update-0.2.7
 - completed:
     hackage: configurator-pg-0.2.11@sha256:de0c56386591e85159436b0af04a8f15a4f4e156354e99709676c2c2ee959505,2850
     pantry-tree:


### PR DESCRIPTION
Backport for https://github.com/PostgREST/postgrest/pull/5159.