### PR TITLE
chore: raise text lower bound

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,7 +1,8 @@
 packages: postgrest.cabal
 tests: true
 allow-newer:
-  hasql:postgresql-libpq
+  , fuzzyset:text
+  , hasql:postgresql-libpq
 
 -- https://github.com/martijnbastiaan/doctest-parallel/blob/main/example/README.md#cabalproject
 write-ghc-environment-files: always

--- a/postgrest.cabal
+++ b/postgrest.cabal
@@ -271,7 +271,7 @@ library
                     , scientific                >= 0.3.4 && < 0.4
                     , streaming-commons         >= 0.2.3.1 && < 0.3
                     , swagger2                  >= 2.4 && < 2.9
-                    , text                      >= 1.2.2 && < 2.2
+                    , text                      >= 2.1.2 && < 2.2
                     , time                      >= 1.6 && < 1.15
                     , unordered-containers      >= 0.2.8 && < 0.3
                     , unix-compat               >= 0.5.4 && < 0.8


### PR DESCRIPTION
The update to text 2.1.2 fixed a bug where hPutStrLn would not print the newline together with the log line when run concurrently. This is not an issue in v16 anymore, because we have been building our releases with GHC 9.12, which ships 2.1.2 already - but it still makes sense to raise the lower bound to clarify our requirements.

Resolves #5234
