### PR TITLE
add: log JWT time validation difference

### DIFF
--- a/src/library/PostgREST/App.hs
+++ b/src/library/PostgREST/App.hs
@@ -160,11 +160,14 @@ postgrest appState =
       appConf@AppConfig{..} <- AppState.getConfig appState -- the config must be read again because it can reload
       maybeSchemaCache <- AppState.getSchemaCache appState
 
-      let handleError = fmap (either (Error.errorResponseFor configClientErrorVerbosity) identity)
+      let logError (Error.JwtErr jwtErr@(Error.JwtClaimsErr Error.JWTExpired{})) = AppState.getObserver appState $ JwtErrorObs jwtErr
+          logError (Error.JwtErr jwtErr@(Error.JwtClaimsErr Error.JWTNotYetValid{})) = AppState.getObserver appState $ JwtErrorObs jwtErr
+          logError (Error.JwtErr jwtErr@(Error.JwtClaimsErr Error.JWTIssuedAtFuture{})) = AppState.getObserver appState $ JwtErrorObs jwtErr
+          logError _ = pure ()
 
       -- writer to save authRole (uses `tell` for this and `getLast` to obtain it)
       -- has to be before runExceptT to make sure role is not lost on error
-      (response, authRole) <- runWriterT . handleError . runExceptT $ do
+      (result, authRole) <- runWriterT . runExceptT $ do
         (jwtTime, authResult@AuthResult{..}) <- withTiming appConf $
           Auth.getAuthResult appState $ ApiRequest.userBearerAuth req
 
@@ -172,7 +175,13 @@ postgrest appState =
 
         postgrestResponse appState appConf maybeSchemaCache jwtTime authResult req
 
+      let response = either (Error.errorResponseFor configClientErrorVerbosity) identity result
+
       AppState.getObserver appState $ genResponseObs (getLast authRole) req response
+
+      case result of
+        Left err -> logError err
+        Right _  -> pure ()
 
       delay <- AppState.getNextDelay appState
       respond $ addRetryHint delay response

--- a/src/library/PostgREST/Auth/Jwt.hs
+++ b/src/library/PostgREST/Auth/Jwt.hs
@@ -59,7 +59,7 @@ checkForErrors time audMatches = mconcat
     claim "exp" ExpClaimNotNumber $ inThePast JWTExpired
   , claim "nbf" NbfClaimNotNumber $ inTheFuture JWTNotYetValid
   , claim "iat" IatClaimNotNumber $ inTheFuture JWTIssuedAtFuture
-  , claim "aud" AudClaimNotStringOrArray $ checkValue (not . validAud) JWTNotInAudience
+  , claim "aud" AudClaimNotStringOrArray $ checkValue (not . validAud) (const JWTNotInAudience)
   ]
   where
       allowedSkewSeconds = 30 :: Int64
@@ -67,10 +67,12 @@ checkForErrors time audMatches = mconcat
       toSec = floor . nominalDiffTimeToSeconds . utcTimeToPOSIXSeconds
       now = toSec time
 
-      inTheFuture = checkTime ((now + allowedSkewSeconds) <)
-      inThePast = checkTime ((now - allowedSkewSeconds) >)
-
-      checkTime cond = checkValue (cond. sciToInt)
+      inTheFuture msg = checkValue (((now + allowedSkewSeconds) <) . sciToInt) $ \val ->
+        let claimTime = sciToInt val
+        in msg (claimTime - now) now claimTime
+      inThePast msg = checkValue (((now - allowedSkewSeconds) >) . sciToInt) $ \val ->
+        let claimTime = sciToInt val
+        in msg (now - claimTime) now claimTime
 
       validAud = \case
         (VAString aud) -> audMatches aud
@@ -78,7 +80,7 @@ checkForErrors time audMatches = mconcat
 
       checkValue invalid msg val =
         if invalid val then
-          pure msg
+          pure $ msg val
         else
           mempty
 

--- a/src/library/PostgREST/Error.hs
+++ b/src/library/PostgREST/Error.hs
@@ -21,6 +21,7 @@ module PostgREST.Error
   , status
   , noRelBetweenHint
   , noRpcHint
+  , jwtErrorMessage
   ) where
 
 import qualified Data.Aeson                as JSON
@@ -663,9 +664,9 @@ instance ErrorBody JwtError where
     UnreachableDecodeError -> "JWT couldn't be decoded"
   message JwtTokenRequired = "Anonymous access is disabled"
   message (JwtClaimsErr e) = case e of
-    JWTExpired               -> "JWT expired"
-    JWTNotYetValid           -> "JWT not yet valid"
-    JWTIssuedAtFuture        -> "JWT issued at future"
+    JWTExpired{}             -> "JWT expired"
+    JWTNotYetValid{}         -> "JWT not yet valid"
+    JWTIssuedAtFuture{}      -> "JWT issued at future"
     JWTNotInAudience         -> "JWT not in audience"
     ParsingClaimsFailed      -> "Parsing claims failed"
     ExpClaimNotNumber        -> "The JWT 'exp' claim must be a number"
@@ -680,6 +681,18 @@ instance ErrorBody JwtError where
   details _ = Nothing
 
   hint _    = Nothing
+
+jwtErrorMessage :: JwtError -> Text
+jwtErrorMessage e = case e of
+  JwtClaimsErr ce -> case ce of
+    JWTExpired difference now claim        -> timeMsg "JWT expired" "exp" difference now claim
+    JWTNotYetValid difference now claim    -> timeMsg "JWT not yet valid" "nbf" difference now claim
+    JWTIssuedAtFuture difference now claim -> timeMsg "JWT issued at future" "iat" difference now claim
+    _                      -> message e
+  _ -> message e
+  where
+    timeMsg msg claimName difference now claim =
+      msg <> ", diff: " <> show difference <> " seconds, current time (epoch): " <> show now <> ", " <> claimName <> " (epoch): " <> show claim
 
 invalidTokenHeader :: Text -> Header
 invalidTokenHeader m =

