### PR TITLE
nix(tools): fix using HTTP headers with postgrest-parallel-curl

### DIFF
--- a/nix/tools/devTools.nix
+++ b/nix/tools/devTools.nix
@@ -158,17 +158,16 @@ let
         ];
       }
       ''
-        curl_command="${curl}/bin/curl --parallel --parallel-immediate "
-        curl_command+="''${_arg_leftovers[*]} "
+        curl_command=("${curl}/bin/curl" --parallel --parallel-immediate)
+        curl_command+=("''${_arg_leftovers[@]}")
 
         x=1
-        while [ $x -le "$1" ]
-        do
-          curl_command+="$_arg_host "
+        while [ $x -le "$1" ]; do
+          curl_command+=("$_arg_host")
           x=$((x + 1))
         done
 
-        eval "$curl_command"
+        "''${curl_command[@]}"
       '';
 
   genCtags =


### PR DESCRIPTION
`postgrest-parallel-curl` doesn't parse HTTP headers correctly. In my case, the issue came up when using `Authorization: Bearer ...` header.