### PR TITLE
fix: wrong time appearing on logs after long idle periods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. From versio
 ### Changes
 
 - Fix sporadic "PGRST303 JWT issued at future" errors by @steve-chavez in #5196
+- Fix wrong time appearing on logs after long idle periods by @taimoorzaeem in #5213
 
 ## [16.2] - 2026-08-21
 

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -48,16 +48,6 @@ _: prev:
   fuzzyset = prev.fuzzyset_0_2_4;
 
   # TODO: Remove once available in nixpkgs
-  auto-update =
-    prev.callHackageDirect
-      {
-        pkg = "auto-update";
-        ver = "0.2.7";
-        sha256 = "sha256-fHX/OqF/cB9rbpGpLUtA29bcEJS43HUWHcK55yUxKoo=";
-      }
-      { };
-
-  # TODO: Remove once available in nixpkgs
   aeson-jsonpath =
     prev.callHackageDirect
       {

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -236,7 +236,6 @@ library
                     , Ranged-sets               >= 0.3 && < 0.6
                     , aeson                     >= 2.0.3 && < 2.3
                     , aeson-jsonpath            >= 0.4.2 && < 0.5
-                    , auto-update               >= 0.2.7 && < 0.3
                     , base64-bytestring         >= 1 && < 1.3
                     , bytestring                >= 0.10.8 && < 0.13
                     , case-insensitive          >= 1.2 && < 1.3

--- a/src/library/PostgREST/Logger.hs
+++ b/src/library/PostgREST/Logger.hs
@@ -12,8 +12,6 @@ module PostgREST.Logger
   , LoggerState
   ) where
 
-import           Control.AutoUpdate                (defaultUpdateSettings,
-                                                    mkAutoUpdate, updateAction)
 import qualified Data.ByteString.Char8             as BS
 import qualified Data.Text.Encoding                as T
 import qualified Hasql.Decoders                    as HD
@@ -44,8 +42,7 @@ import qualified PostgREST.Error            as Error
 import           Protolude
 
 data LoggerState = LoggerState
-  { stateGetZTime               :: IO ZonedTime  -- ^ Time with time zone used for logs
-  , stateLogDebouncePoolTimeout :: IO ()         -- ^ Logs with a debounce
+  { stateLogDebouncePoolTimeout :: IO ()         -- ^ Logs with a debounce
   , getLogLevel                 :: IO LogLevel   -- ^ Get LogLevel from Config
   }
 
@@ -53,10 +50,9 @@ init :: IO LogLevel -> IO LoggerState
 init getLogLvl = mdo
   let
     oneSecond = 1_000_000
-    loggerState = LoggerState zTime debouncePoolTimeout getLogLvl
-  zTime <- mkAutoUpdate defaultUpdateSettings { updateAction = getZonedTime }
+    loggerState = LoggerState debouncePoolTimeout getLogLvl
   debouncePoolTimeout <- makeDebouncer $
-    logWithZTime loggerState (observationMessages PoolAcqTimeoutObs) *> threadDelay (5 * oneSecond)
+    logWithZTime (observationMessages PoolAcqTimeoutObs) *> threadDelay (5 * oneSecond)
   pure loggerState
 
 shouldLogResponse :: LogLevel -> Status -> Bool
@@ -77,44 +73,44 @@ observationLogger loggerState obs = do
         stateLogDebouncePoolTimeout loggerState
     o@(QueryErrorCodeHighObs _) -> do
       when (logLevel >= LogError) $ do
-        logWithZTime loggerState $ observationMessages o
+        logWithZTime $ observationMessages o
     o@SchemaCacheEmptyObs ->
       when (logLevel >= LogError) $ do
-      logWithZTime loggerState $ observationMessages o
+      logWithZTime $ observationMessages o
     o@(HasqlPoolObs _) -> do
       when (logLevel >= LogDebug) $ do
-        logWithZTime loggerState $ observationMessages o
+        logWithZTime $ observationMessages o
     o@(QueryObs _ status) -> do
       when (shouldLogResponse logLevel status) $
-        logWithZTime loggerState $ observationMessages o
+        logWithZTime $ observationMessages o
     o@PoolRequest ->
       when (logLevel >= LogDebug) $ do
-        logWithZTime loggerState $ observationMessages o
+        logWithZTime $ observationMessages o
     o@PoolRequestFullfilled ->
       when (logLevel >= LogDebug) $ do
-        logWithZTime loggerState $ observationMessages o
+        logWithZTime $ observationMessages o
     ResponseObs maybeRole req status contentLen ->
       when (shouldLogResponse logLevel status) $ do
-        zTime <- stateGetZTime loggerState
+        zTime <- getZonedTime
         putStr $ apacheFormat maybeRole (BS.pack $ formatZonedTime zTime) req status contentLen -- putStr prints to stdout
     o@PoolFlushed ->
       when (logLevel >= LogDebug) $ do
-        logWithZTime loggerState $ observationMessages o
+        logWithZTime $ observationMessages o
     o@JwtCacheEviction ->
       when (logLevel >= LogDebug) $ do
-        logWithZTime loggerState $ observationMessages o
+        logWithZTime $ observationMessages o
     o@(JwtCacheLookup _) ->
       when (logLevel >= LogDebug) $ do
-        logWithZTime loggerState $ observationMessages o
+        logWithZTime $ observationMessages o
     o@(WarpServerObs _) ->
       when (logLevel >= LogDebug) $ do
-        logWithZTime loggerState $ observationMessages o
+        logWithZTime $ observationMessages o
     o ->
-      logWithZTime loggerState $ observationMessages o
+      logWithZTime $ observationMessages o
 
-logWithZTime :: LoggerState -> [Text] -> IO ()
-logWithZTime loggerState txts = do
-  zTime <- stateGetZTime loggerState
+logWithZTime :: [Text] -> IO ()
+logWithZTime txts = do
+  zTime <- getZonedTime
   let prefix = toS (formatZonedTime zTime) <> ": "
   traverse_ (hPutStrLn stderr . (prefix <>)) txts
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,7 +10,6 @@ nix:
 
 extra-deps:
   - aeson-jsonpath-0.4.2.0
-  - auto-update-0.2.7
   - configurator-pg-0.2.11
   - fuzzyset-0.2.4
   - hasql-notifications-0.2.4.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,13 +12,6 @@ packages:
   original:
     hackage: aeson-jsonpath-0.4.2.0
 - completed:
-    hackage: auto-update-0.2.7@sha256:32ca6ce351604a17ee79e4086939f798f958f8407478288e9adb7adeb194c6ea,1670
-    pantry-tree:
-      sha256: 641faa7d5ee516195ecd4b538f170722d56f84e3bc5714c6bbe8123849b49983
-      size: 1105
-  original:
-    hackage: auto-update-0.2.7
-- completed:
     hackage: configurator-pg-0.2.11@sha256:de0c56386591e85159436b0af04a8f15a4f4e156354e99709676c2c2ee959505,2850
     pantry-tree:
       sha256: 7b4daa4ea970335414f26b313a168cd12182b7b34ea8af2616c83d38699c4301


### PR DESCRIPTION
Closes #5212.

Removes usage of `auto-update` and use `getZonedTime` directly. Internally, `getZonedTime` uses `getCurrentTime` which performs well as noted in #5208.

- [x] Fix
- [x] ~Test?~
- [x] Changelog