### PR TITLE
add: return RAISE WARNING notices in error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. From versio
 
 ## Unreleased
 
+### Added
+
+- New `db-warnings-enabled` config: include PostgreSQL `RAISE WARNING` messages (severity, SQLSTATE, message, detail, hint) as a structured `warnings` array in error responses. Warnings are only surfaced when the request fails; successful responses are unaffected. Fixes #1071.
+
 ### Changes
 
 - Fix sporadic "PGRST303 JWT issued at future" errors by @steve-chavez in #5196

--- a/docs/references/configuration.rst
+++ b/docs/references/configuration.rst
@@ -433,6 +433,23 @@ db-plan-enabled
 
   When this is set to :code:`true`, the execution plan of a request can be retrieved by using the :code:`Accept: application/vnd.pgrst.plan` header. See :ref:`explain_plan`.
 
+.. _db-warnings-enabled:
+
+db-warnings-enabled
+-------------------
+
+  =============== ==========================
+  **Type**        Boolean
+  **Default**     False
+  **Reloadable**  Y
+  **Environment** PGRST_DB_WARNINGS_ENABLED
+  **In-Database** pgrst.db_warnings_enabled
+  =============== ==========================
+
+  When this is set to :code:`true`, error responses include a :code:`warnings` array with the messages raised with :code:`RAISE WARNING` (and other non-fatal levels) by the failing statement — severity, SQLSTATE code, message, detail and hint for each. Only requests that already fail get the array; successful responses are unchanged. This is useful for reporting all validation problems from a database function at once instead of only the first fatal error.
+
+  Warnings may reveal information your functions log internally, so keep this off for untrusted clients.
+
 .. _db-pool:
 
 db-pool

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -100,6 +100,7 @@ library hasql
                       Hasql.Statement
                       Hasql.Transaction
                       Hasql.Transaction.Sessions
+                      Hasql.LibPq14.Notices
   other-modules:      Hasql.Commands
                       Hasql.Connection.Config
                       Hasql.Connection.Config.ConnectionString

--- a/src/hasql/Hasql/Connection/Core.hs
+++ b/src/hasql/Hasql/Connection/Core.hs
@@ -6,6 +6,8 @@ import qualified Hasql.Connection.Config         as Config
 import qualified Hasql.Connection.Setting        as Setting
 import qualified Hasql.IO                        as IO
 import qualified Hasql.LibPq14                   as LibPQ
+import           Hasql.LibPq14.Notices           (NoticeChannel)
+import qualified Hasql.LibPq14.Notices           as Notices
 import           Hasql.Prelude
 import qualified Hasql.PreparedStatementRegistry as PreparedStatementRegistry
 
@@ -21,6 +23,8 @@ data Connection
       !Bool
       -- | Prepared statement registry.
       !PreparedStatementRegistry.PreparedStatementRegistry
+      -- | Buffer of notices received from the server during command execution.
+      !Notices.NoticeChannel
 
 -- |
 -- Possible details of the connection acquistion error.
@@ -37,27 +41,38 @@ acquire settings =
   runExceptT $ do
     pqConnection <- lift (IO.acquireConnection (Config.connectionString config))
     lift (IO.checkConnectionStatus pqConnection) >>= traverse_ throwError
-    lift (IO.initConnection pqConnection)
     integerDatetimes <- lift (IO.getIntegerDatetimes pqConnection)
     registry <- lift IO.acquirePreparedStatementRegistry
     pqConnectionRef <- lift (newMVar pqConnection)
-    pure (Connection (Config.usePreparedStatements config) pqConnectionRef integerDatetimes registry)
+    -- The channel is created last so that only 'initConnection' can fail
+    -- after its FunPtr exists; that one call is guarded below.
+    noticeChannel <- lift Notices.newNoticeChannel
+    lift
+      ( IO.initConnection pqConnection noticeChannel
+          `onException` do
+            -- Finish libpq first so its receiver can no longer fire, then
+            -- free the closure; also covers the underlying connection itself.
+            IO.releaseConnection pqConnection
+            Notices.destroyNoticeChannel noticeChannel
+      )
+    pure (Connection (Config.usePreparedStatements config) pqConnectionRef integerDatetimes registry noticeChannel)
   where
     config = Config.fromUpdates settings
 
 -- |
 -- Release the connection.
 release :: Connection -> IO ()
-release (Connection _ pqConnectionRef _ _) =
+release (Connection _ pqConnectionRef _ _ noticeChannel) =
   mask_ $ do
     nullConnection <- LibPQ.newNullConnection
     pqConnection <- swapMVar pqConnectionRef nullConnection
     IO.releaseConnection pqConnection
+    Notices.destroyNoticeChannel noticeChannel
 
 -- |
 -- Execute an operation on the raw @libpq@ 'LibPQ.Connection'.
 --
 -- The access to the connection is exclusive.
 withLibPQConnection :: Connection -> (LibPQ.Connection -> IO a) -> IO a
-withLibPQConnection (Connection _ pqConnectionRef _ _) =
+withLibPQConnection (Connection _ pqConnectionRef _ _ _) =
   withMVar pqConnectionRef

--- a/src/hasql/Hasql/Errors.hs
+++ b/src/hasql/Hasql/Errors.hs
@@ -1,6 +1,7 @@
 module Hasql.Errors where
 
 import qualified Data.ByteString.Char8 as BC
+import qualified Hasql.LibPq14.Notices as Notices
 import           Hasql.Prelude
 
 -- | Error during execution of a session.
@@ -14,15 +15,19 @@ data SessionError
       [Text]
       -- | Error details.
       CommandError
+      -- | Notices (e.g. RAISE WARNING messages) buffered during the query's execution.
+      [Notices.Notice]
   | -- | Error during the execution of a pipeline.
     PipelineError
       -- | Error details.
       CommandError
+      -- | Notices (e.g. RAISE WARNING messages) buffered during the pipeline's execution.
+      [Notices.Notice]
   deriving (Show, Eq)
 
 instance Exception SessionError where
   displayException = \case
-    QueryError query params commandError ->
+    QueryError query params commandError notices ->
       let queryContext :: Maybe (ByteString, Int)
           queryContext = case commandError of
             ClientError _ -> Nothing
@@ -68,9 +73,28 @@ instance Exception SessionError where
             <> show params
             <> "\n  Error: "
             <> renderCommandErrorAsReason commandError
-    PipelineError commandError ->
-      "PipelineError!\n  Reason: " <> renderCommandErrorAsReason commandError
+            <> renderNotices notices
+    PipelineError commandError notices ->
+      "PipelineError!\n  Reason: "
+        <> renderCommandErrorAsReason commandError
+        <> renderNotices notices
     where
+      renderNotices = \case
+        [] -> mempty
+        ns ->
+          mconcat
+            [ "\n  Warnings:"
+            , mconcat (renderNotice <$> ns)
+            ]
+      renderNotice n =
+        "\n    - "
+          <> BC.unpack (Notices.noticeSeverity n)
+          <> " ("
+          <> BC.unpack (Notices.noticeCode n)
+          <> "): "
+          <> BC.unpack (Notices.noticeMessage n)
+          <> maybe "" (\d -> "\n      Details: " <> BC.unpack d) (Notices.noticeDetail n)
+          <> maybe "" (\h -> "\n      Hint: " <> BC.unpack h) (Notices.noticeHint n)
       renderCommandErrorAsReason = \case
         ClientError (Just message) -> "Client error: " <> show message
         ClientError Nothing -> "Client error without details"
