### PR TITLE
nix: add merge-driver for treefmt

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -150,7 +150,7 @@ rec {
 
   # Git tools.
   gitTools =
-    pkgs.callPackage nix/tools/gitTools.nix { };
+    pkgs.callPackage nix/tools/gitTools.nix { inherit treefmtNix; };
 
   # Load testing tools.
   loadtest =

--- a/nix/tools/gitTools.nix
+++ b/nix/tools/gitTools.nix
@@ -1,6 +1,10 @@
 { buildToolbox
 , checkedShellScript
 , commitlint
+, lib
+, moreutils
+, treefmtNix
+, writeShellApplication
 , writeText
 }:
 let
@@ -52,9 +56,54 @@ let
 
         ${commitlint}/bin/commitlint --config ${commitlintConfig} --from "$_arg_from" --to "$_arg_to"
       '';
+
+  mergeDriver = writeShellApplication
+    {
+      name = "treefmt-merge-driver";
+      runtimeInputs = [
+        moreutils
+        treefmtNix.wrapper
+      ];
+      text = ''
+        # The first argument (%P) is the path to the original file, which is used
+        # by treefmt to decide which formatters to run based on the extension.
+        filename="$1"
+        shift 1
+
+        >&2 echo "Running treefmt-merge-driver for '$filename'..."
+
+        function format() {
+          cat "$1" | treefmt --stdin "$filename" | sponge "$1"
+        }
+
+        # The next three arguments %A, %O and %B are temporary files which contain
+        # the three states of this file: current version, ancestor's version and
+        # other branch's version.
+        format "$1"
+        format "$2"
+        format "$3"
+
+        git merge-file "$@"
+      '';
+    };
+
+  # This addition to the git configuration is appended to .git/config in shell.nix, i.e.
+  # when entering the nix-shell environment.
+  # It sets up our wrapper script as the default merge-driver, which allows commands such
+  # as `git rebase` to rebase transparently through formatter induced changes without
+  # conflicts.
+  config = writeText "git-config" ''
+    [merge]
+      default = treefmt
+    [merge.treefmt]
+      # The first argument is consumed by the merge driver script, the remaining
+      # arguments are passed through as-is to `git merge-file`.
+      driver = ${lib.getExe mergeDriver} %P %A %O %B -L %X -L %S -L %Y
+  '';
 in
 buildToolbox
 {
   name = "postgrest-commitlint";
   tools = { inherit commitCheck; };
+  extra = { inherit config; };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -52,6 +52,13 @@ lib.overrideDerivation postgrest.env (
         source ${pkgs.git}/share/git/contrib/completion/git-completion.bash
         source ${postgrest.hsie.bash-completion}
 
+        # Activate current shell's additional .git configuration.
+        # Since there can only be a single such value, this will not cause a garbage
+        # collection problem - older references to the /nix/store will be cleaned up
+        # automatically when entering the nix-shell on a newer branch.
+        # Git ignores files it can't find, which means that once a file has been garbage
+        # collected, git will continue to work even without entering nix-shell.
+        git config --local include.path ${postgrest.gitTools.config}
       ''
       + builtins.concatStringsSep "\n" (
         map (bash-completion: "source ${bash-completion}") (


### PR DESCRIPTION
This adds a custom merge-driver and sets our nix-shell up to automatically activate it when entering the shell. This will allow us to transparently rebase through formatter-related changes without conflicts.

I tested this with a branch changing the default nix formatter to `nixfmt` (which is something that we should do as well - the one we're currently using is archived since 2024!).

Let's assume this script is merged and we then merge a formatter change such as `nixfmt` or `fourmolu` to `main`. Usage is then as simple as:
- Enter `nix-shell` on `main`. The merge-driver is activated via git config.
- Switch to the branch that needs to be rebased... and rebase it.
- Formatting-related merge conflicts will be resolved automatically. Other conflicts can of course still appear.
- New code is also not necessarily formatted immediately, so running `treefmt` still makes sense.

The important part is entering `nix-shell` on the branch that already has the formatter changes in `nix/treefmt.nix`. When entering the shell on the branch that needs rebasing, it would enable the *old* configuration, so would format everything the wrong way.