### PR TITLE
fix: decrement pgrst_db_pool_waiting before tx execution

### DIFF
--- a/src/library/PostgREST/AppState/Pool.hs
+++ b/src/library/PostgREST/AppState/Pool.hs
@@ -42,9 +42,9 @@ usePool :: AppState -> SQL.Session a -> IO (Either SQL.UsageError a)
 usePool appState@AppState{stateObserver=observer, ..} sess = do
     observer PoolRequest
 
-    res <- SQL.use statePool sess
-
-    observer PoolRequestFullfilled
+    res <- SQL.use statePool $ do
+      liftIO $ observer PoolRequestFullfilled
+      sess
 
     whenLeft res (\case
       SQL.AcquisitionTimeoutUsageError ->


### PR DESCRIPTION
`pgrst_db_pool_waiting` is currently misleading. It is incremented before `SQL.use` and decremented after the complete query finishes, not immediately after acquisition. So it includes executing queries as well as requests actually waiting for connection.

This change moves publishing PoolRequestFulfilled observation to right after connection acquisition but before actual tx execution.

TODO:

- [ ] tests
- [ ] changelog