### PR TITLE
ci(chore): change PR title prefix format in backport workflow

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -54,4 +54,4 @@ jobs:
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           pull_description: 'Backport for #${pull_number}.'
-          pull_title: '${target_branch}: ${pull_title}'
+          pull_title: '[${target_branch}] ${pull_title}'


### PR DESCRIPTION
This changes the PR title prefix to `[v16] fix: ...` from `v16: fix: ...`. It improves visibility when scrolling through pull requests.