### PR TITLE
add: Proxy-status' details for PGRST303

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. From versio
 ### Changes
 
 - Error response body now includes details for JWT time validation errors by @steve-chavez in #5196
+- `Proxy-Status` now includes a `details` parameter for `PGRST303` error codes by @steve-chavez in #5196
 
 ## [16.2] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. From versio
 
 - Error response body now includes details for JWT time validation errors by @steve-chavez in #5196
 - `Proxy-Status` now includes a `details` parameter for `PGRST303` error codes by @steve-chavez in #5196
+- `Proxy-Status` `details` is hidden according to `client-error-verbosity` by @steve-chavez in #5196
 
 ## [16.2] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. From versio
 
 ## Unreleased
 
+### Changes
+
+- Error response body now includes details for JWT time validation errors by @steve-chavez in #5196
+
 ## [16.2] - 2026-08-21
 
 ### Added

--- a/docs/references/errors.rst
+++ b/docs/references/errors.rst
@@ -517,3 +517,5 @@ With ``minimal``, just ``code`` and ``message`` is returned.
       "code": "PGRST205",
       "message": "Could not find the table 'public.itemsxx' in the schema cache"
   }
+
+``minimal`` also applies to the :ref:`proxy-status_header` ``details`` field.

--- a/docs/references/errors.rst
+++ b/docs/references/errors.rst
@@ -474,6 +474,15 @@ For example, doing a request on a table with high count (say 30_000_000), we get
 
 The PostgreSQL error code ``57014`` (`ref <https://www.postgresql.org/docs/current/errcodes-appendix.html>`_) reveals that the error is due to a short ``statement_timeout`` value.
 
+For ``PGRST303`` JWT claims validation errors, ``Proxy-Status`` also includes ``details``.
+
+.. code-block:: http
+
+  HTTP/1.1 401 Unauthorized
+  Proxy-Status: PostgREST; error=PGRST303; details="Invalid by 35 seconds"
+
+``details`` are only shown for ``PGRST303`` for now.
+
 .. _client_error_verbosity:
 
 Client Error Verbosity

--- a/docs/tutorials/tut1.rst
+++ b/docs/tutorials/tut1.rst
@@ -197,7 +197,6 @@ After expiration, the API returns HTTP 401 Unauthorized:
 
   {
     "code": "PGRST301",
-    "details": null,
     "hint": null,
     "message": "JWT expired"
   }

--- a/src/library/PostgREST/Auth/Jwt.hs
+++ b/src/library/PostgREST/Auth/Jwt.hs
@@ -59,7 +59,7 @@ checkForErrors time audMatches = mconcat
     claim "exp" ExpClaimNotNumber $ inThePast JWTExpired
   , claim "nbf" NbfClaimNotNumber $ inTheFuture JWTNotYetValid
   , claim "iat" IatClaimNotNumber $ inTheFuture JWTIssuedAtFuture
-  , claim "aud" AudClaimNotStringOrArray $ checkValue (not . validAud) JWTNotInAudience
+  , claim "aud" AudClaimNotStringOrArray $ checkValue (not . validAud) (const JWTNotInAudience)
   ]
   where
       allowedSkewSeconds = 30 :: Int64
@@ -67,10 +67,8 @@ checkForErrors time audMatches = mconcat
       toSec = floor . nominalDiffTimeToSeconds . utcTimeToPOSIXSeconds
       now = toSec time
 
-      inTheFuture = checkTime ((now + allowedSkewSeconds) <)
-      inThePast = checkTime ((now - allowedSkewSeconds) >)
-
-      checkTime cond = checkValue (cond. sciToInt)
+      inTheFuture msg = checkValue (((now + allowedSkewSeconds) <) . sciToInt) (msg . subtract now . sciToInt)
+      inThePast msg = checkValue (((now - allowedSkewSeconds) >) . sciToInt) (msg . (now -) . sciToInt)
 
       validAud = \case
         (VAString aud) -> audMatches aud
@@ -78,7 +76,7 @@ checkForErrors time audMatches = mconcat
 
       checkValue invalid msg val =
         if invalid val then
-          pure msg
+          pure $ msg val
         else
           mempty
 

--- a/src/library/PostgREST/Error.hs
+++ b/src/library/PostgREST/Error.hs
@@ -663,9 +663,9 @@ instance ErrorBody JwtError where
     UnreachableDecodeError -> "JWT couldn't be decoded"
   message JwtTokenRequired = "Anonymous access is disabled"
   message (JwtClaimsErr e) = case e of
