### PR TITLE
add: seconds in JWT time validations errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. From versio
 
 ## Unreleased
 
+### Changes
+
+- Error responses and the `WWW-Authenticate` header now include seconds in JWT time validation errors by @steve-chavez in #5196
+
 ## [16.2] - 2026-08-21
 
 ### Added

--- a/src/library/PostgREST/Auth/Jwt.hs
+++ b/src/library/PostgREST/Auth/Jwt.hs
@@ -59,7 +59,7 @@ checkForErrors time audMatches = mconcat
     claim "exp" ExpClaimNotNumber $ inThePast JWTExpired
   , claim "nbf" NbfClaimNotNumber $ inTheFuture JWTNotYetValid
   , claim "iat" IatClaimNotNumber $ inTheFuture JWTIssuedAtFuture
-  , claim "aud" AudClaimNotStringOrArray $ checkValue (not . validAud) JWTNotInAudience
+  , claim "aud" AudClaimNotStringOrArray $ checkValue (not . validAud) (const JWTNotInAudience)
   ]
   where
       allowedSkewSeconds = 30 :: Int64
@@ -67,10 +67,8 @@ checkForErrors time audMatches = mconcat
       toSec = floor . nominalDiffTimeToSeconds . utcTimeToPOSIXSeconds
       now = toSec time
 
-      inTheFuture = checkTime ((now + allowedSkewSeconds) <)
-      inThePast = checkTime ((now - allowedSkewSeconds) >)
-
-      checkTime cond = checkValue (cond. sciToInt)
+      inTheFuture msg = checkValue (((now + allowedSkewSeconds) <) . sciToInt) (msg . subtract now . sciToInt)
+      inThePast msg = checkValue (((now - allowedSkewSeconds) >) . sciToInt) (msg . (now -) . sciToInt)
 
       validAud = \case
         (VAString aud) -> audMatches aud
@@ -78,7 +76,7 @@ checkForErrors time audMatches = mconcat
 
       checkValue invalid msg val =
         if invalid val then
-          pure msg
+          pure $ msg val
         else
           mempty
 

--- a/src/library/PostgREST/Error.hs
+++ b/src/library/PostgREST/Error.hs
@@ -663,9 +663,9 @@ instance ErrorBody JwtError where
     UnreachableDecodeError -> "JWT couldn't be decoded"
   message JwtTokenRequired = "Anonymous access is disabled"
   message (JwtClaimsErr e) = case e of
-    JWTExpired               -> "JWT expired"
-    JWTNotYetValid           -> "JWT not yet valid"
-    JWTIssuedAtFuture        -> "JWT issued at future"
+    JWTExpired secs          -> "JWT expired by " <> show secs <> " seconds"
+    JWTNotYetValid secs      -> "JWT not yet valid by " <> show secs <> " seconds"
+    JWTIssuedAtFuture secs   -> "JWT issued at future by " <> show secs <> " seconds"
     JWTNotInAudience         -> "JWT not in audience"
     ParsingClaimsFailed      -> "Parsing claims failed"
     ExpClaimNotNumber        -> "The JWT 'exp' claim must be a number"

--- a/src/library/PostgREST/Error/Types.hs
+++ b/src/library/PostgREST/Error/Types.hs
@@ -106,9 +106,9 @@ data JwtDecodeError
   deriving Show
 
 data JwtClaimsError
-  = JWTExpired
-  | JWTNotYetValid
-  | JWTIssuedAtFuture
+  = JWTExpired Int64
+  | JWTNotYetValid Int64
+  | JWTIssuedAtFuture Int64
   | JWTNotInAudience
   | ParsingClaimsFailed
   | ExpClaimNotNumber

--- a/test/spec/Feature/Auth/AuthSpec.hs
+++ b/test/spec/Feature/Auth/AuthSpec.hs
@@ -104,14 +104,15 @@ spec withConfig = withConfig baseCfg $ describe "authorization" $ do
       }
 
   it "fails with an expired token" $ do
-    let jwtPayload = [json|{ "exp": 1446678149, "role": "postgrest_test_author", "id": "jdoe" }|]
+    currentTime <- liftIO $ relativeSeconds (-35)
+    let jwtPayload = [json|{ "exp": #{currentTime}, "role": "postgrest_test_author", "id": "jdoe" }|]
         auth = authHeaderJWT $ generateJWT jwtPayload
     request methodGet "/authors_only" [auth] ""
-      `shouldRespondWith` [json| {"message":"JWT expired","code":"PGRST303","hint":null,"details":null} |]
+      `shouldRespondWith` [json| {"message":"JWT expired by 35 seconds","code":"PGRST303","hint":null,"details":null} |]
         { matchStatus = 401
         , matchHeaders = [
             "WWW-Authenticate" <:>
-            "Bearer error=\"invalid_token\", error_description=\"JWT expired\""
+            "Bearer error=\"invalid_token\", error_description=\"JWT expired by 35 seconds\""
           ]
         }
 

--- a/test/spec/Feature/Query/ErrorSpec.hs
+++ b/test/spec/Feature/Query/ErrorSpec.hs
@@ -141,7 +141,7 @@ spec withConfig = do
               "code":"PGRST303",
               "details":null,
               "hint":null,
-              "message":"JWT expired"
+              "message":"JWT expired by 35 seconds"
             }|]
             { matchStatus = 401 }
 
@@ -155,7 +155,7 @@ spec withConfig = do
               "code":"PGRST303",
               "details":null,
               "hint":null,
-              "message":"JWT not yet valid"
+              "message":"JWT not yet valid by 35 seconds"
             }|]
             { matchStatus = 401 }
 
@@ -169,7 +169,7 @@ spec withConfig = do
               "code":"PGRST303",
               "details":null,
               "hint":null,
-              "message":"JWT issued at future"
+              "message":"JWT issued at future by 35 seconds"
             }|]
             { matchStatus = 401 }
 


### PR DESCRIPTION
For debugging https://github.com/PostgREST/postgrest/issues/5196.

Response errors message now contain extra detail:
```
{
  "code":"PGRST303",
  "details":null,
  "hint":null,
  "message":"JWT issued at future by 35 seconds"
}
```

Plus the header:

```
WWW-Authenticate: Bearer error="invalid_token", error_description="JWT expired by 35 seconds"
```