### PR TITLE
docs: warning for jwt-secret-is-base64

### DIFF
--- a/docs/references/configuration.rst
+++ b/docs/references/configuration.rst
@@ -729,6 +729,10 @@ jwt-secret-is-base64
 
   When this is set to :code:`true`, the value derived from :code:`jwt-secret` will be treated as a base64 encoded secret.
 
+  .. warning::
+
+     Base64 decoding is strict following `RFC 4648 <https://www.rfc-editor.org/info/rfc4648/#section-3.3>`_, hence a base64 ``jwt-secret`` must not contain any line breaks.
+
 .. _jwt-cache-max-entries:
 
 jwt-cache-max-entries


### PR DESCRIPTION
Added a warning about base64 decoding for jwt-secret. Addresses #5215

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `add`, Add a new feature
  + `amend`, To amend an unrealease commit
  + `change`, Breaking changes
  + `chore`, Maintenance, update sponsors, changelog, readme etc
  + `ci`, CI configuration files and scripts
  + `docs`, Documentation
  + `fix`, Bug fix
  + `nix`, Related to Nix
  + `perf`, Performance improvements
  + `refactor`, Refactoring code
  + `remove`, Remove a feature or fix
  + `test`, Adding tests
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
