### PR TITLE
chore: update CONTRIBUTING.md and PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,8 @@
 <!--
-When submitting a new feature or fix:
+Before submitting a PR, please make sure you have done the following:
 
-- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
+- Please confirm that you've read our [contributing guide](https://github.com/PostgREST/postgrest/blob/main/CONTRIBUTING.md#code).
+- If relevant, add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased. See previous entries for reference.
 - If relevant, update the docs
 - Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
   + `add`, Add a new feature

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,8 @@ For questions on how to use PostgREST, please use
 We have a fully nix-based development environment with many tools for a smooth development workflow available.
 Check the [development docs](https://github.com/PostgREST/postgrest/blob/main/nix/README.md) on how to set it up and use it.
 
+* Before submitting a PR, make sure an open Github Issue exists related to it and the proposed change is approved by the maintainers. If the PR is related to something trivial (e.g. correcting spelling mistakes, docs improvement etc), then a Github Issue is not necessary.
+
 * All contributions must pass the tests before being merged. When
   you create a pull request your code will automatically be tested.
 


### PR DESCRIPTION
Now mentions that we require and open issue before a PR is submitted.