-    JWTExpired               -> "JWT expired"
-    JWTNotYetValid           -> "JWT not yet valid"
-    JWTIssuedAtFuture        -> "JWT issued at future"
+    JWTExpired{}             -> "JWT expired"
+    JWTNotYetValid{}         -> "JWT not yet valid"
+    JWTIssuedAtFuture{}      -> "JWT issued at future"
     JWTNotInAudience         -> "JWT not in audience"
     ParsingClaimsFailed      -> "Parsing claims failed"
     ExpClaimNotNumber        -> "The JWT 'exp' claim must be a number"
@@ -677,6 +677,13 @@ instance ErrorBody JwtError where
     KeyError dets     -> Just $ JSON.String dets
     BadAlgorithm dets -> Just $ JSON.String dets
     _                 -> Nothing
+  details (JwtClaimsErr e) = case e of
+    JWTExpired secs        -> invalidBy secs
+    JWTNotYetValid secs    -> invalidBy secs
+    JWTIssuedAtFuture secs -> invalidBy secs
+    _                      -> Nothing
+    where
+      invalidBy secs = Just $ JSON.String $ "Invalid by " <> show secs <> " seconds"
   details _ = Nothing
 
   hint _    = Nothing

--- a/src/library/PostgREST/Error.hs
+++ b/src/library/PostgREST/Error.hs
@@ -86,8 +86,10 @@ errorResponseFor verb err =
     pSHeader code' =
       ("Proxy-Status", "PostgREST; error=" <> T.encodeUtf8 code' <> detailsHeader)
       where
-        detailsHeader = if code' == "PGRST303"
-          then maybe mempty (\d -> "; details=" <> LBS.toStrict (JSON.encode d)) (details err)
+        detailsHeader = if code' == "PGRST303" then
+          case verb of
+            Verbose -> maybe mempty (\d -> "; details=" <> LBS.toStrict (JSON.encode d)) (details err)
+            Minimal -> mempty
           else mempty
   in
   responseLBS (status err) (baseHeader : cLHeader (errorPayload verb err) : pSHeader (code err) : headers err) $ errorPayload verb err

--- a/src/library/PostgREST/Error.hs
+++ b/src/library/PostgREST/Error.hs
@@ -83,7 +83,12 @@ errorResponseFor verb err =
   let
     baseHeader = MediaType.toContentType MTApplicationJSON
     cLHeader body = (,) "Content-Length" (show $ LBS.length body) :: Header
-    pSHeader code' = ("Proxy-Status", "PostgREST; error=" <> T.encodeUtf8 code')
+    pSHeader code' =
+      ("Proxy-Status", "PostgREST; error=" <> T.encodeUtf8 code' <> detailsHeader)
+      where
+        detailsHeader = if code' == "PGRST303"
+          then maybe mempty (\d -> "; details=" <> LBS.toStrict (JSON.encode d)) (details err)
+          else mempty
   in
   responseLBS (status err) (baseHeader : cLHeader (errorPayload verb err) : pSHeader (code err) : headers err) $ errorPayload verb err
 

--- a/src/library/PostgREST/Error/Types.hs
+++ b/src/library/PostgREST/Error/Types.hs
@@ -106,9 +106,9 @@ data JwtDecodeError
   deriving Show
 
 data JwtClaimsError
-  = JWTExpired
-  | JWTNotYetValid
-  | JWTIssuedAtFuture
+  = JWTExpired Int64
+  | JWTNotYetValid Int64
+  | JWTIssuedAtFuture Int64
   | JWTNotInAudience
   | ParsingClaimsFailed
   | ExpClaimNotNumber

--- a/test/spec/Feature/Auth/AuthSpec.hs
+++ b/test/spec/Feature/Auth/AuthSpec.hs
@@ -107,8 +107,9 @@ spec withConfig = withConfig baseCfg $ describe "authorization" $ do
     let jwtPayload = [json|{ "exp": 1446678149, "role": "postgrest_test_author", "id": "jdoe" }|]
         auth = authHeaderJWT $ generateJWT jwtPayload
     request methodGet "/authors_only" [auth] ""
-      `shouldRespondWith` [json| {"message":"JWT expired","code":"PGRST303","hint":null,"details":null} |]
+      `shouldRespondWith` ResponseMatcher
         { matchStatus = 401
+        , matchBody = matchErrorPresent "PGRST303" (Just "JWT expired") Nothing (Just "Invalid by")
         , matchHeaders = [
             "WWW-Authenticate" <:>
             "Bearer error=\"invalid_token\", error_description=\"JWT expired\""

--- a/test/spec/Feature/Query/ErrorSpec.hs
+++ b/test/spec/Feature/Query/ErrorSpec.hs
@@ -218,7 +218,7 @@ spec withConfig = do
 
   -- By default, error verbosity is set to 'verbose', which returns all error
   -- fields. No need to test that explicitly.
-  withConfig baseCfg { configClientErrorVerbosity = Minimal } $ describe "Test client-error-verbosity config" $
+  withConfig baseCfg { configClientErrorVerbosity = Minimal } $ describe "Test client-error-verbosity config" $ do
     it "hides details and hint when set to 'minimal'" $
       request methodGet "/itemsx" [] ""
         `shouldRespondWith`
@@ -227,3 +227,16 @@ spec withConfig = do
           "message":"Could not find the table 'test.itemsx' in the schema cache"
         }|]
         { matchStatus = 404 }
+
+    it "hides Proxy-Status details when set to 'minimal'" $ do
+      currentTime <- liftIO $ relativeSeconds (-35)
+      let jwtPayload = [json|{ "exp": #{currentTime} }|]
+          auth = authHeaderJWT $ generateJWT jwtPayload
+      request methodGet "/authors_only" [auth] ""
+        `shouldRespondWith`
+        [json|{
+          "code":"PGRST303",
+          "message":"JWT expired"
+        }|]
+        { matchStatus = 401
+        , matchHeaders = [ "Proxy-Status" <:> "PostgREST; error=PGRST303" ] }

--- a/test/spec/Feature/Query/ErrorSpec.hs
+++ b/test/spec/Feature/Query/ErrorSpec.hs
@@ -136,42 +136,31 @@ spec withConfig = do
           let jwtPayload = [json|{ "exp": #{currentTime} }|]
               auth = authHeaderJWT $ generateJWT jwtPayload
           request methodGet "/authors_only" [auth] ""
-            `shouldRespondWith`
-            [json|{
-              "code":"PGRST303",
-              "details":null,
-              "hint":null,
-              "message":"JWT expired"
-            }|]
-            { matchStatus = 401 }
+            `shouldRespondWith` ResponseMatcher
+              { matchStatus = 401
+              , matchBody = matchErrorPresent "PGRST303" (Just "JWT expired") Nothing (Just "Invalid by")
+              , matchHeaders = [] }
 
         it "it should return error if used before it is valid" $ do
           currentTime <- liftIO $ relativeSeconds 35
           let jwtPayload = [json|{ "nbf": #{currentTime} }|]
               auth = authHeaderJWT $ generateJWT jwtPayload
           request methodGet "/authors_only" [auth] ""
-            `shouldRespondWith`
-            [json|{
-              "code":"PGRST303",
-              "details":null,
-              "hint":null,
-              "message":"JWT not yet valid"
-            }|]
-            { matchStatus = 401 }
+            `shouldRespondWith` ResponseMatcher
+              { matchStatus = 401
+              , matchBody = matchErrorPresent "PGRST303" (Just "JWT not yet valid") Nothing (Just "Invalid by")
+              , matchHeaders = [] }
 
         it "it should return error if issued at future" $ do
           currentTime <- liftIO $ relativeSeconds 35
           let jwtPayload = [json|{ "iat": #{currentTime} }|]
               auth = authHeaderJWT $ generateJWT jwtPayload
           request methodGet "/authors_only" [auth] ""
-            `shouldRespondWith`
-            [json|{
-              "code":"PGRST303",
-              "details":null,
-              "hint":null,
-              "message":"JWT issued at future"
-            }|]
-            { matchStatus = 401 }
+            `shouldRespondWith` ResponseMatcher
+              { matchStatus = 401
+              , matchBody = matchErrorPresent "PGRST303" (Just "JWT issued at future") Nothing (Just "Invalid by")
+              , matchHeaders = []
+              }
 
   withConfig baseCfg { configJwtAudience = Just "spec tests" } $ describe "Test JWT Audience error" $ do
     it "it should return error if JWT not in audience" $ do

--- a/test/spec/Feature/Query/ErrorSpec.hs
+++ b/test/spec/Feature/Query/ErrorSpec.hs
@@ -139,7 +139,7 @@ spec withConfig = do
             `shouldRespondWith` ResponseMatcher
               { matchStatus = 401
               , matchBody = matchErrorPresent "PGRST303" (Just "JWT expired") Nothing (Just "Invalid by")
-              , matchHeaders = [] }
+              , matchHeaders = [matchHeaderValuePresent "Proxy-Status" "PostgREST; error=PGRST303; details=\"Invalid by"] }
 
         it "it should return error if used before it is valid" $ do
           currentTime <- liftIO $ relativeSeconds 35
@@ -149,7 +149,7 @@ spec withConfig = do
             `shouldRespondWith` ResponseMatcher
               { matchStatus = 401
               , matchBody = matchErrorPresent "PGRST303" (Just "JWT not yet valid") Nothing (Just "Invalid by")
-              , matchHeaders = [] }
+              , matchHeaders = [matchHeaderValuePresent "Proxy-Status" "PostgREST; error=PGRST303; details=\"Invalid by"] }
 
         it "it should return error if issued at future" $ do
           currentTime <- liftIO $ relativeSeconds 35
@@ -159,8 +159,7 @@ spec withConfig = do
             `shouldRespondWith` ResponseMatcher
               { matchStatus = 401
               , matchBody = matchErrorPresent "PGRST303" (Just "JWT issued at future") Nothing (Just "Invalid by")
-              , matchHeaders = []
-              }
+              , matchHeaders = [matchHeaderValuePresent "Proxy-Status" "PostgREST; error=PGRST303; details=\"Invalid by"] }
 
   withConfig baseCfg { configJwtAudience = Just "spec tests" } $ describe "Test JWT Audience error" $ do
     it "it should return error if JWT not in audience" $ do
@@ -174,7 +173,8 @@ spec withConfig = do
           "hint":null,
           "message":"JWT not in audience"
         }|]
-        { matchStatus = 401 }
+        { matchStatus = 401
+        , matchHeaders = [ "Proxy-Status" <:> "PostgREST; error=PGRST303" ] }
 
   withConfig baseCfg $ describe "Test JWT Token format errors" $ do
     it "when partial token is provided" $ do
@@ -187,7 +187,8 @@ spec withConfig = do
           "hint":null,
           "message":"Expected 3 parts in JWT; got 2"
         }|]
-        { matchStatus = 401 }
+        { matchStatus = 401
+        , matchHeaders = [ "Proxy-Status" <:> "PostgREST; error=PGRST301" ] }
 
     it "when token is complete but random characters" $ do
       let auth = authHeaderJWT "quifquirndsjagnrgniur.fonvoienqhhdj.iuqvnvhojah"
@@ -199,7 +200,8 @@ spec withConfig = do
           "hint":null,
           "message":"JWT cryptographic operation failed"
         }|]
