### PR TITLE
fix: sporadic JWT issued at future failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. From versio
 
 ## Unreleased
 
+### Changes
+
+- Fix sporadic "PGRST303 JWT issued at future" errors by @steve-chavez in #5196
+
 ## [16.2] - 2026-08-21
 
 ### Added

--- a/src/library/PostgREST/AppState.hs
+++ b/src/library/PostgREST/AppState.hs
@@ -36,8 +36,6 @@ import qualified PostgREST.Metrics       as Metrics
 import           PostgREST.Observation
 import           PostgREST.Version       (prettyVersion)
 
-import Control.AutoUpdate         (defaultUpdateSettings, mkAutoUpdate,
-                                   updateAction)
 import Control.Concurrent.STM     (newEmptyTMVarIO)
 import Data.IORef                 (IORef, newIORef, readIORef)
 import Data.Time.Clock            (getCurrentTime)
@@ -78,7 +76,7 @@ initWithPool pool confRef loggerState metricsState observer appKiller = mdo
     <*> newIORef Nothing
     <*> makeDebouncer (retryingSchemaCacheLoad appState *> threadDelay 100000)  -- 100ms cooldown
     <*> pure confRef
-    <*> mkAutoUpdate defaultUpdateSettings { updateAction = getCurrentTime }
+    <*> pure getCurrentTime
     <*> pure appKiller
     <*> newIORef 0
     <*> pure observer


### PR DESCRIPTION
Fixes https://github.com/PostgREST/postgrest/issues/5196 by removing `auto-update` and using `getSystemTime` directly.

Historically this was added as a form of "premature optimization" on https://github.com/PostgREST/postgrest/pull/703#issuecomment-251161811, then removed in https://github.com/PostgREST/postgrest/pull/919 and added back again on https://github.com/PostgREST/postgrest/pull/1091.

On "modern Linux" ([since 2007](https://lkml.iu.edu/0705.0/0013.html)) a call to `clock_gettime` ([called by getSystemTime](https://github.com/haskell/time/blob/master/lib/Data/Time/Clock/Internal/SystemTime.hs#L94C17-L94C35)) uses [vDSO](https://man7.org/linux/man-pages/man7/vdso.7.html) which avoids a slow system call.

To confirm there's no perf regression I've benched v14.17 vs this patch via `postgrest-benchmark`:

<details>
<summary>v14.17</summary>
<pre>
$ postgrest-bench-k6 10 k6/GETSingleJWT.js 5m

 data_received..................: 188 MB 627 kB/s
 data_sent......................: 298 MB 992 kB/s
 http_req_blocked...............: avg=3.08µs  min=951ns   med=2.46µs  max=1.15ms   p(90)=3. 01µs  p(95)=3.55µs
 http_req_connecting............: avg=283ns   min=0s      med=0s      max=620.79µs p(90)=0s p(95)=0s
✓ http_req_duration..............: avg=4.54ms  min=1.51ms  med=4.37ms  max=23.12ms  p(90)=6. 12ms  p(95)=6.74ms
   { expected_response:true }...: avg=4.54ms  min=1.51ms  med=4.37ms  max=23.12ms  p(90)=6. 12ms  p(95)=6.74ms
✓ http_req_failed................: 0.00%  ✓ 0           ✗ 637720
 http_req_receiving.............: avg=45.17µs min=15.38µs med=43.07µs max=5.16ms   p(90)=55 .27µs p(95)=66.14µs
 http_req_sending...............: avg=18.38µs min=6.67µs  med=13.16µs max=7.79ms   p(90)=28 .92µs p(95)=30.35µs
 http_req_tls_handshaking.......: avg=0s      min=0s      med=0s      max=0s       p(90)=0s p(95)=0s
 http_req_waiting...............: avg=4.47ms  min=1.46ms  med=4.3ms   max=23.07ms  p(90)=6. 05ms  p(95)=6.68ms
 http_reqs......................: 637720 2125.710676/s
 iteration_duration.............: avg=4.69ms  min=1.65ms  med=4.52ms  max=23.25ms  p(90)=6. 27ms  p(95)=6.89ms
 iterations.....................: 637720 2125.710676/s
 vus............................: 10     min=10        max=10
 vus_max........................: 10
</pre>
</details>

<details>
<summary>PR</summary>
<pre>
$ postgrest-bench-k6 10 k6/GETSingleJWT.js 5m

 data_received..................: 210 MB 700 kB/s
 data_sent......................: 302 MB 1.0 MB/s
 http_req_blocked...............: avg=3.11µs  min=970ns   med=2.46µs  max=3.72ms  p(90)=3.0 3µs  p(95)=3.6µs
 http_req_connecting............: avg=283ns   min=0s      med=0s      max=1.14ms  p(90)=0s p(95)=0s
✓ http_req_duration..............: avg=4.46ms  min=1.6ms   med=4.3ms   max=17.85ms p(90)=6.0 2ms  p(95)=6.62ms
   { expected_response:true }...: avg=4.46ms  min=1.6ms   med=4.3ms   max=17.85ms p(90)=6.0 2ms  p(95)=6.62ms
✓ http_req_failed................: 0.00%  ✓ 0           ✗ 647848
 http_req_receiving.............: avg=46.16µs min=17.42µs med=43.91µs max=4.69ms  p(90)=56. 48µs p(95)=67.51µs
 http_req_sending...............: avg=18.42µs min=6.77µs  med=13.23µs max=1.98ms  p(90)=28. 81µs p(95)=30.23µs
 http_req_tls_handshaking.......: avg=0s      min=0s      med=0s      max=0s      p(90)=0s p(95)=0s
 http_req_waiting...............: avg=4.4ms   min=1.53ms  med=4.24ms  max=17.79ms p(90)=5.9 5ms  p(95)=6.56ms
 http_reqs......................: 647848 2159.455081/s
 iteration_duration.............: avg=4.61ms  min=1.75ms  med=4.45ms  max=17.99ms p(90)=6.1 7ms  p(95)=6.77ms
 iterations.....................: 647848 2159.455081/s
 vus............................: 10     min=10        max=10
</pre>
</details>

(in fact this PR seems slightly faster)

We never had a problem with auto-update but recently there's been some bugs like https://github.com/yesodweb/wai/pull/1111