@@ -87,6 +111,16 @@ instance Exception SessionError where
             "Error in row " <> show row <> ", column " <> show column <> ": " <> show rowError
           UnexpectedAmountOfRows amount ->
             "Unexpected amount of rows: " <> show amount
+
+-- |
+-- Attach drained notices to a session error. No-op on success paths by
+-- construction: callers only invoke this when the session failed.
+addNotices :: [Notices.Notice] -> SessionError -> SessionError
+addNotices notices = \case
+  QueryError template params commandError _ ->
+    QueryError template params commandError notices
+  PipelineError commandError _ ->
+    PipelineError commandError notices
 
 -- |
 -- An error of some command in the session.

--- a/src/hasql/Hasql/IO.hs
+++ b/src/hasql/Hasql/IO.hs
@@ -8,6 +8,7 @@ import qualified Hasql.Decoders.Results          as ResultsDecoders
 import qualified Hasql.Encoders.Params           as ParamsEncoders
 import           Hasql.Errors
 import qualified Hasql.LibPq14                   as LibPQ
+import qualified Hasql.LibPq14.Notices           as Notices
 import           Hasql.Prelude
 import qualified Hasql.PreparedStatementRegistry as PreparedStatementRegistry
 
@@ -50,9 +51,17 @@ getIntegerDatetimes c =
         _ -> False
 
 {-# INLINE initConnection #-}
-initConnection :: LibPQ.Connection -> IO ()
-initConnection c =
+initConnection :: LibPQ.Connection -> Notices.NoticeChannel -> IO ()
+initConnection c noticeChannel = do
   void $ LibPQ.exec c (Commands.asBytes (Commands.setEncodersToUTF8 <> Commands.setMinClientMessagesToWarning))
+  Notices.registerNoticeReceiver noticeChannel c
+
+-- |
+-- Remove and return the notices buffered during command execution.
+{-# INLINE drainNotices #-}
+drainNotices :: Notices.NoticeChannel -> IO [Notices.Notice]
+drainNotices =
+  Notices.drainNotices
 
 {-# INLINE getResults #-}
 getResults :: LibPQ.Connection -> Bool -> ResultsDecoders.Results a -> IO (Either CommandError a)

--- a/src/hasql/Hasql/LibPq14/Notices.hs
+++ b/src/hasql/Hasql/LibPq14/Notices.hs
@@ -1,0 +1,147 @@
+{-# LANGUAGE CApiFFI #-}
+
+-- |
+-- Programmatic capture of server notices (RAISE WARNING et al).
+--
+-- Registers a libpq notice receiver that copies the structured diagnostic
+-- fields off each notice's PGresult before libpq frees it. Notices accumulate
+-- in a bounded per-connection buffer; sessions drain it after each command.
+--
+-- This bypasses postgresql-libpq's NoticeBuffer machinery entirely
+-- ("enableNoticeReporting" / "getNotice"), which flattens every notice to its
+-- rendered text and loses severity, SQLSTATE, detail and hint.
+module Hasql.LibPq14.Notices
+  ( Notice (..),
+    NoticeChannel,
+    newNoticeChannel,
+    registerNoticeReceiver,
+    destroyNoticeChannel,
+    drainNotices,
+    noticeChannelCapacity,
+  )
+where
+
+import qualified Data.ByteString                    as BS
+import           Data.IORef
+import qualified Database.PostgreSQL.LibPQ          as LibPQ
+import           Database.PostgreSQL.LibPQ.Internal (PGconn, withConn)
+import           Foreign.C.String                   (CString)
+import           Foreign.C.Types                    (CInt (..))
+import           Foreign.Ptr                        (FunPtr, Ptr,
+                                                     freeHaskellFunPtr, nullPtr)
+import           Hasql.Prelude
+
+-- |
+-- A single non-fatal message received from the server.
+--
+-- Fields mirror the libpq @PG_DIAG_*@ diagnostics of the notice's PGresult.
+data Notice = Notice
+  { -- | e.g. @WARNING@ or @NOTICE@
+    noticeSeverity :: BS.ByteString,
+    -- | SQLSTATE code
+    noticeCode     :: BS.ByteString,
+    -- | Primary human-readable message
+    noticeMessage  :: BS.ByteString,
+    noticeDetail   :: Maybe BS.ByteString,
+    noticeHint     :: Maybe BS.ByteString
+  }
+  deriving (Show, Eq)
+
+-- | Maximum notices buffered per connection. Overflow drops the oldest,
+-- bounding memory on connections that receive notices outside of sessions
+-- (e.g. dedicated LISTEN connections that never drain).
+noticeChannelCapacity :: Int
+noticeChannelCapacity = 100
+
+-- | Callback signature libpq expects: @void (*)(void *arg, const PGresult *res)@.
+-- The result pointer is typed as @Ptr ()@ because postgresql-libpq's Internal
+-- module does not export @PGresult@; the same approach is used by
+-- "Hasql.LibPq14.Ffi" for its @PQresultStatus@ import.
+type NoticeReceiverCb = Ptr () -> Ptr () -> IO ()
+
+foreign import ccall "wrapper"
+  mkNoticeReceiver :: NoticeReceiverCb -> IO (FunPtr NoticeReceiverCb)
+
+foreign import capi "libpq-fe.h PQsetNoticeReceiver"
+  pqSetNoticeReceiver :: Ptr PGconn -> FunPtr NoticeReceiverCb -> Ptr () -> IO (FunPtr NoticeReceiverCb)
+
+foreign import capi "libpq-fe.h PQresultErrorField"
+  pqResultErrorField :: Ptr () -> CInt -> IO CString
+
+foreign import capi "postgres_ext.h value PG_DIAG_SEVERITY"        diagSeverityField :: CInt
+foreign import capi "postgres_ext.h value PG_DIAG_SQLSTATE"        diagSqlstateField :: CInt
+foreign import capi "postgres_ext.h value PG_DIAG_MESSAGE_PRIMARY" diagMessagePrimaryField :: CInt
+foreign import capi "postgres_ext.h value PG_DIAG_MESSAGE_DETAIL"  diagMessageDetailField :: CInt
+foreign import capi "postgres_ext.h value PG_DIAG_MESSAGE_HINT"    diagMessageHintField :: CInt
+
+-- | Per-connection channel: the accumulating buffer plus the registered
+-- receiver closure, so the 'FunPtr' can be freed on connection release.
+data NoticeChannel = NoticeChannel
+  { noticeChannelRef    :: !(IORef [Notice]),
+    noticeChannelFunPtr :: !(FunPtr NoticeReceiverCb)
+  }
+
+-- | Allocate an empty channel with its receiver closure already wired to it.
+newNoticeChannel :: IO NoticeChannel
+newNoticeChannel = do
+  ref <- newIORef []
+  funPtr <- mkNoticeReceiver (\_ result -> receiveNotice ref result)
+  pure (NoticeChannel ref funPtr)
+
+-- | Install the channel's receiver on the given connection. The previously
+-- installed receiver returned by libpq is dropped without freeing: if it was
+-- libpq's default handler it is a static address, and freeing foreign static
+-- function pointers is undefined behavior.
+registerNoticeReceiver :: NoticeChannel -> LibPQ.Connection -> IO ()
+registerNoticeReceiver channel connection =
+  withConn connection $ \conn -> do
+    _ <- pqSetNoticeReceiver conn (noticeChannelFunPtr channel) nullPtr
+    pure ()
+
+-- | Free the receiver closure. Must be called exactly once per channel,
+-- after the connection using it is finished.
+destroyNoticeChannel :: NoticeChannel -> IO ()
+destroyNoticeChannel =
+  freeHaskellFunPtr . noticeChannelFunPtr
+
+-- | Remove and return all buffered notices, oldest first.
+drainNotices :: NoticeChannel -> IO [Notice]
+drainNotices channel =
+  atomicModifyIORef' (noticeChannelRef channel) (\old -> ([], old))
+
+-- | Receiver entry point: decode the PGresult's diagnostics and buffer them.
+-- Runs inside libpq's input processing, while the calling session holds the
+-- connection lock, so 'atomicModifyIORef'' suffices.
+receiveNotice :: IORef [Notice] -> Ptr () -> IO ()
+receiveNotice buffer result = do
+  mNotice <- decodeNotice result
+  traverse_ (appendNotice buffer) mNotice
+
+decodeNotice :: Ptr () -> IO (Maybe Notice)
+decodeNotice result = do
+  mSeverity <- field diagSeverityField
+  mCode <- field diagSqlstateField
+  mMessage <- field diagMessagePrimaryField
+  mDetail <- field diagMessageDetailField
+  mHint <- field diagMessageHintField
+  case (mSeverity, mCode, mMessage) of
+    (Just severity, Just code, Just message) ->
+      pure (Just (Notice severity code message mDetail mHint))
+    _ ->
+      pure Nothing
+  where
+    field ::
+      CInt ->
+      IO (Maybe BS.ByteString)
+    field code = do
+      cstr <- pqResultErrorField result code
+      if cstr == nullPtr
+        then pure Nothing
+        else Just <$> BS.packCString cstr
+
+appendNotice :: IORef [Notice] -> Notice -> IO ()
+appendNotice buffer notice =
+  atomicModifyIORef' buffer $ \old ->
+    let grown = old ++ [notice]
+        excess = max 0 (length grown - noticeChannelCapacity)
+     in (drop excess grown, ())

--- a/src/hasql/Hasql/Pipeline/Core.hs
+++ b/src/hasql/Hasql/Pipeline/Core.hs
@@ -6,6 +6,7 @@ import qualified Hasql.Decoders.Results          as Decoders.Results
 import qualified Hasql.Encoders.All              as Encoders
 import qualified Hasql.Encoders.Params           as Encoders.Params
 import           Hasql.Errors
+import qualified Hasql.IO                        as IO
 import qualified Hasql.LibPq14                   as Pq
 import           Hasql.Prelude
 import qualified Hasql.PreparedStatementRegistry as PreparedStatementRegistry
@@ -44,13 +45,13 @@ run (Pipeline sendQueriesInIO) usePreparedStatements connection registry integer
 
     runResultsDecoder :: forall a. Decoders.Results.Results a -> ExceptT SessionError IO a
     runResultsDecoder decoder =
-      ExceptT (first PipelineError <$> Decoders.Results.run decoder connection integerDatetimes)
+      ExceptT (first (`PipelineError` []) <$> IO.getResults connection integerDatetimes decoder)
 
     runCommand :: IO Bool -> ExceptT SessionError IO ()
     runCommand action =
       lift action >>= \case
         True -> pure ()
-        False -> ExceptT (Left . PipelineError . ClientError <$> Pq.errorMessage connection)
+        False -> ExceptT (Left . (`PipelineError` []) . ClientError <$> Pq.errorMessage connection)
 
 -- |
 -- Composable abstraction over the execution of queries in [the pipeline mode](https://www.postgresql.org/docs/current/libpq-pipeline-mode.html).
@@ -167,37 +168,30 @@ statement params (Statement.Statement sql (Encoders.Params encoder) (Decoders.Re
                     sent <- Pq.sendPrepare connection key sql (mfilter (not . null) (Just oidList))
                     if sent
                       then pure (True, Right (key, recv))
-                      else (False,) . Left . commandToSessionError . ClientError <$> Pq.errorMessage connection
+                      else (False,) . Left . commandToSessionError [] . ClientError <$> Pq.errorMessage connection
                   where
                     recv =
-                      fmap (first commandToSessionError)
-                        $ (<*)
-                        <$> Decoders.Results.run (Decoders.Results.single Decoders.Result.noResult) connection integerDatetimes
-                        <*> Decoders.Results.run Decoders.Results.dropRemainders connection integerDatetimes
+                      fmap (first (commandToSessionError []))
+                        $ IO.getResults connection integerDatetimes
+                        $ Decoders.Results.single Decoders.Result.noResult
                 onOldRemoteKey key =
                   pure (Right (key, pure (Right ())))
 
             sendQuery key =
               Pq.sendQueryPrepared connection key valueAndFormatList Pq.Binary >>= \case
-                False -> Left . commandToSessionError . ClientError <$> Pq.errorMessage connection
+                False -> Left . commandToSessionError [] . ClientError <$> Pq.errorMessage connection
                 True -> pure (Right recv)
               where
                 recv =
-                  fmap (first commandToSessionError)
-                    $ (<*)
-                    <$> Decoders.Results.run decoder connection integerDatetimes
-                    <*> Decoders.Results.run Decoders.Results.dropRemainders connection integerDatetimes
+                  first (commandToSessionError []) <$> IO.getResults connection integerDatetimes decoder
 
         runUnprepared =
           Pq.sendQueryParams connection sql (Encoders.Params.compileUnpreparedStatementData encoder integerDatetimes params) Pq.Binary >>= \case
-            False -> Left . commandToSessionError . ClientError <$> Pq.errorMessage connection
+            False -> Left . commandToSessionError [] . ClientError <$> Pq.errorMessage connection
             True -> pure (Right recv)
           where
             recv =
-              fmap (first commandToSessionError)
-                $ (<*)
-                <$> Decoders.Results.run decoder connection integerDatetimes
-                <*> Decoders.Results.run Decoders.Results.dropRemainders connection integerDatetimes
+              first (commandToSessionError []) <$> IO.getResults connection integerDatetimes decoder
 
-    commandToSessionError =
-      QueryError sql (Encoders.Params.renderReadable encoder params)
+    commandToSessionError notices commandError =
+      QueryError sql (Encoders.Params.renderReadable encoder params) commandError notices

--- a/src/hasql/Hasql/Pool/Prelude.hs
+++ b/src/hasql/Hasql/Pool/Prelude.hs
@@ -79,7 +79,7 @@ import Prelude                as Exports hiding (all, and, any, concat,
                                           (.))
 import System.Environment     as Exports
 import System.Exit            as Exports
-import System.IO              as Exports (Handle, hClose)
+import System.IO              as Exports (Handle, hClose, hPutStrLn, stderr)
 import System.IO.Error        as Exports
 import System.IO.Unsafe       as Exports
 import System.Mem             as Exports

--- a/src/hasql/Hasql/Pool/SessionErrorDestructors.hs
+++ b/src/hasql/Hasql/Pool/SessionErrorDestructors.hs
@@ -5,6 +5,6 @@ import qualified Hasql.Session      as Session
 
 reset :: (Maybe ByteString -> x) -> x -> Session.SessionError -> x
 reset onReset onNoReset = \case
-  Session.QueryError _ _ (Session.ClientError details) -> onReset details
-  Session.PipelineError (Session.ClientError details) -> onReset details
+  Session.QueryError _ _ (Session.ClientError details) _ -> onReset details
+  Session.PipelineError (Session.ClientError details) _ -> onReset details
   _ -> onNoReset

--- a/src/hasql/Hasql/Session/Core.hs
+++ b/src/hasql/Hasql/Session/Core.hs
@@ -30,13 +30,14 @@ run (Session impl) connection =
       runExceptT $ runReaderT impl connection
     handler =
       case connection of
-        Connection.Connection _ pqConnVar _ registry ->
-          withMVar pqConnVar \pqConn ->
+        Connection.Connection _ pqConnVar _ registry noticeChannel ->
+          withMVar pqConnVar \pqConn -> do
             Pq.transactionStatus pqConn >>= \case
               Pq.TransIdle -> pure ()
               _ -> do
                 PreparedStatementRegistry.reset registry
                 Pq.reset pqConn
+            void $ IO.drainNotices noticeChannel
 
 -- |
 -- Possibly a multi-statement query,
@@ -46,14 +47,16 @@ sql :: ByteString -> Session ()
 sql sql =
   Session
     $ ReaderT
-    $ \(Connection.Connection _ pqConnectionRef integerDatetimes _) ->
+    $ \(Connection.Connection _ pqConnectionRef integerDatetimes _ noticeChannel) ->
       ExceptT
-        $ fmap (first (QueryError sql []))
         $ withMVar pqConnectionRef
         $ \pqConnection -> do
           r1 <- IO.sendNonparametricStatement pqConnection sql
           r2 <- IO.getResults pqConnection integerDatetimes decoder
-          return $ r1 *> r2
+          notices <- IO.drainNotices noticeChannel
+          return $ case r1 *> r2 of
+            Left commandError -> Left (QueryError sql [] commandError notices)
+            Right result      -> Right result
   where
     decoder =
       Decoders.Results.single Decoders.Result.noResult
@@ -64,19 +67,23 @@ statement :: params -> Statement.Statement params result -> Session result
 statement input (Statement.Statement template (Encoders.Params paramsEncoder) (Decoders.Result decoder) preparable) =
   Session
     $ ReaderT
-    $ \(Connection.Connection usePreparedStatements pqConnectionRef integerDatetimes registry) ->
+    $ \(Connection.Connection usePreparedStatements pqConnectionRef integerDatetimes registry noticeChannel) ->
       ExceptT
-        $ fmap (first (QueryError template (Encoders.Params.renderReadable paramsEncoder input)))
         $ withMVar pqConnectionRef
         $ \pqConnection -> do
           r1 <- IO.sendParametricStatement pqConnection integerDatetimes registry template paramsEncoder (usePreparedStatements && preparable) input
           r2 <- IO.getResults pqConnection integerDatetimes decoder
-          return $ r1 *> r2
+          notices <- IO.drainNotices noticeChannel
+          return $ case r1 *> r2 of
+            Left commandError -> Left (QueryError template (Encoders.Params.renderReadable paramsEncoder input) commandError notices)
+            Right result -> Right result
 
 -- |
 -- Execute a pipeline.
 pipeline :: Pipeline.Pipeline result -> Session result
 pipeline pipeline =
-  Session $ ReaderT \(Connection.Connection usePreparedStatements pqConnectionRef integerDatetimes registry) ->
-    ExceptT $ withMVar pqConnectionRef \pqConnection ->
-      Pipeline.run pipeline usePreparedStatements pqConnection registry integerDatetimes
+  Session $ ReaderT \(Connection.Connection usePreparedStatements pqConnectionRef integerDatetimes registry noticeChannel) ->
+    ExceptT $ withMVar pqConnectionRef \pqConnection -> do
+      result <- Pipeline.run pipeline usePreparedStatements pqConnection registry integerDatetimes
+      notices <- IO.drainNotices noticeChannel
+      return $ first (addNotices notices) result

--- a/src/hasql/Hasql/Transaction/Private/Sessions.hs
+++ b/src/hasql/Hasql/Transaction/Private/Sessions.hs
@@ -37,8 +37,8 @@ commitOrAbort commit =
 
 handleTransactionError :: SessionError -> Bool -> Session a -> Session a
 handleTransactionError error retryOnError onTransactionError = case error of
-  QueryError _ _ clientError -> onCommandError clientError
-  PipelineError clientError  -> onCommandError clientError
+  QueryError _ _ clientError _ -> onCommandError clientError
+  PipelineError clientError _  -> onCommandError clientError
   where
     retryOrThrow = if retryOnError then onTransactionError else throwError error
     onCommandError = \case

--- a/src/library/PostgREST/App.hs
+++ b/src/library/PostgREST/App.hs
@@ -160,7 +160,7 @@ postgrest appState =
       appConf@AppConfig{..} <- AppState.getConfig appState -- the config must be read again because it can reload
       maybeSchemaCache <- AppState.getSchemaCache appState
 
-      let handleError = fmap (either (Error.errorResponseFor configClientErrorVerbosity) identity)
+      let handleError = fmap (either (Error.errorResponseFor configClientErrorVerbosity configDbWarningsEnabled) identity)
 
       -- writer to save authRole (uses `tell` for this and `getLast` to obtain it)
       -- has to be before runExceptT to make sure role is not lost on error

--- a/src/library/PostgREST/AppState/Pool.hs
+++ b/src/library/PostgREST/AppState/Pool.hs
@@ -54,15 +54,15 @@ usePool appState@AppState{stateObserver=observer, ..} sess = do
         when (("FATAL:  password authentication failed" `isInfixOf` failureMessage) || ("no password supplied" `isInfixOf` failureMessage)) $ do
           observer $ ExitDBFatalError ServerAuthError err
           killApp appState
-      err@(SQL.SessionUsageError (SQL.QueryError tpl _ (SQL.ResultError resultErr))) ->
+      err@(SQL.SessionUsageError (SQL.QueryError tpl _ (SQL.ResultError resultErr) _)) ->
         handleResultError err tpl resultErr
-      err@(SQL.SessionUsageError (SQL.PipelineError (SQL.ResultError resultErr))) ->
+      err@(SQL.SessionUsageError (SQL.PipelineError (SQL.ResultError resultErr) _)) ->
         -- Passing the empty template will not work for schema cache queries, see TODO further below.
         handleResultError err mempty resultErr
-      err@(SQL.SessionUsageError (SQL.QueryError _ _ (SQL.ClientError _))) ->
+      err@(SQL.SessionUsageError (SQL.QueryError _ _ (SQL.ClientError _) _)) ->
         -- An error on the client-side, usually indicates problems with connection
         observer $ QueryErrorCodeHighObs err
-      SQL.SessionUsageError (SQL.PipelineError (SQL.ClientError _))  -> pure ()
+      SQL.SessionUsageError (SQL.PipelineError (SQL.ClientError _) _)  -> pure ()
       )
 
     return res

--- a/src/library/PostgREST/Config.hs
+++ b/src/library/PostgREST/Config.hs
@@ -83,6 +83,7 @@ data AppConfig = AppConfig
   , configDbExtraSearchPath         :: [Text]
   , configDbHoistedTxSettings       :: [Text]
   , configDbMaxRows                 :: Maybe Integer
+  , configDbWarningsEnabled         :: Bool
   , configDbPlanEnabled             :: Bool
   , configDbPoolSize                :: Int
   , configDbPoolAcquisitionTimeout  :: Int
@@ -174,6 +175,7 @@ toText conf =
       ,("db-hoisted-tx-settings",    q . T.intercalate "," . configDbHoistedTxSettings)
       ,("db-max-rows",                   maybe "\"\"" show . configDbMaxRows)
       ,("db-plan-enabled",               T.toLower . show . configDbPlanEnabled)
+      ,("db-warnings-enabled",           T.toLower . show . configDbWarningsEnabled)
       ,("db-pool",                       show . configDbPoolSize)
       ,("db-pool-acquisition-timeout",   show . configDbPoolAcquisitionTimeout)
       ,("db-pool-max-lifetime",          show . configDbPoolMaxLifetime)
@@ -289,6 +291,7 @@ parser optPath env dbSettings roleSettings roleIsolationLvl =
     <*> (maybe defaultHoistedAllowList splitOnCommas <$> optString "db-hoisted-tx-settings")
     <*> optWithAlias (optInt "db-max-rows")
                      (optInt "max-rows")
+    <*> (fromMaybe False <$> optBool "db-warnings-enabled")
     <*> (fromMaybe False <$> optBool "db-plan-enabled")
     <*> (fromMaybe 10 <$> optInt "db-pool")
     <*> (fromMaybe 10 <$> optInt "db-pool-acquisition-timeout")
@@ -717,6 +720,9 @@ exampleConfigFile = S.unlines
   , ""
   , "## Allow getting the EXPLAIN plan through the `Accept: application/vnd.pgrst.plan` header"
   , "# db-plan-enabled = false"
+  , ""
+  , "## Include server warnings (RAISE WARNING) in error responses"
+  , "# db-warnings-enabled = false"
   , ""
   , "## Number of open connections in the pool"
   , "db-pool = 10"

--- a/src/library/PostgREST/Config/Database.hs
+++ b/src/library/PostgREST/Config/Database.hs
@@ -51,6 +51,7 @@ dbSettingsNames =
   ,"db_extra_search_path"
   ,"db_max_rows"
   ,"db_plan_enabled"
+  ,"db_warnings_enabled"
   ,"db_pre_request"
   ,"db_prepared_statements"
   ,"db_root_spec"

--- a/src/library/PostgREST/Error.hs
+++ b/src/library/PostgREST/Error.hs
@@ -32,6 +32,7 @@ import qualified Data.HashMap.Strict       as HM
 import qualified Data.Map.Internal         as M
 import qualified Data.Text                 as T
 import qualified Data.Text.Encoding        as T
+import qualified Hasql.LibPq14.Notices     as Notices
 import qualified Hasql.Pool                as SQL
 import qualified Hasql.Session             as SQL
 import qualified Network.HTTP.Types.Status as HTTP
@@ -61,31 +62,39 @@ import Protolude
 -- >>> import PostgREST.SchemaCache.Relationship (Relationship (..))
 -- >>> import PostgREST.SchemaCache.Routine (Routine (..), RoutineParam (..))
 
--- | Encode Error to ByteString
-errorPayload :: (ErrorBody a, ErrorHeaders a) => Verbosity -> a -> LByteString
-errorPayload verb = JSON.encode . toJsonPgrstError verb
+-- | Encode Error to ByteString. @includeWarnings@ gates emission of the
+-- structured notices array (db-warnings-enabled); logging callers pass True.
+errorPayload :: (ErrorBody a, ErrorHeaders a) => Verbosity -> Bool -> a -> LByteString
+errorPayload verb includeWarnings = JSON.encode . toJsonPgrstError verb includeWarnings
   where
-    toJsonPgrstError :: (ErrorBody a, ErrorHeaders a) => Verbosity -> a -> JSON.Value
-    toJsonPgrstError Verbose err = JSON.object [
-        "code"    .= code err
-      , "message" .= message err
-      , "details" .= details err
-      , "hint"    .= hint err
-      ]
-    toJsonPgrstError Minimal err = JSON.object [
-        "code"    .= code err
-      , "message" .= message err
-      ]
+    toJsonPgrstError :: (ErrorBody a, ErrorHeaders a) => Verbosity -> Bool -> a -> JSON.Value
+    toJsonPgrstError v w err =
+      let warningValues = warnings err
+       in case v of
+            Verbose ->
+              JSON.object $
+                [ "code"    .= code err
+                , "message" .= message err
+                , "details" .= details err
+                , "hint"    .= hint err
+                ]
+                <> ["warnings" .= warningValues | w, not (null warningValues)]
+            Minimal ->
+              JSON.object [
+                  "code"    .= code err
+                , "message" .= message err
+                ]
 
 -- | Create HTTP response from Error
-errorResponseFor :: (ErrorBody a, ErrorHeaders a) => Verbosity -> a -> Response
-errorResponseFor verb err =
+errorResponseFor :: (ErrorBody a, ErrorHeaders a) => Verbosity -> Bool -> a -> Response
+errorResponseFor verb includeWarnings err =
   let
     baseHeader = MediaType.toContentType MTApplicationJSON
     cLHeader body = (,) "Content-Length" (show $ LBS.length body) :: Header
     pSHeader code' = ("Proxy-Status", "PostgREST; error=" <> T.encodeUtf8 code')
+    payload = errorPayload verb includeWarnings err
   in
-  responseLBS (status err) (baseHeader : cLHeader (errorPayload verb err) : pSHeader (code err) : headers err) $ errorPayload verb err
+  responseLBS (status err) (baseHeader : cLHeader payload : pSHeader (code err) : headers err) payload
 
 class ErrorHeaders a where
   status  :: a -> HTTP.Status
@@ -96,6 +105,10 @@ class ErrorBody a where
   message :: a -> Text
   details :: a -> Maybe JSON.Value
   hint    :: a -> Maybe JSON.Value
+  -- | Structured server notices (e.g. RAISE WARNING messages) collected while
+  -- the failing query executed.
+  warnings :: a -> [JSON.Value]
+  warnings _ = []
 
 instance ErrorHeaders ApiRequestError where
   status AggregatesNotAllowed{}      = HTTP.status400
@@ -457,7 +470,7 @@ pgrstParseErrorHint err = case err of
 instance ErrorHeaders PgError where
   status (PgError authed usageError) = pgErrorStatus authed usageError
 
-  headers (PgError _ (SQL.SessionUsageError (SQL.QueryError _ _ (SQL.ResultError (SQL.ServerError "PGRST" m d _ _p))))) =
+  headers (PgError _ (SQL.SessionUsageError (SQL.QueryError _ _ (SQL.ResultError (SQL.ServerError "PGRST" m d _ _p)) _))) =
     case parseRaisePGRST m d of
       Right (_, r) -> map intoHeader (M.toList $ getHeaders r)
       Left e       -> headers e
@@ -470,34 +483,49 @@ instance ErrorHeaders PgError where
        else mempty
 
 instance ErrorBody PgError where
-  code    (PgError _ usageError) = code usageError
-  message (PgError _ usageError) = message usageError
-  details (PgError _ usageError) = details usageError
-  hint    (PgError _ usageError) = hint usageError
+  code     (PgError _ usageError) = code usageError
+  message  (PgError _ usageError) = message usageError
+  details  (PgError _ usageError) = details usageError
+  hint     (PgError _ usageError) = hint usageError
+  warnings (PgError _ usageError) = warnings usageError
+
+noticeToJson :: Notices.Notice -> JSON.Value
+noticeToJson n = JSON.object [
+    "severity" .= T.decodeUtf8 (Notices.noticeSeverity n)
+  , "code"     .= T.decodeUtf8 (Notices.noticeCode n)
+  , "message"  .= T.decodeUtf8 (Notices.noticeMessage n)
+  , "details"  .= fmap T.decodeUtf8 (Notices.noticeDetail n)
+  , "hint"     .= fmap T.decodeUtf8 (Notices.noticeHint n)
+  ]
 
 instance ErrorBody SQL.UsageError where
-  code    (SQL.ConnectionUsageError _)                   = "PGRST000"
-  code    (SQL.SessionUsageError (SQL.PipelineError e))  = code e
-  code    (SQL.SessionUsageError (SQL.QueryError _ _ e)) = code e
-  code    SQL.AcquisitionTimeoutUsageError               = "PGRST003"
+  code    (SQL.ConnectionUsageError _)                     = "PGRST000"
+  code    (SQL.SessionUsageError (SQL.PipelineError e _))  = code e
+  code    (SQL.SessionUsageError (SQL.QueryError _ _ e _)) = code e
+  code    SQL.AcquisitionTimeoutUsageError                 = "PGRST003"
 
   message (SQL.ConnectionUsageError _) = "Database connection error."
-  message (SQL.SessionUsageError (SQL.PipelineError e))  = message e
-  message (SQL.SessionUsageError (SQL.QueryError _ _ e)) = message e
+  message (SQL.SessionUsageError (SQL.PipelineError e _))  = message e
+  message (SQL.SessionUsageError (SQL.QueryError _ _ e _)) = message e
   message SQL.AcquisitionTimeoutUsageError = "Timed out acquiring connection from connection pool."
 
   details (SQL.ConnectionUsageError e) = JSON.String . T.decodeUtf8 <$> e
-  details (SQL.SessionUsageError (SQL.PipelineError e))  = details e
-  details (SQL.SessionUsageError (SQL.QueryError _ _ e)) = details e
+  details (SQL.SessionUsageError (SQL.PipelineError e _))  = details e
+  details (SQL.SessionUsageError (SQL.QueryError _ _ e _)) = details e
   details SQL.AcquisitionTimeoutUsageError               = Nothing
 
-  hint    (SQL.ConnectionUsageError _)                   = Nothing
-  hint    (SQL.SessionUsageError (SQL.PipelineError e))  = hint e
-  hint    (SQL.SessionUsageError (SQL.QueryError _ _ e)) = hint e
-  hint    SQL.AcquisitionTimeoutUsageError               = Nothing
+  hint    (SQL.ConnectionUsageError _)                     = Nothing
+  hint    (SQL.SessionUsageError (SQL.PipelineError e _))  = hint e
+  hint    (SQL.SessionUsageError (SQL.QueryError _ _ e _)) = hint e
+  hint    SQL.AcquisitionTimeoutUsageError                 = Nothing
+
+  warnings (SQL.SessionUsageError (SQL.PipelineError _ ns))  = map noticeToJson ns
+  warnings (SQL.SessionUsageError (SQL.QueryError _ _ _ ns)) = map noticeToJson ns
+  warnings SQL.AcquisitionTimeoutUsageError                  = []
+  warnings (SQL.ConnectionUsageError _)                      = []
+
 
 instance ErrorBody SQL.CommandError where
-  -- Special error raised with code PGRST, to allow full response control
   code (SQL.ResultError (SQL.ServerError "PGRST" m d _ _)) =
     case parseRaisePGRST m d of
       Right (r, _) -> getCode r
@@ -537,10 +565,10 @@ instance ErrorBody SQL.CommandError where
 pgErrorStatus :: Bool -> SQL.UsageError -> HTTP.Status
 pgErrorStatus _      (SQL.ConnectionUsageError _) = HTTP.status503
 pgErrorStatus _      SQL.AcquisitionTimeoutUsageError = HTTP.status504
-pgErrorStatus _      (SQL.SessionUsageError (SQL.PipelineError (SQL.ClientError _)))       = HTTP.status503
-pgErrorStatus _      (SQL.SessionUsageError (SQL.QueryError _ _ (SQL.ClientError _)))      = HTTP.status503
-pgErrorStatus authed (SQL.SessionUsageError (SQL.PipelineError (SQL.ResultError rError)))  = mapSQLtoHTTP authed rError
-pgErrorStatus authed (SQL.SessionUsageError (SQL.QueryError _ _ (SQL.ResultError rError))) = mapSQLtoHTTP authed rError
+pgErrorStatus _      (SQL.SessionUsageError (SQL.PipelineError (SQL.ClientError _) _))       = HTTP.status503
+pgErrorStatus _      (SQL.SessionUsageError (SQL.QueryError _ _ (SQL.ClientError _) _))      = HTTP.status503
+pgErrorStatus authed (SQL.SessionUsageError (SQL.PipelineError (SQL.ResultError rError) _))  = mapSQLtoHTTP authed rError
+pgErrorStatus authed (SQL.SessionUsageError (SQL.QueryError _ _ (SQL.ResultError rError) _)) = mapSQLtoHTTP authed rError
 
 mapSQLtoHTTP :: Bool -> SQL.ResultError -> HTTP.Status
 mapSQLtoHTTP authed rError =
@@ -634,6 +662,12 @@ instance ErrorBody Error where
   hint (JwtErr err)         = hint err
   hint NoSchemaCacheError   = Nothing
   hint (PgErr err)          = hint err
+
+  warnings (ApiRequestErr err)  = warnings err
+  warnings (SchemaCacheErr err) = warnings err
+  warnings (JwtErr err)         = warnings err
+  warnings NoSchemaCacheError   = []
+  warnings (PgErr err)          = warnings err
 
 instance ErrorHeaders JwtError where
   status JwtDecodeErr{}   = HTTP.unauthorized401

--- a/src/library/PostgREST/Logger.hs
+++ b/src/library/PostgREST/Logger.hs
@@ -155,7 +155,7 @@ observationMessages = \case
   ExitDBFatalError ServerError08P01 usageErr ->
     pure $ "Connection poolers in statement mode are not supported." <> jsonMessage usageErr
   SchemaCacheEmptyObs ->
-    pure $ T.decodeUtf8 . LBS.toStrict . Error.errorPayload Verbose $ Error.NoSchemaCacheError
+    pure $ T.decodeUtf8 . LBS.toStrict . Error.errorPayload Verbose True $ Error.NoSchemaCacheError
   SchemaCacheErrorObs dbSchemas extraPaths usageErr ->
     pure $ "Failed to load the schema cache using "
       <> "db-schemas=" <> T.intercalate "," (toList dbSchemas)
@@ -251,8 +251,7 @@ observationMessages = \case
     showMillis :: Double -> Text
     showMillis x = toS $ showFFloat (Just 1) x ""
 
-    jsonMessage err = T.decodeUtf8 . LBS.toStrict . Error.errorPayload Verbose $ Error.PgError False err
-
+    jsonMessage err = T.decodeUtf8 . LBS.toStrict . Error.errorPayload Verbose True $ Error.PgError False err
 
     showListenerConnError :: SQL.ConnectionError -> Text
     showListenerConnError = maybe "Connection error" (showOnSingleLine '\t' . T.decodeUtf8)

--- a/src/library/PostgREST/Response.hs
+++ b/src/library/PostgREST/Response.hs
@@ -73,7 +73,7 @@ actionResponse (DbCrudResult plan@WrappedReadPlan{pMedia, wrHdrsOnly=headersOnly
       ++ cLHeader
       ++ contentTypeHeaders pMedia ctxApiRequest
       ++ prefHeader
-    bod | status == HTTP.status416 = Error.errorPayload configClientErrorVerbosity $ Error.ApiRequestErr $ Error.InvalidRange $
+    bod | status == HTTP.status416 = Error.errorPayload configClientErrorVerbosity True $ Error.ApiRequestErr $ Error.InvalidRange $
                                      Error.OutOfBounds (show $ RangeQuery.rangeOffset iTopLevelRange) (maybe "0" show rsTableTotal)
         | headersOnly              = mempty
         | otherwise                = LBS.fromStrict rsBody
@@ -177,7 +177,7 @@ actionResponse (DbCrudResult plan@CallReadPlan{pMedia, crInvMthd=invMethod, crPr
     (status, contentRange) =
       RangeQuery.rangeStatusHeader iTopLevelRange rsQueryTotal rsTableTotal
     rsOrErrBody = if status == HTTP.status416
-      then Error.errorPayload configClientErrorVerbosity $ Error.ApiRequestErr $ Error.InvalidRange
+      then Error.errorPayload configClientErrorVerbosity True $ Error.ApiRequestErr $ Error.InvalidRange
         $ Error.OutOfBounds (show $ RangeQuery.rangeOffset iTopLevelRange) (maybe "0" show rsTableTotal)
       else LBS.fromStrict rsBody
     isHeadMethod = invMethod == InvRead True

--- a/test/io/__snapshots__/test_cli/test_schema_cache_snapshot[dbRoutines].yaml
+++ b/test/io/__snapshots__/test_cli/test_schema_cache_snapshot[dbRoutines].yaml
@@ -170,6 +170,24 @@
       pdSchema: public
       pdVolatility: Volatile
 
+- - qiName: raise_warnings_then_exception
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdIsoLvl: null
+      pdName: raise_warnings_then_exception
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: void
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+
 - - qiName: reset_max_rows_config
     qiSchema: public
   - - pdDescription: null
@@ -259,6 +277,24 @@
         contents:
           contents:
             qiName: text
+            qiSchema: pg_catalog
+          tag: Scalar
+        tag: Single
+      pdSchema: public
+      pdVolatility: Volatile
+
+- - qiName: raise_warning_only
+    qiSchema: public
+  - - pdDescription: null
+      pdFuncSettings: []
+      pdHasVariadic: false
+      pdIsoLvl: null
+      pdName: raise_warning_only
+      pdParams: []
+      pdReturnType:
+        contents:
+          contents:
+            qiName: void
             qiSchema: pg_catalog
           tag: Scalar
         tag: Single

--- a/test/io/configs/expected/aliases.config
+++ b/test/io/configs/expected/aliases.config
@@ -24,6 +24,7 @@ db-root-spec = "open_alias"
 db-schemas = "provided_through_alias"
 db-tx-end = "commit"
 db-uri = "postgresql://"
+db-warnings-enabled = false
 jwt-aud = ""
 jwt-cache-max-entries = 1000
 jwt-role-claim-key = "$$.aliased"

--- a/test/io/configs/expected/boolean-numeric.config
+++ b/test/io/configs/expected/boolean-numeric.config
@@ -24,6 +24,7 @@ db-root-spec = ""
 db-schemas = "public"
 db-tx-end = "commit"
 db-uri = "postgresql://"
+db-warnings-enabled = false
 jwt-aud = ""
 jwt-cache-max-entries = 1000
 jwt-role-claim-key = "$$.role"

--- a/test/io/configs/expected/boolean-string.config
+++ b/test/io/configs/expected/boolean-string.config
@@ -24,6 +24,7 @@ db-root-spec = ""
 db-schemas = "public"
 db-tx-end = "commit"
 db-uri = "postgresql://"
+db-warnings-enabled = false
 jwt-aud = ""
 jwt-cache-max-entries = 1000
 jwt-role-claim-key = "$$.role"

--- a/test/io/configs/expected/defaults.config
+++ b/test/io/configs/expected/defaults.config
@@ -24,6 +24,7 @@ db-root-spec = ""
 db-schemas = "public"
 db-tx-end = "commit"
 db-uri = "postgresql://"
+db-warnings-enabled = false
 jwt-aud = ""
 jwt-cache-max-entries = 1000
 jwt-role-claim-key = "$$.role"

--- a/test/io/configs/expected/jspath-str-op-dump1.config
+++ b/test/io/configs/expected/jspath-str-op-dump1.config
@@ -24,6 +24,7 @@ db-root-spec = ""
 db-schemas = "public"
 db-tx-end = "commit"
 db-uri = "postgresql://"
+db-warnings-enabled = false
 jwt-aud = ""
 jwt-cache-max-entries = 1000
 jwt-role-claim-key = ".\"roles\"[?(@ == \"role1\")]"

--- a/test/io/configs/expected/jspath-str-op-dump2.config
+++ b/test/io/configs/expected/jspath-str-op-dump2.config
@@ -24,6 +24,7 @@ db-root-spec = ""
 db-schemas = "public"
 db-tx-end = "commit"
 db-uri = "postgresql://"
+db-warnings-enabled = false
 jwt-aud = ""
 jwt-cache-max-entries = 1000
 jwt-role-claim-key = ".\"roles\"[?(@ != \"role1\")]"

--- a/test/io/configs/expected/jspath-str-op-dump3.config
+++ b/test/io/configs/expected/jspath-str-op-dump3.config
@@ -24,6 +24,7 @@ db-root-spec = ""
 db-schemas = "public"
 db-tx-end = "commit"
 db-uri = "postgresql://"
+db-warnings-enabled = false
 jwt-aud = ""
 jwt-cache-max-entries = 1000
 jwt-role-claim-key = ".\"roles\"[?(@ ^== \"role1\")]"

--- a/test/io/configs/expected/jspath-str-op-dump4.config
+++ b/test/io/configs/expected/jspath-str-op-dump4.config
@@ -24,6 +24,7 @@ db-root-spec = ""
 db-schemas = "public"
 db-tx-end = "commit"
 db-uri = "postgresql://"
+db-warnings-enabled = false
 jwt-aud = ""
 jwt-cache-max-entries = 1000
 jwt-role-claim-key = ".\"roles\"[?(@ ==^ \"role1\")]"

--- a/test/io/configs/expected/jspath-str-op-dump5.config
+++ b/test/io/configs/expected/jspath-str-op-dump5.config
@@ -24,6 +24,7 @@ db-root-spec = ""
 db-schemas = "public"
 db-tx-end = "commit"
 db-uri = "postgresql://"
+db-warnings-enabled = false
 jwt-aud = ""
 jwt-cache-max-entries = 1000
 jwt-role-claim-key = ".\"roles\"[?(@ *== \"role1\")]"

--- a/test/io/configs/expected/no-defaults-with-db-other-authenticator.config
+++ b/test/io/configs/expected/no-defaults-with-db-other-authenticator.config
@@ -26,6 +26,7 @@ db-root-spec = "other_root"
 db-schemas = "test,other_tenant1,other_tenant2"
 db-tx-end = "rollback-allow-override"
 db-uri = "postgresql://"
+db-warnings-enabled = false
 jwt-aud = "https://otherexample.org"
 jwt-cache-max-entries = 86400
 jwt-role-claim-key = "$$.other.pre_config_role"

--- a/test/io/configs/expected/no-defaults-with-db.config
+++ b/test/io/configs/expected/no-defaults-with-db.config
@@ -26,6 +26,7 @@ db-root-spec = "root"
 db-schemas = "test,tenant1,tenant2"
 db-tx-end = "commit-allow-override"
 db-uri = "postgresql://"
+db-warnings-enabled = false
 jwt-aud = "https://example.org"
 jwt-cache-max-entries = 86400
 jwt-role-claim-key = "$$.a.role"

--- a/test/io/configs/expected/no-defaults.config
+++ b/test/io/configs/expected/no-defaults.config
@@ -26,6 +26,7 @@ db-root-spec = "openapi_v3"
 db-schemas = "multi,tenant,setup"
 db-tx-end = "rollback-allow-override"
 db-uri = "tmp_db"
+db-warnings-enabled = false
 jwt-aud = "https://postgrest.org"
 jwt-cache-max-entries = 86400
 jwt-role-claim-key = "$$.user[0].real_role"

--- a/test/io/configs/expected/types.config
+++ b/test/io/configs/expected/types.config
@@ -25,6 +25,7 @@ db-root-spec = ""
 db-schemas = "public"
 db-tx-end = "commit"
 db-uri = "postgresql://"
+db-warnings-enabled = false
 jwt-aud = ""
 jwt-cache-max-entries = 1000
 jwt-role-claim-key = "$$.role"

--- a/test/io/configs/expected/utf-8.config
+++ b/test/io/configs/expected/utf-8.config
@@ -24,6 +24,7 @@ db-root-spec = ""
 db-schemas = "public"
 db-tx-end = "commit"
 db-uri = "postgresql://"
+db-warnings-enabled = false
 jwt-aud = ""
 jwt-cache-max-entries = 1000
 jwt-role-claim-key = "$$.role"

--- a/test/io/fixtures/schema.sql
+++ b/test/io/fixtures/schema.sql
@@ -212,6 +212,25 @@ create or replace function one_sec_timeout() returns void as $$
   select pg_sleep(3);
 $$ language sql set statement_timeout = '1s';
 
+create or replace function raise_warnings_then_exception() returns void
+language plpgsql as $$
+begin
+  raise warning 'first warning';
+  raise warning 'second warning' using
+    errcode = 'XX999',
+    detail = 'extra detail',
+    hint = 'a hint';
+  raise exception 'the real error';
+end;
+$$;
+
+create or replace function raise_warning_only() returns void
+language plpgsql as $$
+begin
+  raise warning 'harmless warning';
+end;
+$$;
+
 create or replace function four_sec_timeout() returns void as $$
   select pg_sleep(3);
 $$ language sql set statement_timeout = '4s';

--- a/test/io/test_warnings.py
+++ b/test/io/test_warnings.py
@@ -1,0 +1,84 @@
+"Server notices (RAISE WARNING) surfaced in error responses. See issue #1071."
+
+import pytest
+
+from postgrest import run
+
+
+@pytest.fixture
+def warnings_env(defaultenv):
+    "Environment with db-warnings-enabled turned on."
+    return {**defaultenv, "PGRST_DB_WARNINGS_ENABLED": "true"}
+
+
+def test_warnings_attached_to_error(warnings_env):
+    "Warnings raised before an exception are included in the error body."
+    with run(env=warnings_env) as postgrest:
+        response = postgrest.session.post("/rpc/raise_warnings_then_exception")
+
+        assert response.status_code == 400
+        body = response.json()
+        assert body["message"] == "the real error"
+        assert body["warnings"] == [
+            {
+                "severity": "WARNING",
+                "code": "01000",
+                "message": "first warning",
+                "details": None,
+                "hint": None,
+            },
+            {
+                "severity": "WARNING",
+                "code": "XX999",
+                "message": "second warning",
+                "details": "extra detail",
+                "hint": "a hint",
+            },
+        ]
+
+
+def test_no_warnings_on_success(warnings_env):
+    "A successful request that raised a warning carries an empty body (204)."
+    with run(env=warnings_env) as postgrest:
+        response = postgrest.session.post("/rpc/raise_warning_only")
+
+        assert response.status_code == 204
+        assert response.text == ""
+
+
+def test_warnings_absent_when_disabled(defaultenv):
+    "With the flag off, no warnings key is emitted even on error."
+    with run(env=defaultenv) as postgrest:
+        response = postgrest.session.post("/rpc/raise_warnings_then_exception")
+
+        assert response.status_code == 400
+        assert "warnings" not in response.json()
+
+
+def test_warnings_minimal_verbosity(warnings_env):
+    "Minimal verbosity keeps code and message only, without warnings."
+    env = {
+        **warnings_env,
+        "PGRST_CLIENT_ERROR_VERBOSITY": "minimal",
+    }
+    with run(env=env) as postgrest:
+        response = postgrest.session.post("/rpc/raise_warnings_then_exception")
+
+        assert response.status_code == 400
+        body = response.json()
+        assert set(body.keys()) == {"code", "message"}
+
+
+def test_warnings_are_drained_between_requests(warnings_env):
+    "A warning from a successful request is not carried into the next request."
+    env = {**warnings_env, "PGRST_DB_POOL": "1"}
+    with run(env=env) as postgrest:
+        response = postgrest.session.post("/rpc/raise_warning_only")
+        assert response.status_code == 204
+
+        response = postgrest.session.post("/rpc/raise_warnings_then_exception")
+        assert response.status_code == 400
+        assert [warning["message"] for warning in response.json()["warnings"]] == [
+            "first warning",
+            "second warning",
+        ]

--- a/test/observability/ObsHelper.hs
+++ b/test/observability/ObsHelper.hs
@@ -70,6 +70,7 @@ baseCfg = let secret = encodeUtf8 "reallyreallyreallyreallyverysafe" in
   , configDbExtraSearchPath         = []
   , configDbHoistedTxSettings       = ["default_transaction_isolation","plan_filter.statement_cost_limit","statement_timeout"]
   , configDbMaxRows                 = Nothing
+  , configDbWarningsEnabled         = True
   , configDbPlanEnabled             = False
   , configDbPoolSize                = 10
   , configDbPoolAcquisitionTimeout  = 10

--- a/test/spec/SpecHelper.hs
+++ b/test/spec/SpecHelper.hs
@@ -139,6 +139,7 @@ baseCfg = let secret = encodeUtf8 "reallyreallyreallyreallyverysafe" in
   , configDbExtraSearchPath         = []
   , configDbHoistedTxSettings       = ["default_transaction_isolation","plan_filter.statement_cost_limit","statement_timeout"]
   , configDbMaxRows                 = Nothing
+  , configDbWarningsEnabled         = True
   , configDbPlanEnabled             = False
   , configDbPoolSize                = 10
   , configDbPoolAcquisitionTimeout  = 10


### PR DESCRIPTION
Add a `db-warnings-enabled` config (default `false`). When enabled and a request fails, PostgreSQL warnings raised during the failing statement are returned as a structured "warnings" array alongside the existing error fields (severity, SQLSTATE code, message, detail, hint). Successful responses are unchanged.

Capture uses a custom libpq notice receiver in the vendored hasql (Hasql.LibPq14.Notices) that copies the PGresult diagnostics before libpq frees them, instead of postgresql-libpq's notice buffer, which flattens every notice to text and drops severity, SQLSTATE, detail and hint. Notices accumulate in a bounded per-connection buffer (100, oldest dropped on overflow), are drained after every statement execution and attached to the session error, and the receiver closure is freed on connection release.

The internal hasql pipeline result loop is consolidated through IO.getResults, replacing three copies of the same
single `<*> dropRemainders` glue.

Fixes #1071

<!--
When submitting a new feature or fix:

- Add a new entry to the CHANGELOG - https://github.com/PostgREST/postgrest/blob/main/CHANGELOG.md#unreleased
- If relevant, update the docs
- Use a prefix for the PR title or commits, e.g. "fix: description of the fix".
  + `add`, Add a new feature
  + `amend`, To amend an unrealease commit
  + `change`, Breaking changes
  + `chore`, Maintenance, update sponsors, changelog, readme etc
  + `ci`, CI configuration files and scripts
  + `docs`, Documentation
  + `fix`, Bug fix
  + `nix`, Related to Nix
  + `perf`, Performance improvements
  + `refactor`, Refactoring code
  + `remove`, Remove a feature or fix
  + `test`, Adding tests
  + Other prefixes may be used if necessary
- If there's a breaking change, add `BREAKING CHANGE` and an explanation to your commit message
-->