-        { matchStatus = 401 }
+        { matchStatus = 401
+        , matchHeaders = [ "Proxy-Status" <:> "PostgREST; error=PGRST301" ] }
 
     it "when token with algorithm 'none' is used" $ do
       let auth = authHeaderJWT "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.e30.yOBhlOIqn56T-4NvyEXCjfi3UmyQZ-BzXtePMO2NgRI"
@@ -211,7 +213,8 @@ spec withConfig = do
           "hint":null,
           "message":"Wrong or unsupported encoding algorithm"
         }|]
-        { matchStatus = 401 }
+        { matchStatus = 401
+        , matchHeaders = [ "Proxy-Status" <:> "PostgREST; error=PGRST301" ] }
 
   -- By default, error verbosity is set to 'verbose', which returns all error
   -- fields. No need to test that explicitly.

--- a/test/spec/SpecHelper.hs
+++ b/test/spec/SpecHelper.hs
@@ -6,6 +6,7 @@ import qualified Data.ByteString.Char8  as BS
 import qualified Data.ByteString.Lazy   as BL
 import qualified Data.Map.Strict        as M
 import qualified Data.Set               as S
+import qualified Data.Text              as T
 import qualified Jose.Jwa               as JWT
 import qualified Jose.Jws               as JWT
 import qualified Jose.Jwt               as JWT