--- a/src/library/PostgREST/Error/Types.hs
+++ b/src/library/PostgREST/Error/Types.hs
@@ -13,6 +13,7 @@ module PostgREST.Error.Types
   , JwtError (..)
   , JwtDecodeError(..)
   , JwtClaimsError(..)
+  , EpochTime
   , PgRaiseErrMessage(..)
   , PgRaiseErrDetails(..)
   ) where
@@ -105,10 +106,12 @@ data JwtDecodeError
   | UnreachableDecodeError
   deriving Show
 
+type EpochTime = Int64
+
 data JwtClaimsError
-  = JWTExpired
-  | JWTNotYetValid
-  | JWTIssuedAtFuture
+  = JWTExpired Int64 EpochTime EpochTime
+  | JWTNotYetValid Int64 EpochTime EpochTime
+  | JWTIssuedAtFuture Int64 EpochTime EpochTime
   | JWTNotInAudience
   | ParsingClaimsFailed
   | ExpClaimNotNumber

--- a/src/library/PostgREST/Logger.hs
+++ b/src/library/PostgREST/Logger.hs
@@ -78,6 +78,9 @@ observationLogger loggerState obs = do
     o@(QueryErrorCodeHighObs _) -> do
       when (logLevel >= LogError) $ do
         logWithZTime loggerState $ observationMessages o
+    o@(JwtErrorObs _) -> do
+      when (logLevel >= LogError) $ do
+        logWithZTime loggerState $ observationMessages o
     o@SchemaCacheEmptyObs ->
       when (logLevel >= LogError) $ do
       logWithZTime loggerState $ observationMessages o
@@ -208,6 +211,8 @@ observationMessages = \case
     pure $ "Failed to query the role settings. " <> jsonMessage usageErr
   QueryErrorCodeHighObs usageErr ->
     pure $ jsonMessage usageErr
+  JwtErrorObs jwtErr ->
+    pure $ Error.jwtErrorMessage jwtErr
   ConfigInvalidObs err ->
     pure $ "Failed reloading config: " <> err
   ConfigSucceededObs ->

--- a/src/library/PostgREST/Observation.hs
+++ b/src/library/PostgREST/Observation.hs
@@ -18,6 +18,7 @@ import           Network.HTTP.Types.Status         (Status)
 import qualified Network.Wai                       as Wai
 import           PostgREST.Config.DeprecatedJSPath (DeprecatedJSPath)
 import           PostgREST.Config.PgVersion
+import           PostgREST.Error.Types             (JwtError)
 import           PostgREST.Query                   (MainQuery)
 import           PostgREST.SchemaCache             (QueryTimings)
 
@@ -51,6 +52,7 @@ data Observation
   | ConfigSucceededObs
   | QueryRoleSettingsErrorObs SQL.UsageError
   | QueryErrorCodeHighObs SQL.UsageError
+  | JwtErrorObs JwtError
   | QueryPgVersionError SQL.UsageError
   | PoolInit Int
   | PoolAcqTimeoutObs

--- a/test/io/test_log.py
+++ b/test/io/test_log.py
@@ -507,6 +507,7 @@ def test_expired_jwt_log_lacks_role(defaultenv):
     with run(env=env) as postgrest:
         response = postgrest.session.get("/authors_only", headers=headers)
         assert response.status_code == 401
+        assert response.json()["details"] is None
 
         output = postgrest.read_stdout(nlines=1)
 
@@ -514,6 +515,39 @@ def test_expired_jwt_log_lacks_role(defaultenv):
     assert re.match(
         r'- - - \[.+\] "GET /authors_only HTTP/1.1" 401 \d+ "" "python-requests/.+"',
         output[0],
+    )
+
+
+@pytest.mark.parametrize(
+    ("claim", "offset", "message"),
+    [
+        ("exp", -35, "JWT expired"),
+        ("nbf", 35, "JWT not yet valid"),
+        ("iat", 35, "JWT issued at future"),
+    ],
+)
+def test_jwt_time_validation_difference_is_logged(claim, offset, message, defaultenv):
+    "JWT time validation differences are logged"
+
+    env = {
+        **defaultenv,
+        "PGRST_JWT_SECRET": SECRET,
+        "PGRST_LOG_LEVEL": "warn",
+    }
+    headers = jwtauthheader({claim: relativeSeconds(offset)}, SECRET)
+
+    with run(env=env) as postgrest:
+        response = postgrest.session.get("/authors_only", headers=headers)
+        assert response.status_code == 401
+
+        output = postgrest.read_stdout(nlines=2)
+
+    assert any(
+        f"{message}, diff: " in line
+        and re.search(
+            r", current time \(epoch\): \d+, (exp|nbf|iat) \(epoch\): \d+$", line
+        )
+        for line in output
     )
 
 


### PR DESCRIPTION
Whenever the JWT time validation fails, we now get:

```
127.0.0.1 - - [31/Aug/2026:19:35:50 -0500] "GET /authors_only HTTP/1.1" 401 70 "" "curl/7.81.0"
31/Aug/2026:19:35:50 -0500: JWT expired, diff: 32 seconds, current time (epoch): 1788222950, exp (epoch): 1788222918
```

Keeping it simple and not transforming the epoch into human readable form to avoid other possible errors there.

Logs all the failures regarding `iat`, `nbf` and `exp` because the main purpose is to detect clock drift.

Part of #5196.