@@ -242,6 +243,21 @@ isErrorFormat s =
   obj = JSON.decode s :: Maybe (M.Map Text JSON.Value)
   keys = maybe S.empty M.keysSet obj
   validKeys = S.fromList ["message", "details", "hint", "code"]
+
+-- matches equality for code and infixes for message, detail and hint
+matchErrorPresent :: Text -> Maybe Text -> Maybe Text -> Maybe Text -> MatchBody
+matchErrorPresent code msg hint details = MatchBody $ \_ body ->
+  case JSON.decode body :: Maybe (M.Map Text JSON.Value) of
+    Just obj
+      | M.lookup "code" obj == Just (JSON.String code)
+      , matchesInfix msg (M.lookup "message" obj)
+      , matchesInfix hint (M.lookup "hint" obj)
+      , matchesInfix details (M.lookup "details" obj) -> Nothing
+    _ -> Just $ toS (decodeUtf8 (BL.toStrict body))
+  where
+    matchesInfix Nothing _ = True
+    matchesInfix (Just expected) (Just (JSON.String actual)) = expected `T.isInfixOf` actual
+    matchesInfix _ _ = False
 
 planCost :: SResponse -> Float
 planCost resp =


### PR DESCRIPTION
For debugging https://github.com/PostgREST/postgrest/issues/5196.

Response errors message now contain extra detail:

```json
{
  "code":"PGRST303",
  "details":"Invalid by 35 seconds",
  "hint":null,
  "message":"JWT issued at future"
}
```

Additionally, it includes an improvement related to https://github.com/PostgREST/postgrest/issues/4637:

```
Proxy-Status: PostgREST; error=PGRST303; details="Invalid by 35 seconds"
```

Right now this is only added for `PGRST303` to be extra careful about not including big error messages in headers.